### PR TITLE
feat: add duration offsets for timestamps and RTS time helpers

### DIFF
--- a/_examples/basic.http
+++ b/_examples/basic.http
@@ -20,6 +20,19 @@ Accept: application/json
   "userId": 1
 }
 
+### Timestamp Helpers
+# @name timestampHelpers
+POST {{base.url}}/anything/time
+Content-Type: application/json
+Accept: application/json
+
+{
+  "now_unix": "{{$timestamp}}",
+  "now_unix_plus_6d": "{{$timestamp + 6d}}",
+  "now_iso_minus_90m": "{{$timestampISO8601 - 90m}}",
+  "now_unix_ms": "{{$timestampMs}}"
+}
+
 ### Bearer Auth Example
 # @name bearerEcho
 # @auth bearer {{auth.token}}

--- a/_examples/rts/rts_all_features.http
+++ b/_examples/rts/rts_all_features.http
@@ -37,6 +37,19 @@ X-Url: {{= url.encode("a b") }}
 X-Time: {{= time.nowISO() }}
 X-Trace-Id: {{= helpers.traceId() }}
 
+### RTS Time Helpers
+# @name RTS_TimeHelpers
+# @description Shows duration parsing and timestamp math.
+# @assert response.json("json.offset_seconds") == 5400
+# @assert match("^\\d{4}-\\d{2}-\\d{2}T", response.json("json.expires_iso"))
+POST {{base_url}}/anything/time
+Content-Type: application/json
+
+{
+  "offset_seconds": {{= time.duration("1h30m") }},
+  "expires_iso": "{{= time.formatUnix(time.addUnix(time.nowUnix(), '6d'), '2006-01-02T15:04:05Z07:00') }}"
+}
+
 ### RTS Pre-request Mutation
 # @name RTS_PreRequest
 # @description Mutates request, vars, and globals in pre-request.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -308,7 +308,9 @@ When expanding `{{variable}}` templates, Resterm looks in:
 7. Selected environment JSON.
 8. OS environment variables (case-sensitive with an uppercase fallback).
 
-Dynamic helpers are also available: `{{$uuid}}` (alias `{{$guid}}`), `{{$timestamp}}` (Unix), `{{$timestampISO8601}}`, and `{{$randomInt}}`.
+Dynamic helpers are also available: `{{$uuid}}` (alias `{{$guid}}`), `{{$timestamp}}` (Unix seconds), `{{$timestampMs}}` (Unix milliseconds), `{{$timestampISO8601}}`, and `{{$randomInt}}`.
+
+Timestamp helpers accept optional offsets: `{{$timestamp + 6d}}`, `{{$timestampISO8601 - 90m}}`, `{{$timestampMs + 2h}}`. Supported units are the standard Go duration units plus `d` (days) and `w` (weeks).
 
 ---
 

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -301,7 +301,8 @@ RTS provides a small standard library that covers common request needs without e
 - `rts.time.format(layout)` formats the current time with the given layout string.
 - `rts.time.parse(layout, value)` parses the time string and returns unix seconds (fractional).
 - `rts.time.formatUnix(ts, layout)` formats a unix timestamp with the given layout.
-- `rts.time.addUnix(ts, seconds)` adds seconds to a unix timestamp.
+- `rts.time.addUnix(ts, secondsOrDuration)` adds seconds (number) or a duration string to a unix timestamp.
+- `rts.time.duration(value)` parses a duration string (including `d` and `w`) and returns seconds.
 
 ### JSON helpers
 

