### PR TITLE
refactor: request execution UX and editor performance

### DIFF
--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -80,18 +80,19 @@ const (
 )
 
 type Config struct {
-	FilePath        string
-	InitialContent  string
-	Client          *httpclient.Client
-	Theme           *theme.Theme
-	EnvironmentSet  vars.EnvironmentSet
-	EnvironmentName string
-	EnvironmentFile string
-	HTTPOptions     httpclient.Options
-	GRPCOptions     grpcclient.Options
-	History         *history.Store
-	WorkspaceRoot   string
-	Recursive       bool
+	FilePath            string
+	InitialContent      string
+	Client              *httpclient.Client
+	Theme               *theme.Theme
+	EnvironmentSet      vars.EnvironmentSet
+	EnvironmentName     string
+	EnvironmentFile     string
+	EnvironmentFallback string
+	HTTPOptions         httpclient.Options
+	GRPCOptions         grpcclient.Options
+	History             *history.Store
+	WorkspaceRoot       string
+	Recursive           bool
 }
 
 type operatorState struct {
@@ -228,6 +229,12 @@ func New(cfg Config) Model {
 	if err != nil {
 		initialStatus = statusMsg{text: fmt.Sprintf("workspace error: %v", err), level: statusWarn}
 		entries = nil
+	}
+	if initialStatus.text == "" && cfg.EnvironmentFallback != "" {
+		initialStatus = statusMsg{
+			text:  fmt.Sprintf("Environment defaulted to %q; press Ctrl+E to change.", cfg.EnvironmentFallback),
+			level: statusInfo,
+		}
 	}
 
 	items := makeFileItems(entries)

--- a/internal/ui/model_environment_test.go
+++ b/internal/ui/model_environment_test.go
@@ -1,0 +1,35 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnvironmentSelectorRendersItems(t *testing.T) {
+	cfg := Config{
+		EnvironmentSet: map[string]map[string]string{
+			"dev":  {"baseUrl": "https://dev"},
+			"prod": {"baseUrl": "https://prod"},
+		},
+		EnvironmentName: "dev",
+	}
+
+	model := New(cfg)
+	model.ready = true
+	model.width = 80
+	model.height = 24
+	model.frameWidth = 80
+	model.frameHeight = 24
+	model.applyLayout()
+
+	model.openEnvironmentSelector()
+	view := model.View()
+
+	if !containsSubstring(view, "dev") || !containsSubstring(view, "prod") {
+		t.Fatalf("environment selector should list environments, got view:\n%s", view)
+	}
+}
+
+func containsSubstring(view, substr string) bool {
+	return strings.Contains(view, substr)
+}

--- a/internal/ui/model_execution_test.go
+++ b/internal/ui/model_execution_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/errdef"
 	"github.com/unkn0wn-root/resterm/internal/grpcclient"
@@ -186,5 +187,21 @@ func TestHandleResponseMsgShowsGrpcErrors(t *testing.T) {
 			got = model.responseLatest.pretty
 		}
 		t.Fatalf("expected response view to mention grpc status, got %q", got)
+	}
+}
+
+func TestResolveRequestTimeout(t *testing.T) {
+	req := &restfile.Request{Settings: map[string]string{"timeout": "5s"}}
+	if got := resolveRequestTimeout(req, 30*time.Second); got != 5*time.Second {
+		t.Fatalf("expected timeout override to return 5s, got %s", got)
+	}
+
+	req.Settings["timeout"] = "invalid"
+	if got := resolveRequestTimeout(req, 10*time.Second); got != 10*time.Second {
+		t.Fatalf("expected fallback to base timeout, got %s", got)
+	}
+
+	if got := resolveRequestTimeout(nil, 15*time.Second); got != 15*time.Second {
+		t.Fatalf("expected base timeout when request nil, got %s", got)
 	}
 }

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -46,6 +46,7 @@ func (m *Model) handleResponseMessage(msg responseMsg) tea.Cmd {
 		level := statusError
 		if code == errdef.CodeScript {
 			level = statusWarn
+			m.openErrorModal(errdef.Message(msg.err))
 		}
 		m.setStatusMessage(statusMsg{text: errdef.Message(msg.err), level: level})
 		return nil

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -49,13 +49,7 @@ func (m Model) View() string {
 		return m.renderWithinAppFrame(m.renderHelpOverlay())
 	}
 	if m.showEnvSelector {
-		content := lipgloss.JoinVertical(
-			lipgloss.Left,
-			header,
-			m.renderEnvironmentSelector(),
-			body,
-		)
-		return m.renderWithinAppFrame(content)
+		return m.renderWithinAppFrame(m.renderEnvironmentModal())
 	}
 	return m.renderWithinAppFrame(base)
 }
@@ -803,7 +797,22 @@ func (m Model) renderStatusBar() string {
 		builder.WriteString(fmt.Sprintf("Mode: %s", mode))
 	}
 
-	return m.theme.StatusBar.Render(builder.String())
+	return m.theme.StatusBar.Render(truncateStatus(builder.String(), m.width))
+}
+
+func truncateStatus(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+	maxWidth := maxInt(width-2, 1)
+	if lipgloss.Width(text) <= maxWidth {
+		return text
+	}
+	trim := text
+	for lipgloss.Width(trim) > maxWidth-1 && len(trim) > 0 {
+		trim = trim[:len(trim)-1]
+	}
+	return strings.TrimSpace(trim) + "…"
 }
 
 func (m Model) renderErrorModal() string {
@@ -852,7 +861,7 @@ func (m Model) renderErrorModal() string {
 	)
 }
 
-func (m Model) renderEnvironmentSelector() string {
+func (m Model) renderEnvironmentModal() string {
 	width := minInt(m.width-10, 48)
 	if width < 24 {
 		width = 24
@@ -869,7 +878,12 @@ func (m Model) renderEnvironmentSelector() string {
 		commands,
 	)
 	box := m.theme.BrowserBorder.Copy().Width(width).Render(content)
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box,
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		box,
 		lipgloss.WithWhitespaceChars(" "),
 		lipgloss.WithWhitespaceForeground(lipgloss.Color("#1A1823")),
 	)

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -33,7 +33,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.setStatusMessage(*typed.status)
 		}
 	case tea.KeyMsg:
-		if !m.showSearchPrompt {
+		if !m.showSearchPrompt && !m.showEnvSelector {
 			if cmd := m.handleKey(typed); cmd != nil {
 				cmds = append(cmds, cmd)
 			}


### PR DESCRIPTION
- Fix CLI (--recursive flag and keep the old one in case someone uses it already) and respect per-request @timeout.
- Auto-select default environment and fallback choice with a status hint.
- Rebuild the env selector as a proper modal and block global key handling while it’s open.
- Show script failures in an error modal and trim status bar strings to fit the viewport.
- Optimise editor rendering by styling only visible lines and caching metadata styles.