### PR TITLE
fix: template expansion via rts scripts and stdlib

### DIFF
--- a/internal/rts/stdlib_test.go
+++ b/internal/rts/stdlib_test.go
@@ -285,6 +285,19 @@ func TestStdlibQueryHelpers(t *testing.T) {
 	if v.K != VNum || v.N != 1 {
 		t.Fatalf("expected query length 1")
 	}
+	v = evalExprCtx(t, ctx, "query.merge(\"{{host}}/path?keep=1\", {q: \"x\"})")
+	if v.K != VStr {
+		t.Fatalf("expected query.merge to return string")
+	}
+	if !strings.Contains(v.S, "{{host}}") {
+		t.Fatalf("expected templated host preserved, got %q", v.S)
+	}
+	if strings.Contains(v.S, "%7B%7B") || strings.Contains(v.S, "%7D%7D") {
+		t.Fatalf("expected template braces to remain unescaped, got %q", v.S)
+	}
+	if !strings.Contains(v.S, "keep=1") || !strings.Contains(v.S, "q=x") {
+		t.Fatalf("expected merged query params, got %q", v.S)
+	}
 }
 
 func TestStdlibTextHelpers(t *testing.T) {

--- a/internal/ui/rts_pre_request.go
+++ b/internal/ui/rts_pre_request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/rts"
 	"github.com/unkn0wn-root/resterm/internal/scripts"
+	"github.com/unkn0wn-root/resterm/internal/urltpl"
 )
 
 type rtsPreMut struct {
@@ -297,17 +297,16 @@ func setReqQuery(req *rts.Req, name, value string) {
 		req.Q = make(map[string][]string)
 	}
 	req.Q[name] = []string{value}
-	if req.URL == "" {
+	raw := strings.TrimSpace(req.URL)
+	if raw == "" {
 		return
 	}
-	parsed, err := url.Parse(req.URL)
+	val := value
+	updated, err := urltpl.PatchQuery(raw, map[string]*string{name: &val})
 	if err != nil {
 		return
 	}
-	query := parsed.Query()
-	query.Set(name, value)
-	parsed.RawQuery = query.Encode()
-	req.URL = parsed.String()
+	req.URL = updated
 }
 
 func lowerKey(name string) string {

--- a/internal/urltpl/urltpl.go
+++ b/internal/urltpl/urltpl.go
@@ -1,0 +1,254 @@
+package urltpl
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	tokenPrefix      = "rtpl_"
+	tokenRandomBytes = 16
+	tokenMaxAttempts = 8
+)
+
+// HasTemplate reports whether the string contains a template marker.
+func HasTemplate(s string) bool {
+	return strings.Contains(s, "{{")
+}
+
+func PatchQuery(raw string, patch map[string]*string) (string, error) {
+	if len(patch) == 0 {
+		return raw, nil
+	}
+
+	state := newTemplateState(collectSources(raw, patch, nil)...)
+	raw = state.replace(raw)
+	patch = state.replacePatch(patch)
+
+	updated, err := patchQueryURL(raw, patch)
+	if err != nil {
+		return "", err
+	}
+	return state.restore(updated), nil
+}
+
+func MergeQuery(raw string, patch map[string][]string) (string, error) {
+	if len(patch) == 0 {
+		return raw, nil
+	}
+
+	state := newTemplateState(collectSources(raw, nil, patch)...)
+	raw = state.replace(raw)
+	patch = state.replaceMergePatch(patch)
+
+	updated, err := mergeQueryURL(raw, patch)
+	if err != nil {
+		return "", err
+	}
+	return state.restore(updated), nil
+}
+
+func patchQueryURL(raw string, patch map[string]*string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", err
+	}
+
+	vals := parsed.Query()
+	for key, val := range patch {
+		if val == nil {
+			vals.Del(key)
+			continue
+		}
+		vals.Set(key, *val)
+	}
+	parsed.RawQuery = vals.Encode()
+	return parsed.String(), nil
+}
+
+func mergeQueryURL(raw string, patch map[string][]string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", err
+	}
+
+	vals := parsed.Query()
+	for key, items := range patch {
+		if len(items) == 0 {
+			vals.Del(key)
+			continue
+		}
+		vals.Del(key)
+		for _, item := range items {
+			vals.Add(key, item)
+		}
+	}
+	parsed.RawQuery = vals.Encode()
+	return parsed.String(), nil
+}
+
+type templateState struct {
+	sources []string
+	tokens  map[string]string
+	nextID  int
+}
+
+func newTemplateState(sources ...string) *templateState {
+	return &templateState{
+		sources: sources,
+		tokens:  make(map[string]string),
+	}
+}
+
+func (s *templateState) replace(input string) string {
+	if !strings.Contains(input, "{{") {
+		return input
+	}
+
+	var b strings.Builder
+	for {
+		start := strings.Index(input, "{{")
+		if start == -1 {
+			b.WriteString(input)
+			break
+		}
+
+		end := strings.Index(input[start+2:], "}}")
+		if end == -1 {
+			b.WriteString(input)
+			break
+		}
+
+		end += start + 2
+		b.WriteString(input[:start])
+		tpl := input[start : end+2]
+		token := s.nextToken()
+		s.tokens[token] = tpl
+		b.WriteString(token)
+		input = input[end+2:]
+	}
+	return b.String()
+}
+
+func (s *templateState) replacePatch(patch map[string]*string) map[string]*string {
+	if len(patch) == 0 {
+		return patch
+	}
+
+	out := make(map[string]*string, len(patch))
+	for key, val := range patch {
+		rkey := s.replace(key)
+		if val == nil {
+			out[rkey] = nil
+			continue
+		}
+		rval := s.replace(*val)
+		out[rkey] = &rval
+	}
+	return out
+}
+
+func (s *templateState) replaceMergePatch(patch map[string][]string) map[string][]string {
+	if len(patch) == 0 {
+		return patch
+	}
+
+	out := make(map[string][]string, len(patch))
+	for key, vals := range patch {
+		rkey := s.replace(key)
+		if len(vals) == 0 {
+			out[rkey] = nil
+			continue
+		}
+
+		outVals := make([]string, 0, len(vals))
+		for _, val := range vals {
+			outVals = append(outVals, s.replace(val))
+		}
+		out[rkey] = outVals
+	}
+	return out
+}
+
+func (s *templateState) restore(input string) string {
+	if len(s.tokens) == 0 {
+		return input
+	}
+
+	keys := make([]string, 0, len(s.tokens))
+	for key := range s.tokens {
+		keys = append(keys, key)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return len(keys[i]) > len(keys[j])
+	})
+
+	out := input
+	for _, key := range keys {
+		out = strings.ReplaceAll(out, key, s.tokens[key])
+	}
+	return out
+}
+
+func (s *templateState) nextToken() string {
+	for range tokenMaxAttempts {
+		token, err := randomToken()
+		if err == nil && s.tokenAvailable(token) {
+			return token
+		}
+	}
+	for {
+		token := tokenPrefix + strconv.FormatInt(int64(s.nextID), 36) + "x"
+		s.nextID++
+		if s.tokenAvailable(token) {
+			return token
+		}
+	}
+}
+
+func (s *templateState) tokenAvailable(token string) bool {
+	if _, exists := s.tokens[token]; exists {
+		return false
+	}
+	for _, src := range s.sources {
+		if strings.Contains(src, token) {
+			return false
+		}
+	}
+	return true
+}
+
+func collectSources(raw string, patch map[string]*string, merge map[string][]string) []string {
+	var sources []string
+	if raw != "" {
+		sources = append(sources, raw)
+	}
+	if len(patch) > 0 {
+		for key, val := range patch {
+			sources = append(sources, key)
+			if val != nil {
+				sources = append(sources, *val)
+			}
+		}
+	}
+	if len(merge) > 0 {
+		for key, vals := range merge {
+			sources = append(sources, key)
+			sources = append(sources, vals...)
+		}
+	}
+	return sources
+}
+
+func randomToken() (string, error) {
+	buf := make([]byte, tokenRandomBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return tokenPrefix + hex.EncodeToString(buf), nil
+}

--- a/internal/urltpl/urltpl_test.go
+++ b/internal/urltpl/urltpl_test.go
@@ -1,0 +1,138 @@
+package urltpl
+
+import (
+	"strings"
+	"testing"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestPatchQueryTemplateKeepsTemplateSeparators(t *testing.T) {
+	raw := "{{base}}/path?q={{a&b}}&keep=1"
+	patch := map[string]*string{"x": strPtr("1")}
+
+	got, err := PatchQuery(raw, patch)
+	if err != nil {
+		t.Fatalf("PatchQuery: %v", err)
+	}
+	if !strings.Contains(got, "q={{a&b}}") {
+		t.Fatalf("expected template value preserved, got %q", got)
+	}
+	if !strings.Contains(got, "keep=1") {
+		t.Fatalf("expected keep query preserved, got %q", got)
+	}
+	if !strings.Contains(got, "x=1") {
+		t.Fatalf("expected added query param, got %q", got)
+	}
+}
+
+func TestPatchQueryTemplateMatchesNetURLOrder(t *testing.T) {
+	raw := "{{base}}/path?b=2&a=1"
+	patch := map[string]*string{
+		"a": strPtr("x"),
+		"c": strPtr("3"),
+	}
+
+	got, err := PatchQuery(raw, patch)
+	if err != nil {
+		t.Fatalf("PatchQuery: %v", err)
+	}
+	want := "{{base}}/path?a=x&b=2&c=3"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPatchQueryTemplateEncodedKeyMatch(t *testing.T) {
+	raw := "{{base}}/path?q%5B%5D=1&keep=1"
+	patch := map[string]*string{"q[]": nil}
+
+	got, err := PatchQuery(raw, patch)
+	if err != nil {
+		t.Fatalf("PatchQuery: %v", err)
+	}
+	want := "{{base}}/path?keep=1"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPatchQueryTemplateQuestionMarkInTemplate(t *testing.T) {
+	raw := "{{base?x=1}}/path?keep=1#frag"
+	patch := map[string]*string{"q": strPtr("1")}
+
+	got, err := PatchQuery(raw, patch)
+	if err != nil {
+		t.Fatalf("PatchQuery: %v", err)
+	}
+	want := "{{base?x=1}}/path?keep=1&q=1#frag"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPatchQueryTemplateValueInPatch(t *testing.T) {
+	raw := "https://example.com/path?keep=1"
+	patch := map[string]*string{"q": strPtr("{{token}}")}
+
+	got, err := PatchQuery(raw, patch)
+	if err != nil {
+		t.Fatalf("PatchQuery: %v", err)
+	}
+	if strings.Contains(got, "%7B%7B") || strings.Contains(got, "%7D%7D") {
+		t.Fatalf("expected template braces unescaped, got %q", got)
+	}
+	if !strings.Contains(got, "q={{token}}") {
+		t.Fatalf("expected template value, got %q", got)
+	}
+}
+
+func TestPatchQueryTemplateEncodesNonTemplateValues(t *testing.T) {
+	raw := "{{base}}/path?keep=1"
+	patch := map[string]*string{"q": strPtr("hello world {{token}}")}
+
+	got, err := PatchQuery(raw, patch)
+	if err != nil {
+		t.Fatalf("PatchQuery: %v", err)
+	}
+	if !strings.Contains(got, "q=hello+world+{{token}}") {
+		t.Fatalf("expected encoded spaces with template preserved, got %q", got)
+	}
+}
+
+func TestPatchQueryUnbalancedTemplateUsesNetURLParsing(t *testing.T) {
+	raw := "https://example.com/path?q={{a&b"
+	patch := map[string]*string{"x": strPtr("1")}
+
+	got, err := PatchQuery(raw, patch)
+	if err != nil {
+		t.Fatalf("PatchQuery: %v", err)
+	}
+	if !strings.Contains(got, "b=") {
+		t.Fatalf("expected raw query split at &, got %q", got)
+	}
+	if !strings.Contains(got, "x=1") {
+		t.Fatalf("expected added query param, got %q", got)
+	}
+	if !strings.Contains(got, "q=%7B%7Ba") {
+		t.Fatalf("expected net/url encoding, got %q", got)
+	}
+}
+
+func TestPatchQueryTemplatePreservesEmptyKey(t *testing.T) {
+	raw := "{{base}}/path?=1&keep=1"
+	patch := map[string]*string{"x": strPtr("1")}
+
+	got, err := PatchQuery(raw, patch)
+	if err != nil {
+		t.Fatalf("PatchQuery: %v", err)
+	}
+	if !strings.Contains(got, "?=1") {
+		t.Fatalf("expected empty key to remain, got %q", got)
+	}
+	if !strings.Contains(got, "x=1") {
+		t.Fatalf("expected added query param, got %q", got)
+	}
+}


### PR DESCRIPTION
Using `@apply` or rts scripts like `let mergedURL = query.merge(request.url, {applied: "1"})` or {{...}} would cause net/url to encode those and then parser couldn't expand variables so added template URL/query patcher so pre‑request/query mutations keep {{…}} intact and don’t split on &/=