### PR TITLE
RST-179: make auth command reuse already cached key via cache_key

### DIFF
--- a/_examples/auth_command.http
+++ b/_examples/auth_command.http
@@ -1,9 +1,30 @@
+### Reusable Command Auth Profile
+# @patch global githubCliAuth {auth: {type: "command", argv: '["gh","auth","token"]', cache_key: "github-cli"}}
+
+### GitHub CLI Token Via @apply
+# @name GitHubCLITokenPatched
+# @tag auth command
+# @description Reuses command-backed bearer auth through a global apply profile.
+# @apply use=githubCliAuth
+GET https://api.github.com/user
+Accept: application/vnd.github+json
+X-GitHub-Api-Version: 2022-11-28
+
 ### GitHub CLI Token
 # @name GitHubCLIToken
 # @tag auth command
 # @description Uses the GitHub CLI token printer. Run `gh auth login` outside Resterm first.
 # @auth command argv=["gh","auth","token"] cache_key=github-cli
 GET https://api.github.com/user
+Accept: application/vnd.github+json
+X-GitHub-Api-Version: 2022-11-28
+
+### GitHub CLI Token Reuse
+# @name GitHubCLITokenReuse
+# @tag auth command
+# @description Reuses the seeded github-cli command auth slot without repeating argv.
+# @auth command cache_key=github-cli
+GET https://api.github.com/user/repos
 Accept: application/vnd.github+json
 X-GitHub-Api-Version: 2022-11-28
 

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -924,7 +924,7 @@ If you skip `token_url` on a follow-up directive and the cache hasn’t been see
 
 | Parameter | Required | Default | Description |
 | --- | --- | --- | --- |
-| `argv` | Yes | - | JSON array of command arguments. Bare JSON works, for example `argv=["gh","auth","token"]`. Outer single quotes are also accepted and are useful when you want to preserve whitespace exactly, for example `argv='["gh", "auth", "token"]'`. |
+| `argv` | Yes for the first use of a `cache_key` | - | JSON array of command arguments. Bare JSON works, for example `argv=["gh","auth","token"]`. Outer single quotes are also accepted and are useful when you want to preserve whitespace exactly, for example `argv='["gh", "auth", "token"]'`. Once a `cache_key` has been seeded, follow-up directives may omit `argv` and reuse the stored command config. |
 | `format` | No | `text` | Parse `stdout` as `text` or `json`. |
 | `header` | No | `Authorization` | Target header name. |
 | `scheme` | No | auto | Explicit prefix for the final header value. When omitted, `Authorization` defaults to `Bearer`, while custom headers get the raw token. |
@@ -932,13 +932,15 @@ If you skip `token_url` on a follow-up directive and the cache hasn’t been see
 | `type_path` | No | - | Optional token type for `Authorization` headers when `scheme` is omitted. |
 | `expiry_path` | No | - | Optional absolute expiry value (RFC3339, RFC3339Nano, Unix seconds, or Unix milliseconds). |
 | `expires_in_path` | No | - | Optional relative lifetime in seconds. |
-| `cache_key` | No | - | Enables in-memory cache reuse per environment. |
+| `cache_key` | No | - | Enables in-memory cache reuse per environment and names a reusable command-auth slot. Seed it once with the full command/extraction config, then reuse it with `cache_key` only on later requests. Reusing the same `cache_key` with different command/extraction settings is rejected. |
 | `ttl` | No | - | Cache fallback TTL when the command output has no expiry fields. Requires `cache_key`. |
 | `timeout` | No | request timeout | Per-command timeout, bounded by the request timeout. |
 
 #### Command auth behavior
 
 - Resterm runs `@auth command` without a shell. Pipes, redirects, globbing, and shell interpolation are intentionally not supported.
+- With `cache_key`, the first full directive seeds a reusable command-auth config for that environment. Later directives can use only `cache_key`; empty fields inherit from the seeded config.
+- Reusing the same `cache_key` with different acquisition settings (`argv`, `format`, JSON paths, `ttl`, and related source fields) fails fast. `header`, `scheme`, and `timeout` can still vary per request.
 - Explain preview never executes commands. It only injects a header when a valid cached result already exists.
 - Text mode accepts exactly one non-empty line from `stdout`. Multi-line output fails with an error and should be switched to `format=json`.
 - Successful command output is treated as secret. Resterm redacts the raw token and the final injected header value in explain/history views.
@@ -950,6 +952,15 @@ Examples:
 # Requires `gh auth login` to be done outside Resterm first.
 # @auth command argv=["gh","auth","token"] cache_key=github-cli
 GET https://api.github.com/user
+Accept: application/vnd.github+json
+X-GitHub-Api-Version: 2022-11-28
+```
+
+```http
+### Reuse a seeded command-auth slot
+# After the first request seeds github-cli, later requests can reference only the cache key.
+# @auth command cache_key=github-cli
+GET https://api.github.com/user/repos
 Accept: application/vnd.github+json
 X-GitHub-Api-Version: 2022-11-28
 ```
@@ -1300,9 +1311,16 @@ When `header` is set to something other than `Authorization`, Resterm injects ju
 Use `@auth command` when your existing CLI already knows how reterive or print tokens.
 
 ```http
-### GitHub CLI profile
+### Seed a reusable command-auth slot
 # @auth command argv=["gh","auth","token"] cache_key=github-cli
 GET https://api.github.com/user
