### PR TITLE
RST-166: prevent $shared from being used as a concrete env

### DIFF
--- a/cmd/resterm/main.go
+++ b/cmd/resterm/main.go
@@ -207,6 +207,9 @@ func main() {
 		}
 		os.Exit(0)
 	}
+	if err := validateReservedEnvironment(envName, "--env"); err != nil {
+		log.Fatalf("%v", err)
+	}
 
 	updateHTTP := &http.Client{Timeout: 60 * time.Second}
 	upClient, err := update.NewClient(updateHTTP, updateRepo)
@@ -462,9 +465,12 @@ func main() {
 
 	compareTargets, compareErr := parseCompareTargets(compareTargetsRaw)
 	if compareErr != nil {
-		log.Printf("invalid --compare value: %v", compareErr)
+		log.Fatalf("invalid --compare value: %v", compareErr)
 	}
 	compareBaseline = strings.TrimSpace(compareBaseline)
+	if err := validateReservedEnvironment(compareBaseline, "--compare-base"); err != nil {
+		log.Fatalf("invalid --compare-base value: %v", err)
+	}
 
 	settings, settingsHandle, err := config.LoadSettings()
 	if err != nil {
@@ -594,22 +600,32 @@ func parseCompareTargets(raw string) ([]string, error) {
 	seen := make(map[string]struct{}, len(fields))
 	targets := make([]string, 0, len(fields))
 	for _, field := range fields {
-		value := strings.TrimSpace(field)
-		if value == "" {
-			continue
+		if vars.IsReservedEnvironment(field) {
+			return nil, fmt.Errorf("environment %q is reserved for shared defaults", field)
 		}
-		lower := strings.ToLower(value)
+		lower := strings.ToLower(field)
 		if _, ok := seen[lower]; ok {
 			continue
 		}
 		seen[lower] = struct{}{}
-		targets = append(targets, value)
+		targets = append(targets, field)
 	}
 
 	if len(targets) < 2 {
 		return nil, fmt.Errorf("expected at least two environments, got %d", len(targets))
 	}
 	return targets, nil
+}
+
+func validateReservedEnvironment(value, flagName string) error {
+	if vars.IsReservedEnvironment(value) {
+		return fmt.Errorf(
+			"%s %q is reserved for shared defaults; choose a concrete environment",
+			flagName,
+			value,
+		)
+	}
+	return nil
 }
 
 func executableChecksum() (string, error) {

--- a/cmd/resterm/shared_env_test.go
+++ b/cmd/resterm/shared_env_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCompareTargetsRejectsShared(t *testing.T) {
+	_, err := parseCompareTargets("dev $shared")
+	if err == nil {
+		t.Fatalf("expected parseCompareTargets to reject $shared")
+	}
+	if !strings.Contains(err.Error(), "reserved for shared defaults") {
+		t.Fatalf("expected reserved-name error, got %v", err)
+	}
+}
+
+func TestValidateReservedEnvironmentSelection(t *testing.T) {
+	if err := validateReservedEnvironment("dev", "--env"); err != nil {
+		t.Fatalf("expected dev to be accepted, got %v", err)
+	}
+	if err := validateReservedEnvironment("", "--env"); err != nil {
+		t.Fatalf("expected empty value to be accepted, got %v", err)
+	}
+
+	err := validateReservedEnvironment("$shared", "--env")
+	if err == nil {
+		t.Fatalf("expected $shared to be rejected")
+	}
+	if !strings.Contains(err.Error(), "reserved for shared defaults") {
+		t.Fatalf("expected reserved-name error, got %v", err)
+	}
+}

--- a/internal/parser/directive_parsers.go
+++ b/internal/parser/directive_parsers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/duration"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 func parseApplySpec(rest string, line int) (restfile.ApplySpec, error) {
@@ -422,11 +423,20 @@ func parseCompareDirective(rest string) (*restfile.CompareSpec, error) {
 				if val == "" {
 					return nil, fmt.Errorf("@compare baseline cannot be empty")
 				}
+				if vars.IsReservedEnvironment(val) {
+					return nil, fmt.Errorf(
+						"@compare baseline %q is reserved for shared defaults",
+						val,
+					)
+				}
 				baseline = val
 			default:
 				return nil, fmt.Errorf("@compare unsupported option %q", key)
 			}
 			continue
+		}
+		if vars.IsReservedEnvironment(value) {
+			return nil, fmt.Errorf("@compare environment %q is reserved for shared defaults", value)
 		}
 		lowered := strings.ToLower(value)
 		if _, exists := seen[lowered]; exists {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1459,6 +1459,44 @@ GET https://example.com
 	}
 }
 
+func TestParseCompareDirectiveRejectsSharedEnvironment(t *testing.T) {
+	src := `# @name Compare
+# @compare dev $shared
+GET https://example.com
+`
+
+	doc := Parse("compare.http", []byte(src))
+	if len(doc.Errors) == 0 {
+		t.Fatalf("expected parse errors")
+	}
+	if !hasParseMessage(doc.Errors, "reserved for shared defaults") {
+		t.Fatalf("expected reserved-name parse error, got %v", doc.Errors)
+	}
+	req := doc.Requests[0]
+	if req.Metadata.Compare != nil {
+		t.Fatalf("expected compare metadata to be nil on error")
+	}
+}
+
+func TestParseCompareDirectiveRejectsSharedBaseline(t *testing.T) {
+	src := `# @name Compare
+# @compare dev stage base=$shared
+GET https://example.com
+`
+
+	doc := Parse("compare.http", []byte(src))
+	if len(doc.Errors) == 0 {
+		t.Fatalf("expected parse errors")
+	}
+	if !hasParseMessage(doc.Errors, "reserved for shared defaults") {
+		t.Fatalf("expected reserved-name parse error, got %v", doc.Errors)
+	}
+	req := doc.Requests[0]
+	if req.Metadata.Compare != nil {
+		t.Fatalf("expected compare metadata to be nil on error")
+	}
+}
+
 func TestParseMultiLineScripts(t *testing.T) {
 	src := `# @name Scripted
 # @script pre-request

--- a/internal/vars/environment.go
+++ b/internal/vars/environment.go
@@ -18,6 +18,12 @@ const SharedEnvKey = "$shared"
 
 type EnvironmentSet map[string]map[string]string
 
+// IsReservedEnvironment reports whether the name is reserved for
+// framework behavior and cannot be selected as a concrete environment.
+func IsReservedEnvironment(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(name), SharedEnvKey)
+}
+
 func LoadEnvironmentFile(path string) (EnvironmentSet, error) {
 	if IsDotEnvPath(path) {
 		return loadDotEnvEnvironment(path)
@@ -41,21 +47,33 @@ func loadJSONEnvironmentFile(path string) (envs EnvironmentSet, err error) {
 		return nil, errdef.Wrap(errdef.CodeFilesystem, err, "read env file %s", path)
 	}
 
-	var raw interface{}
+	var raw any
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, errdef.Wrap(errdef.CodeParse, err, "parse env file %s", path)
 	}
 
 	envs = make(EnvironmentSet)
 	switch v := raw.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for envName, value := range v {
 			envs[envName] = flattenEnv(value)
 		}
 	default:
 		return nil, errdef.New(errdef.CodeParse, "unsupported env file format: %T", raw)
 	}
+	hadShared := false
+	if _, ok := envs[SharedEnvKey]; ok {
+		hadShared = true
+	}
 	applyShared(envs)
+	if hadShared && len(envs) == 0 {
+		return nil, errdef.New(
+			errdef.CodeParse,
+			`env file %s defines only %q; add at least one concrete environment`,
+			path,
+			SharedEnvKey,
+		)
+	}
 	return envs, nil
 }
 
@@ -80,7 +98,7 @@ func applyShared(envs EnvironmentSet) {
 	delete(envs, SharedEnvKey)
 }
 
-func flattenEnv(value interface{}) map[string]string {
+func flattenEnv(value any) map[string]string {
 	result := make(map[string]string)
 	flattenEnvValue("", value, result)
 	return result
@@ -89,9 +107,9 @@ func flattenEnv(value interface{}) map[string]string {
 // Recursively walks through JSON structure to build dot-notation paths.
 // Nested objects become "parent.child" and arrays become "parent[0]".
 // Makes deeply nested config accessible via simple string keys.
-func flattenEnvValue(prefix string, value interface{}, out map[string]string) {
+func flattenEnvValue(prefix string, value any, out map[string]string) {
 	switch v := value.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for key, child := range v {
 			if key == "" {
 				continue
@@ -102,7 +120,7 @@ func flattenEnvValue(prefix string, value interface{}, out map[string]string) {
 			}
 			flattenEnvValue(next, child, out)
 		}
-	case []interface{}:
+	case []any:
 		for idx, item := range v {
 			childKey := strconv.Itoa(idx)
 			if prefix != "" {

--- a/internal/vars/environment_test.go
+++ b/internal/vars/environment_test.go
@@ -3,6 +3,7 @@ package vars
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -102,5 +103,26 @@ func TestSharedMergesIntoAllEnvironments(t *testing.T) {
 	}
 	if prod["auth.clientId"] != "prod-client" {
 		t.Fatalf("prod should override auth.clientId, got %q", prod["auth.clientId"])
+	}
+}
+
+func TestLoadEnvironmentFileOnlySharedReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env.json")
+	data := []byte(`{
+  "$shared": {
+    "base": { "url": "https://api.example.com" }
+  }
+}`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	_, err := LoadEnvironmentFile(path)
+	if err == nil {
+		t.Fatalf("expected parse error for env file containing only $shared")
+	}
+	if !strings.Contains(err.Error(), `defines only "$shared"`) {
+		t.Fatalf("expected only-shared parse error, got %v", err)
 	}
 }


### PR DESCRIPTION
`$shared` key is reserved for default variables that merge into all environments.