### PR TITLE
RST-154(parser): add {% ... %} script blocks

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -809,6 +809,40 @@ Add `# @script pre-request` or `# @script test` followed by lines that start wit
 > request.setBody(JSON.stringify({ scope: "reports" }, null, 2));
 ```
 
+You can also use a brace block (`{% ... %}`) to avoid prefixing every line with `>`.
+
+```http
+# @script test
+> {%
+client.test("status ok", function () {
+  tests.assert(response.statusCode === 200, "status code");
+});
+%}
+```
+
+Lines inside the block don't need `>` (but a leading `>` is still stripped if present).
+The `{% ... %}` block is only for inline script content. Script file includes must be written as their own `> < ./path.js` line outside the block.
+
+Allowed example:
+
+```http
+# @script test
+> < ./scripts/pre.js
+> {%
+client.test("ok", function () {});
+%}
+```
+
+Disallowed example:
+
+```http
+# @script test
+> {%
+> < ./scripts/pre.js
+client.test("ok", function () {});
+%}
+```
+
 Reference external scripts with `> < ./scripts/pre.js`.
 
 See [Scripting API](#scripting-api) for available helpers.

--- a/internal/parser/directive_parsers.go
+++ b/internal/parser/directive_parsers.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -12,8 +13,8 @@ import (
 
 func parseApplySpec(rest string, line int) (restfile.ApplySpec, bool) {
 	expr := strings.TrimSpace(rest)
-	if strings.HasPrefix(expr, "=") {
-		expr = strings.TrimSpace(strings.TrimPrefix(expr, "="))
+	if after, ok := strings.CutPrefix(expr, "="); ok {
+		expr = strings.TrimSpace(after)
 	}
 	if expr == "" {
 		return restfile.ApplySpec{}, false
@@ -153,9 +154,7 @@ func parseAuthSpec(rest string) *restfile.AuthSpec {
 		if len(fields) < 2 {
 			return nil
 		}
-		for key, value := range parseKeyValuePairs(fields[1:]) {
-			params[key] = value
-		}
+		maps.Copy(params, parseKeyValuePairs(fields[1:]))
 		if params["token_url"] == "" && params["cache_key"] == "" {
 			return nil
 		}

--- a/internal/parser/ssh_builder.go
+++ b/internal/parser/ssh_builder.go
@@ -23,9 +23,7 @@ func (b *documentBuilder) handleSSH(line int, rest string) {
 	}
 
 	if res.scope == restfile.SSHScopeRequest {
-		if !b.ensureRequest(line) {
-			return
-		}
+		b.ensureRequest(line)
 		if b.request.ssh != nil {
 			b.addError(line, "@ssh already defined for this request")
 			return

--- a/internal/parser/workflow_builder.go
+++ b/internal/parser/workflow_builder.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -108,9 +109,7 @@ func (b *workflowBuilder) applyOptions(opts map[string]string) {
 	if b.wf.Options == nil {
 		b.wf.Options = make(map[string]string, len(opts))
 	}
-	for key, value := range opts {
-		b.wf.Options[key] = value
-	}
+	maps.Copy(b.wf.Options, opts)
 }
 
 func (b *workflowBuilder) handleDirective(key, rest string, line int) (bool, string) {

--- a/internal/parser/ws_builder.go
+++ b/internal/parser/ws_builder.go
@@ -161,8 +161,8 @@ func parseWSSendBase64(rest string, step *restfile.WebSocketStep) bool {
 
 func parseWSSendFile(rest string, step *restfile.WebSocketStep) bool {
 	step.Type = restfile.WebSocketStepSendFile
-	if strings.HasPrefix(rest, "<") {
-		rest = trim(strings.TrimPrefix(rest, "<"))
+	if after, ok := strings.CutPrefix(rest, "<"); ok {
+		rest = trim(after)
 	}
 	if rest == "" {
 		return false

--- a/internal/util/whitespace.go
+++ b/internal/util/whitespace.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+func TrimLeftSpace(s string) string {
+	return strings.TrimLeftFunc(s, unicode.IsSpace)
+}
+
+func TrimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+func TrimLeadingSpaceOnce(s string) string {
+	if s == "" {
+		return s
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	if unicode.IsSpace(r) {
+		return s[size:]
+	}
+	return s
+}


### PR DESCRIPTION
- added `{% %}` script block syntax for inline scripts, allowing multi-line script bodies without prefixing every line with `>`
- improved whitespace handling to support Unicode whitespace (NBSP, em space, etc.) in script lines
- refactor `handleScript` into smaller composable functions (`trimScriptLine`, `addScript`, `scriptInc`)
- simplified `ensureRequest` to return nothing (it never failed)
- removed dead branches in `handleRequestMetadataDirective` - file-level `@settings`/`@setting` is always handled earlier by `handleFileSettingsDirective`
