### PR TITLE
feat: allow loading @script blocks from external files

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Environment files are simple JSON maps keyed by environment name, for example:
   - `@auth Authorization <value>` (custom header)
 - `@setting <key> <value>` - per-request overrides. Recognised keys (`timeout`, `proxy`, `followredirects`, `insecure`), and `@timeout <duration>` is accepted as a shorthand.
 - `@no-log` - skip storing the response body snippet for that request in history.
-- `@script <kind>` followed by lines beginning with `>` - executes JavaScript either as `pre-request` (mutate method/url/headers/body/variables) or `test` blocks whose assertions appear in the UI and history.
+- `@script <kind>` followed by lines beginning with `>` - executes JavaScript either as `pre-request` (mutate method/url/headers/body/variables) or `test` blocks whose assertions appear in the UI and history. Use `> < ./path/to/file.js` to load a script from disk (paths resolve relative to the request file unless absolute).
 
 ### GraphQL
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -334,6 +334,14 @@ func (b *documentBuilder) handleScript(line int, rawLine string) {
 	if kind == "" {
 		kind = "test"
 	}
+	trimmedHead := strings.TrimLeft(body, " \t")
+	if strings.HasPrefix(trimmedHead, "<") {
+		path := strings.TrimSpace(strings.TrimPrefix(trimmedHead, "<"))
+		if path != "" {
+			b.request.appendScriptInclude(kind, path)
+		}
+		return
+	}
 	b.request.appendScriptLine(kind, body)
 }
 
@@ -419,6 +427,15 @@ func (r *requestBuilder) flushPendingScript() {
 	r.metadata.Scripts = append(r.metadata.Scripts, restfile.ScriptBlock{Kind: r.scriptBufferKind, Body: script})
 	r.scriptBuffer = nil
 	r.scriptBufferKind = ""
+}
+
+func (r *requestBuilder) appendScriptInclude(kind, path string) {
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	if kind == "" {
+		kind = "test"
+	}
+	r.flushPendingScript()
+	r.metadata.Scripts = append(r.metadata.Scripts, restfile.ScriptBlock{Kind: kind, FilePath: path})
 }
 
 func (b *documentBuilder) handleBodyLine(line string) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -93,6 +93,48 @@ GET https://example.com/api
 	}
 }
 
+func TestParseScriptFileInclude(t *testing.T) {
+	src := `# @name FileScript
+# @script test
+> < ./scripts/validation.js
+GET https://example.com/api
+`
+
+	doc := Parse("filescript.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if len(req.Metadata.Scripts) != 1 {
+		t.Fatalf("expected 1 script block, got %d", len(req.Metadata.Scripts))
+	}
+	script := req.Metadata.Scripts[0]
+	if script.FilePath != "./scripts/validation.js" {
+		t.Fatalf("unexpected script file path: %q", script.FilePath)
+	}
+	if script.Body != "" {
+		t.Fatalf("expected script body to be empty for file include, got %q", script.Body)
+	}
+}
+
+func TestParseScriptFileIncludeWithIndent(t *testing.T) {
+	src := `# @script test
+>     < ./script.js
+GET https://example.com`
+
+	doc := Parse("indent.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if len(req.Metadata.Scripts) != 1 {
+		t.Fatalf("expected 1 script block, got %d", len(req.Metadata.Scripts))
+	}
+	if req.Metadata.Scripts[0].FilePath != "./script.js" {
+		t.Fatalf("unexpected script file path: %q", req.Metadata.Scripts[0].FilePath)
+	}
+}
+
 func TestParseBlockComments(t *testing.T) {
 	src := `/**
  * @name Blocked

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -31,6 +31,7 @@ type AuthSpec struct {
 type ScriptBlock struct {
 	Kind string
 	Body string
+	FilePath string
 }
 
 type BodySource struct {

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -289,7 +289,7 @@ func New(cfg Config) Model {
 		historyStore:       cfg.History,
 		currentFile:        cfg.FilePath,
 		statusMessage:      initialStatus,
-		scriptRunner:       scripts.NewRunner(),
+		scriptRunner:       scripts.NewRunner(nil),
 		editorInsertMode:   false,
 		editorWriteKeyMap:  writeKeyMap,
 		editorViewKeyMap:   viewKeyMap,

--- a/internal/ui/model_execution.go
+++ b/internal/ui/model_execution.go
@@ -77,6 +77,7 @@ func (m *Model) executeRequest(doc *restfile.Document, req *restfile.Request, op
 		preResult, err := runner.RunPreRequest(req.Metadata.Scripts, scripts.PreRequestInput{
 			Request:   req,
 			Variables: preVars,
+			BaseDir:   options.BaseDir,
 		})
 		if err != nil {
 			return responseMsg{err: errdef.Wrap(errdef.CodeScript, err, "pre-request script")}
@@ -131,6 +132,7 @@ func (m *Model) executeRequest(doc *restfile.Document, req *restfile.Request, op
 		tests, testErr := runner.RunTests(req.Metadata.Scripts, scripts.TestInput{
 			Response:  response,
 			Variables: testVars,
+			BaseDir:   options.BaseDir,
 		})
 
 		return responseMsg{


### PR DESCRIPTION
- buffer script lines while accepting `> < path` entries
- pass request base directory to the runner and load script files from fs