--- a/internal/duration/parse.go
+++ b/internal/duration/parse.go
@@ -1,0 +1,139 @@
+package duration
+
+import (
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxDurationFloat = float64(^uint64(0) >> 1)
+
+var unitTable = map[string]time.Duration{
+	"ns": time.Nanosecond,
+	"us": time.Microsecond,
+	"ms": time.Millisecond,
+	"s":  time.Second,
+	"m":  time.Minute,
+	"h":  time.Hour,
+	"d":  24 * time.Hour,
+	"w":  7 * 24 * time.Hour,
+}
+
+// Parses a duration string with support for d (days) and w (weeks).
+// Accepts the same units as time.ParseDuration plus d and w, and also
+// allows mixed units such as "1h30m" or "2d3h".
+func Parse(value string) (time.Duration, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, false
+	}
+	if d, err := time.ParseDuration(trimmed); err == nil {
+		return d, true
+	}
+	return parseExtended(trimmed)
+}
+
+func parseExtended(input string) (time.Duration, bool) {
+	s := strings.TrimSpace(input)
+	if s == "" {
+		return 0, false
+	}
+
+	sign := 1.0
+	if s[0] == '+' || s[0] == '-' {
+		if s[0] == '-' {
+			sign = -1.0
+		}
+		s = strings.TrimSpace(s[1:])
+	}
+	if s == "" {
+		return 0, false
+	}
+
+	var total float64
+	parsed := false
+	for len(s) > 0 {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			break
+		}
+		numEnd := scanNumber(s)
+		if numEnd == 0 {
+			return 0, false
+		}
+		numStr := s[:numEnd]
+		n, err := strconv.ParseFloat(numStr, 64)
+		if err != nil {
+			return 0, false
+		}
+
+		unitEnd := scanUnit(s[numEnd:])
+		if unitEnd == 0 {
+			return 0, false
+		}
+		unit := strings.ToLower(s[numEnd : numEnd+unitEnd])
+		scale, ok := unitTable[unit]
+		if !ok {
+			return 0, false
+		}
+
+		part := n * float64(scale)
+		if math.IsNaN(part) || math.IsInf(part, 0) {
+			return 0, false
+		}
+
+		total += part
+		if math.Abs(total) > maxDurationFloat {
+			return 0, false
+		}
+		parsed = true
+		s = s[numEnd+unitEnd:]
+	}
+
+	if !parsed {
+		return 0, false
+	}
+
+	total *= sign
+	if math.Abs(total) > maxDurationFloat {
+		return 0, false
+	}
+
+	return time.Duration(math.Round(total)), true
+}
+
+func scanNumber(s string) int {
+	dotSeen := false
+	digitSeen := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch >= '0' && ch <= '9':
+			digitSeen = true
+		case ch == '.' && !dotSeen:
+			dotSeen = true
+		default:
+			if !digitSeen {
+				return 0
+			}
+			return i
+		}
+	}
+	if !digitSeen {
+		return 0
+	}
+	return len(s)
+}
+
+// scanUnit returns the length of the contiguous alphabetic unit suffix.
+// Example: "h30m" -> 1 (unit "h").
+func scanUnit(s string) int {
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') {
+			return i
+		}
+	}
+	return len(s)
+}

--- a/internal/duration/parse_test.go
+++ b/internal/duration/parse_test.go
@@ -1,0 +1,63 @@
+package duration
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  time.Duration
+	}{
+		{name: "zero", input: "0", want: 0},
+		{name: "hours", input: "1h", want: time.Hour},
+		{name: "mixed", input: "1h30m", want: time.Hour + 30*time.Minute},
+		{name: "days", input: "2d", want: 48 * time.Hour},
+		{name: "weeks", input: "1w2d3h4m5s", want: 9*24*time.Hour + 3*time.Hour + 4*time.Minute + 5*time.Second},
+		{name: "decimal", input: "1.5d", want: 36 * time.Hour},
+		{name: "spaces", input: "1h 30m", want: time.Hour + 30*time.Minute},
+		{name: "negative", input: "-6d", want: -6 * 24 * time.Hour},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := Parse(tc.input)
+			if !ok {
+				t.Fatalf("expected ok for %q", tc.input)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		"",
+		"   ",
+		"d",
+		"1x",
+		"1d2",
+		"1.2.3s",
+		"1h-30m",
+	}
+
+	for _, input := range inputs {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := Parse(input); ok {
+				t.Fatalf("expected invalid for %q", input)
+			}
+		})
+	}
+}

