### PR TITLE
RST-183: websocket key bindings and ws persistance fix

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -142,7 +142,7 @@ Once the files exist, run `resterm` in the same directory to open the workspace.
 | Cycle focus (navigator -> editor -> response) | `Tab` / `Shift+Tab` |
 | Focus navigator / editor / response panes | `g+r` / `g+i` / `g+p` |
 | Open timeline tab | `Ctrl+Alt+L` (or `g+t`) |
-| Toggle WebSocket console (Stream tab) | `Ctrl+I` |
+| WebSocket commands (Stream tab) | `g+w`, then `i`/`p`/`c`/`l` |
 | Adjust sidebar or editor width | `g+h` / `g+l` (contextual) |
 | Collapse / expand current navigator branch | `g+j` / `g+k` |
 | Collapse all / expand all in navigator | `g+Shift+J` / `g+Shift+K` |
@@ -226,7 +226,7 @@ send_request = ["ctrl+enter", "cmd+enter"]
 | `focus_requests` / `focus_response` / `focus_editor_normal` | Jump directly to a pane. | `g r`, `g p`, `g i` | ✗ |
 | `set_main_split_horizontal` / `set_main_split_vertical` | Stack vs side-by-side editor/response. | `g s`, `g v` | ✗ |
 | `start_compare_run` | Trigger compare sweep for the current request. | `g c` | ✗ |
-| `toggle_ws_console` | Toggle the WebSocket console. | `g w` | ✗ |
+| `toggle_ws_console` | Enter WebSocket command mode (`i` console, `p` ping, `c` close, `l` clear). | `g w` | ✗ |
 | `toggle_sidebar_collapse` / `toggle_editor_collapse` / `toggle_response_collapse` | Collapse/expand panes. | `g 1`, `g 2`, `g 3` | ✗ |
 | `toggle_zoom` / `clear_zoom` | Zoom current region / clear zoom. | `g z`, `g shift+z` | ✗ |
 
@@ -243,7 +243,7 @@ send_request = ["ctrl+enter", "cmd+enter"]
 - **Diff**: compare the focused pane against the other response pane.
 - **History**: chronological responses for the selected request (live updates). Open a full JSON preview with `p` or delete the focused entry with `d`.
 
-When a request opens a stream, the Stream tab becomes available. Use `Ctrl+I` to reveal the WebSocket console inside the Stream tab, `F2` to switch payload modes (text, JSON, base64, file), `Ctrl+S` or `Ctrl+Enter` to send frames, arrow keys to replay recent payloads, `Ctrl+P` to send ping, and `Ctrl+W` to close the session.
+When a request opens a stream, the Stream tab becomes available. Use `g+w` to enter WebSocket command mode, then press `i` to toggle the console, `p` to send ping, `c` to close the socket, or `l` to clear the live buffer. If the console is actively focused for typing, press `Esc` first so text entry is not interrupted. Inside the console, use `F2` to switch payload modes (text, JSON, base64, file), `Ctrl+S` or `Ctrl+Enter` to send frames, and the arrow keys to replay recent payloads.
 
 Use `Ctrl+V` or `Ctrl+U` to split the response pane. The secondary pane can be pinned so subsequent calls populate only the primary pane, making comparisons easy.
 
@@ -860,7 +860,7 @@ Handshake failures surface the HTTP response so upgrade issues are easy to debug
 ### Stream tab, history, and console
 
 - The Stream tab appears automatically whenever a streaming session is active. Scroll to review frames, press `b` to bookmark important events, and switch tabs with the arrow keys (`Ctrl+H` / `Ctrl+L`).
