### PR TITLE
feat: editor motion improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Note: resize chords (`gh`, `gl`, `gj`, `gk`) stay active until you press another
 - `gg`, `G` - top/bottom of buffer
 - `Ctrl+f` / `Ctrl+b` - page down/up (`Ctrl+d` / `Ctrl+u` half-page)
 - `v`, `y`, `d` - visual select, yank selection, delete selection
+- `u` - undo last edit
 - `Shift+F` - open search prompt; `Ctrl+R` toggles regex while open
 - `n` - jump to the next match (wraps around)
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Note: resize chords (`gh`, `gl`, `gj`, `gk`) stay active until you press another
 - `0`, `$`, `^` - start/end/first non-blank of line
 - `gg`, `G` - top/bottom of buffer
 - `Ctrl+f` / `Ctrl+b` - page down/up (`Ctrl+d` / `Ctrl+u` half-page)
-- `v`, `y` - visual select, yank selection
+- `v`, `y`, `d` - visual select, yank selection, delete selection
 - `Shift+F` - open search prompt; `Ctrl+R` toggles regex while open
 - `n` - jump to the next match (wraps around)
 

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -94,6 +94,7 @@ type editorSnapshot struct {
 	cursor    cursorPosition
 	selection selectionState
 	mode      selectionMode
+	viewStart int
 }
 
 type searchMatch struct {
@@ -127,6 +128,7 @@ func (e *requestEditor) pushUndoSnapshot() {
 		cursor:    e.caretPosition(),
 		selection: e.selection,
 		mode:      e.mode,
+		viewStart: e.Model.ViewStart(),
 	}
 	e.undoStack = append(e.undoStack, snapshot)
 	if len(e.undoStack) > editorUndoLimit {
@@ -424,6 +426,7 @@ func (e requestEditor) UndoLastChange() (requestEditor, tea.Cmd) {
 	e.mode = last.mode
 	e.pendingMotion = ""
 	e.applySelectionHighlight()
+	e.Model.SetViewStart(last.viewStart)
 	status := statusMsg{text: "Undid last change", level: statusInfo}
 	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
 }
@@ -622,6 +625,8 @@ func (e *requestEditor) removeSelection() bool {
 		return false
 	}
 
+	prevView := e.Model.ViewStart()
+
 	e.pushUndoSnapshot()
 
 	runes := []rune(e.Value())
@@ -642,6 +647,7 @@ func (e *requestEditor) removeSelection() bool {
 	e.clearSelection()
 	e.moveCursorTo(start.Line, start.Column)
 	e.applySelectionHighlight()
+	e.Model.SetViewStart(prevView)
 	return true
 }
 

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -122,13 +122,21 @@ func (e *requestEditor) SetMotionsEnabled(enabled bool) {
 	}
 }
 
+func (e requestEditor) ViewStart() int {
+	return e.Model.ViewStart()
+}
+
+func (e *requestEditor) SetViewStart(offset int) {
+	e.Model.SetViewStart(offset)
+}
+
 func (e *requestEditor) pushUndoSnapshot() {
 	snapshot := editorSnapshot{
 		value:     e.Value(),
 		cursor:    e.caretPosition(),
 		selection: e.selection,
 		mode:      e.mode,
-		viewStart: e.Model.ViewStart(),
+		viewStart: e.ViewStart(),
 	}
 	e.undoStack = append(e.undoStack, snapshot)
 	if len(e.undoStack) > editorUndoLimit {

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -79,10 +79,10 @@ func toEditorEventCmd(evt editorEvent) tea.Cmd {
 
 type requestEditor struct {
 	textarea.Model
-	selection     selectionState
-	mode          selectionMode
-	pendingMotion string
-	search        editorSearch
+	selection      selectionState
+	mode           selectionMode
+	pendingMotion  string
+	search         editorSearch
 	motionsEnabled bool
 }
 
@@ -375,6 +375,18 @@ func (e requestEditor) YankSelection() (requestEditor, tea.Cmd) {
 	cmd := e.copyToClipboard(text)
 	e.clearSelection()
 	return e, cmd
+}
+
+func (e requestEditor) DeleteSelection() (requestEditor, tea.Cmd) {
+	text := e.selectedText()
+	if text == "" {
+		return e, toEditorEventCmd(editorEvent{status: &statusMsg{text: "No selection to delete", level: statusWarn}})
+	}
+	if e.removeSelection() {
+		status := statusMsg{text: "Selection deleted", level: statusInfo}
+		return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	}
+	return e, nil
 }
 
 func (e requestEditor) HandleMotion(command string) (requestEditor, tea.Cmd, bool) {

--- a/internal/ui/model_files.go
+++ b/internal/ui/model_files.go
@@ -34,7 +34,9 @@ func (m *Model) openFile(path string) tea.Cmd {
 	m.setInsertMode(false, false)
 	m.editor.ClearSelection()
 	m.editor.SetValue(string(data))
-	m.editor.SetCursor(0)
+	m.editor.undoStack = nil
+	m.editor.SetViewStart(0)
+	m.editor.moveCursorTo(0, 0)
 	m.editor.ClearSelection()
 	m.doc = parser.Parse(path, data)
 	m.syncRequestList(m.doc)

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -575,7 +575,7 @@ func (m Model) renderHelpOverlay() string {
 		helpRow(m, "0 / ^ / $", "Line start / first non-blank / line end"),
 		helpRow(m, "gg / G", "Top / bottom of buffer"),
 		helpRow(m, "Ctrl+f / Ctrl+b", "Page down / up (Ctrl+d / Ctrl+u half-page)"),
-		helpRow(m, "v / y", "Visual select / yank selection"),
+		helpRow(m, "v / y / d", "Visual select / yank / delete selection"),
 		"",
 		m.theme.HeaderTitle.Width(width - 4).Align(lipgloss.Left).Render("Search"),
 		helpRow(m, "Shift+F", "Open search prompt (Ctrl+R toggles regex)"),

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -576,6 +576,7 @@ func (m Model) renderHelpOverlay() string {
 		helpRow(m, "gg / G", "Top / bottom of buffer"),
 		helpRow(m, "Ctrl+f / Ctrl+b", "Page down / up (Ctrl+d / Ctrl+u half-page)"),
 		helpRow(m, "v / y / d", "Visual select / yank / delete selection"),
+		helpRow(m, "u", "Undo last edit"),
 		"",
 		m.theme.HeaderTitle.Width(width - 4).Align(lipgloss.Left).Render("Search"),
 		helpRow(m, "Shift+F", "Open search prompt (Ctrl+R toggles regex)"),

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -441,6 +441,11 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 				m.editor, cmd = m.editor.NextSearchMatch()
 				m.suppressEditorKey = true
 				return combine(cmd)
+			case "u":
+				var cmd tea.Cmd
+				m.editor, cmd = m.editor.UndoLastChange()
+				m.suppressEditorKey = true
+				return combine(cmd)
 			case "d":
 				var cmd tea.Cmd
 				m.editor, cmd = m.editor.DeleteSelection()

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -441,6 +441,11 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 				m.editor, cmd = m.editor.NextSearchMatch()
 				m.suppressEditorKey = true
 				return combine(cmd)
+			case "d":
+				var cmd tea.Cmd
+				m.editor, cmd = m.editor.DeleteSelection()
+				m.suppressEditorKey = true
+				return combine(cmd)
 			case "i":
 				m.setInsertMode(true, true)
 				m.suppressEditorKey = true

--- a/internal/ui/model_update_test.go
+++ b/internal/ui/model_update_test.go
@@ -202,3 +202,60 @@ func TestChordFallbackMaintainsEditorMotions(t *testing.T) {
 		t.Fatalf("expected repeat chord state to be cleared after fallback")
 	}
 }
+
+func TestHandleKeyDDeletesSelection(t *testing.T) {
+	model := New(Config{WorkspaceRoot: t.TempDir()})
+	model.width = 120
+	model.height = 40
+	model.ready = true
+	model.setFocus(focusEditor)
+	model.setInsertMode(false, false)
+	model.editor.SetValue("alpha")
+
+	editorPtr := &model.editor
+	editorPtr.moveCursorTo(0, 0)
+	start := model.editor.caretPosition()
+	editorPtr.startSelection(start, selectionManual)
+	editorPtr.selection.Update(cursorPosition{Line: 0, Column: 5, Offset: 5})
+	editorPtr.applySelectionHighlight()
+
+	cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if cmd == nil {
+		t.Fatalf("expected delete selection to emit command")
+	}
+	if got := model.editor.Value(); got != "" {
+		t.Fatalf("expected selection to be removed, got %q", got)
+	}
+	if model.editor.hasSelection() {
+		t.Fatal("expected selection to be cleared after delete")
+	}
+}
+
+func TestHandleKeyDWithoutSelectionShowsStatus(t *testing.T) {
+	model := New(Config{WorkspaceRoot: t.TempDir()})
+	model.width = 120
+	model.height = 40
+	model.ready = true
+	model.setFocus(focusEditor)
+	model.setInsertMode(false, false)
+	model.editor.SetValue("alpha")
+
+	cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if cmd == nil {
+		t.Fatalf("expected command when deleting without selection")
+	}
+	msg := cmd()
+	evt, ok := msg.(editorEvent)
+	if !ok {
+		t.Fatalf("expected editorEvent, got %T", msg)
+	}
+	if evt.dirty {
+		t.Fatalf("expected dirty to remain false when nothing deleted")
+	}
+	if evt.status == nil || evt.status.text != "No selection to delete" {
+		t.Fatalf("expected warning status, got %+v", evt.status)
+	}
+	if got := model.editor.Value(); got != "alpha" {
+		t.Fatalf("expected content to remain unchanged, got %q", got)
+	}
+}

--- a/internal/ui/model_update_test.go
+++ b/internal/ui/model_update_test.go
@@ -259,3 +259,69 @@ func TestHandleKeyDWithoutSelectionShowsStatus(t *testing.T) {
 		t.Fatalf("expected content to remain unchanged, got %q", got)
 	}
 }
+
+func TestHandleKeyUUdoesUndo(t *testing.T) {
+	model := New(Config{WorkspaceRoot: t.TempDir()})
+	model.width = 120
+	model.height = 40
+	model.ready = true
+	model.setFocus(focusEditor)
+	model.setInsertMode(false, false)
+	model.editor.SetValue("alpha")
+
+	editorPtr := &model.editor
+	editorPtr.moveCursorTo(0, 0)
+	start := model.editor.caretPosition()
+	editorPtr.startSelection(start, selectionManual)
+	editorPtr.selection.Update(cursorPosition{Line: 0, Column: 5, Offset: 5})
+	editorPtr.applySelectionHighlight()
+
+	_ = model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if got := model.editor.Value(); got != "" {
+		t.Fatalf("expected deletion to clear content, got %q", got)
+	}
+	cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	if cmd == nil {
+		t.Fatalf("expected undo command")
+	}
+	msg := cmd()
+	evt, ok := msg.(editorEvent)
+	if !ok {
+		t.Fatalf("expected editorEvent, got %T", msg)
+	}
+	if evt.status == nil || evt.status.text != "Undid last change" {
+		t.Fatalf("expected undo status, got %+v", evt.status)
+	}
+	if got := model.editor.Value(); got != "alpha" {
+		t.Fatalf("expected undo to restore content, got %q", got)
+	}
+}
+
+func TestHandleKeyUWithoutHistoryShowsStatus(t *testing.T) {
+	model := New(Config{WorkspaceRoot: t.TempDir()})
+	model.width = 120
+	model.height = 40
+	model.ready = true
+	model.setFocus(focusEditor)
+	model.setInsertMode(false, false)
+	model.editor.SetValue("alpha")
+
+	cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	if cmd == nil {
+		t.Fatalf("expected undo command")
+	}
+	msg := cmd()
+	evt, ok := msg.(editorEvent)
+	if !ok {
+		t.Fatalf("expected editorEvent, got %T", msg)
+	}
+	if evt.status == nil || evt.status.text != "Nothing to undo" {
+		t.Fatalf("expected no-history status, got %+v", evt.status)
+	}
+	if evt.dirty {
+		t.Fatalf("expected dirty to remain false when no undo")
+	}
+	if got := model.editor.Value(); got != "alpha" {
+		t.Fatalf("expected content unchanged, got %q", got)
+	}
+}

--- a/internal/ui/textarea/textarea.go
+++ b/internal/ui/textarea/textarea.go
@@ -909,6 +909,22 @@ func (m *Model) SetSelectionStyle(style lipgloss.Style) {
 	m.selectionStyle = style
 }
 
+// ViewStart returns the index of the first visible line in the viewport.
+func (m Model) ViewStart() int {
+	if m.viewport == nil {
+		return 0
+	}
+	return m.viewport.YOffset
+}
+
+// SetViewStart updates the viewport so that the line at offset becomes the first visible line.
+func (m *Model) SetViewStart(offset int) {
+	if m.viewport == nil {
+		return
+	}
+	m.viewport.SetYOffset(offset)
+}
+
 // repositionView repositions the view of the viewport based on the defined
 // scrolling behavior.
 func (m *Model) repositionView() {


### PR DESCRIPTION
  - add a 'd' motion so visual selections can be deleted without touching insert mode
  - introduce a small undo stack to track selection edits, wire u to restore text/cursor/selection
  - preserve viewport offsets when deleting and undoing so the editor no longer jumps the scroll position
  - reset the editor scroll/cursor when opening files, keeping the buffer anchored at the top