### PR TITLE
feat: add request-headers toggle, capture request metadata, and add scroll to workflows with j/k

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -151,6 +151,7 @@ send_request = ["ctrl+enter", "cmd+enter"]
 | `quit_app` | Quit Resterm. | `ctrl+q`, `ctrl+d` |
 | `send_request` | Send the active request (single-step only). | `ctrl+enter`, `cmd+enter`, `alt+enter`, `ctrl+j`, `ctrl+m` |
 | `copy_response_tab` | Copy the focused Pretty/Raw/Headers response tab to the clipboard. | `ctrl+shift+c`, `g y` |
+| `toggle_header_preview` | Toggle request vs response headers in the Headers tab. | `g shift+h` |
 
 | Action ID | Description | Default bindings | Repeatable |
 | --- | --- | --- | --- |
@@ -171,7 +172,7 @@ send_request = ["ctrl+enter", "cmd+enter"]
 - **Pretty**: formatted JSON (or best-effort formatting for other types).
 - **Raw**: exact payload text.
 - **Stream**: live transcript viewer for WebSocket and SSE sessions with bookmarking and console integration.
-- **Headers**: response headers only. Request headers are captured for history/scripting but not rendered in this tab.
+- **Headers**: response headers by default; press `g+Shift+H` to toggle into the sent request headers view (cookies included) and back.
 - **Stats**: latency summaries and histograms from `@profile` runs.
 - **Timeline**: per-phase HTTP timings with budget overlays; available whenever tracing is enabled.
 - **Diff**: compare the focused pane against the other response pane.

