### PR TITLE
feat: improve workflow stats navigation and align gRPC display with HTTP formatting

### DIFF
--- a/_examples/scripts.http
+++ b/_examples/scripts.http
@@ -29,7 +29,7 @@ X-Shared-Secret: {{reporting.sharedSecret}}
 # @tag scripts reuse
 # @description Uses the global token populated by the pre-request script along with the top-level API key.
 # @auth bearer {{reporting.token}}
-# @capture request reporting.lastTrace {{response.headers.X-Amzn-Trace-Id}}
+# @capture request reporting.lastTrace {{response.json.headers.X-Trace-Id}}
 # @script test
 > client.test("script-created token is available", function () {
 >   var token = vars.get("reporting.token");

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -452,17 +452,26 @@ func (m *Model) consumeGRPCResponse(resp *grpcclient.Response, tests []scripts.T
 	}
 	headersContent := strings.TrimRight(headersBuilder.String(), "\n")
 
-	body := strings.TrimSpace(resp.Message)
-	if body == "" {
-		body = "<empty>"
-	}
 	statusLine := fmt.Sprintf("gRPC %s - %s", strings.TrimPrefix(req.GRPC.FullMethod, "/"), resp.StatusCode.String())
 	if resp.StatusMessage != "" {
 		statusLine += " (" + resp.StatusMessage + ")"
 	}
+
+	contentType := "application/json"
+	prettyBodyRaw := prettifyBody([]byte(resp.Message), contentType)
+	prettyBody := trimResponseBody(prettyBodyRaw)
+	if isBodyEmpty(prettyBody) {
+		prettyBody = "<empty>"
+	}
+
+	rawBody := formatRawBody([]byte(resp.Message), contentType)
+	if isBodyEmpty(rawBody) {
+		rawBody = "<empty>"
+	}
+
 	snapshot := &responseSnapshot{
-		pretty:      joinSections(statusLine, body),
-		raw:         joinSections(statusLine, body),
+		pretty:      joinSections(statusLine, prettyBody),
+		raw:         joinSections(statusLine, rawBody),
 		headers:     joinSections(statusLine, headersContent),
 		ready:       true,
 		environment: environment,

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -973,13 +973,16 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 			}
 			cmd := m.retreatResponseSearch()
 			return combine(cmd)
-		case "down", "j":
+		case "down", "j", "shift+j", "J":
 			if pane == nil {
 				return combine(nil)
 			}
 			if pane.activeTab == responseTabStats {
 				snapshot := pane.snapshot
 				if snapshot != nil && snapshot.statsKind == statsReportKindWorkflow && snapshot.workflowStats != nil {
+					if keyStr == "shift+j" || keyStr == "J" {
+						return combine(m.jumpWorkflowStatsSelection(1))
+					}
 					if snapshot.workflowStats.scrollExpanded(pane, 1) {
 						pane.setCurrPosition()
 						return combine(nil)
@@ -993,13 +996,16 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 			pane.viewport.ScrollDown(1)
 			pane.setCurrPosition()
 			return combine(nil)
-		case "up", "k":
+		case "up", "k", "shift+k", "K":
 			if pane == nil {
 				return combine(nil)
 			}
 			if pane.activeTab == responseTabStats {
 				snapshot := pane.snapshot
 				if snapshot != nil && snapshot.statsKind == statsReportKindWorkflow && snapshot.workflowStats != nil {
+					if keyStr == "shift+k" || keyStr == "K" {
+						return combine(m.jumpWorkflowStatsSelection(-1))
+					}
 					if snapshot.workflowStats.scrollExpanded(pane, -1) {
 						pane.setCurrPosition()
 						return combine(nil)

--- a/internal/ui/model_workflow_stats.go
+++ b/internal/ui/model_workflow_stats.go
@@ -18,6 +18,56 @@ func (m *Model) currentWorkflowStats() (*responseSnapshot, *workflowStatsView) {
 	return snapshot, view
 }
 
+func (m *Model) jumpWorkflowStatsSelection(delta int) tea.Cmd {
+	snapshot, view := m.currentWorkflowStats()
+	if view == nil {
+		return nil
+	}
+	if !view.move(delta) {
+		return nil
+	}
+
+	needsAlign := false
+	statsPaneCount := 0
+	for _, id := range m.visiblePaneIDs() {
+		pane := m.pane(id)
+		if pane == nil || pane.snapshot != snapshot || pane.activeTab != responseTabStats {
+			continue
+		}
+		statsPaneCount++
+		width := pane.viewport.Width
+		if width <= 0 {
+			width = defaultResponseViewportWidth
+		}
+		render := view.render(width)
+		if view.selected < 0 || view.selected >= len(render.metrics) {
+			continue
+		}
+		metric := render.metrics[view.selected]
+		height := pane.viewport.Height
+		if height <= 0 {
+			height = 1
+		}
+		offset := pane.viewport.YOffset
+		if metric.start < offset || metric.end > offset+height-1 {
+			needsAlign = true
+		}
+	}
+
+	view.alignTopSelected = needsAlign
+	if needsAlign {
+		view.alignTopRemaining = statsPaneCount
+		if view.alignTopRemaining == 0 {
+			view.alignTopRemaining = 1
+		}
+	} else {
+		view.alignTopRemaining = 0
+		m.ensureWorkflowStatsVisible(snapshot)
+	}
+	m.invalidateWorkflowStatsCaches(snapshot)
+	return m.syncResponsePanes()
+}
+
 func (m *Model) moveWorkflowStatsSelection(delta int) tea.Cmd {
 	snapshot, view := m.currentWorkflowStats()
 	if view == nil {
@@ -38,6 +88,11 @@ func (m *Model) toggleWorkflowStatsExpansion() tea.Cmd {
 	}
 	if !view.toggle() {
 		return nil
+	}
+	view.alignTopSelected = true
+	view.alignTopRemaining = m.workflowStatsPaneCount(snapshot)
+	if view.alignTopRemaining == 0 {
+		view.alignTopRemaining = 1
 	}
 	m.invalidateWorkflowStatsCaches(snapshot)
 	m.ensureWorkflowStatsVisible(snapshot)
@@ -89,4 +144,19 @@ func (m *Model) activateWorkflowStatsView(snapshot *responseSnapshot) tea.Cmd {
 		pane.setActiveTab(responseTabStats)
 	}
 	return m.syncResponsePanes()
+}
+
+func (m *Model) workflowStatsPaneCount(snapshot *responseSnapshot) int {
+	if snapshot == nil || snapshot.workflowStats == nil {
+		return 0
+	}
+	count := 0
+	for _, id := range m.visiblePaneIDs() {
+		pane := m.pane(id)
+		if pane == nil || pane.snapshot != snapshot || pane.activeTab != responseTabStats {
+			continue
+		}
+		count++
+	}
+	return count
 }

--- a/internal/ui/response_split.go
+++ b/internal/ui/response_split.go
@@ -365,7 +365,27 @@ func (m *Model) syncWorkflowStatsPane(pane *responsePaneState, width int, snapsh
 	decorated = m.applyResponseContentStyles(responseTabStats, decorated)
 	pane.viewport.SetContent(decorated)
 	pane.restoreScrollForActiveTab()
-	snapshot.workflowStats.ensureVisible(pane, render)
+	alignTop := snapshot.workflowStats.alignTopSelected
+	if alignTop && snapshot.workflowStats.alignTopRemaining <= 0 {
+		snapshot.workflowStats.alignTopRemaining = m.workflowStatsPaneCount(snapshot)
+		if snapshot.workflowStats.alignTopRemaining == 0 {
+			snapshot.workflowStats.alignTopRemaining = 1
+		}
+	}
+	if alignTop && snapshot.workflowStats.selected >= 0 && snapshot.workflowStats.selected < len(render.metrics) {
+		start := render.metrics[snapshot.workflowStats.selected].start
+		if start < 0 {
+			start = 0
+		}
+		pane.viewport.SetYOffset(start)
+		snapshot.workflowStats.alignTopRemaining--
+		if snapshot.workflowStats.alignTopRemaining <= 0 {
+			snapshot.workflowStats.alignTopSelected = false
+			snapshot.workflowStats.alignTopRemaining = 0
+		}
+	} else {
+		snapshot.workflowStats.ensureVisible(pane, render)
+	}
 	ensureResponseMatchInView(pane, render.content)
 	pane.setCurrPosition()
 	return nil

--- a/internal/ui/workflow_stats_view.go
+++ b/internal/ui/workflow_stats_view.go
@@ -15,6 +15,8 @@ type workflowStatsView struct {
 	selected    int
 	expanded    map[int]bool
 	renderCache map[int]workflowStatsRender
+	alignTopSelected  bool
+	alignTopRemaining int
 }
 
 type workflowStatsEntry struct {


### PR DESCRIPTION
- Add Shift+J/Shift+K shortcuts to jump between workflow stats entries, only aligning to top when the target isn't visible.
- Pretty print gRPC responses.