### PR TITLE
history: small code improvements and refactor

### DIFF
--- a/cmd/resterm/history.go
+++ b/cmd/resterm/history.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/config"
+	"github.com/unkn0wn-root/resterm/internal/history"
 	histdb "github.com/unkn0wn-root/resterm/internal/history/sqlite"
 )
 
@@ -185,40 +186,20 @@ func runHistoryStats(args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := writef(os.Stdout, "History DB: %s\n", st.Path); err != nil {
-		return fmt.Errorf("history stats: write output: %w", err)
-	}
-	if err := writef(os.Stdout, "Schema: %d\n", st.Schema); err != nil {
-		return fmt.Errorf("history stats: write output: %w", err)
-	}
-	if err := writef(os.Stdout, "Rows: %d\n", st.Rows); err != nil {
-		return fmt.Errorf("history stats: write output: %w", err)
-	}
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "History DB: %s\n", st.Path)
+	_, _ = fmt.Fprintf(&b, "Schema: %d\n", st.Schema)
+	_, _ = fmt.Fprintf(&b, "Rows: %d\n", st.Rows)
 	if !st.Oldest.IsZero() {
-		if err := writef(
-			os.Stdout,
-			"Oldest: %s\n",
-			st.Oldest.UTC().Format(time.RFC3339),
-		); err != nil {
-			return fmt.Errorf("history stats: write output: %w", err)
-		}
+		_, _ = fmt.Fprintf(&b, "Oldest: %s\n", st.Oldest.UTC().Format(time.RFC3339))
 	}
 	if !st.Newest.IsZero() {
-		if err := writef(
-			os.Stdout,
-			"Newest: %s\n",
-			st.Newest.UTC().Format(time.RFC3339),
-		); err != nil {
-			return fmt.Errorf("history stats: write output: %w", err)
-		}
+		_, _ = fmt.Fprintf(&b, "Newest: %s\n", st.Newest.UTC().Format(time.RFC3339))
 	}
