### PR TITLE
fix workflow expect.status* handling

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -606,6 +606,7 @@ Key directives and tokens:
 - `vars.workflow.*` keys persist between steps and are available anywhere in the workflow as `{{vars.workflow.<name>}}`, letting later requests reuse or mutate shared context (e.g. `vars.workflow.userId`).
 - Unknown tokens on `@workflow` or `@step` are preserved in `Options`, allowing custom scripts or future features to consume them without changing the file format.
 - `expect.status` supports quoted or escaped values, so you can write `expect.status="201 Created"` alongside `expect.statuscode=201`.
+- `expect.status` / `expect.statuscode` require non-empty values, and `expect.statuscode` must be numeric.
 
 > **Tip:** Workflow assignments are expanded once when the request executes. If you need helpers such as `{{$uuid}}`, place them directly in the request/template or compute them via a pre-request script before assigning the value.
 > **Tip:** Options are parsed like CLI flags; wrap values in quotes or escape spaces (`\ `) to keep text together (e.g. `expect.status="201 Created"`).

--- a/internal/ui/model_workflow.go
+++ b/internal/ui/model_workflow.go
@@ -1350,8 +1350,12 @@ func evaluateWorkflowStep(state *workflowState, msg responseMsg) workflowStepRes
 	if hasResp && !hasErr {
 		if exp, ok := step.Expect["status"]; ok {
 			expected := strings.TrimSpace(exp)
-			if strings.TrimSpace(status) == "" ||
-				!strings.EqualFold(expected, strings.TrimSpace(status)) {
+			trimmedStatus := strings.TrimSpace(status)
+			if expected == "" {
+				success = false
+				message = "invalid expected status"
+			} else if trimmedStatus == "" ||
+				!strings.EqualFold(expected, trimmedStatus) {
 				success = false
 				if expected != "" {
 					message = fmt.Sprintf("expected status %s", expected)

--- a/internal/ui/model_workflow_test.go
+++ b/internal/ui/model_workflow_test.go
@@ -77,6 +77,15 @@ func TestEvaluateWorkflowStep(t *testing.T) {
 			ok:   false,
 		},
 		{
+			name: "expect status empty",
+			exp:  map[string]string{"status": ""},
+			rsp:  true,
+			code: 200,
+			st:   "200 OK",
+			ok:   false,
+			msg:  "invalid expected status",
+		},
+		{
 			name: "err skips expect",
 			exp:  map[string]string{"statuscode": "200"},
 			err:  boom,


### PR DESCRIPTION
- let expected 4xx/5xx pass when expect.status/expect.statuscode is set
- preserve error messages when no response exists

fixes: #156 