### PR TITLE
RST-182: global auth scope

### DIFF
--- a/_examples/auth_command.http
+++ b/_examples/auth_command.http
@@ -1,5 +1,16 @@
+### Global Command Auth Default
+# @auth global command argv=["gh","auth","token"] cache_key=github-cli-global
+
 ### Reusable Command Auth Profile
 # @patch global githubCliAuth {auth: {type: "command", argv: '["gh","auth","token"]', cache_key: "github-cli"}}
+
+### GitHub CLI Token Via Global Auth
+# @name GitHubCLITokenGlobal
+# @tag auth command global
+# @description Inherits command-backed bearer auth from the global @auth directive above.
+GET https://api.github.com/user
+Accept: application/vnd.github+json
+X-GitHub-Api-Version: 2022-11-28
 
 ### GitHub CLI Token Via @apply
 # @name GitHubCLITokenPatched

--- a/_examples/auth_scopes.http
+++ b/_examples/auth_scopes.http
@@ -1,0 +1,36 @@
+# @global auth.globalToken demo-global-token
+# @global auth.fileToken demo-file-token
+
+# @auth global bearer {{auth.globalToken}}
+
+### Global Default Auth
+# @name AuthGlobalDefault
+# @tag auth scopes global
+# @description Inherits the global default because no file-scoped auth has been defined yet.
+GET https://httpbin.org/anything/auth/global-default
+Accept: application/json
+
+# @auth file bearer {{auth.fileToken}}
+
+### File Default Auth
+# @name AuthFileDefault
+# @tag auth scopes file
+# @description Inherits the file default, which overrides the earlier global default for later requests in this document.
+GET https://httpbin.org/anything/auth/file-default
+Accept: application/json
+
+### Explicit Request Override
+# @name AuthRequestOverride
+# @tag auth scopes request
+# @description Uses explicit request-scoped auth instead of the inherited file default.
+# @auth request bearer request-token-{{$uuid}}
+GET https://httpbin.org/anything/auth/request-override
+Accept: application/json
+
+### Disable Inherited Auth
+# @name AuthNone
+# @tag auth scopes none
+# @description Disables inherited auth for this request with @auth none.
+# @auth none
+GET https://httpbin.org/anything/auth/no-auth
+Accept: application/json

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -1725,7 +1725,8 @@ Explore `_examples/` for ready-to-run:
 - `graphql.http` - inline and file-based GraphQL requests.
 - `grpc.http` - gRPC reflection and descriptor usage.
 - `k8s.http` - Kubernetes profile scopes, non-pod targets, named ports, and gRPC over `@k8s`.
-- `auth_command.http` - command-backed auth with `gh auth token`, JSON output parsing, and custom header examples.
+- `auth_scopes.http` - default auth inheritance across global/file/request scopes plus `@auth none`.
+- `auth_command.http` - command-backed auth with global defaults, `gh auth token`, patch-based reuse, JSON output parsing, and custom header examples.
 - `oauth2.http` - manual capture vs using the `@auth oauth2` directive.
 - `transport.http` - timeout, proxy, and `@no-log` samples.
 - `compare.http` - demonstrates `@compare` directives and CLI-triggered multi-environment sweeps.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -874,6 +874,14 @@ Handshake failures surface the HTTP response so upgrade issues are easy to debug
 | Command | `# @auth command argv=["gh","auth","token"]` | Runs a non-interactive command without a shell, parses `stdout`, and injects a header during auth preparation. |
 | OAuth 2.0 | `# @auth oauth2 token_url=... client_id=...` | Built-in token acquisition and caching (client_credentials/password/authorization_code + PKCE). |
 
+Scopes:
+
+- Bare `@auth ...` is request-scoped.
+- `@auth request ...` is an explicit request-scoped form.
+- `@auth file ...` defines inherited auth for later requests in the same document.
+- `@auth global ...` defines workspace-global inherited auth; file-scoped auth wins when both exist.
+- `@auth none` disables inherited auth for the current request.
+
 #### OAuth 2.0 parameters
 
 | Parameter | Required | Default | Description |
@@ -1191,6 +1199,19 @@ Example test block:
 
 Use `@auth bearer {{token}}` or `Authorization: Bearer {{token}}` headers. Combine with `@global` or environment values for reuse.
 
