### PR TITLE
Add $shared Environment Variables

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -336,6 +336,28 @@ Example environment (`_examples/resterm.env.json`):
 
 Switch environments with `Ctrl+E`. If multiple environments exist, Resterm defaults to `dev`, `default`, or `local` when available.
 
+#### Shared variables (`$shared`)
+
+Use the reserved `$shared` key to define variables that apply to **all** environments. This avoids duplicating common values (auth credentials, token URLs, etc.) across every environment. Environment-specific values override `$shared` when names collide.
+
+```json
+{
+  "$shared": {
+    "api": { "version": "v2" },
+    "auth": { "clientId": "demo-client" }
+  },
+  "dev": {
+    "base": { "url": "https://dev.example.com" }
+  },
+  "prod": {
+    "base": { "url": "https://prod.example.com" },
+    "auth": { "clientId": "prod-client" }
+  }
+}
+```
+
+In this example `dev` inherits `auth.clientId=demo-client` from `$shared`, while `prod` overrides it with `prod-client`. Both environments receive `api.version=v2`. The `$shared` key itself never appears in the environment selector.
+
 #### Dotenv files via `--env-file`
 
 Prefer JSON for multi-environment bundles, but you can point Resterm at a dotenv file when you only need a single workspace:

--- a/internal/vars/environment.go
+++ b/internal/vars/environment.go
@@ -12,6 +12,10 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/errdef"
 )
 
+// SharedEnvKey is the reserved environment name whose variables are merged
+// as defaults into every other environment. Environment-specific values win.
+const SharedEnvKey = "$shared"
+
 type EnvironmentSet map[string]map[string]string
 
 func LoadEnvironmentFile(path string) (EnvironmentSet, error) {
@@ -51,7 +55,29 @@ func loadJSONEnvironmentFile(path string) (envs EnvironmentSet, err error) {
 	default:
 		return nil, errdef.New(errdef.CodeParse, "unsupported env file format: %T", raw)
 	}
+	applyShared(envs)
 	return envs, nil
+}
+
+// applyShared merges the $shared environment's values as defaults into every
+// other environment (environment-specific values take precedence), then removes
+// $shared from the set so it never appears as a selectable environment.
+func applyShared(envs EnvironmentSet) {
+	shared, ok := envs[SharedEnvKey]
+	if !ok {
+		return
+	}
+	for name, env := range envs {
+		if name == SharedEnvKey {
+			continue
+		}
+		for k, v := range shared {
+			if _, exists := env[k]; !exists {
+				env[k] = v
+			}
+		}
+	}
+	delete(envs, SharedEnvKey)
 }
 
 func flattenEnv(value interface{}) map[string]string {

--- a/internal/vars/environment_test.go
+++ b/internal/vars/environment_test.go
@@ -52,3 +52,55 @@ func TestLoadEnvironmentFileFlattensNestedObjects(t *testing.T) {
 		t.Fatalf("expected null to become empty string, got %q", dev["empty"])
 	}
 }
+
+func TestSharedMergesIntoAllEnvironments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env.json")
+	data := []byte(`{
+  "$shared": {
+    "api": { "version": "v2" },
+    "auth": { "clientId": "demo-client" }
+  },
+  "dev": {
+    "base": { "url": "https://dev.example.com" }
+  },
+  "prod": {
+    "base": { "url": "https://prod.example.com" },
+    "auth": { "clientId": "prod-client" }
+  }
+}`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	envs, err := LoadEnvironmentFile(path)
+	if err != nil {
+		t.Fatalf("load env: %v", err)
+	}
+
+	// $shared must be removed from the set.
+	if _, ok := envs[SharedEnvKey]; ok {
+		t.Fatal("$shared should not appear in the returned EnvironmentSet")
+	}
+
+	// dev inherits shared values.
+	dev := envs["dev"]
+	if dev["api.version"] != "v2" {
+		t.Fatalf("dev should inherit api.version from $shared, got %q", dev["api.version"])
+	}
+	if dev["auth.clientId"] != "demo-client" {
+		t.Fatalf("dev should inherit auth.clientId from $shared, got %q", dev["auth.clientId"])
+	}
+	if dev["base.url"] != "https://dev.example.com" {
+		t.Fatalf("dev base.url wrong, got %q", dev["base.url"])
+	}
+
+	// prod overrides auth.clientId but inherits api.version.
+	prod := envs["prod"]
+	if prod["api.version"] != "v2" {
+		t.Fatalf("prod should inherit api.version from $shared, got %q", prod["api.version"])
+	}
+	if prod["auth.clientId"] != "prod-client" {
+		t.Fatalf("prod should override auth.clientId, got %q", prod["auth.clientId"])
+	}
+}


### PR DESCRIPTION
Hi, I needed a way to store values common across multiple environments in the resterm.env.json file, and didn’t have a way to do so besides copying them for each one. I added a feature implemented in other applications that use HTTP files (listed below), which allows values to be added to the $shared environment. Values added here will be available in all environments.

https://learn.microsoft.com/en-us/aspnet/core/test/http-files?view=aspnetcore-10.0#shared-variables
https://marketplace.visualstudio.com/items?itemName=humao.rest-client#environment-variables

## Things to consider:
- There are two functions exported by the internal/vars/environment.go file that loads the environment: LoadEnvironmentFile and ResolveEnvironment. To keep my changes minimal, I’ve added them to LoadEnvironmentFile, as this function is called by ResolveEnvironment
- Within the LoadEnvironmentFile function, two types of files are loaded: a .env file using the loadDotEnvEnvironment function and a JSON file using the loadJSONEnvironmentFile function. Currently, my changes only apply to the JSON file, as the .env file can only have one environment within it

## Changes
- Added the applyShared function, which adds each key value pair in the $shared key to each other key in the EnvironmentSet, making sure not to override any key that already exists in that environment, then deletes the $shared key, as a user should not be able to select it as an environment.
- Added the applyShared function to the loadJSONEnvironmentFile function