+Accept: application/vnd.github+json
+```
+
+```http
+### Reuse it later with cache_key only
+# @auth command cache_key=github-cli
+GET https://api.github.com/user/repos
 Accept: application/vnd.github+json
 ```
 
@@ -1321,6 +1339,7 @@ Key points:
 - Interactive login flows are not supported. Authenticate the CLI outside Resterm first, then use the non-interactive token-printing command.
 - Custom headers are supported with `header=...`; `Authorization` defaults to `Bearer <token>`.
 - Add `cache_key` when you want preview support and in-memory reuse across requests in the same environment.
+- `cache_key` now behaves like OAuth: it names a reusable slot. Seed it once, then reuse it. If the cache has not been seeded yet, Resterm errors with `@auth command requires argv (include it once per cache_key to seed the cache)`.
 
 ---
 

--- a/internal/authcmd/cache.go
+++ b/internal/authcmd/cache.go
@@ -1,9 +1,12 @@
 package authcmd
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/unkn0wn-root/resterm/internal/errdef"
 )
 
 func cacheKey(env string, cfg Config) string {
@@ -14,15 +17,6 @@ func cacheKey(env string, cfg Config) string {
 	var b strings.Builder
 	appendCachePart(&b, strings.ToLower(trim(env)))
 	appendCachePart(&b, cfg.cacheKey())
-	appendCachePart(&b, cfg.Dir)
-	appendCachePart(&b, string(cfg.Format))
-	appendCachePart(&b, cfg.TokenPath)
-	appendCachePart(&b, cfg.TypePath)
-	appendCachePart(&b, cfg.ExpiryPath)
-	appendCachePart(&b, cfg.ExpiresInPath)
-	for _, arg := range cfg.Argv {
-		appendCachePart(&b, arg)
-	}
 	return b.String()
 }
 
@@ -43,13 +37,79 @@ func effectiveExpiry(cred credential, cfg Config) time.Time {
 	return time.Time{}
 }
 
-func validAt(cred credential, cfg Config, now time.Time) (valid bool, purge bool) {
+func validAt(cred credential, cfg Config, now time.Time) bool {
 	expiry := effectiveExpiry(cred, cfg)
 	if expiry.IsZero() {
-		return true, false
+		return true
 	}
 	if now.Before(expiry) {
-		return true, false
+		return true
 	}
-	return false, !cred.Expiry.IsZero()
+	return false
+}
+
+func mergeCfg(base, cur Config) Config {
+	merged := cur
+	if len(merged.Argv) == 0 && len(base.Argv) > 0 {
+		merged.Argv = append([]string(nil), base.Argv...)
+	}
+	merged.Dir = inheritIfEmpty(merged.Dir, base.Dir)
+	if merged.Format == "" {
+		merged.Format = base.Format
+	}
+	merged.Header = inheritIfEmpty(merged.Header, base.Header)
+	merged.Scheme = inheritIfEmpty(merged.Scheme, base.Scheme)
+	merged.TokenPath = inheritIfEmpty(merged.TokenPath, base.TokenPath)
+	merged.TypePath = inheritIfEmpty(merged.TypePath, base.TypePath)
+	merged.ExpiryPath = inheritIfEmpty(merged.ExpiryPath, base.ExpiryPath)
+	merged.ExpiresInPath = inheritIfEmpty(merged.ExpiresInPath, base.ExpiresInPath)
+	merged.TTL = inheritIfZero(merged.TTL, base.TTL)
+	merged.Timeout = inheritIfZero(merged.Timeout, base.Timeout)
+	return merged
+}
+
+func inheritIfEmpty(cur, base string) string {
+	if cur != "" {
+		return cur
+	}
+	return base
+}
+
+func inheritIfZero(cur, base time.Duration) time.Duration {
+	if cur != 0 {
+		return cur
+	}
+	return base
+}
+
+func sameSeed(base, cur Config) (string, bool) {
+	switch {
+	case !slices.Equal(base.Argv, cur.Argv):
+		return "argv", false
+	case base.Dir != cur.Dir:
+		return "dir", false
+	case effectiveFormat(base) != effectiveFormat(cur):
+		return "format", false
+	case base.TokenPath != cur.TokenPath:
+		return "token_path", false
+	case base.TypePath != cur.TypePath:
+		return "type_path", false
+	case base.ExpiryPath != cur.ExpiryPath:
+		return "expiry_path", false
+	case base.ExpiresInPath != cur.ExpiresInPath:
+		return "expires_in_path", false
+	case base.TTL != cur.TTL:
+		return "ttl", false
+	default:
+		return "", true
+	}
+}
+
+func conflictError(cfg Config, field string) error {
+	return errdef.New(
+		errdef.CodeHTTP,
+		"@auth command cache_key %q conflicts with seeded %s",
+		cfg.CacheKey,
+		field,
+	)
 }

--- a/internal/authcmd/config.go
+++ b/internal/authcmd/config.go
@@ -50,9 +50,6 @@ func (cfg Config) normalize() Config {
 	cfg.Dir = trim(cfg.Dir)
 	cfg.Format = normalizeConfigFormat(cfg.Format)
 	cfg.Header = trim(cfg.Header)
-	if cfg.Header == "" {
-		cfg.Header = defaultHeader
-	}
 	cfg.Scheme = trim(cfg.Scheme)
 	cfg.TokenPath = trim(cfg.TokenPath)
 	cfg.TypePath = trim(cfg.TypePath)
@@ -73,7 +70,7 @@ func (cfg Config) WithBaseTimeout(base time.Duration) Config {
 	return cfg
 }
 
-func (cfg Config) headerName() string {
+func (cfg Config) HeaderName() string {
 	if cfg.Header != "" {
 		return cfg.Header
 	}
@@ -108,7 +105,9 @@ func (cfg Config) commandName() string {
 
 func normalizeConfigFormat(raw Format) Format {
 	switch strings.ToLower(strings.TrimSpace(string(raw))) {
-	case "", string(FormatText):
+	case "":
+		return ""
+	case string(FormatText):
 		return FormatText
 	case string(FormatJSON):
 		return FormatJSON

--- a/internal/authcmd/config_test.go
+++ b/internal/authcmd/config_test.go
@@ -20,8 +20,8 @@ func TestConfigHeaderName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := tt.cfg.headerName(); got != tt.want {
-				t.Fatalf("headerName() = %q, want %q", got, tt.want)
+			if got := tt.cfg.HeaderName(); got != tt.want {
+				t.Fatalf("HeaderName() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/authcmd/extract.go
+++ b/internal/authcmd/extract.go
@@ -15,7 +15,7 @@ import (
 func extract(cfg Config, out []byte, now time.Time) (Result, error) {
 	cred, err := extractCredential(cfg, out, now)
 	if err != nil {
-		return Result{Header: cfg.headerName()}, err
+		return Result{Header: cfg.HeaderName()}, err
 	}
 	return renderResult(cfg, cred), nil
 }
@@ -226,7 +226,7 @@ func buildHeaderValue(cfg Config, header, tok, typ string) (string, string) {
 
 func renderResult(cfg Config, cred credential) Result {
 	cfg = cfg.normalize()
-	header := cfg.headerName()
+	header := cfg.HeaderName()
 	value, typ := buildHeaderValue(cfg, header, cred.Token, cred.Type)
 	return Result{
 		Header: header,

--- a/internal/authcmd/manager.go
+++ b/internal/authcmd/manager.go
@@ -11,12 +11,23 @@ type runFunc func(context.Context, Config) (runOutput, error)
 type call struct {
 	done chan struct{}
 	cred credential
+	cfg  Config
 	err  error
+}
+
+type entry struct {
+	cred credential
+	cfg  Config
+}
+
+type Prepared struct {
+	key string
+	cfg Config
 }
 
 type Manager struct {
 	mu       sync.Mutex
-	cache    map[string]credential
+	cache    map[string]entry
 	inflight map[string]*call
 	now      func() time.Time
 	run      runFunc
@@ -24,7 +35,7 @@ type Manager struct {
 
 func NewManager() *Manager {
 	return &Manager{
-		cache:    make(map[string]credential),
+		cache:    make(map[string]entry),
 		inflight: make(map[string]*call),
 		now:      time.Now,
 		run:      run,
@@ -57,25 +68,77 @@ func (m *Manager) SetExecFunc(fn func(context.Context, Config) ([]byte, error)) 
 	}
 }
 
-func (m *Manager) Cached(env string, cfg Config) (Result, bool) {
+func (m *Manager) MergeCachedConfig(env string, cfg Config) Config {
 	cfg = cfg.normalize()
 	key := cacheKey(env, cfg)
 	if key == "" {
-		return Result{}, false
+		return cfg
 	}
-	cred, ok := m.cached(key, cfg, m.now())
+	ent, ok := m.cacheEntry(key)
 	if !ok {
-		return Result{}, false
+		return cfg
 	}
-	return renderResult(cfg, cred), true
+	return mergeCfg(ent.cfg, cfg)
+}
+
+func (p Prepared) Config() Config {
+	return p.cfg
+}
+
+func (m *Manager) Prepare(env string, cfg Config) (Prepared, error) {
+	key, cfg, err := m.prepare(env, cfg)
+	if err != nil {
+		return Prepared{}, err
+	}
+	return Prepared{key: key, cfg: cfg}, nil
+}
+
+func (m *Manager) Cached(env string, cfg Config) (Result, bool, error) {
+	prep, err := m.Prepare(env, cfg)
+	if err != nil {
+		return Result{}, false, err
+	}
+	return m.CachedPrepared(prep)
+}
+
+func (m *Manager) CachedPrepared(prep Prepared) (Result, bool, error) {
+	key := prep.key
+	cfg := prep.cfg
+	if key == "" {
+		return Result{}, false, nil
+	}
+
+	now := m.now()
+	m.mu.Lock()
+	ent, ok := m.cache[key]
+	if !ok {
+		m.mu.Unlock()
+		return Result{}, false, nil
+	}
+	if field, same := sameSeed(ent.cfg, cfg); !same {
+		m.mu.Unlock()
+		return Result{}, false, conflictError(cfg, field)
+	}
+	cred, ok := cachedEntry(ent, cfg, now)
+	m.mu.Unlock()
+	if !ok {
+		return Result{}, false, nil
+	}
+	return renderResult(cfg, cred), true, nil
 }
 
 func (m *Manager) Resolve(ctx context.Context, env string, cfg Config) (Result, error) {
-	cfg = cfg.normalize()
-	if err := validate(cfg); err != nil {
+	prep, err := m.Prepare(env, cfg)
+	if err != nil {
 		return Result{}, err
 	}
-	if !cfg.usesCache() {
+	return m.ResolvePrepared(ctx, prep)
+}
+
+func (m *Manager) ResolvePrepared(ctx context.Context, prep Prepared) (Result, error) {
+	key := prep.key
+	cfg := prep.cfg
+	if key == "" {
 		cred, err := m.fetch(ctx, cfg)
 		if err != nil {
 			return Result{}, err
@@ -83,13 +146,25 @@ func (m *Manager) Resolve(ctx context.Context, env string, cfg Config) (Result, 
 		return renderResult(cfg, cred), nil
 	}
 
-	key := cacheKey(env, cfg)
-	if cred, ok := m.cached(key, cfg, m.now()); ok {
-		return renderResult(cfg, cred), nil
-	}
-
+	now := m.now()
 	m.mu.Lock()
+	seed := cfg
+	if ent, ok := m.cache[key]; ok {
+		if field, same := sameSeed(ent.cfg, cfg); !same {
+			m.mu.Unlock()
+			return Result{}, conflictError(cfg, field)
+		}
+		if cred, ok := cachedEntry(ent, cfg, now); ok {
+			m.mu.Unlock()
+			return renderResult(cfg, cred), nil
+		}
+		seed = ent.cfg
+	}
 	if c, ok := m.inflight[key]; ok {
+		if field, same := sameSeed(c.cfg, cfg); !same {
+			m.mu.Unlock()
+			return Result{}, conflictError(cfg, field)
+		}
 		done := c.done
 		m.mu.Unlock()
 		select {
@@ -102,13 +177,14 @@ func (m *Manager) Resolve(ctx context.Context, env string, cfg Config) (Result, 
 			return renderResult(cfg, c.cred), nil
 		}
 	}
-	c := &call{done: make(chan struct{})}
+
+	c := &call{done: make(chan struct{}), cfg: seed}
 	m.inflight[key] = c
 	m.mu.Unlock()
 
 	cred, err := m.fetch(ctx, cfg)
 	if err == nil {
-		m.store(key, cred)
+		m.store(key, seed, cred)
 	}
 	c.cred = cred
 	c.err = err
@@ -139,26 +215,52 @@ func (m *Manager) fetch(ctx context.Context, cfg Config) (credential, error) {
 	return cred, nil
 }
 
-func (m *Manager) cached(key string, cfg Config, now time.Time) (credential, bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, ok := m.cache[key]
-	if !ok {
+func cachedEntry(ent entry, cfg Config, now time.Time) (credential, bool) {
+	if ent.cred == (credential{}) {
 		return credential{}, false
 	}
-	valid, purge := validAt(entry, cfg, now)
-	if !valid {
-		if purge {
-			delete(m.cache, key)
-		}
+	if !validAt(ent.cred, cfg, now) {
 		return credential{}, false
 	}
-	return entry, true
+	return ent.cred, true
 }
 
-func (m *Manager) store(key string, cred credential) {
+func (m *Manager) store(key string, cfg Config, cred credential) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.cache[key] = cred
+	m.cache[key] = entry{cred: cred, cfg: cfg}
+}
+
+func (m *Manager) cacheEntry(key string) (entry, bool) {
+	if key == "" {
+		return entry{}, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ent, ok := m.cache[key]
+	return ent, ok
+}
+
+func (m *Manager) prepare(env string, cfg Config) (string, Config, error) {
+	cfg = cfg.normalize()
+	key := cacheKey(env, cfg)
+	if key == "" {
+		cfg, err := Finalize(cfg)
+		return "", cfg, err
+	}
+
+	ent, ok := m.cacheEntry(key)
+	if ok {
+		cfg = mergeCfg(ent.cfg, cfg)
+	}
+	cfg, err := Finalize(cfg)
+	if err != nil {
+		return key, cfg, err
+	}
+	if ok {
+		if field, same := sameSeed(ent.cfg, cfg); !same {
+			return key, cfg, conflictError(cfg, field)
+		}
+	}
+	return key, cfg, nil
 }

--- a/internal/authcmd/manager_test.go
+++ b/internal/authcmd/manager_test.go
@@ -3,6 +3,7 @@ package authcmd
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -71,12 +72,12 @@ func TestManagerResolveTTLRefreshesExpiredEntry(t *testing.T) {
 		t.Fatalf("Resolve() error = %v", err)
 	}
 	now = now.Add(30 * time.Second)
-	second, err := mgr.Resolve(context.Background(), "dev", cfg)
+	second, err := mgr.Resolve(context.Background(), "dev", Config{CacheKey: "github"})
 	if err != nil {
 		t.Fatalf("Resolve() cached error = %v", err)
 	}
 	now = now.Add(40 * time.Second)
-	third, err := mgr.Resolve(context.Background(), "dev", cfg)
+	third, err := mgr.Resolve(context.Background(), "dev", Config{CacheKey: "github"})
 	if err != nil {
 		t.Fatalf("Resolve() refreshed error = %v", err)
 	}
@@ -98,12 +99,15 @@ func TestManagerCachedUsesPreviewCacheOnly(t *testing.T) {
 	mgr := NewManager()
 	mgr.now = func() time.Time { return time.Unix(100, 0) }
 	cfg := Config{Argv: []string{"gh"}, CacheKey: "github"}
-	mgr.store(cacheKey("dev", cfg.normalize()), credential{
+	mgr.store(cacheKey("dev", cfg.normalize()), cfg.normalize(), credential{
 		Token:     "abc",
 		FetchedAt: time.Unix(90, 0),
 	})
 
-	res, ok := mgr.Cached(" dev ", Config{Argv: []string{"gh"}, CacheKey: " github "})
+	res, ok, err := mgr.Cached(" dev ", Config{CacheKey: " github "})
+	if err != nil {
+		t.Fatalf("Cached() error = %v", err)
+	}
 	if !ok {
 		t.Fatal("expected cached result")
 	}
@@ -179,8 +183,10 @@ func TestManagerResolveRendersCachedCredentialPerRequestConfig(t *testing.T) {
 	authCfg := base
 	authCfg.Scheme = "Token"
 
-	customCfg := base
-	customCfg.Header = "X-Registry-Token"
+	customCfg := Config{
+		CacheKey: "github",
+		Header:   "X-Registry-Token",
+	}
 
 	first, err := mgr.Resolve(context.Background(), "dev", authCfg)
 	if err != nil {
@@ -194,7 +200,7 @@ func TestManagerResolveRendersCachedCredentialPerRequestConfig(t *testing.T) {
 	if first.Header != "Authorization" || first.Value != "Token token-1" {
 		t.Fatalf("unexpected auth result %#v", first)
 	}
-	if second.Header != "X-Registry-Token" || second.Value != "token-1" {
+	if second.Header != "X-Registry-Token" || second.Value != "Token token-1" {
 		t.Fatalf("unexpected custom result %#v", second)
 	}
 	if got := calls.Load(); got != 1 {
@@ -202,7 +208,7 @@ func TestManagerResolveRendersCachedCredentialPerRequestConfig(t *testing.T) {
 	}
 }
 
-func TestManagerResolveSeparatesCacheByResolvedArgv(t *testing.T) {
+func TestManagerResolveRejectsConflictingArgv(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
@@ -227,27 +233,23 @@ func TestManagerResolveSeparatesCacheByResolvedArgv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve(alphaCfg) error = %v", err)
 	}
-	beta, err := mgr.Resolve(context.Background(), "dev", betaCfg)
-	if err != nil {
-		t.Fatalf("Resolve(betaCfg) error = %v", err)
-	}
-	alphaAgain, err := mgr.Resolve(context.Background(), "dev", alphaCfg)
-	if err != nil {
-		t.Fatalf("Resolve(alphaCfg) second error = %v", err)
-	}
 
-	if alpha.Token != "alpha" || beta.Token != "beta" {
-		t.Fatalf("unexpected tokens alpha=%q beta=%q", alpha.Token, beta.Token)
+	_, err = mgr.Resolve(context.Background(), "dev", betaCfg)
+	if err == nil {
+		t.Fatal("expected conflict error")
 	}
-	if alphaAgain.Token != alpha.Token {
-		t.Fatalf("expected alpha cache hit, got %q then %q", alpha.Token, alphaAgain.Token)
+	if got := err.Error(); got == "" || !containsAll(got, `cache_key "shared"`, "argv") {
+		t.Fatalf("unexpected conflict error %q", got)
 	}
-	if got := calls.Load(); got != 2 {
-		t.Fatalf("expected 2 command executions, got %d", got)
+	if alpha.Token != "alpha" {
+		t.Fatalf("unexpected alpha token %q", alpha.Token)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 command execution, got %d", got)
 	}
 }
 
-func TestManagerResolveSeparatesCacheByExtractionConfig(t *testing.T) {
+func TestManagerResolveRejectsConflictingExtractionConfig(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
@@ -276,16 +278,75 @@ func TestManagerResolveSeparatesCacheByExtractionConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve(alphaCfg) error = %v", err)
 	}
-	beta, err := mgr.Resolve(context.Background(), "dev", betaCfg)
-	if err != nil {
-		t.Fatalf("Resolve(betaCfg) error = %v", err)
-	}
 
-	if alpha.Token != "token-a" || beta.Token != "token-b" {
-		t.Fatalf("unexpected tokens alpha=%q beta=%q", alpha.Token, beta.Token)
+	_, err = mgr.Resolve(context.Background(), "dev", betaCfg)
+	if err == nil {
+		t.Fatal("expected conflict error")
 	}
-	if got := calls.Load(); got != 2 {
-		t.Fatalf("expected 2 command executions, got %d", got)
+	if got := err.Error(); got == "" || !containsAll(got, `cache_key "shared"`, "token_path") {
+		t.Fatalf("unexpected conflict error %q", got)
+	}
+	if alpha.Token != "token-a" {
+		t.Fatalf("unexpected alpha token %q", alpha.Token)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 command execution, got %d", got)
+	}
+}
+
+func TestManagerResolveUnseededCacheOnlyFails(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+
+	_, err := mgr.Resolve(context.Background(), "dev", Config{CacheKey: "github"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); !containsAll(got, "requires argv", "seed the cache") {
+		t.Fatalf("unexpected error %q", got)
+	}
+}
+
+func TestManagerMergeCachedConfig(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	base := Config{
+		Argv:      []string{"gh", "auth", "token"},
+		Dir:       "/tmp/project",
+		Format:    FormatJSON,
+		Header:    "X-Seeded",
+		Scheme:    "Token",
+		TokenPath: "access_token",
+		CacheKey:  "github",
+		TTL:       time.Minute,
+		Timeout:   3 * time.Second,
+	}
+	mgr.store(cacheKey("dev", base), base, credential{
+		Token:     "abc",
+		FetchedAt: time.Unix(100, 0),
+	})
+
+	merged := mgr.MergeCachedConfig("dev", Config{
+		CacheKey: "github",
+		Header:   "Authorization",
+	})
+
+	if len(merged.Argv) != 3 || merged.Argv[0] != "gh" {
+		t.Fatalf("expected argv to be inherited, got %#v", merged.Argv)
+	}
+	if merged.Format != FormatJSON || merged.TokenPath != "access_token" {
+		t.Fatalf("expected extraction config to be inherited, got %#v", merged)
+	}
+	if merged.Header != "Authorization" {
+		t.Fatalf("expected request header override to win, got %q", merged.Header)
+	}
+	if merged.Scheme != "Token" {
+		t.Fatalf("expected scheme to be inherited, got %q", merged.Scheme)
+	}
+	if merged.Timeout != 3*time.Second {
+		t.Fatalf("expected timeout to be inherited, got %s", merged.Timeout)
 	}
 }
 
@@ -349,4 +410,13 @@ func TestManagerResolveDeduplicatesInflightCalls(t *testing.T) {
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("expected 1 inflight run, got %d", got)
 	}
+}
+
+func containsAll(s string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(s, part) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/authcmd/parse.go
+++ b/internal/authcmd/parse.go
@@ -24,8 +24,10 @@ func Parse(params map[string]string, dir string) (Config, error) {
 	cfg := Config{Dir: dir}
 
 	var err error
-	if cfg.Argv, err = parseArgv(params["argv"]); err != nil {
-		return cfg, err
+	if trim(params["argv"]) != "" {
+		if cfg.Argv, err = parseArgv(params["argv"]); err != nil {
+			return cfg, err
+		}
 	}
 	cfg.Format = Format(params["format"])
 	cfg.Header = params["header"]
@@ -41,6 +43,13 @@ func Parse(params map[string]string, dir string) (Config, error) {
 	}
 	if cfg.Timeout, err = parseDur(params["timeout"], "timeout"); err != nil {
 		return cfg, err
+	}
+	cfg = cfg.normalize()
+	if err := validateParsed(cfg); err != nil {
+		return cfg, err
+	}
+	if cfg.usesCache() {
+		return cfg, nil
 	}
 	return Finalize(cfg)
 }
@@ -88,20 +97,33 @@ func parseDur(raw, name string) (time.Duration, error) {
 }
 
 func validate(cfg Config) error {
-	if len(cfg.Argv) == 0 {
-		return errdef.New(errdef.CodeHTTP, "command argv must not be empty")
+	if err := validateParsed(cfg); err != nil {
+		return err
 	}
-	if cfg.Argv[0] == "" {
+	if len(cfg.Argv) == 0 {
+		return missingArgvError(cfg)
+	}
+	if effectiveFormat(cfg) == FormatJSON && cfg.TokenPath == "" {
+		return errdef.New(errdef.CodeHTTP, "token_path is required for format=json")
+	}
+	return nil
+}
+
+func validateParsed(cfg Config) error {
+	if len(cfg.Argv) == 0 && !cfg.usesCache() {
+		return missingArgvError(cfg)
+	}
+	if len(cfg.Argv) > 0 && cfg.Argv[0] == "" {
 		return errdef.New(errdef.CodeHTTP, "command argv[0] must not be empty")
 	}
-	if isShell(cfg.Argv[0]) {
+	if len(cfg.Argv) > 0 && isShell(cfg.Argv[0]) {
 		return errdef.New(
 			errdef.CodeHTTP,
 			"@auth command does not allow shell front-end %q",
 			filepath.Base(cfg.Argv[0]),
 		)
 	}
-	switch cfg.Format {
+	switch effectiveFormat(cfg) {
 	case FormatText, FormatJSON:
 	default:
 		return errdef.New(errdef.CodeHTTP, "unsupported command auth format %q", cfg.Format)
@@ -112,13 +134,27 @@ func validate(cfg Config) error {
 	if cfg.Timeout < 0 {
 		return errdef.New(errdef.CodeHTTP, "timeout must not be negative")
 	}
-	if cfg.Format == FormatJSON && cfg.TokenPath == "" {
-		return errdef.New(errdef.CodeHTTP, "token_path is required for format=json")
-	}
 	if cfg.TTL > 0 && !cfg.usesCache() {
 		return errdef.New(errdef.CodeHTTP, "ttl requires cache_key")
 	}
 	return nil
+}
+
+func effectiveFormat(cfg Config) Format {
+	if cfg.Format == "" {
+		return FormatText
+	}
+	return cfg.Format
+}
+
+func missingArgvError(cfg Config) error {
+	if cfg.usesCache() {
+		return errdef.New(
+			errdef.CodeHTTP,
+			"@auth command requires argv (include it once per cache_key to seed the cache)",
+		)
+	}
+	return errdef.New(errdef.CodeHTTP, "@auth command requires argv")
 }
 
 func isShell(cmd string) bool {

--- a/internal/authcmd/parse_test.go
+++ b/internal/authcmd/parse_test.go
@@ -21,11 +21,11 @@ func TestParse(t *testing.T) {
 			},
 			check: func(t *testing.T, cfg Config) {
 				t.Helper()
-				if cfg.Format != FormatText {
+				if effectiveFormat(cfg) != FormatText {
 					t.Fatalf("expected text format, got %q", cfg.Format)
 				}
-				if cfg.Header != "Authorization" {
-					t.Fatalf("expected Authorization header, got %q", cfg.Header)
+				if cfg.HeaderName() != "Authorization" {
+					t.Fatalf("expected Authorization header, got %q", cfg.HeaderName())
 				}
 				if got := len(cfg.Argv); got != 3 {
 					t.Fatalf("expected 3 argv entries, got %d", got)
@@ -63,6 +63,21 @@ func TestParse(t *testing.T) {
 				}
 				if cfg.Timeout != 3*time.Second {
 					t.Fatalf("expected timeout 3s, got %s", cfg.Timeout)
+				}
+			},
+		},
+		{
+			name: "cache only reuse",
+			params: map[string]string{
+				"cache_key": "github",
+			},
+			check: func(t *testing.T, cfg Config) {
+				t.Helper()
+				if len(cfg.Argv) != 0 {
+					t.Fatalf("expected argv to stay empty, got %#v", cfg.Argv)
+				}
+				if cfg.CacheKey != "github" {
+					t.Fatalf("expected cache key github, got %q", cfg.CacheKey)
 				}
 			},
 		},
@@ -168,6 +183,14 @@ func TestParseErrors(t *testing.T) {
 			want: "token_path is required",
 		},
 		{
+			name: "cache only json defers token path validation",
+			params: map[string]string{
+				"cache_key": "github",
+				"format":    "json",
+			},
+			want: "",
+		},
+		{
 			name: "ttl without cache key",
 			params: map[string]string{
 				"argv": `["gh","auth","token"]`,
@@ -212,6 +235,12 @@ func TestParseErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := Parse(tt.params, "")
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("Parse() unexpected error = %v", err)
+				}
+				return
+			}
 			if err == nil {
 				t.Fatal("expected error")
 			}

--- a/internal/parser/directive_parsers.go
+++ b/internal/parser/directive_parsers.go
@@ -270,7 +270,7 @@ func parseAuthSpec(rest string) *restfile.AuthSpec {
 			return nil
 		}
 		maps.Copy(params, parseKeyValuePairs(fields[1:]))
-		if params["argv"] == "" {
+		if params["argv"] == "" && params["cache_key"] == "" {
 			return nil
 		}
 	default:

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1491,6 +1491,22 @@ func TestParseCommandAuthSpecBareJSONArgv(t *testing.T) {
 	}
 }
 
+func TestParseCommandAuthSpecCacheOnly(t *testing.T) {
+	spec := parseAuthSpec(`command cache_key=github header=X-Token`)
+	if spec == nil {
+		t.Fatalf("expected command auth spec")
+	}
+	if spec.Type != "command" {
+		t.Fatalf("unexpected auth type %q", spec.Type)
+	}
+	if spec.Params["cache_key"] != "github" {
+		t.Fatalf("expected cache_key github, got %q", spec.Params["cache_key"])
+	}
+	if spec.Params["argv"] != "" {
+		t.Fatalf("expected argv to be empty, got %q", spec.Params["argv"])
+	}
+}
+
 func TestParseCompareDirective(t *testing.T) {
 	src := `# @name Compare
 # @compare dev stage prod base=stage

