### PR TITLE
feat: add backward search navigation and cover regex behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Note: resize chords (`gh`, `gl`, `gj`, `gk`) stay active until you press another
 - `p`, `P` - paste after/before cursor
 - `f`, `t`, `T` - find character (forward / forward before target / backward before target)
 - `Shift+F` - open search prompt; `Ctrl+R` toggles regex while open
-- `n` - jump to the next match (wraps around)
+- `n` / `p` - jump to the next / previous match (wraps around)
 
 ### CLI Flags
 - `--file`: path to a `.http`/`.rest` file to open.

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1076,7 +1076,7 @@ func (m Model) renderHelpOverlay() string {
 		"",
 		header("Search", lipgloss.Left),
 		helpRow(m, "Shift+F", "Open search prompt (Ctrl+R toggles regex)"),
-		helpRow(m, "n", "Next match (wraps around)"),
+		helpRow(m, "n / p", "Next / previous match (wraps around)"),
 		"",
 		m.theme.HeaderValue.Render("Press Esc to close this help"),
 	}

--- a/internal/ui/model_search_test.go
+++ b/internal/ui/model_search_test.go
@@ -1,0 +1,61 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRetreatResponseSearchWrap(t *testing.T) {
+	model := New(Config{})
+	model.responsePaneFocus = responsePanePrimary
+	model.searchResponsePane = responsePanePrimary
+	pane := model.pane(responsePanePrimary)
+	if pane == nil {
+		t.Fatal("expected response pane to be available")
+	}
+	pane.viewport.Width = 80
+	pane.snapshot = &responseSnapshot{
+		id:      "snap-1",
+		pretty:  ensureTrailingNewline("foo bar\nfoo baz\nfoo"),
+		raw:     ensureTrailingNewline("foo bar\nfoo baz\nfoo"),
+		headers: ensureTrailingNewline("Status: 200 OK"),
+		ready:   true,
+	}
+
+	if status := statusFromCmd(t, model.applyResponseSearch("foo", false)); status == nil {
+		t.Fatal("expected initial response search status")
+	}
+
+	cmd := model.retreatResponseSearch()
+	status := statusFromCmd(t, cmd)
+	if status == nil {
+		t.Fatal("expected status after retreating search")
+	}
+	if status.level != statusInfo {
+		t.Fatalf("expected info level, got %v", status.level)
+	}
+	if !strings.Contains(status.text, "Match 3/3") {
+		t.Fatalf("expected wrap to last match, got %q", status.text)
+	}
+	if !strings.Contains(status.text, "(wrapped)") {
+		t.Fatalf("expected wrapped indicator, got %q", status.text)
+	}
+	if pane.search.index != 2 {
+		t.Fatalf("expected search index 2, got %d", pane.search.index)
+	}
+
+	cmd = model.retreatResponseSearch()
+	status = statusFromCmd(t, cmd)
+	if status == nil {
+		t.Fatal("expected status after moving to previous match")
+	}
+	if !strings.Contains(status.text, "Match 2/3") {
+		t.Fatalf("expected to move to second match, got %q", status.text)
+	}
+	if strings.Contains(status.text, "(wrapped)") {
+		t.Fatalf("did not expect wrapped indicator on second match, got %q", status.text)
+	}
+	if pane.search.index != 1 {
+		t.Fatalf("expected search index 1, got %d", pane.search.index)
+	}
+}

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"strings"
+
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/unkn0wn-root/resterm/internal/ui/textarea"
@@ -484,6 +486,16 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 				m.editor, cmd = m.editor.NextSearchMatch()
 				m.suppressEditorKey = true
 				return combine(cmd)
+			case "p":
+				if strings.TrimSpace(m.editor.search.query) != "" {
+					var cmd tea.Cmd
+					m.editor, cmd = m.editor.PrevSearchMatch()
+					m.suppressEditorKey = true
+					return combine(cmd)
+				}
+				cmd := m.runPasteClipboard(true)
+				m.suppressEditorKey = true
+				return combine(cmd)
 			case "u":
 				var cmd tea.Cmd
 				m.editor, cmd = m.editor.UndoLastChange()
@@ -518,10 +530,6 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 				cmd := m.runChangeCurrentLine()
 				m.suppressEditorKey = true
 				m.setInsertMode(true, true)
-				return combine(cmd)
-			case "p":
-				cmd := m.runPasteClipboard(true)
-				m.suppressEditorKey = true
 				return combine(cmd)
 			case "P":
 				cmd := m.runPasteClipboard(false)
@@ -648,6 +656,9 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 			return combine(cmd)
 		case "n":
 			cmd := m.advanceResponseSearch()
+			return combine(cmd)
+		case "p":
+			cmd := m.retreatResponseSearch()
 			return combine(cmd)
 		case "down", "j":
 			if pane == nil || pane.activeTab == responseTabHistory {


### PR DESCRIPTION
- map p to prior search hits in editor/request panes and reuse search state across directions
- update tests