--- a/internal/parser/directive_parsers.go
+++ b/internal/parser/directive_parsers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/duration"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -210,7 +211,7 @@ func parseProfileSpec(rest string) *restfile.ProfileSpec {
 	}
 
 	if raw, ok := params["delay"]; ok {
-		if dur, err := time.ParseDuration(strings.TrimSpace(raw)); err == nil && dur >= 0 {
+		if dur, ok := duration.Parse(raw); ok && dur >= 0 {
 			spec.Delay = dur
 		}
 	}
@@ -367,8 +368,8 @@ func parseCompareDirective(rest string) (*restfile.CompareSpec, error) {
 }
 
 func parseDuration(value string) time.Duration {
-	dur, err := time.ParseDuration(strings.TrimSpace(value))
-	if err != nil {
+	dur, ok := duration.Parse(value)
+	if !ok {
 		return 0
 	}
 	return dur

--- a/internal/parser/sse_builder.go
+++ b/internal/parser/sse_builder.go
@@ -2,8 +2,8 @@ package parser
 
 import (
 	"strings"
-	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/duration"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -46,14 +46,14 @@ func (b *sseBuilder) HandleDirective(key, rest string) bool {
 func (b *sseBuilder) applyOption(name, value string) {
 	switch strings.ToLower(name) {
 	case "duration", "timeout":
-		if dur, err := time.ParseDuration(value); err == nil {
+		if dur, ok := duration.Parse(value); ok {
 			if dur < 0 {
 				return
 			}
 			b.options.TotalTimeout = dur
 		}
 	case "idle", "idle-timeout":
-		if dur, err := time.ParseDuration(value); err == nil {
+		if dur, ok := duration.Parse(value); ok {
 			if dur < 0 {
 				return
 			}

--- a/internal/parser/ssh_builder.go
+++ b/internal/parser/ssh_builder.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/duration"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -146,14 +146,14 @@ func applySSHOptions(prof *restfile.SSHProfile, opts map[string]string) {
 	if raw := strings.TrimSpace(opts["timeout"]); raw != "" {
 		prof.TimeoutStr = raw
 		prof.Timeout.Set = true
-		if dur, err := time.ParseDuration(raw); err == nil && dur >= 0 {
+		if dur, ok := duration.Parse(raw); ok && dur >= 0 {
 			prof.Timeout.Val = dur
 		}
 	}
 	if raw := strings.TrimSpace(opts["keepalive"]); raw != "" {
 		prof.KeepAliveStr = raw
 		prof.KeepAlive.Set = true
-		if dur, err := time.ParseDuration(raw); err == nil && dur >= 0 {
+		if dur, ok := duration.Parse(raw); ok && dur >= 0 {
 			prof.KeepAlive.Val = dur
 		}
 	}

--- a/internal/parser/ws_builder.go
+++ b/internal/parser/ws_builder.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"strconv"
 	"strings"
-	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/duration"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -78,11 +78,11 @@ func (b *wsBuilder) reset() {
 func (b *wsBuilder) applyOption(name, value string) {
 	switch normKey(name) {
 	case wsOptTimeout:
-		if dur, err := time.ParseDuration(value); err == nil && dur >= 0 {
+		if dur, ok := duration.Parse(value); ok && dur >= 0 {
 			b.opts.HandshakeTimeout = dur
 		}
 	case wsOptIdle, wsOptIdleAlt:
-		if dur, err := time.ParseDuration(value); err == nil && dur >= 0 {
+		if dur, ok := duration.Parse(value); ok && dur >= 0 {
 			b.opts.IdleTimeout = dur
 		}
 	case wsOptMaxMsg:
@@ -185,8 +185,8 @@ func parseWSPong(rest string, step *restfile.WebSocketStep) bool {
 
 func parseWSWait(rest string, step *restfile.WebSocketStep) bool {
 	step.Type = restfile.WebSocketStepWait
-	dur, err := time.ParseDuration(rest)
-	if err != nil || dur < 0 {
+	dur, ok := duration.Parse(rest)
+	if !ok || dur < 0 {
 		return false
 	}
 	step.Duration = dur

--- a/internal/rts/stdlib_test.go
+++ b/internal/rts/stdlib_test.go
@@ -183,6 +183,14 @@ func TestStdlibTimeExtras(t *testing.T) {
 	if v.K != VNum || v.N != 3.75 {
 		t.Fatalf("expected time.addUnix")
 	}
+	v = evalExprCtx(t, ctx, "time.addUnix(1.5, \"2.25s\")")
+	if v.K != VNum || v.N != 3.75 {
+		t.Fatalf("expected time.addUnix duration string")
+	}
+	v = evalExprCtx(t, ctx, "time.duration(\"1h30m\")")
+	if v.K != VNum || v.N != 5400 {
+		t.Fatalf("expected time.duration")
+	}
 }
 
 func TestStdlibJSONFile(t *testing.T) {


### PR DESCRIPTION
  - add shared duration parser with d/w support
  - allow timestamp helpers to accept +/- offsets and add $timestampMs
  - extend RTS time helpers with time.duration + string inputs for time.addUnix