+When you want one auth definition to apply to many requests, scope it:
+
+```http
+# @auth file bearer {{auth.token}}
+
+### Inherits file auth
+GET {{base.url}}/profile
+
+### Opt out for one request
+# @auth none
+GET {{base.url}}/public
+```
+
 ### Captured tokens
 
 Capture values at runtime and reuse them in subsequent requests:
@@ -1309,6 +1330,22 @@ When `header` is set to something other than `Authorization`, Resterm injects ju
 ### Command-backed auth
 
 Use `@auth command` when your existing CLI already knows how reterive or print tokens.
+
+To apply command auth to every request in a file, define it once with file scope:
+
+```http
+# @auth file command argv=["gh","auth","token"] cache_key=github-cli
+
+### User
+GET https://api.github.com/user
+
+### Repos
+GET https://api.github.com/user/repos
+
+### Public endpoint without inherited auth
+# @auth none
+GET https://api.github.com/rate_limit
+```
 
 ```http
 ### Seed a reusable command-auth slot

--- a/internal/parser/comment_handlers.go
+++ b/internal/parser/comment_handlers.go
@@ -36,6 +36,9 @@ func (b *documentBuilder) handleComment(line int, text string) {
 	if b.handleConstDirective(line, key, rest) {
 		return
 	}
+	if b.handleAuthDirective(line, key, rest) {
+		return
+	}
 	if b.handleSSHDirective(line, key, rest) {
 		return
 	}
@@ -119,6 +122,54 @@ func (b *documentBuilder) handleConstDirective(line int, key, rest string) bool 
 	if name, value := parseNameValue(rest); name != "" {
 		b.addConstant(name, value, line)
 	}
+	return true
+}
+
+func (b *documentBuilder) handleAuthDirective(line int, key, rest string) bool {
+	if key != "auth" {
+		return false
+	}
+
+	dir, ok, err := parseAuthDirective(rest)
+	if !ok {
+		return true
+	}
+	if err != nil {
+		b.addError(line, err.Error())
+		return true
+	}
+
+	switch dir.Scope {
+	case restfile.AuthScopeFile, restfile.AuthScopeGlobal:
+		if b.inRequest {
+			b.addError(
+				line,
+				"@auth "+restfile.AuthScopeLabel(dir.Scope)+" scope must be declared outside a request",
+			)
+			return true
+		}
+		if dir.Disable || dir.Spec == nil {
+			return true
+		}
+		b.authDefs = append(b.authDefs, restfile.AuthProfile{
+			Scope: dir.Scope,
+			Name:  dir.Name,
+			Spec:  restfile.CloneAuthSpecValue(*dir.Spec),
+			Line:  line,
+		})
+	case restfile.AuthScopeRequest:
+		b.ensureRequest(line)
+		if dir.Disable {
+			b.request.metadata.Auth = nil
+			b.request.metadata.AuthDisabled = true
+			return true
+		}
+		if dir.Spec != nil {
+			b.request.metadata.Auth = restfile.CloneAuthSpec(dir.Spec)
+			b.request.metadata.AuthDisabled = false
+		}
+	}
+
 	return true
 }
 
@@ -229,12 +280,6 @@ func (b *documentBuilder) handleRequestMetadataDirective(line int, key, rest str
 		}
 		if value, ok := parseBool(rest); ok {
 			b.request.metadata.AllowSensitiveHeaders = value
-		}
-		return true
-	case "auth":
-		spec := parseAuthSpec(rest)
-		if spec != nil {
-			b.request.metadata.Auth = spec
 		}
 		return true
 	case "settings":

--- a/internal/parser/directive_parsers.go
+++ b/internal/parser/directive_parsers.go
@@ -228,6 +228,75 @@ func parseCaptureScope(token string) (restfile.CaptureScope, bool, bool) {
 	}
 }
 
+type authDirective struct {
+	Scope   restfile.AuthScope
+	Name    string
+	Spec    *restfile.AuthSpec
+	Disable bool
+}
+
+func parseAuthDirective(rest string) (authDirective, bool, error) {
+	dir := authDirective{Scope: restfile.AuthScopeRequest}
+	trimmed := strings.TrimSpace(rest)
+	if trimmed == "" {
+		return dir, false, nil
+	}
+
+	fields := tokenizeFields(trimmed)
+	if len(fields) == 0 {
+		return dir, false, nil
+	}
+
+	explicitScope := false
+	if scope, ok := parseAuthScope(fields[0]); ok {
+		dir.Scope = scope
+		explicitScope = true
+		fields = fields[1:]
+		if len(fields) == 0 {
+			return dir, true, fmt.Errorf(
+				"@auth %s scope requires an auth spec",
+				restfile.AuthScopeLabel(scope),
+			)
+		}
+	}
+
+	if strings.EqualFold(fields[0], "none") {
+		if dir.Scope != restfile.AuthScopeRequest {
+			return dir, true, fmt.Errorf(
+				"@auth %s scope does not support none",
+				restfile.AuthScopeLabel(dir.Scope),
+			)
+		}
+		if len(fields) != 1 {
+			return dir, true, fmt.Errorf("@auth none does not accept additional tokens")
+		}
+		dir.Disable = true
+		return dir, true, nil
+	}
+
+	spec := parseAuthSpec(strings.Join(fields, " "))
+	if spec == nil {
+		if explicitScope {
+			return dir, true, fmt.Errorf(
+				"@auth %s scope requires a valid auth spec",
+				restfile.AuthScopeLabel(dir.Scope),
+			)
+		}
+		return dir, false, nil
+	}
+	dir.Spec = spec
+	return dir, true, nil
+}
+
+func parseAuthScope(token string) (restfile.AuthScope, bool) {
+	return parseDirectiveScope(
+		token,
+		restfile.AuthScopeRequest,
+		restfile.AuthScopeFile,
+		restfile.AuthScopeGlobal,
+	)
+}
+
 func parseAuthSpec(rest string) *restfile.AuthSpec {
 	fields := tokenizeFields(rest)
 	if len(fields) == 0 {

--- a/internal/parser/document_builder.go
+++ b/internal/parser/document_builder.go
@@ -23,6 +23,7 @@ type documentBuilder struct {
 	globalVars           []restfile.Variable
 	fileSettings         map[string]string
 	consts               []restfile.Constant
+	authDefs             []restfile.AuthProfile
 	sshDefs              []restfile.SSHProfile
 	k8sDefs              []restfile.K8sProfile
 	patchDefs            []restfile.PatchProfile
@@ -697,6 +698,7 @@ func (b *documentBuilder) finish() {
 	b.doc.Variables = append(b.doc.Variables, b.fileVars...)
 	b.doc.Globals = append(b.doc.Globals, b.globalVars...)
 	b.doc.Constants = append(b.doc.Constants, b.consts...)
+	b.doc.Auth = append(b.doc.Auth, b.authDefs...)
 	b.doc.Uses = append(b.doc.Uses, b.fileUses...)
 	b.doc.SSH = append(b.doc.SSH, b.sshDefs...)
 	b.doc.K8s = append(b.doc.K8s, b.k8sDefs...)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -77,6 +77,81 @@ GET https://example.com/api
 	}
 }
 
+func TestParseFileScopedAuthDirective(t *testing.T) {
+	src := `# @auth file command argv=["gh","auth","token"] cache_key=github
+GET https://example.com
+`
+
+	doc := Parse("file-auth.http", []byte(src))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("expected no parse errors, got %v", doc.Errors)
+	}
+	if len(doc.Auth) != 1 {
+		t.Fatalf("expected 1 auth profile, got %d", len(doc.Auth))
+	}
+	prof := doc.Auth[0]
+	if prof.Scope != restfile.AuthScopeFile {
+		t.Fatalf("expected file scope, got %v", prof.Scope)
+	}
+	if prof.Spec.Type != "command" {
+		t.Fatalf("expected command auth type, got %q", prof.Spec.Type)
+	}
+	if prof.Spec.Params["cache_key"] != "github" {
+		t.Fatalf("expected cache_key github, got %q", prof.Spec.Params["cache_key"])
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	if doc.Requests[0].Metadata.Auth != nil {
+		t.Fatalf("expected request auth to remain unset until execution")
+	}
+}
+
+func TestParseRequestAuthNone(t *testing.T) {
+	src := `# @auth none
+GET https://example.com
+`
+
+	doc := Parse("request-auth-none.http", []byte(src))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("expected no parse errors, got %v", doc.Errors)
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if req.Metadata.Auth != nil {
+		t.Fatalf("expected request auth to be cleared")
+	}
+	if !req.Metadata.AuthDisabled {
+		t.Fatalf("expected request auth to be explicitly disabled")
+	}
+}
+
+func TestParseExplicitRequestScopedAuth(t *testing.T) {
+	src := `# @auth request bearer token-123
+GET https://example.com
+`
+
+	doc := Parse("request-auth-explicit.http", []byte(src))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("expected no parse errors, got %v", doc.Errors)
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if req.Metadata.Auth == nil {
+		t.Fatalf("expected request auth metadata")
+	}
+	if req.Metadata.Auth.Type != "bearer" {
+		t.Fatalf("expected bearer auth, got %q", req.Metadata.Auth.Type)
+	}
+	if req.Metadata.AuthDisabled {
+		t.Fatalf("expected auth disable flag to remain false")
+	}
+}
+
 func TestParseMethodLineWithHTTPVersion(t *testing.T) {
 	src := `###
 