-- Toggle the interactive WebSocket console with `Ctrl+I` while the Stream tab is focused. Cycle payload modes with `F2` (text → JSON → base64 → file), send payloads with `Ctrl+S` or `Ctrl+Enter`, reuse previous payloads with the arrow keys, issue ping frames via `Ctrl+P`, close gracefully with `Ctrl+W`, and clear the live buffer with `Ctrl+L`.
+- While the Stream tab is focused, use `g+w` then `i` to toggle the interactive WebSocket console, `p` to send ping, `c` to close gracefully, or `l` to clear the live buffer. If the console is focused for typing, press `Esc` first. Inside the console, cycle payload modes with `F2`, send payloads with `Ctrl+S` or `Ctrl+Enter`, and reuse previous payloads with the arrow keys.
 - Completed transcripts are saved alongside the request in history with summary headers (`X-Resterm-Stream-Type`, `X-Resterm-Stream-Summary`). Scripts and captures can access the same data via `stream.*` templates and APIs (see [Scripting](#scripting-api)).
 
 ### Authentication directives

--- a/internal/parser/comment_handlers.go
+++ b/internal/parser/comment_handlers.go
@@ -144,7 +144,9 @@ func (b *documentBuilder) handleAuthDirective(line int, key, rest string) bool {
 		if b.inRequest {
 			b.addError(
 				line,
-				"@auth "+restfile.AuthScopeLabel(dir.Scope)+" scope must be declared outside a request",
+				"@auth "+restfile.AuthScopeLabel(
+					dir.Scope,
+				)+" scope must be declared outside a request",
 			)
 			return true
 		}

--- a/internal/ui/model_console.go
+++ b/internal/ui/model_console.go
@@ -485,7 +485,7 @@ func (m *Model) armWebSocketCommandMode() tea.Cmd {
 	}
 	m.wsCommandChord = true
 	m.setStatusMessage(statusMsg{
-		text:  "WebSocket commands: i console, p ping, c close, l clear, Esc cancel",
+		text:  "WebSocket: [i] console | [p] ping | [c] close | [l] clear | [Esc] cancel",
 		level: statusInfo,
 	})
 	return m.focusStreamPane()

--- a/internal/ui/model_console.go
+++ b/internal/ui/model_console.go
@@ -397,9 +397,6 @@ func (m *Model) ensureWebSocketConsole(
 func (m *Model) handleWebSocketConsoleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	key := msg.String()
 	sessionID := m.sessionIDForRequest(m.currentRequest)
-	if key == "ctrl+i" || key == "ctrl+alt+i" || key == "alt+ctrl+i" {
-		return m.toggleWebSocketConsole(), true
-	}
 
 	console := m.wsConsole
 	if console == nil || console.sessionID != sessionID {
@@ -436,15 +433,6 @@ func (m *Model) handleWebSocketConsoleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		console.clearStatus()
 		m.refreshStreamPanes()
 		return nil, true
-	case "ctrl+p":
-		console.clearStatus()
-		return m.sendConsolePing(), true
-	case "ctrl+w":
-		console.clearStatus()
-		return m.sendConsoleClose(), true
-	case "ctrl+l":
-		console.clearStatus()
-		return m.clearStreamBufferCmd(), true
 	case "up":
 		if console.historyPrev() {
 			console.clearStatus()
@@ -467,6 +455,63 @@ func (m *Model) handleWebSocketConsoleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	console.input = updated
 	m.refreshStreamPanes()
 	return cmd, true
+}
+
+func (m *Model) websocketConsoleCapturesInput() bool {
+	if m == nil || m.focus != focusResponse {
+		return false
+	}
+	console := m.wsConsole
+	if console == nil || !console.active {
+		return false
+	}
+	pane := m.pane(responsePanePrimary)
+	if pane == nil || pane.activeTab != responseTabStream {
+		return false
+	}
+	sessionID := m.sessionIDForRequest(m.currentRequest)
+	if sessionID == "" {
+		return false
+	}
+	return console.sessionID == sessionID
+}
+
+func (m *Model) armWebSocketCommandMode() tea.Cmd {
+	sessionID := m.sessionIDForRequest(m.currentRequest)
+	if sessionID == "" {
+		m.wsCommandChord = false
+		m.setStatusMessage(statusMsg{text: "No active websocket stream", level: statusWarn})
+		return nil
+	}
+	m.wsCommandChord = true
+	m.setStatusMessage(statusMsg{
+		text:  "WebSocket commands: i console, p ping, c close, l clear, Esc cancel",
+		level: statusInfo,
+	})
+	return m.focusStreamPane()
+}
+
+func (m *Model) handleWebSocketCommandChord(msg tea.KeyMsg) (tea.Cmd, bool) {
+	if !m.wsCommandChord {
+		return nil, false
+	}
+	m.wsCommandChord = false
+
+	switch msg.String() {
+	case "esc":
+		m.setStatusMessage(statusMsg{text: "WebSocket command canceled", level: statusInfo})
+		return nil, true
+	case "i":
+		return m.toggleWebSocketConsole(), true
+	case "p":
+		return m.sendConsolePing(), true
+	case "c":
+		return m.sendConsoleClose(), true
+	case "l":
+		return m.clearStreamBufferCmd(), true
+	default:
+		return nil, false
+	}
 }
 
 func (m *Model) toggleWebSocketConsole() tea.Cmd {

--- a/internal/ui/model_console.go
+++ b/internal/ui/model_console.go
@@ -220,7 +220,7 @@ func (wc *websocketConsole) view(width int, th theme.Theme) string {
 	title := th.StreamConsoleTitle.Render("WebSocket Console")
 	modeLabel := th.StreamSummary.Render("Mode:")
 	modeValue := th.StreamConsoleMode.Render(strings.ToUpper(wc.mode.String()))
-	help := th.StreamSummary.Render("(Ctrl+S send, Enter newline, F2 cycle, Ctrl+I toggle)")
+	help := th.StreamSummary.Render("(Ctrl+S send, Enter newline, F2 cycle, Esc exit)")
 
 	var builder strings.Builder
 	builder.WriteString(title)
@@ -497,7 +497,8 @@ func (m *Model) handleWebSocketCommandChord(msg tea.KeyMsg) (tea.Cmd, bool) {
 	}
 	m.wsCommandChord = false
 
-	switch msg.String() {
+	key := msg.String()
+	switch key {
 	case "esc":
 		m.setStatusMessage(statusMsg{text: "WebSocket command canceled", level: statusInfo})
 		return nil, true
@@ -510,7 +511,16 @@ func (m *Model) handleWebSocketCommandChord(msg tea.KeyMsg) (tea.Cmd, bool) {
 	case "l":
 		return m.clearStreamBufferCmd(), true
 	default:
-		return nil, false
+		if key == "" {
+			key = "<unknown>"
+		}
+		m.setStatusMessage(
+			statusMsg{
+				text:  fmt.Sprintf("Unknown WebSocket command: %s", key),
+				level: statusWarn,
+			},
+		)
+		return nil, true
 	}
 }
 

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -209,6 +209,7 @@ type Model struct {
 	responseSplitOrientation responseSplitOrientation
 	responsePaneFocus        responsePaneID
 	responsePaneChord        bool
+	wsCommandChord           bool
 	sidebarCollapsed         bool
 	editorCollapsed          bool
 	responseCollapsed        bool

--- a/internal/ui/model_exec_run.go
+++ b/internal/ui/model_exec_run.go
@@ -264,7 +264,11 @@ func (e *execContext) run() tea.Msg {
 		return *msg
 	}
 
-	defer e.sendCancel()
+	defer func() {
+		if e.sendCancel != nil {
+			e.sendCancel()
+		}
+	}()
 
 	if msg := e.evaluateCondition(); msg != nil {
 		return *msg
@@ -1029,10 +1033,17 @@ func (e *execContext) executeHTTP() tea.Msg {
 			if len(e.req.WebSocket.Steps) == 0 {
 				if handle != nil && handle.Session != nil {
 					sessionDone := handle.Session.Done()
+					releaseSend := e.sendCancel
 					go func() {
 						<-sessionDone
 						cancel()
+						if releaseSend != nil {
+							releaseSend()
+						}
 					}()
+					// Interactive websocket sessions must outlive the initial request
+					// command so the Stream tab and console stay attached.
+					e.sendCancel = nil
 					cancelActive = false
 				}
 				response = streamingPlaceholderResponse(handle.Meta)

--- a/internal/ui/model_exec_test.go
+++ b/internal/ui/model_exec_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httptrace"
 	"net/url"
 	"os"
@@ -28,12 +29,41 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/scripts"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 	"google.golang.org/grpc/codes"
+	"nhooyr.io/websocket"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func startUIWebSocketServer(t *testing.T) (*httptest.Server, func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Fatalf("websocket accept failed: %v", err)
+		}
+		defer func() {
+			if err := conn.Close(websocket.StatusNormalClosure, "bye"); err != nil {
+				t.Logf("close websocket: %v", err)
+			}
+		}()
+		<-r.Context().Done()
+	}))
+	srv.Listener = ln
+	srv.Start()
+
+	return srv, func() {
+		srv.Close()
+	}
 }
 
 func TestPrepareGRPCRequestExpandsTemplKeepMsg(t *testing.T) {
@@ -1442,6 +1472,63 @@ func TestExecuteRequestCancelsBeforePreRequest(t *testing.T) {
 	}
 	if !errors.Is(resp.err, context.Canceled) {
 		t.Fatalf("expected cancellation error, got %v", resp.err)
+	}
+}
+
+func TestExecuteRequestInteractiveWebSocketStaysAlive(t *testing.T) {
+	srv, cleanup := startUIWebSocketServer(t)
+	defer cleanup()
+
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/ws/chat"
+	model := New(Config{})
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    wsURL,
+		WebSocket: &restfile.WebSocketRequest{
+			Options: restfile.WebSocketOptions{},
+		},
+	}
+
+	cmd := model.executeRequest(nil, req, httpclient.Options{}, "", nil)
+	if cmd == nil {
+		t.Fatalf("expected executeRequest to return command")
+	}
+
+	msg := cmd()
+	resp, ok := msg.(responseMsg)
+	if !ok {
+		t.Fatalf("expected responseMsg, got %T", msg)
+	}
+	if resp.err != nil {
+		t.Fatalf("unexpected error: %v", resp.err)
+	}
+	if resp.response == nil {
+		t.Fatalf("expected placeholder websocket response")
+	}
+	if got := resp.response.Headers.Get(streamHeaderType); got != "websocket" {
+		t.Fatalf("expected websocket placeholder header, got %q", got)
+	}
+
+	sessionID := model.sessionIDForRequest(req)
+	if sessionID == "" {
+		t.Fatalf("expected websocket session to be recorded")
+	}
+	session := model.sessionHandles[sessionID]
+	if session == nil {
+		t.Fatalf("expected websocket session handle for %s", sessionID)
+	}
+
+	select {
+	case <-session.Done():
+		t.Fatal("interactive websocket session canceled immediately after request returned")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	session.Cancel()
+	select {
+	case <-session.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for websocket session shutdown")
 	}
 }
 

--- a/internal/ui/model_exec_test.go
+++ b/internal/ui/model_exec_test.go
@@ -46,18 +46,20 @@ func startUIWebSocketServer(t *testing.T) (*httptest.Server, func()) {
 		t.Fatalf("listen: %v", err)
 	}
 
-	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
-		if err != nil {
-			t.Fatalf("websocket accept failed: %v", err)
-		}
-		defer func() {
-			if err := conn.Close(websocket.StatusNormalClosure, "bye"); err != nil {
-				t.Logf("close websocket: %v", err)
+	srv := httptest.NewUnstartedServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+			if err != nil {
+				t.Fatalf("websocket accept failed: %v", err)
 			}
-		}()
-		<-r.Context().Done()
-	}))
+			defer func() {
+				if err := conn.Close(websocket.StatusNormalClosure, "bye"); err != nil {
+					t.Logf("close websocket: %v", err)
+				}
+			}()
+			<-r.Context().Done()
+		}),
+	)
 	srv.Listener = ln
 	srv.Start()
 

--- a/internal/ui/model_focus.go
+++ b/internal/ui/model_focus.go
@@ -88,6 +88,7 @@ func (m *Model) setFocus(target paneFocus) tea.Cmd {
 	}
 	if target != focusResponse {
 		m.responsePaneChord = false
+		m.wsCommandChord = false
 	}
 	if target == focusEditor {
 		if m.editorInsertMode {

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -605,6 +605,7 @@ func (m *Model) resetChordState() {
 	m.hasPendingChord = false
 	m.pendingChord = ""
 	m.pendingChordMsg = tea.KeyMsg{}
+	m.wsCommandChord = false
 	m.clearRepeatChord()
 }
 
@@ -1398,6 +1399,7 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 				return combine(nil)
 			default:
 				m.responsePaneChord = false
+				return combine(nil)
 			}
 		}
 		if keyStr == "ctrl+f" || keyStr == "ctrl+b" {

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -980,7 +980,7 @@ func (m *Model) runShortcutBinding(binding bindings.Binding, msg tea.KeyMsg) (te
 	case bindings.ActionStartCompareRun:
 		return m.startConfigCompareFromEditor(), true
 	case bindings.ActionToggleWebsocketConsole:
-		return m.toggleWebSocketConsole(), true
+		return m.armWebSocketCommandMode(), true
 	case bindings.ActionToggleSidebarCollapse:
 		return m.togglePaneCollapse(paneRegionSidebar), true
 	case bindings.ActionToggleEditorCollapse:
@@ -1113,6 +1113,10 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 
 	if m.focus != focusFile && m.focus != focusRequests && m.focus != focusWorkflows {
 		m.suppressListKey = false
+	}
+
+	if cmd, handled := m.handleWebSocketCommandChord(msg); handled {
+		return combine(cmd)
 	}
 
 	if allowChord {
@@ -1642,6 +1646,9 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 
 func (m *Model) canStartChord(msg tea.KeyMsg, key string) bool {
 	if key == "" || m.bindingsMap == nil {
+		return false
+	}
+	if m.websocketConsoleCapturesInput() {
 		return false
 	}
 	if !m.bindingsMap.HasChordPrefix(key) {

--- a/internal/ui/model_update_test.go
+++ b/internal/ui/model_update_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/unkn0wn-root/resterm/internal/httpclient"
 	"github.com/unkn0wn-root/resterm/internal/parser"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/stream"
 	"github.com/unkn0wn-root/resterm/internal/ui/navigator"
 )
 
@@ -1156,6 +1159,85 @@ func TestResponsePaneFocusChord(t *testing.T) {
 				t.Fatalf("expected chord to clear after navigation")
 			}
 		})
+	}
+}
+
+func TestWebSocketConsoleTypingDoesNotStartChord(t *testing.T) {
+	model := New(Config{})
+	req := &restfile.Request{Method: "GET", URL: "ws://example.test"}
+
+	model.currentRequest = req
+	model.requestSessions = map[*restfile.Request]string{req: "ws-1"}
+	model.wsConsole = newWebsocketConsole("ws-1", nil, nil, "")
+	model.responsePanes[0].activeTab = responseTabStream
+	_ = model.setFocus(focusResponse)
+
+	sendKeys(t, &model, "g", "w")
+
+	if model.hasPendingChord {
+		t.Fatal("expected console typing to avoid starting a chord")
+	}
+	if model.wsConsole == nil || !model.wsConsole.active {
+		t.Fatal("expected websocket console to remain active while typing")
+	}
+	if got := model.wsConsole.input.Value(); got != "gw" {
+		t.Fatalf("expected console input to receive typed text, got %q", got)
+	}
+}
+
+func TestWebSocketCommandChordTogglesConsole(t *testing.T) {
+	model := New(Config{})
+	req := &restfile.Request{Method: "GET", URL: "ws://example.test"}
+
+	model.currentRequest = req
+	model.requestSessions = map[*restfile.Request]string{req: "ws-1"}
+	model.wsSenders = map[string]*httpclient.WebSocketSender{
+		"ws-1": {},
+	}
+	model.responsePanes[0].activeTab = responseTabStream
+	_ = model.setFocus(focusResponse)
+
+	sendKeys(t, &model, "g", "w")
+	if !model.wsCommandChord {
+		t.Fatal("expected g w to arm websocket command mode")
+	}
+
+	sendKeys(t, &model, "i")
+	if model.wsCommandChord {
+		t.Fatal("expected websocket command mode to clear after command")
+	}
+	if model.wsConsole == nil || !model.wsConsole.active {
+		t.Fatal("expected websocket console to become active")
+	}
+}
+
+func TestWebSocketCommandChordClearsStreamBuffer(t *testing.T) {
+	model := New(Config{})
+	req := &restfile.Request{Method: "GET", URL: "ws://example.test"}
+
+	model.currentRequest = req
+	model.requestSessions = map[*restfile.Request]string{req: "ws-1"}
+	model.liveSessions = map[string]*liveSession{
+		"ws-1": {
+			id:        "ws-1",
+			events:    []*stream.Event{{Payload: []byte("hello")}},
+			maxEvents: 100,
+		},
+	}
+	model.responsePanes[0].activeTab = responseTabStream
+	_ = model.setFocus(focusResponse)
+
+	sendKeys(t, &model, "g", "w", "l")
+
+	if model.wsCommandChord {
+		t.Fatal("expected websocket command mode to clear after command")
+	}
+	ls := model.liveSessions["ws-1"]
+	if ls == nil {
+		t.Fatal("expected live session to remain present")
+	}
+	if len(ls.events) != 0 {
+		t.Fatalf("expected stream buffer to be cleared, got %d events", len(ls.events))
 	}
 }
 

--- a/internal/ui/model_update_test.go
+++ b/internal/ui/model_update_test.go
@@ -1162,6 +1162,65 @@ func TestResponsePaneFocusChord(t *testing.T) {
 	}
 }
 
+func TestResponsePaneFocusChordSwallowsUnknownKey(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.width = 120
+	model.height = 40
+	if cmd := model.applyLayout(); cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	_ = model.setFocus(focusResponse)
+	if out := model.toggleResponseSplitVertical(); out != nil {
+		collectMsgs(out)
+	}
+	if !model.responseSplit {
+		t.Fatalf("expected split to be enabled")
+	}
+
+	pane := model.pane(responsePanePrimary)
+	if pane == nil {
+		t.Fatal("expected primary response pane")
+	}
+	pane.viewport.SetContent(strings.Repeat("line\n", 80))
+	pane.viewport.GotoTop()
+
+	if cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyCtrlF}); cmd != nil {
+		collectMsgs(cmd)
+	}
+	if !model.responsePaneChord {
+		t.Fatal("expected response pane chord to be armed")
+	}
+
+	if cmd := model.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}}); cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	if model.responsePaneChord {
+		t.Fatal("expected response pane chord to clear after unknown key")
+	}
+	if pane.viewport.YOffset != 0 {
+		t.Fatalf("expected unknown chord key to be swallowed, got offset %d", pane.viewport.YOffset)
+	}
+}
+
+func TestResetChordStateClearsWebSocketCommandChord(t *testing.T) {
+	model := New(Config{})
+	model.wsCommandChord = true
+	model.hasPendingChord = true
+	model.pendingChord = "g"
+
+	model.resetChordState()
+
+	if model.wsCommandChord {
+		t.Fatal("expected websocket command chord to be cleared")
+	}
+	if model.hasPendingChord || model.pendingChord != "" {
+		t.Fatal("expected standard chord state to be cleared")
+	}
+}
+
 func TestWebSocketConsoleTypingDoesNotStartChord(t *testing.T) {
 	model := New(Config{})
 	req := &restfile.Request{Method: "GET", URL: "ws://example.test"}
@@ -1238,6 +1297,33 @@ func TestWebSocketCommandChordClearsStreamBuffer(t *testing.T) {
 	}
 	if len(ls.events) != 0 {
 		t.Fatalf("expected stream buffer to be cleared, got %d events", len(ls.events))
+	}
+}
+
+func TestWebSocketCommandChordSwallowsUnknownKey(t *testing.T) {
+	model := New(Config{})
+	req := &restfile.Request{Method: "GET", URL: "ws://example.test"}
+
+	model.currentRequest = req
+	model.requestSessions = map[*restfile.Request]string{req: "ws-1"}
+	model.responsePanes[0].activeTab = responseTabStream
+	_ = model.setFocus(focusResponse)
+
+	sendKeys(t, &model, "g", "w")
+	if !model.wsCommandChord {
+		t.Fatal("expected g w to arm websocket command mode")
+	}
+
+	sendKeys(t, &model, "x")
+
+	if model.wsCommandChord {
+		t.Fatal("expected websocket command mode to clear after unknown key")
+	}
+	if !strings.Contains(model.statusMessage.text, "Unknown WebSocket command: x") {
+		t.Fatalf("expected unknown-command status, got %q", model.statusMessage.text)
+	}
+	if model.statusMessage.level != statusWarn {
+		t.Fatalf("expected warning status, got %v", model.statusMessage.level)
 	}
 }
 


### PR DESCRIPTION
- interactive websocket session now stays alive after the send command returns
- change websocket key chords