--- a/internal/bindings/defaults.go
+++ b/internal/bindings/defaults.go
@@ -42,6 +42,7 @@ var (
 	ActionClearZoom               ActionID = "clear_zoom"
 	ActionSendRequest             ActionID = "send_request"
 	ActionCopyResponseTab         ActionID = "copy_response_tab"
+	ActionToggleHeaderPreview     ActionID = "toggle_header_preview"
 )
 
 type definition struct {
@@ -89,6 +90,7 @@ var definitions = []definition{
 	def(ActionClearZoom, false, "g shift+z"),
 	def(ActionSendRequest, false, "ctrl+enter", "cmd+enter", "alt+enter", "ctrl+j", "ctrl+m"),
 	def(ActionCopyResponseTab, false, "ctrl+shift+c", "g y"),
+	def(ActionToggleHeaderPreview, false, "g shift+h"),
 }
 
 var definitionLookup = func() map[ActionID]definition {

--- a/internal/httpclient/stream_types.go
+++ b/internal/httpclient/stream_types.go
@@ -9,14 +9,19 @@ import (
 )
 
 type StreamMeta struct {
-	Status       string
-	StatusCode   int
-	Proto        string
-	Headers      http.Header
-	EffectiveURL string
-	ConnectedAt  time.Time
-	Request      *restfile.Request
-	BaseDir      string
+	Status         string
+	StatusCode     int
+	Proto          string
+	Headers        http.Header
+	RequestHeaders http.Header
+	RequestMethod  string
+	RequestHost    string
+	RequestLength  int64
+	RequestTE      []string
+	EffectiveURL   string
+	ConnectedAt    time.Time
+	Request        *restfile.Request
+	BaseDir        string
 }
 
 type StreamHandle struct {

--- a/internal/ui/model_execution.go
+++ b/internal/ui/model_execution.go
@@ -389,12 +389,17 @@ func streamingPlaceholderResponse(meta httpclient.StreamMeta) *httpclient.Respon
 	}
 
 	return &httpclient.Response{
-		Status:       status,
-		StatusCode:   statusCode,
-		Proto:        meta.Proto,
-		Headers:      headers,
-		EffectiveURL: meta.EffectiveURL,
-		Request:      meta.Request,
+		Status:         status,
+		StatusCode:     statusCode,
+		Proto:          meta.Proto,
+		Headers:        headers,
+		ReqMethod:      meta.RequestMethod,
+		RequestHeaders: cloneHeader(meta.RequestHeaders),
+		ReqHost:        meta.RequestHost,
+		ReqLen:         meta.RequestLength,
+		ReqTE:          append([]string(nil), meta.RequestTE...),
+		EffectiveURL:   meta.EffectiveURL,
+		Request:        meta.Request,
 	}
 }
 

--- a/internal/ui/model_profile.go
+++ b/internal/ui/model_profile.go
@@ -265,15 +265,16 @@ func (m *Model) finalizeProfileRun(msg responseMsg, state *profileState) tea.Cmd
 		}
 	} else {
 		snapshot := &responseSnapshot{
-			pretty:        report,
-			raw:           report,
-			headers:       report,
-			stats:         report,
-			statsColorize: true,
-			statsKind:     statsReportKindProfile,
-			profileStats:  statsPtr,
-			statsColored:  "",
-			ready:         true,
+			pretty:         report,
+			raw:            report,
+			headers:        report,
+			requestHeaders: report,
+			stats:          report,
+			statsColorize:  true,
+			statsKind:      statsReportKindProfile,
+			profileStats:   statsPtr,
+			statsColored:   "",
+			ready:          true,
 		}
 		m.responseLatest = snapshot
 		m.responsePending = nil

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1973,6 +1973,7 @@ func (m Model) renderHelpOverlay() string {
 		helpRow(m, m.helpCombinedKey([]bindings.ActionID{bindings.ActionToggleResponseSplitVert, bindings.ActionToggleResponseSplitHorz}, "Ctrl+V / Ctrl+U"), "Split response vertically / horizontally"),
 		helpRow(m, m.helpActionKey(bindings.ActionTogglePaneFollowLatest, "Ctrl+Shift+V"), "Pin or unpin focused response pane"),
 		helpRow(m, m.helpActionKey(bindings.ActionCopyResponseTab, "Ctrl+Shift+C"), "Copy Pretty / Raw / Headers response tab"),
+		helpRow(m, m.helpActionKey(bindings.ActionToggleHeaderPreview, "g Shift+H"), "Toggle request/response headers view"),
 		helpRow(m, "Ctrl+F or Ctrl+B, ←/→", "Send future responses to selected pane"),
 		helpRow(m, m.helpActionKey(bindings.ActionShowGlobals, "Ctrl+G"), "Show globals summary"),
 		helpRow(m, m.helpActionKey(bindings.ActionClearGlobals, "Ctrl+Shift+G"), "Clear globals for environment"),

--- a/internal/ui/model_response_copy_test.go
+++ b/internal/ui/model_response_copy_test.go
@@ -69,6 +69,33 @@ func TestResponseCopyPayloadHeadersFallback(t *testing.T) {
 	}
 }
 
+func TestResponseCopyPayloadRequestHeaders(t *testing.T) {
+	snap := &responseSnapshot{
+		pretty:         ensureTrailingNewline("pretty"),
+		raw:            ensureTrailingNewline("raw"),
+		headers:        ensureTrailingNewline("Headers:\nX-Resp: ok"),
+		requestHeaders: ensureTrailingNewline("Headers:\nCookie: demo=1"),
+		ready:          true,
+	}
+	model := newModelWithResponseTab(responseTabHeaders, snap)
+	pane := model.pane(responsePanePrimary)
+	pane.headersView = headersViewRequest
+
+	label, text, status := model.responseCopyPayload()
+	if status != nil {
+		t.Fatalf("expected nil status, got %+v", status)
+	}
+	if label != "Headers" {
+		t.Fatalf("expected Headers label, got %q", label)
+	}
+	if !strings.Contains(text, "Cookie: demo=1") {
+		t.Fatalf("expected request headers in copy, got %q", text)
+	}
+	if strings.Contains(text, "X-Resp") {
+		t.Fatalf("unexpected response header in request copy, got %q", text)
+	}
+}
+
 func TestCopyResponseTabWritesClipboard(t *testing.T) {
 	if err := clipboard.WriteAll(""); err != nil {
 		t.Skipf("clipboard unavailable: %v", err)

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -593,6 +593,8 @@ func (m *Model) runShortcutBinding(binding bindings.Binding, msg tea.KeyMsg) (te
 		return m.clearZoomCmd(), true
 	case bindings.ActionCopyResponseTab:
 		return m.copyResponseTab(), true
+	case bindings.ActionToggleHeaderPreview:
+		return m.toggleHeaderPreview(), true
 	default:
 		return nil, false
 	}
@@ -978,6 +980,10 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 			if pane.activeTab == responseTabStats {
 				snapshot := pane.snapshot
 				if snapshot != nil && snapshot.statsKind == statsReportKindWorkflow && snapshot.workflowStats != nil {
+					if snapshot.workflowStats.scrollExpanded(pane, 1) {
+						pane.setCurrPosition()
+						return combine(nil)
+					}
 					return combine(m.moveWorkflowStatsSelection(1))
 				}
 			}
@@ -994,6 +1000,10 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 			if pane.activeTab == responseTabStats {
 				snapshot := pane.snapshot
 				if snapshot != nil && snapshot.statsKind == statsReportKindWorkflow && snapshot.workflowStats != nil {
+					if snapshot.workflowStats.scrollExpanded(pane, -1) {
+						pane.setCurrPosition()
+						return combine(nil)
+					}
 					return combine(m.moveWorkflowStatsSelection(-1))
 				}
 			}

--- a/internal/ui/model_workflow.go
+++ b/internal/ui/model_workflow.go
@@ -330,15 +330,16 @@ func (m *Model) finalizeWorkflowRun(state *workflowState) tea.Cmd {
 		m.responseLatest.workflowStats = statsView
 	} else {
 		snapshot := &responseSnapshot{
-			pretty:        report,
-			raw:           report,
-			headers:       report,
-			stats:         report,
-			statsColorize: true,
-			statsKind:     statsReportKindWorkflow,
-			statsColored:  "",
-			workflowStats: statsView,
-			ready:         true,
+			pretty:         report,
+			raw:            report,
+			headers:        report,
+			requestHeaders: report,
+			stats:          report,
+			statsColorize:  true,
+			statsKind:      statsReportKindWorkflow,
+			statsColored:   "",
+			workflowStats:  statsView,
+			ready:          true,
 		}
 		m.responseLatest = snapshot
 		m.responsePending = nil

--- a/internal/ui/workflow_stats_view.go
+++ b/internal/ui/workflow_stats_view.go
@@ -105,6 +105,26 @@ func (v *workflowStatsView) invalidate() {
 	}
 }
 
+func (v *workflowStatsView) scrollExpanded(pane *responsePaneState, delta int) bool {
+	if pane == nil || v == nil {
+		return false
+	}
+	if v.selected < 0 || v.selected >= len(v.entries) {
+		return false
+	}
+	if v.expanded == nil || !v.expanded[v.selected] {
+		return false
+	}
+
+	before := pane.viewport.YOffset
+	if delta > 0 {
+		pane.viewport.ScrollDown(1)
+	} else if delta < 0 {
+		pane.viewport.ScrollUp(1)
+	}
+	return pane.viewport.YOffset != before
+}
+
 func (v *workflowStatsView) render(width int) workflowStatsRender {
 	if width <= 0 {
 		width = defaultResponseViewportWidth


### PR DESCRIPTION
- Add request/response headers toggle (g+Shift+H), including copy support.
- Capture executed request metadata (method/headers/host/len/TE) across HTTP, WebSocket, and SSE responses
- Fix WebSocket EffectiveURL to use the final URL.
- Render request headers with inferred Host/TE/Content-Length.
- Preserve per-view scroll when toggling headers. Workflow Stats tab j/k now scroll expanded details before moving between runs.