### PR TITLE
refactor: smooth response tab spinner with dedicated tick loop

### DIFF
--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -12,6 +12,10 @@ import (
 type statusPulseMsg struct {
 	seq int
 }
+
+type tabSpinMsg struct {
+	seq int
+}
 type profileNextIterationMsg struct{}
 type updateTickMsg struct{}
 

--- a/internal/ui/model_compare_run.go
+++ b/internal/ui/model_compare_run.go
@@ -107,7 +107,7 @@ func (m *Model) startCompareRun(
 	m.lastCompareResults = nil
 	m.lastCompareSpec = nil
 	m.compareBundle = nil
-	m.sending = true
+	spin := m.startSending()
 	m.statusPulseBase = state.label
 	m.statusPulseFrame = -1
 
@@ -124,10 +124,10 @@ func (m *Model) startCompareRun(
 	if cmd := m.executeCompareIteration(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
-	if len(cmds) == 0 {
-		return nil
+	if spin != nil {
+		cmds = append(cmds, spin)
 	}
-	return tea.Batch(cmds...)
+	return batchCmds(cmds)
 }
 
 // Each iteration swaps in its own environment so resolvers see the right values
@@ -147,7 +147,7 @@ func (m *Model) executeCompareIteration() tea.Cmd {
 	state.currentEnv = env
 	state.requestText = renderRequestText(clone)
 
-	m.sending = true
+	spin := m.startSending()
 	m.statusPulseBase = state.statusLine()
 	m.setStatusMessage(statusMsg{text: state.statusLine(), level: statusInfo})
 
@@ -155,10 +155,8 @@ func (m *Model) executeCompareIteration() tea.Cmd {
 		return m.executeRequest(state.doc, clone, state.options, env, nil)
 	})
 
-	if tick := m.startStatusPulse(); tick != nil {
-		return tea.Batch(runCmd, tick)
-	}
-	return runCmd
+	pulse := m.startStatusPulse()
+	return batchCmds([]tea.Cmd{runCmd, pulse, spin})
 }
 
 // Snapshot each iteration immediately so the compare tab and diff panes can
@@ -172,7 +170,7 @@ func (m *Model) handleCompareResponse(msg responseMsg) tea.Cmd {
 	currentReq := state.current
 	currentEnv := state.currentEnv
 	state.current = nil
-	m.sending = false
+	m.stopSending()
 
 	canceled := state.canceled || isCanceled(msg.err)
 	if canceled {
@@ -275,7 +273,7 @@ func (m *Model) finalizeCompareRun(state *compareState) tea.Cmd {
 	m.compareRun = nil
 	m.lastCompareResults = state.results
 	m.lastCompareSpec = cloneCompareSpec(state.spec)
-	m.sending = false
+	m.stopSending()
 	m.stopStatusPulseIfIdle()
 
 	if secondary := m.pane(responsePaneSecondary); secondary != nil {

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -258,6 +258,9 @@ type Model struct {
 	statusPulseFrame int
 	statusPulseSeq   int
 	statusPulseOn    bool
+	tabSpinIdx       int
+	tabSpinSeq       int
+	tabSpinOn        bool
 	lastResponse     *httpclient.Response
 	lastGRPC         *grpcclient.Response
 	lastError        error

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -1822,7 +1822,7 @@ func (m *Model) loadHistorySelection(send bool) tea.Cmd {
 	m.scriptError = nil
 
 	if !send {
-		m.sending = false
+		m.stopSending()
 		label := strings.TrimSpace(m.statusRequestTitle(doc, req, targetEnv))
 		if label == "" {
 			label = "history request"
@@ -1870,14 +1870,15 @@ func (m *Model) loadHistorySelection(send bool) tea.Cmd {
 		return m.presentHistoryEntry(entry, req)
 	}
 
-	m.sending = true
+	spin := m.startSending()
 	replayTarget := m.statusRequestTarget(doc, req, targetEnv)
 	replayText := "Replaying"
 	if trimmed := strings.TrimSpace(replayTarget); trimmed != "" {
 		replayText = fmt.Sprintf("Replaying %s", trimmed)
 	}
 	m.setStatusMessage(statusMsg{text: replayText, level: statusInfo})
-	return m.executeRequest(doc, req, options, "", nil)
+	cmd := m.executeRequest(doc, req, options, "", nil)
+	return batchCmds([]tea.Cmd{cmd, spin})
 }
 
 func (m *Model) presentHistoryEntry(entry history.Entry, req *restfile.Request) tea.Cmd {

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1054,7 +1054,18 @@ func (m Model) buildTabRowContent(
 	return ""
 }
 
-var tabSpinFrames = []string{"⠋", "⠙", "⠹"}
+var tabSpinFrames = []string{
+	"⠋",
+	"⠙",
+	"⠹",
+	"⠸",
+	"⠼",
+	"⠴",
+	"⠦",
+	"⠧",
+	"⠇",
+	"⠏",
+}
 
 const responseSendingBase = "Sending request"
 
@@ -1062,7 +1073,7 @@ func (m Model) tabSpinner() string {
 	if !m.sending || len(tabSpinFrames) == 0 {
 		return ""
 	}
-	idx := m.statusPulseFrame
+	idx := m.tabSpinIdx
 	if idx < 0 {
 		idx = 0
 	}

--- a/internal/ui/model_render_test.go
+++ b/internal/ui/model_render_test.go
@@ -167,7 +167,7 @@ func TestResponsePaneShowsSendingSpinner(t *testing.T) {
 	snap := &responseSnapshot{pretty: ensureTrailingNewline("ok"), ready: true}
 	model := newModelWithResponseTab(responseTabPretty, snap)
 	model.sending = true
-	model.statusPulseFrame = 1
+	model.tabSpinIdx = 1
 	pane := model.pane(responsePanePrimary)
 	pane.viewport.Width = 40
 	pane.viewport.Height = 10

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -59,7 +59,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case responseMsg:
-		m.sending = false
+		m.stopSending()
 		m.sendCancel = nil
 		if cmd := m.handleResponseMessage(typed); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -69,6 +69,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setStatusMessage(typed)
 	case statusPulseMsg:
 		if cmd := m.handleStatusPulse(typed); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	case tabSpinMsg:
+		if cmd := m.handleTabSpin(typed); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	case responseRenderedMsg:


### PR DESCRIPTION
Small refactor of req. tab spinner which was "sluggish" because it piggybacked on the status bar pulse timer (1 second intervals). This separates the spinner into its own tick loop running at 100ms with a full 10-frame braille animation cycle.