--- a/internal/restfile/auth.go
+++ b/internal/restfile/auth.go
@@ -1,0 +1,55 @@
+package restfile
+
+import "strings"
+
+func CloneAuthSpec(auth *AuthSpec) *AuthSpec {
+	if auth == nil {
+		return nil
+	}
+	cp := *auth
+	cp.Params = cloneAuthParams(auth.Params)
+	return &cp
+}
+
+func CloneAuthSpecValue(auth AuthSpec) AuthSpec {
+	cp := auth
+	cp.Params = cloneAuthParams(auth.Params)
+	return cp
+}
+
+func AuthScopeLabel(scope AuthScope) string {
+	switch scope {
+	case AuthScopeRequest:
+		return "request"
+	case AuthScopeFile:
+		return "file"
+	case AuthScopeGlobal:
+		return "global"
+	default:
+		return strings.ToLower(strings.TrimSpace(scope.String()))
+	}
+}
+
+func (s AuthScope) String() string {
+	switch s {
+	case AuthScopeRequest:
+		return "request"
+	case AuthScopeFile:
+		return "file"
+	case AuthScopeGlobal:
+		return "global"
+	default:
+		return "unknown"
+	}
+}
+
+func cloneAuthParams(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -37,6 +37,21 @@ type AuthSpec struct {
 	Params map[string]string
 }
 
+type AuthScope int
+
+const (
+	AuthScopeRequest AuthScope = iota
+	AuthScopeFile
+	AuthScopeGlobal
+)
+
+type AuthProfile struct {
+	Scope AuthScope
+	Name  string
+	Spec  AuthSpec
+	Line  int
+}
+
 type ScriptBlock struct {
 	Kind     string
 	Lang     string
@@ -199,6 +214,7 @@ type RequestMetadata struct {
 	NoLog                 bool
 	AllowSensitiveHeaders bool
 	Auth                  *AuthSpec
+	AuthDisabled          bool
 	Scripts               []ScriptBlock
 	Uses                  []UseSpec
 	Applies               []ApplySpec
@@ -353,6 +369,7 @@ type Document struct {
 	Variables []Variable
 	Globals   []Variable
 	Constants []Constant
+	Auth      []AuthProfile
 	SSH       []SSHProfile
 	K8s       []K8sProfile
 	Patches   []PatchProfile

--- a/internal/ui/auth_store.go
+++ b/internal/ui/auth_store.go
@@ -1,0 +1,27 @@
+package ui
+
+import "github.com/unkn0wn-root/resterm/internal/restfile"
+
+type authStore struct {
+	st *namedStore[restfile.AuthProfile]
+}
+
+func newAuthStore() *authStore {
+	ok := func(p restfile.AuthProfile) bool { return p.Scope == restfile.AuthScopeGlobal }
+	nm := func(p restfile.AuthProfile) string { return p.Name }
+	return &authStore{st: newNamedStore(ok, nm)}
+}
+
+func (s *authStore) set(p string, xs []restfile.AuthProfile) {
+	if s == nil || s.st == nil {
+		return
+	}
+	s.st.set(p, xs)
+}
+
+func (s *authStore) all() []restfile.AuthProfile {
+	if s == nil || s.st == nil {
+		return nil
+	}
+	return s.st.all()
+}

--- a/internal/ui/hint/metadata.go
+++ b/internal/ui/hint/metadata.go
@@ -112,6 +112,28 @@ var workflowRunHints = []Hint{
 var metaSub = map[string][]Hint{
 	"auth": {
 		{
+			Label:      "request",
+			Summary:    "Make the auth directive explicitly request-scoped",
+			Insert:     "request bearer {{token}}",
+			CursorBack: len("bearer {{token}}"),
+		},
+		{
+			Label:      "file",
+			Summary:    "Define auth inherited by later requests in this file",
+			Insert:     "file bearer {{token}}",
+			CursorBack: len("bearer {{token}}"),
+		},
+		{
+			Label:      "global",
+			Summary:    "Define auth inherited across the workspace",
+			Insert:     "global bearer {{token}}",
+			CursorBack: len("bearer {{token}}"),
+		},
+		{
+			Label:   "none",
+			Summary: "Disable inherited auth for the current request",
+		},
+		{
 			Label:      "basic",
 			Summary:    "Basic auth with username and password",
 			Insert:     "basic user pass",

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -184,6 +184,7 @@ type Model struct {
 	grpcOptions        grpcclient.Options
 	sshMgr             *ssh.Manager
 	sshGlobals         *namedStore[restfile.SSHProfile]
+	authGlobals        *authStore
 	k8sMgr             *k8s.Manager
 	k8sGlobals         *namedStore[restfile.K8sProfile]
 	patchGlobals       *patchStore
@@ -614,6 +615,7 @@ func New(cfg Config) Model {
 		k8sMgr = k8s.NewManager()
 	}
 	sshGlobals := newSSHStore()
+	authGlobals := newAuthStore()
 	k8sGlobals := newK8sStore()
 	patchGlobals := newPatchStore()
 
@@ -635,6 +637,7 @@ func New(cfg Config) Model {
 		grpcOptions:            cfg.GRPCOptions,
 		sshMgr:                 sshMgr,
 		sshGlobals:             sshGlobals,
+		authGlobals:            authGlobals,
 		k8sMgr:                 k8sMgr,
 		k8sGlobals:             k8sGlobals,
 		patchGlobals:           patchGlobals,

--- a/internal/ui/model_exec_auth.go
+++ b/internal/ui/model_exec_auth.go
@@ -126,6 +126,44 @@ func commandAuthSecrets(res authcmd.Result) []string {
 	}
 }
 
+func lookupDefaultAuthProfile(
+	xs []restfile.AuthProfile,
+	scope restfile.AuthScope,
+) (*restfile.AuthProfile, bool) {
+	for i := len(xs) - 1; i >= 0; i-- {
+		profile := &xs[i]
+		if profile.Scope != scope {
+			continue
+		}
+		if strings.TrimSpace(profile.Name) != "" {
+			continue
+		}
+		return profile, true
+	}
+	return nil, false
+}
+
+func (m *Model) resolveInheritedAuth(doc *restfile.Document, req *restfile.Request) {
+	if req == nil || req.Metadata.Auth != nil || req.Metadata.AuthDisabled {
+		return
+	}
+
+	if profile, ok := lookupDefaultAuthProfile(docAuthProfiles(doc), restfile.AuthScopeFile); ok {
+		req.Metadata.Auth = restfile.CloneAuthSpec(&profile.Spec)
+		return
+	}
+	if profile, ok := lookupDefaultAuthProfile(docAuthProfiles(doc), restfile.AuthScopeGlobal); ok {
+		req.Metadata.Auth = restfile.CloneAuthSpec(&profile.Spec)
+		return
+	}
+	if m.authGlobals == nil {
+		return
+	}
+	if profile, ok := lookupDefaultAuthProfile(m.authGlobals.all(), restfile.AuthScopeGlobal); ok {
+		req.Metadata.Auth = restfile.CloneAuthSpec(&profile.Spec)
+	}
+}
+
 func (m *Model) prepareExplainAuthPreview(
 	req *restfile.Request,
 	resolver *vars.Resolver,

--- a/internal/ui/model_exec_request.go
+++ b/internal/ui/model_exec_request.go
@@ -85,6 +85,7 @@ func cloneRequest(req *restfile.Request) *restfile.Request {
 
 	clone.Variables = append([]restfile.Variable(nil), req.Variables...)
 	clone.Metadata.Tags = append([]string(nil), req.Metadata.Tags...)
+	clone.Metadata.Auth = restfile.CloneAuthSpec(req.Metadata.Auth)
 	clone.Metadata.Scripts = append([]restfile.ScriptBlock(nil), req.Metadata.Scripts...)
 	clone.Metadata.Uses = append([]restfile.UseSpec(nil), req.Metadata.Uses...)
 	if len(req.Metadata.Applies) > 0 {

--- a/internal/ui/model_exec_run.go
+++ b/internal/ui/model_exec_run.go
@@ -407,6 +407,7 @@ func (e *execContext) evaluateCondition() *responseMsg {
 }
 
 func (e *execContext) runPreRequestScripts() *responseMsg {
+	e.model.resolveInheritedAuth(e.doc, e.req)
 	preVars := cloneStringMap(e.baseVars)
 	applyBefore := cloneRequestIf(e.req, len(e.req.Metadata.Applies) > 0)
 	if err := e.model.runRTSApply(

--- a/internal/ui/model_exec_test.go
+++ b/internal/ui/model_exec_test.go
@@ -737,6 +737,119 @@ func TestResolveRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPRequestUsesInheritedFileAuth(t *testing.T) {
+	model := Model{
+		cfg:         Config{EnvironmentName: "dev"},
+		globals:     newGlobalStore(),
+		authGlobals: newAuthStore(),
+	}
+	doc := &restfile.Document{
+		Path: "/tmp/inherited-auth.http",
+		Auth: []restfile.AuthProfile{{
+			Scope: restfile.AuthScopeFile,
+			Spec: restfile.AuthSpec{
+				Type:   "bearer",
+				Params: map[string]string{"token": "file-token"},
+			},
+			Line: 1,
+		}},
+	}
+	req := &restfile.Request{
+		Method:    "GET",
+		URL:       "https://example.com",
+		LineRange: restfile.LineRange{Start: 2, End: 3},
+	}
+
+	exec := newExecContext(&model, doc, req, httpclient.Options{}, "", false, nil, nil)
+	if msg := exec.runPreRequestScripts(); msg != nil {
+		t.Fatalf("runPreRequestScripts: %v", msg.err)
+	}
+	exec.buildResolver()
+
+	client := httpclient.NewClient(nil)
+	httpReq, _, _, err := client.BuildHTTPRequest(
+		context.Background(),
+		req,
+		exec.resolver,
+		httpclient.Options{},
+	)
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+	if got := httpReq.Header.Get("Authorization"); got != "Bearer file-token" {
+		t.Fatalf("expected inherited bearer header, got %q", got)
+	}
+}
+
+func TestResolveInheritedAuthUsesGlobalFallback(t *testing.T) {
+	model := Model{
+		cfg:         Config{EnvironmentName: "dev"},
+		globals:     newGlobalStore(),
+		authGlobals: newAuthStore(),
+	}
+	model.authGlobals.set("/tmp/other.http", []restfile.AuthProfile{{
+		Scope: restfile.AuthScopeGlobal,
+		Spec: restfile.AuthSpec{
+			Type:   "bearer",
+			Params: map[string]string{"token": "global-token"},
+		},
+		Line: 1,
+	}})
+
+	req := &restfile.Request{}
+	model.resolveInheritedAuth(&restfile.Document{Path: "/tmp/current.http"}, req)
+
+	if req.Metadata.Auth == nil {
+		t.Fatalf("expected inherited global auth")
+	}
+	if got := req.Metadata.Auth.Params["token"]; got != "global-token" {
+		t.Fatalf("expected global token, got %q", got)
+	}
+}
+
+func TestRunPreRequestScriptsApplyCanClearInheritedAuth(t *testing.T) {
+	model := Model{
+		cfg:          Config{EnvironmentName: "dev"},
+		globals:      newGlobalStore(),
+		authGlobals:  newAuthStore(),
+		patchGlobals: newPatchStore(),
+	}
+	doc := &restfile.Document{
+		Path: "/tmp/inherited-auth-apply.http",
+		Auth: []restfile.AuthProfile{{
+			Scope: restfile.AuthScopeFile,
+			Spec: restfile.AuthSpec{
+				Type:   "bearer",
+				Params: map[string]string{"token": "file-token"},
+			},
+			Line: 1,
+		}},
+	}
+	req := &restfile.Request{
+		Method:    "GET",
+		URL:       "https://example.com",
+		LineRange: restfile.LineRange{Start: 2, End: 4},
+		Metadata: restfile.RequestMetadata{
+			Applies: []restfile.ApplySpec{{
+				Expression: `{auth: null}`,
+				Line:       2,
+				Col:        1,
+			}},
+		},
+	}
+
+	exec := newExecContext(&model, doc, req, httpclient.Options{}, "", false, nil, nil)
+	if msg := exec.runPreRequestScripts(); msg != nil {
+		t.Fatalf("runPreRequestScripts: %v", msg.err)
+	}
+	if req.Metadata.Auth != nil {
+		t.Fatalf("expected @apply to clear inherited auth")
+	}
+	if !req.Metadata.AuthDisabled {
+		t.Fatalf("expected cleared inherited auth to stay disabled for this execution")
+	}
+}
+
 func TestEnsureOAuthSetsAuthorizationHeader(t *testing.T) {
 	var calls int32
 	var lastAuth string

--- a/internal/ui/model_exec_vars.go
+++ b/internal/ui/model_exec_vars.go
@@ -318,6 +318,14 @@ func (m *Model) syncSSHGlobals(doc *restfile.Document) {
 	m.sshGlobals.set(path, docSSHProfiles(doc))
 }
 
+func (m *Model) syncAuthGlobals(doc *restfile.Document) {
+	if m.authGlobals == nil {
+		return
+	}
+	path := m.documentRuntimePath(doc)
+	m.authGlobals.set(path, docAuthProfiles(doc))
+}
+
 func (m *Model) syncK8sGlobals(doc *restfile.Document) {
 	if m.k8sGlobals == nil {
 		return
@@ -331,6 +339,13 @@ func docSSHProfiles(doc *restfile.Document) []restfile.SSHProfile {
 		return nil
 	}
 	return doc.SSH
+}
+
+func docAuthProfiles(doc *restfile.Document) []restfile.AuthProfile {
+	if doc == nil {
+		return nil
+	}
+	return doc.Auth
 }
 
 func docK8sProfiles(doc *restfile.Document) []restfile.K8sProfile {
@@ -350,6 +365,7 @@ func (m *Model) syncPatchGlobals(doc *restfile.Document) {
 
 func (m *Model) syncAllGlobals(doc *restfile.Document) {
 	m.syncSSHGlobals(doc)
+	m.syncAuthGlobals(doc)
 	m.syncK8sGlobals(doc)
 	m.syncPatchGlobals(doc)
 }

--- a/internal/ui/rts_apply.go
+++ b/internal/ui/rts_apply.go
@@ -392,17 +392,11 @@ func applyPatchAuth(req *restfile.Request, a *restfile.AuthSpec, set bool) {
 	}
 	if a == nil {
 		req.Metadata.Auth = nil
+		req.Metadata.AuthDisabled = true
 		return
 	}
-	cp := *a
-	if len(a.Params) > 0 {
-		pm := make(map[string]string, len(a.Params))
-		for k, v := range a.Params {
-			pm[k] = v
-		}
-		cp.Params = pm
-	}
-	req.Metadata.Auth = &cp
+	req.Metadata.Auth = restfile.CloneAuthSpec(a)
+	req.Metadata.AuthDisabled = false
 }
 
 func applyPatchSettings(req *restfile.Request, in map[string]*string) {


### PR DESCRIPTION
- Add scoped `@auth` directives (request, file, global) that let a single auth definition apply to many requests
- Add `@auth none` to opt individual requests out of inherited auth
- File scoped auth overrides global scoped auth; explicit request-scoped auth overrides both; `@auth` none disables all inheritance