--- a/internal/ui/model_execution.go
+++ b/internal/ui/model_execution.go
@@ -2828,19 +2828,13 @@ func (m *Model) prepareExplainAuthPreview(
 			notes:   []string{"auth headers/query are applied during HTTP request build"},
 		}, nil
 	case "command":
-		if m.authCmd == nil {
-			return explainAuthPreviewResult{}, errdef.New(
-				errdef.CodeHTTP,
-				"command auth support is not initialised",
-			)
-		}
-
-		cfg, err := m.buildCommandAuthConfig(auth, resolver, 0)
+		prep, err := m.prepareCommandAuth(auth, resolver, envName, 0)
 		if err != nil {
 			return explainAuthPreviewResult{}, err
 		}
+		cfg := prep.Config()
 
-		header := cfg.Header
+		header := cfg.HeaderName()
 		if req.Headers != nil && req.Headers.Get(header) != "" {
 			return explainAuthPreviewResult{
 				status:  xplain.StageOK,
@@ -2849,8 +2843,10 @@ func (m *Model) prepareExplainAuthPreview(
 			}, nil
 		}
 
-		envKey := vars.SelectEnv(m.cfg.EnvironmentSet, envName, m.cfg.EnvironmentName)
-		res, ok := m.authCmd.Cached(envKey, cfg)
+		res, ok, err := m.authCmd.CachedPrepared(prep)
+		if err != nil {
+			return explainAuthPreviewResult{}, err
+		}
 		if !ok {
 			return explainAuthPreviewResult{
 				status:  xplain.StageSkipped,
@@ -2963,25 +2959,18 @@ func (m *Model) ensureCommandAuth(
 	if !strings.EqualFold(req.Metadata.Auth.Type, "command") {
 		return authcmd.Result{}, nil
 	}
-	if m.authCmd == nil {
-		return authcmd.Result{}, errdef.New(
-			errdef.CodeHTTP,
-			"command auth support is not initialised",
-		)
-	}
-
-	cfg, err := m.buildCommandAuthConfig(req.Metadata.Auth, resolver, timeout)
+	prep, err := m.prepareCommandAuth(req.Metadata.Auth, resolver, envName, timeout)
 	if err != nil {
 		return authcmd.Result{}, err
 	}
+	cfg := prep.Config()
 
-	header := cfg.Header
+	header := cfg.HeaderName()
 	if req.Headers != nil && req.Headers.Get(header) != "" {
 		return authcmd.Result{}, nil
 	}
 
-	envKey := vars.SelectEnv(m.cfg.EnvironmentSet, envName, m.cfg.EnvironmentName)
-	res, err := m.authCmd.Resolve(ctx, envKey, cfg)
+	res, err := m.authCmd.ResolvePrepared(ctx, prep)
 	if err != nil {
 		return authcmd.Result{}, errdef.Wrap(errdef.CodeHTTP, err, "resolve command auth")
 	}
@@ -2994,6 +2983,28 @@ func (m *Model) ensureCommandAuth(
 
 	req.Headers.Set(res.Header, res.Value)
 	return res, nil
+}
+
+func (m *Model) prepareCommandAuth(
+	auth *restfile.AuthSpec,
+	resolver *vars.Resolver,
+	envName string,
+	timeout time.Duration,
+) (authcmd.Prepared, error) {
+	if m.authCmd == nil {
+		return authcmd.Prepared{}, errdef.New(
+			errdef.CodeHTTP,
+			"command auth support is not initialised",
+		)
+	}
+
+	cfg, err := m.buildCommandAuthConfig(auth, resolver, timeout)
+	if err != nil {
+		return authcmd.Prepared{}, err
+	}
+
+	envKey := vars.SelectEnv(m.cfg.EnvironmentSet, envName, m.cfg.EnvironmentName)
+	return m.authCmd.Prepare(envKey, cfg)
 }
 
 func (m *Model) ensureOAuth(
@@ -3122,10 +3133,6 @@ func (m *Model) buildCommandAuthConfig(
 			}
 			cfg.Argv[i] = expanded
 		}
-	}
-	cfg, err = authcmd.Finalize(cfg)
-	if err != nil {
-		return cfg, err
 	}
 	return cfg.WithBaseTimeout(timeout), nil
 }

--- a/internal/ui/model_execution_test.go
+++ b/internal/ui/model_execution_test.go
@@ -1082,6 +1082,63 @@ func TestEnsureCommandAuthSkipsWhenHeaderPresent(t *testing.T) {
 	}
 }
 
+func TestEnsureCommandAuthCacheOnlyReuseInheritsSeededConfig(t *testing.T) {
+	var calls int32
+
+	model := Model{
+		cfg:         Config{EnvironmentName: "dev"},
+		authCmd:     authcmd.NewManager(),
+		globals:     newGlobalStore(),
+		currentFile: "/tmp/example.http",
+	}
+	model.authCmd.SetExecFunc(func(_ context.Context, _ authcmd.Config) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return []byte("token-basic"), nil
+	})
+
+	seedAuth := &restfile.AuthSpec{Type: "command", Params: map[string]string{
+		"argv":      `["gh","auth","token"]`,
+		"cache_key": "github",
+		"header":    "X-Registry-Token",
+		"scheme":    "Token",
+	}}
+	cacheOnlyAuth := &restfile.AuthSpec{Type: "command", Params: map[string]string{
+		"cache_key": "github",
+	}}
+
+	seedReq := &restfile.Request{Metadata: restfile.RequestMetadata{Auth: seedAuth}}
+	if _, err := model.ensureCommandAuth(
+		context.Background(),
+		seedReq,
+		vars.NewResolver(),
+		"",
+		time.Second,
+	); err != nil {
+		t.Fatalf("ensureCommandAuth seed: %v", err)
+	}
+
+	req := &restfile.Request{Metadata: restfile.RequestMetadata{Auth: cacheOnlyAuth}}
+	res, err := model.ensureCommandAuth(
+		context.Background(),
+		req,
+		vars.NewResolver(),
+		"",
+		time.Second,
+	)
+	if err != nil {
+		t.Fatalf("ensureCommandAuth cache-only: %v", err)
+	}
+	if got := req.Headers.Get("X-Registry-Token"); got != "Token token-basic" {
+		t.Fatalf("expected inherited seeded header, got %q", got)
+	}
+	if res.Header != "X-Registry-Token" || res.Value != "Token token-basic" {
+		t.Fatalf("unexpected command auth result %#v", res)
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("expected cache-only reuse to skip execution, got %d calls", calls)
+	}
+}
+
 func TestBuildCommandAuthConfigExpandsArgvAfterJSONDecode(t *testing.T) {
 	model := Model{
 		cfg:         Config{EnvironmentName: "dev"},
@@ -1126,6 +1183,8 @@ func TestPrepareExplainAuthPreviewCommandUsesCacheOnly(t *testing.T) {
 	auth := &restfile.AuthSpec{Type: "command", Params: map[string]string{
 		"argv":      `["gh","auth","token"]`,
 		"cache_key": "github",
+		"header":    "X-Registry-Token",
+		"scheme":    "Token",
 	}}
 
 	prime := &restfile.Request{Metadata: restfile.RequestMetadata{Auth: auth}}
@@ -1139,7 +1198,12 @@ func TestPrepareExplainAuthPreviewCommandUsesCacheOnly(t *testing.T) {
 		t.Fatalf("ensureCommandAuth prime: %v", err)
 	}
 
-	req := &restfile.Request{Metadata: restfile.RequestMetadata{Auth: auth}}
+	req := &restfile.Request{Metadata: restfile.RequestMetadata{Auth: &restfile.AuthSpec{
+		Type: "command",
+		Params: map[string]string{
+			"cache_key": "github",
+		},
+	}}}
 	preview, err := model.prepareExplainAuthPreview(req, vars.NewResolver(), "")
 	if err != nil {
 		t.Fatalf("prepareExplainAuthPreview: %v", err)
@@ -1150,7 +1214,7 @@ func TestPrepareExplainAuthPreviewCommandUsesCacheOnly(t *testing.T) {
 	if preview.summary != explainSummaryAuthPrepared {
 		t.Fatalf("expected auth prepared summary, got %q", preview.summary)
 	}
-	if got := req.Headers.Get("Authorization"); got != "Bearer token-basic" {
+	if got := req.Headers.Get("X-Registry-Token"); got != "Token token-basic" {
 		t.Fatalf("expected cached auth header, got %q", got)
 	}
 	if atomic.LoadInt32(&calls) != 1 {
@@ -1158,6 +1222,30 @@ func TestPrepareExplainAuthPreviewCommandUsesCacheOnly(t *testing.T) {
 	}
 	if len(preview.extraSecrets) == 0 {
 		t.Fatalf("expected preview secrets to include cached auth values")
+	}
+}
+
+func TestPrepareExplainAuthPreviewCommandCacheOnlyRequiresSeed(t *testing.T) {
+	model := Model{
+		cfg:     Config{EnvironmentName: "dev"},
+		authCmd: authcmd.NewManager(),
+		globals: newGlobalStore(),
+	}
+
+	req := &restfile.Request{
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{Type: "command", Params: map[string]string{
+				"cache_key": "github",
+			}},
+		},
+	}
+
+	_, err := model.prepareExplainAuthPreview(req, vars.NewResolver(), "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); !strings.Contains(got, "seed the cache") {
+		t.Fatalf("expected seed hint, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Previously every `@auth command` directive required the full `argv` config, even when multiple requests used the same CLI tool and cache key. This made `@patch`/`@apply` workflows verbose - you had to repeat the entire command spec on every request. 

This adds cache-only reuse for `@auth command`, mirroring the existing OAuth `cache_key`. A full directive seeds the cache once. Follow-up requests can reference just `cache_key` to inherit the stored command/extraction config.