### PR TITLE
improve request error UX and harden client handling

### DIFF
--- a/internal/grpcclient/client.go
+++ b/internal/grpcclient/client.go
@@ -61,8 +61,12 @@ func (c *Client) Execute(parent context.Context, req *restfile.Request, grpcReq 
 
 	ctx := parent
 	cancel := func() {}
-	if timeout := req.Settings["timeout"]; timeout != "" {
-		if dur, err := time.ParseDuration(timeout); err == nil && dur > 0 {
+	var timeoutSetting string
+	if req != nil {
+		timeoutSetting = req.Settings["timeout"]
+	}
+	if timeoutSetting != "" {
+		if dur, err := time.ParseDuration(timeoutSetting); err == nil && dur > 0 {
 			ctx, cancel = context.WithTimeout(parent, dur)
 		}
 	} else if options.DialTimeout > 0 {

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -131,19 +131,20 @@ type Model struct {
 	historyList              list.Model
 	envList                  list.Model
 
-	responseLatest      *responseSnapshot
-	responsePrevious    *responseSnapshot
-	responsePending     *responseSnapshot
-	responseTokens      map[string]*responseSnapshot
-	responseLastFocused responsePaneID
-	focus               paneFocus
-	showEnvSelector     bool
-	showHelp            bool
-	helpJustOpened      bool
-	showNewFileModal    bool
-	showOpenModal       bool
-	showErrorModal      bool
-	errorModalMessage   string
+	responseLatest         *responseSnapshot
+	responsePrevious       *responseSnapshot
+	responsePending        *responseSnapshot
+	responseTokens         map[string]*responseSnapshot
+	responseLastFocused    responsePaneID
+	focus                  paneFocus
+	showEnvSelector        bool
+	showHelp               bool
+	helpJustOpened         bool
+	showNewFileModal       bool
+	showOpenModal          bool
+	showErrorModal         bool
+	errorModalMessage      string
+	suppressNextErrorModal bool
 
 	showSearchPrompt   bool
 	searchInput        textinput.Model

--- a/internal/ui/model_status.go
+++ b/internal/ui/model_status.go
@@ -4,7 +4,9 @@ import "strings"
 
 func (m *Model) setStatusMessage(msg statusMsg) {
 	m.statusMessage = msg
-	if msg.level == statusError && strings.TrimSpace(msg.text) != "" {
+	showModal := msg.level == statusError && strings.TrimSpace(msg.text) != "" && !m.suppressNextErrorModal
+	m.suppressNextErrorModal = false
+	if showModal {
 		m.openErrorModal(msg.text)
 	}
 }


### PR DESCRIPTION
  - render request execution failures directly in the response panes while keeping modal behaviour for other errors
  - make httpclient tolerant of nil resolvers, stream body files, transport defaults, and rely on stdlib basic auth
  - prevent nil timeout panics in the gRPC client and surface OAuth/token issues via errdef
  - tigthen file listing helpers and wrap environment file failures with errdef