-	if err := writef(os.Stdout, "DB Size: %s\n", byteLabel(st.DBBytes)); err != nil {
-		return fmt.Errorf("history stats: write output: %w", err)
-	}
-	if err := writef(os.Stdout, "WAL Size: %s\n", byteLabel(st.WALBytes)); err != nil {
-		return fmt.Errorf("history stats: write output: %w", err)
-	}
-	if err := writef(os.Stdout, "SHM Size: %s\n", byteLabel(st.SHMBytes)); err != nil {
+	_, _ = fmt.Fprintf(&b, "DB Size: %s\n", byteLabel(st.DBBytes))
+	_, _ = fmt.Fprintf(&b, "WAL Size: %s\n", byteLabel(st.WALBytes))
+	_, _ = fmt.Fprintf(&b, "SHM Size: %s\n", byteLabel(st.SHMBytes))
+	if _, err := io.WriteString(os.Stdout, b.String()); err != nil {
 		return fmt.Errorf("history stats: write output: %w", err)
 	}
 	return nil
@@ -300,7 +281,7 @@ func runHistoryCheck(args []string) error {
 	return nil
 }
 
-func openHistoryStore(migrate bool) (*histdb.Store, error) {
+func openHistoryStore(migrate bool) (history.MaintenanceStore, error) {
 	// This centralizes all history startup behavior used by CLI maintenance commands.
 	// It loads the database, prints recovery warnings, and optionally runs legacy import.
 	// On migration failure the store is closed before returning.

--- a/cmd/resterm/history_test.go
+++ b/cmd/resterm/history_test.go
@@ -141,7 +141,9 @@ func TestRunHistoryE2E(t *testing.T) {
 	if err := bak.Load(); err != nil {
 		t.Fatalf("load backup db: %v", err)
 	}
-	if got := bak.Entries(); len(got) != 2 {
+	if got, err := bak.Entries(); err != nil {
+		t.Fatalf("backup entries: %v", err)
+	} else if len(got) != 2 {
 		t.Fatalf("expected 2 rows in backup db, got %d", len(got))
 	}
 	_ = bak.Close()
@@ -166,7 +168,9 @@ func TestRunHistoryE2E(t *testing.T) {
 	if err := dst.Load(); err != nil {
 		t.Fatalf("load dst: %v", err)
 	}
-	if got := dst.Entries(); len(got) != 2 {
+	if got, err := dst.Entries(); err != nil {
+		t.Fatalf("dst entries: %v", err)
+	} else if len(got) != 2 {
 		t.Fatalf("expected 2 rows in dst db, got %d", len(got))
 	}
 	_ = dst.Close()

--- a/internal/history/sqlite/io.go
+++ b/internal/history/sqlite/io.go
@@ -16,11 +16,11 @@ func (s *Store) ExportJSON(path string) (int, error) {
 		return 0, err
 	}
 
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return 0, errdef.Wrap(errdef.CodeHistory, errors.New("empty path"), "export history")
+	var err error
+	path, err = cleanPath(path, "export history")
+	if err != nil {
+		return 0, err
 	}
-	path = filepath.Clean(path)
 
 	es, err := s.rows("", nil)
 	if err != nil {
@@ -42,11 +42,11 @@ func (s *Store) ImportJSON(path string) (int, error) {
 		return 0, err
 	}
 
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return 0, errdef.Wrap(errdef.CodeHistory, errors.New("empty path"), "import history")
+	var err error
+	path, err = cleanPath(path, "import history")
+	if err != nil {
+		return 0, err
 	}
-	path = filepath.Clean(path)
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -85,17 +85,17 @@ func (s *Store) ImportJSON(path string) (int, error) {
 
 func (s *Store) Backup(path string) error {
 	// Backup writes a full SQLite snapshot to another file.
-	// It checkpoints WAL first and rejects same-path targets to avoid self-overwrite.
+	// It rejects same-path targets to avoid self-overwrite.
 	// The result is a standalone database that can be opened directly.
 	if err := s.ensure(); err != nil {
 		return err
 	}
 
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return errdef.Wrap(errdef.CodeHistory, errors.New("empty path"), "backup history")
+	var err error
+	path, err = cleanPath(path, "backup history")
+	if err != nil {
+		return err
 	}
-	path = filepath.Clean(path)
 
 	// The destination must be different from the live database path.
 	// Removing an existing file is part of backup preparation.
@@ -113,16 +113,20 @@ func (s *Store) Backup(path string) error {
 		return errdef.Wrap(errdef.CodeFilesystem, err, "remove existing backup")
 	}
 
-	// Force WAL pages back into the main file before snapshotting so the
-	// copy always includes committed rows that were still in the journal.
-	if _, err := s.db.Exec(`PRAGMA wal_checkpoint(FULL);`); err != nil {
-		return errdef.Wrap(errdef.CodeHistory, err, "checkpoint history db")
-	}
-	q := "VACUUM INTO '" + escSQLStr(path) + "'"
-	if _, err := s.db.Exec(q); err != nil {
+	// VACUUM INTO accepts a scalar expression for the output path.
+	// Using a bound value avoids SQL text interpolation and escaping logic.
+	if _, err := s.db.Exec(`VACUUM INTO ?`, path); err != nil {
 		return errdef.Wrap(errdef.CodeHistory, err, "backup history db")
 	}
 	return nil
+}
+
+func cleanPath(path string, op string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errdef.Wrap(errdef.CodeHistory, errors.New("empty path"), "%s", op)
+	}
+	return filepath.Clean(path), nil
 }
 
 func writeFileAtom(path string, data []byte, perm os.FileMode) error {
@@ -155,10 +159,6 @@ func writeFileAtom(path string, data []byte, perm os.FileMode) error {
 		return errdef.Wrap(errdef.CodeFilesystem, err, "replace export file")
 	}
 	return nil
-}
-
-func escSQLStr(v string) string {
-	return strings.ReplaceAll(v, "'", "''")
 }
 
 func samePath(a, b string) bool {

--- a/internal/history/sqlite/io_test.go
+++ b/internal/history/sqlite/io_test.go
@@ -47,7 +47,10 @@ func TestExportImportRoundTrip(t *testing.T) {
 		t.Fatalf("expected 2 imported rows, got %d", n)
 	}
 
-	got := dst.Entries()
+	got, err := dst.Entries()
+	if err != nil {
+		t.Fatalf("dst entries: %v", err)
+	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 rows in dst, got %d", len(got))
 	}
@@ -84,7 +87,10 @@ func TestBackup(t *testing.T) {
 	if err := cpy.Load(); err != nil {
 		t.Fatalf("load backup db: %v", err)
 	}
-	got := cpy.Entries()
+	got, err := cpy.Entries()
+	if err != nil {
+		t.Fatalf("backup entries: %v", err)
+	}
 	if len(got) != 1 {
 		t.Fatalf("expected 1 row in backup db, got %d", len(got))
 	}
@@ -103,6 +109,27 @@ func TestBackupSamePathRejected(t *testing.T) {
 	}
 	if err := s.Backup(db); err == nil {
 		t.Fatalf("expected same-path backup error")
+	}
+}
+
+func TestBackupQuotedPath(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "hist.db")
+	out := filepath.Join(dir, "quoted'snapshot.db")
+
+	s := New(db)
+	if err := s.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := s.Append(history.Entry{ID: "1", ExecutedAt: time.Now()}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	if err := s.Backup(out); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("stat backup: %v", err)
 	}
 }
 

--- a/internal/history/sqlite/mig.go
+++ b/internal/history/sqlite/mig.go
@@ -56,52 +56,35 @@ func (s *Store) MigrateJSON(path string) (int, error) {
 		return 0, errdef.Wrap(errdef.CodeHistory, err, "read legacy history")
 	}
 
-	if len(bytes.TrimSpace(data)) == 0 {
-		if err := metaSet(tx, metaMigJSON, time.Now().UTC().Format(time.RFC3339)); err != nil {
-			return 0, err
-		}
-		if err := tx.Commit(); err != nil {
-			return 0, errdef.Wrap(errdef.CodeHistory, err, "commit history migration tx")
-		}
-		return 0, nil
-	}
-
-	existing, err := rowCount(tx)
-	if err != nil {
-		return 0, err
-	}
-	// If SQLite already has rows we treat it as the source of truth and
-	// only stamp completion, which avoids merging two diverged histories.
-	if existing > 0 {
-		if err := metaSet(tx, metaMigJSON, time.Now().UTC().Format(time.RFC3339)); err != nil {
-			return 0, err
-		}
-		if err := tx.Commit(); err != nil {
-			return 0, errdef.Wrap(errdef.CodeHistory, err, "commit history migration tx")
-		}
-		return 0, nil
-	}
-
-	es, err := dec[[]history.Entry](data)
-	if err != nil {
-		return 0, errdef.Wrap(errdef.CodeHistory, err, "parse legacy history")
-	}
-
 	n := 0
-	for _, e := range es {
-		r, err := mkRow(e)
+	if len(bytes.TrimSpace(data)) != 0 {
+		existing, err := rowCount(tx)
 		if err != nil {
 			return 0, err
 		}
-		// Duplicate IDs from legacy data are ignored so one bad file does
-		// not abort the whole migration transaction.
-		res, err := insertRow(tx, qIgnore, &r)
-		if err != nil {
-			return 0, errdef.Wrap(errdef.CodeHistory, err, "insert migrated history row")
-		}
-		ra, err := res.RowsAffected()
-		if err == nil && ra > 0 {
-			n++
+		// If SQLite already has rows we treat it as the source of truth and
+		// only stamp completion, which avoids merging two diverged histories.
+		if existing == 0 {
+			es, err := dec[[]history.Entry](data)
+			if err != nil {
+				return 0, errdef.Wrap(errdef.CodeHistory, err, "parse legacy history")
+			}
+			for _, e := range es {
+				r, err := mkRow(e)
+				if err != nil {
+					return 0, err
+				}
+				// Duplicate IDs from legacy data are ignored so one bad file does
+				// not abort the whole migration transaction.
+				res, err := insertRow(tx, qIgnore, &r)
+				if err != nil {
+					return 0, errdef.Wrap(errdef.CodeHistory, err, "insert migrated history row")
+				}
+				ra, err := res.RowsAffected()
+				if err == nil && ra > 0 {
+					n++
+				}
+			}
 		}
 	}
 

--- a/internal/history/sqlite/mig_test.go
+++ b/internal/history/sqlite/mig_test.go
@@ -35,7 +35,9 @@ func TestMigrateJSONImportsOnce(t *testing.T) {
 	if n != 2 {
 		t.Fatalf("expected 2 imported rows, got %d", n)
 	}
-	if got := s.Entries(); len(got) != 2 {
+	if got, err := s.Entries(); err != nil {
+		t.Fatalf("entries after first migrate: %v", err)
+	} else if len(got) != 2 {
 		t.Fatalf("expected 2 rows after import, got %d", len(got))
 	}
 
@@ -46,7 +48,9 @@ func TestMigrateJSONImportsOnce(t *testing.T) {
 	if n != 0 {
 		t.Fatalf("expected 0 imported rows on second run, got %d", n)
 	}
-	if got := s.Entries(); len(got) != 2 {
+	if got, err := s.Entries(); err != nil {
+		t.Fatalf("entries after second migrate: %v", err)
+	} else if len(got) != 2 {
 		t.Fatalf("expected 2 rows after second import, got %d", len(got))
 	}
 }
@@ -74,7 +78,9 @@ func TestMigrateJSONSkipsWhenDBHasRows(t *testing.T) {
 	if n != 0 {
 		t.Fatalf("expected 0 imported rows when DB not empty, got %d", n)
 	}
-	if got := s.Entries(); len(got) != 1 {
+	if got, err := s.Entries(); err != nil {
+		t.Fatalf("entries after skip: %v", err)
+	} else if len(got) != 1 {
 		t.Fatalf("expected original rows only, got %d", len(got))
 	}
 }
@@ -151,7 +157,9 @@ func TestMigrateJSONInvalidData(t *testing.T) {
 	if _, err := s.MigrateJSON(jsonPath); err == nil {
 		t.Fatalf("expected migrate parse error")
 	}
-	if got := s.Entries(); len(got) != 0 {
+	if got, err := s.Entries(); err != nil {
+		t.Fatalf("entries after failed migrate: %v", err)
+	} else if len(got) != 0 {
 		t.Fatalf("expected no rows after failed migration, got %d", len(got))
 	}
 }

--- a/internal/history/sqlite/ops.go
+++ b/internal/history/sqlite/ops.go
@@ -2,40 +2,29 @@ package sqlite
 
 import (
 	"os"
-	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/errdef"
+	"github.com/unkn0wn-root/resterm/internal/history"
 )
 
-type Stats struct {
-	Path     string
-	Schema   int
-	Rows     int64
-	Oldest   time.Time
-	Newest   time.Time
-	DBBytes  int64
-	WALBytes int64
-	SHMBytes int64
-}
-
-func (s *Store) Stats() (Stats, error) {
+func (s *Store) Stats() (history.Stats, error) {
 	if err := s.ensure(); err != nil {
-		return Stats{}, err
+		return history.Stats{}, err
 	}
 
-	st := Stats{Path: s.p}
+	st := history.Stats{Path: s.p}
 	var minNS, maxNS int64
 	if err := s.db.QueryRow(
 		`SELECT COUNT(*), COALESCE(MIN(exec_ns), 0), COALESCE(MAX(exec_ns), 0) FROM hist`,
 	).Scan(&st.Rows, &minNS, &maxNS); err != nil {
-		return Stats{}, errdef.Wrap(errdef.CodeHistory, err, "query history stats")
+		return history.Stats{}, errdef.Wrap(errdef.CodeHistory, err, "query history stats")
 	}
 	st.Oldest = nsToTime(minNS)
 	st.Newest = nsToTime(maxNS)
 
 	v, err := schemaVersion(s.db)
 	if err != nil {
-		return Stats{}, err
+		return history.Stats{}, err
 	}
 	st.Schema = v
 	st.DBBytes = fileSize(s.p)

--- a/internal/history/sqlite/recovery_test.go
+++ b/internal/history/sqlite/recovery_test.go
@@ -42,7 +42,11 @@ func TestLoadRecoversCorruptDB(t *testing.T) {
 	if err := s.Append(history.Entry{ID: "1", ExecutedAt: time.Now(), Method: "GET"}); err != nil {
 		t.Fatalf("append after recover: %v", err)
 	}
-	if n := len(s.Entries()); n != 1 {
+	es, err := s.Entries()
+	if err != nil {
+		t.Fatalf("entries after recover: %v", err)
+	}
+	if n := len(es); n != 1 {
 		t.Fatalf("expected 1 row after append, got %d", n)
 	}
 }

--- a/internal/history/sqlite/store.go
+++ b/internal/history/sqlite/store.go
@@ -1,11 +1,9 @@
 package sqlite
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -50,6 +48,7 @@ type RecoverInfo struct {
 }
 
 var _ history.Store = (*Store)(nil)
+var _ history.MaintenanceStore = (*Store)(nil)
 
 func New(path string) *Store {
 	return &Store{p: path}
@@ -93,62 +92,52 @@ func (s *Store) Append(e history.Entry) error {
 		return err
 	}
 
-	tx, err := s.db.BeginTx(context.Background(), nil)
-	if err != nil {
-		return errdef.Wrap(errdef.CodeHistory, err, "begin history tx")
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if _, err = insertRow(tx, qReplace, &r); err != nil {
+	if _, err = insertRow(s.db, qReplace, &r); err != nil {
 		return errdef.Wrap(errdef.CodeHistory, err, "insert history row")
-	}
-
-	if err := tx.Commit(); err != nil {
-		return errdef.Wrap(errdef.CodeHistory, err, "commit history tx")
 	}
 	return nil
 }
 
-func (s *Store) Entries() []history.Entry {
-	return s.list("", nil)
+func (s *Store) Entries() ([]history.Entry, error) {
+	return s.rows("", nil)
 }
 
-func (s *Store) ByRequest(id string) []history.Entry {
+func (s *Store) ByRequest(id string) ([]history.Entry, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return s.Entries()
+		return nil, nil
 	}
 	// Workflow runs use this same field for workflow names, so they are
 	// excluded here to keep request history filtering precise.
-	return s.list(
+	return s.rows(
 		`WHERE method != ? AND (req_name = ? OR url = ?)`,
 		[]any{restfile.HistoryMethodWorkflow, id, id},
 	)
 }
 
-func (s *Store) ByWorkflow(name string) []history.Entry {
+func (s *Store) ByWorkflow(name string) ([]history.Entry, error) {
 	name = history.NormalizeWorkflowName(name)
 	if name == "" {
-		return nil
+		return nil, nil
 	}
 	// Matching trims and lowercases both sides because saved names can
 	// vary in spacing and case across edited files.
-	return s.list(
+	return s.rows(
 		`WHERE method = ? AND LOWER(TRIM(req_name)) = LOWER(TRIM(?))`,
 		[]any{restfile.HistoryMethodWorkflow, name},
 	)
 }
 
-func (s *Store) ByFile(path string) []history.Entry {
+func (s *Store) ByFile(path string) ([]history.Entry, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return nil
+		return nil, nil
 	}
 	n := history.NormPath(path)
 	if n == "" {
-		return nil
+		return nil, nil
 	}
-	return s.list(`WHERE file_norm = ?`, []any{n})
+	return s.rows(`WHERE file_norm = ?`, []any{n})
 }
 
 func (s *Store) Delete(id string) (bool, error) {
@@ -165,15 +154,6 @@ func (s *Store) Delete(id string) (bool, error) {
 		return false, errdef.Wrap(errdef.CodeHistory, err, "history rows affected")
 	}
 	return n > 0, nil
-}
-
-func (s *Store) list(where string, args []any) []history.Entry {
-	es, err := s.rows(where, args)
-	if err != nil {
-		slog.Error("history query failed", "err", err)
-		return nil
-	}
-	return es
 }
 
 func (s *Store) rows(where string, args []any) ([]history.Entry, error) {
@@ -368,8 +348,12 @@ func (r *row) args() []any {
 	}
 }
 
-func insertRow(tx *sql.Tx, q string, r *row) (sql.Result, error) {
-	return tx.Exec(q, r.args()...)
+type execer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+func insertRow(db execer, q string, r *row) (sql.Result, error) {
+	return db.Exec(q, r.args()...)
 }
 
 func parseIDNum(id string) int64 {

--- a/internal/history/sqlite/store_test.go
+++ b/internal/history/sqlite/store_test.go
@@ -36,14 +36,21 @@ func TestByFileFiltersAndSorts(t *testing.T) {
 		t.Fatalf("append 3: %v", err)
 	}
 
-	got := s.ByFile(filepath.Join(dir, ".", "a.http"))
+	got, err := s.ByFile(filepath.Join(dir, ".", "a.http"))
+	if err != nil {
+		t.Fatalf("by file: %v", err)
+	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(got))
 	}
 	if got[0].ID != "2" || got[1].ID != "1" {
 		t.Fatalf("expected 2 then 1, got %q then %q", got[0].ID, got[1].ID)
 	}
-	if len(s.ByFile("")) != 0 {
+	empty, err := s.ByFile("")
+	if err != nil {
+		t.Fatalf("by file blank: %v", err)
+	}
+	if len(empty) != 0 {
 		t.Fatalf("expected empty result for blank file path")
 	}
 }
@@ -67,7 +74,11 @@ func TestDelete(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected delete to return true")
 	}
-	if len(s.Entries()) != 0 {
+	got, err := s.Entries()
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
+	if len(got) != 0 {
 		t.Fatalf("expected empty rows after delete")
 	}
 }
@@ -93,7 +104,10 @@ func TestByRequestSkipsWorkflowRows(t *testing.T) {
 		RequestName: "alpha",
 	})
 
-	got := s.ByRequest("alpha")
+	got, err := s.ByRequest("alpha")
+	if err != nil {
+		t.Fatalf("by request alpha: %v", err)
+	}
 	if len(got) != 1 {
 		t.Fatalf("expected 1 row, got %d", len(got))
 	}
@@ -101,7 +115,10 @@ func TestByRequestSkipsWorkflowRows(t *testing.T) {
 		t.Fatalf("expected ID 1, got %q", got[0].ID)
 	}
 
-	got = s.ByRequest("https://alpha.test")
+	got, err = s.ByRequest("https://alpha.test")
+	if err != nil {
+		t.Fatalf("by request url: %v", err)
+	}
 	if len(got) != 1 {
 		t.Fatalf("expected 1 row, got %d", len(got))
 	}
@@ -134,7 +151,10 @@ func TestByWorkflowCaseInsensitive(t *testing.T) {
 		RequestName: "deploy",
 	})
 
-	got := s.ByWorkflow("deploy")
+	got, err := s.ByWorkflow("deploy")
+	if err != nil {
+		t.Fatalf("by workflow: %v", err)
+	}
 	if len(got) != 1 {
 		t.Fatalf("expected 1 row, got %d", len(got))
 	}
@@ -178,9 +198,48 @@ func TestAppendConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	got := s.Entries()
+	got, err := s.Entries()
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
 	want := workers * perWorker
 	if len(got) != want {
 		t.Fatalf("expected %d rows, got %d", want, len(got))
+	}
+}
+
+func TestByRequestBlankReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "history.db")
+	s := New(p)
+	if err := s.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := s.Append(history.Entry{ID: "1", ExecutedAt: time.Now(), Method: "GET"}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	got, err := s.ByRequest("")
+	if err != nil {
+		t.Fatalf("by request blank: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty rows for blank request id")
+	}
+}
+
+func TestEntriesReturnsErrorOnQueryFailure(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "history.db")
+	s := New(p)
+	if err := s.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if _, err := s.db.Exec(`DROP TABLE hist`); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+
+	if _, err := s.Entries(); err == nil {
+		t.Fatalf("expected query error")
 	}
 }

--- a/internal/history/store.go
+++ b/internal/history/store.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const InitCap = 64
@@ -11,12 +12,34 @@ const InitCap = 64
 type Store interface {
 	Load() error
 	Append(Entry) error
-	Entries() []Entry
-	ByRequest(string) []Entry
-	ByWorkflow(string) []Entry
-	ByFile(string) []Entry
+	Entries() ([]Entry, error)
+	ByRequest(string) ([]Entry, error)
+	ByWorkflow(string) ([]Entry, error)
+	ByFile(string) ([]Entry, error)
 	Delete(string) (bool, error)
 	Close() error
+}
+
+type MaintenanceStore interface {
+	Store
+	Stats() (Stats, error)
+	Check(full bool) error
+	Compact() error
+	Backup(path string) error
+	ExportJSON(path string) (int, error)
+	ImportJSON(path string) (int, error)
+	MigrateJSON(path string) (int, error)
+}
+
+type Stats struct {
+	Path     string
+	Schema   int
+	Rows     int64
+	Oldest   time.Time
+	Newest   time.Time
+	DBBytes  int64
+	WALBytes int64
+	SHMBytes int64
 }
 
 func NormalizeWorkflowName(name string) string {

--- a/internal/ui/history_scope_file.go
+++ b/internal/ui/history_scope_file.go
@@ -8,18 +8,18 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/history"
 )
 
-func (m *Model) historyEntriesForFileScope() []history.Entry {
+func (m *Model) historyEntriesForFileScope() ([]history.Entry, error) {
 	if m.historyStore == nil {
-		return nil
+		return nil, nil
 	}
 	path := strings.TrimSpace(m.historyFilePath())
 	if path == "" {
-		return nil
+		return nil, nil
 	}
 
 	vars := historyPathVariants(path, m.workspaceRoot)
 	if len(vars) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// One entry can match more than one path variant, so dedupe IDs
@@ -27,7 +27,10 @@ func (m *Model) historyEntriesForFileScope() []history.Entry {
 	seen := make(map[string]struct{}, history.InitCap)
 	out := make([]history.Entry, 0, history.InitCap)
 	for _, v := range vars {
-		es := m.historyStore.ByFile(v)
+		es, err := m.historyStore.ByFile(v)
+		if err != nil {
+			return nil, err
+		}
 		for _, e := range es {
 			id := strings.TrimSpace(e.ID)
 			if id == "" {
@@ -41,12 +44,12 @@ func (m *Model) historyEntriesForFileScope() []history.Entry {
 		}
 	}
 	if len(out) < 2 {
-		return out
+		return out, nil
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		return historyEntryNewerFirst(out[i], out[j])
 	})
-	return out
+	return out, nil
 }
 
 func historyPathVariants(path string, workspaceRoot string) []string {

--- a/internal/ui/model_compare_run_test.go
+++ b/internal/ui/model_compare_run_test.go
@@ -186,7 +186,10 @@ func TestRecordCompareHistoryPersists(t *testing.T) {
 	}
 
 	model.recordCompareHistory(state)
-	entries := store.Entries()
+	entries, err := store.Entries()
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -1432,7 +1432,21 @@ func (m *Model) syncHistory() {
 		return
 	}
 
-	entries := m.historyEntriesForScope()
+	entries, err := m.historyEntriesForScope()
+	if err != nil {
+		m.historyEntries = nil
+		m.historyScopeCount = 0
+		m.historyList.SetItems(nil)
+		m.historySelectedID = ""
+		m.historyList.Select(-1)
+		m.setStatusMessage(
+			statusMsg{
+				text:  fmt.Sprintf("History query failed: %v", err),
+				level: statusWarn,
+			},
+		)
+		return
+	}
 	m.historyScopeCount = len(entries)
 	filter := strings.TrimSpace(m.historyFilterInput.Value())
 	if filter != "" {
@@ -1445,21 +1459,21 @@ func (m *Model) syncHistory() {
 	m.restoreHistorySelection()
 }
 
-func (m *Model) historyEntriesForScope() []history.Entry {
+func (m *Model) historyEntriesForScope() ([]history.Entry, error) {
 	switch m.historyScope {
 	case historyScopeWorkflow:
 		name := history.NormalizeWorkflowName(m.historyWorkflowName)
 		if name == "" {
-			return nil
+			return nil, nil
 		}
 		return m.historyStore.ByWorkflow(name)
 	case historyScopeRequest:
 		if m.currentRequest == nil {
-			return nil
+			return nil, nil
 		}
 		identifier := requestIdentifier(m.currentRequest)
 		if identifier == "" {
-			return nil
+			return nil, nil
 		}
 		return m.historyStore.ByRequest(identifier)
 	case historyScopeFile:

--- a/internal/ui/model_history_delete_test.go
+++ b/internal/ui/model_history_delete_test.go
@@ -43,7 +43,10 @@ func TestDeleteHistoryEntryRemovesFromStore(t *testing.T) {
 	updated, _ := model.Update(msg)
 	model = updated.(Model)
 
-	entries := store.Entries()
+	entries, err := store.Entries()
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
 	if len(entries) != 0 {
 		t.Fatalf("expected store to be empty, got %d entries", len(entries))
 	}

--- a/internal/ui/model_history_keys_test.go
+++ b/internal/ui/model_history_keys_test.go
@@ -128,7 +128,11 @@ func TestHistoryMultiSelectDelete(t *testing.T) {
 	model = updated.(Model)
 
 	remaining := map[string]struct{}{}
-	for _, entry := range store.Entries() {
+	entries, err := store.Entries()
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
+	for _, entry := range entries {
 		remaining[entry.ID] = struct{}{}
 	}
 	if len(remaining) != 3-len(selected) {

--- a/internal/ui/model_history_test.go
+++ b/internal/ui/model_history_test.go
@@ -121,7 +121,10 @@ func TestRecordCompareHistoryAppendsEntry(t *testing.T) {
 
 	model.recordCompareHistory(state)
 
-	entries := store.Entries()
+	entries, err := store.Entries()
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}

--- a/internal/ui/profile_history_test.go
+++ b/internal/ui/profile_history_test.go
@@ -87,7 +87,10 @@ func TestRecordProfileHistoryStoresEntry(t *testing.T) {
 
 	model.recordProfileHistory(st, stats, msg, report)
 
-	entries := store.Entries()
+	entries, err := store.Entries()
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 history entry, got %d", len(entries))
 	}
@@ -136,7 +139,11 @@ func TestRecordProfileHistorySkipsNoLog(t *testing.T) {
 	stats := analysis.ComputeLatencyStats(st.successes, []int{}, 1)
 	msg := responseMsg{response: &httpclient.Response{Status: "200 OK", StatusCode: 200}}
 	model.recordProfileHistory(st, stats, msg, "")
-	if entries := store.Entries(); len(entries) != 0 {
+	entries, err := store.Entries()
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
+	if len(entries) != 0 {
 		t.Fatalf("expected no history entries when no-log set, got %d", len(entries))
 	}
 }


### PR DESCRIPTION
  - return errors from Store query methods (Entries/ByRequest/ByWorkflow/ByFile)
  - make history query failures in UI instead of silently showing empty results
  - make ByRequest("") return empty results for consistency
  - simplify Append by removing unnecessary explicit transaction
  - refactor MigrateJSON to a single metaSet+commit path
  - dedupe path validation for export/import/backup
  - switch backup to parameterized `VACUUM INTO ?` and remove redundant WAL checkpoint
  - add MaintenanceStore contract + shared history.Stats type