### PR TITLE
RST-205: k8s same key recconect

### DIFF
--- a/internal/k8s/config.go
+++ b/internal/k8s/config.go
@@ -129,6 +129,12 @@ func (c Config) validate() error {
 	if c.LocalPort < 0 || c.LocalPort > 65535 {
 		return errors.New("local port out of range")
 	}
+	if c.PodWait < 0 {
+		return errors.New("pod wait out of range")
+	}
+	if c.Retries < 0 {
+		return errors.New("retries out of range")
+	}
 	return nil
 }
 

--- a/internal/k8s/config_test.go
+++ b/internal/k8s/config_test.go
@@ -207,3 +207,20 @@ func TestNormalizeProfileRejectsInvalid(t *testing.T) {
 		}
 	})
 }
+
+func TestPrepareExecConfigRejectsInvalidDirectValues(t *testing.T) {
+	t.Run("negative pod wait", func(t *testing.T) {
+		cfg := podConfig("api", 8080)
+		cfg.PodWait = -time.Second
+		if _, err := prepareExecConfig(cfg); err == nil {
+			t.Fatalf("expected pod wait error")
+		}
+	})
+	t.Run("negative retries", func(t *testing.T) {
+		cfg := podConfig("api", 8080)
+		cfg.Retries = -1
+		if _, err := prepareExecConfig(cfg); err == nil {
+			t.Fatalf("expected retries error")
+		}
+	})
+}

--- a/internal/k8s/manager.go
+++ b/internal/k8s/manager.go
@@ -112,16 +112,20 @@ func (e *cacheEntry) close() error {
 }
 
 func NewManager() *Manager {
-	dialer := &net.Dialer{Timeout: defaultLocalDialTimeout}
 	return &Manager{
 		cache:      make(map[sessionKey]*cacheEntry),
 		inflight:   make(map[sessionKey]chan struct{}),
 		ttl:        defaultTTL,
 		now:        time.Now,
 		start:      startSession,
-		dial:       dialer.DialContext,
+		dial:       newLocalDialer(),
 		retryDelay: defaultDialRetryDelay,
 	}
+}
+
+func newLocalDialer() dialFn {
+	dialer := &net.Dialer{Timeout: defaultLocalDialTimeout}
+	return dialer.DialContext
 }
 
 func (m *Manager) SetLoadOptions(opt LoadOptions) {
@@ -168,7 +172,7 @@ func (m *Manager) Close() error {
 func (m *Manager) DialContext(
 	ctx context.Context,
 	cfg Config,
-	network, addr string,
+	network, _ string,
 ) (net.Conn, error) {
 	if err := m.ready(); err != nil {
 		return nil, err
@@ -267,13 +271,14 @@ func (m *Manager) tryCachedSession(
 		m.mu.Unlock()
 		return nil, cachedDialReturn, errManagerClosed
 	}
-	m.purgeLocked()
+	stale := m.purgeLocked()
 
 	ent := m.cache[key]
 	if ent != nil {
 		ent.touch(m.now())
 		ses := ent.ses
 		m.mu.Unlock()
+		closeEntries(stale)
 
 		if ses.alive() {
 			ses.bindRequestDiag(ctx)
@@ -289,6 +294,7 @@ func (m *Manager) tryCachedSession(
 
 	waitCh, waiting := m.inflight[key]
 	m.mu.Unlock()
+	closeEntries(stale)
 	if !waiting {
 		return nil, cachedDialAcquire, nil
 	}
@@ -360,30 +366,31 @@ func (m *Manager) acquireNewSession(
 
 func (m *Manager) claimInflight(key sessionKey) (chan struct{}, cachedDialStep, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	if m.closed {
+		m.mu.Unlock()
 		return nil, cachedDialReturn, errManagerClosed
 	}
-	m.purgeLocked()
+	stale := m.purgeLocked()
 	if m.cache[key] != nil || m.inflight[key] != nil {
+		m.mu.Unlock()
+		closeEntries(stale)
 		return nil, cachedDialRetry, nil
 	}
 
 	token := make(chan struct{})
 	m.inflight[key] = token
+	m.mu.Unlock()
+	closeEntries(stale)
 	return token, cachedDialAcquire, nil
 }
 
 func (m *Manager) evictCachedSession(key sessionKey, ent *cacheEntry) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if cur := m.cache[key]; cur == ent {
-		_ = ent.close()
 		delete(m.cache, key)
-		return
 	}
+	m.mu.Unlock()
 	_ = ent.close()
 }
 
@@ -417,6 +424,12 @@ func (m *Manager) connect(ctx context.Context, cfg execConfig, load loadSettings
 
 	var lastErr error
 	for i := range attempts {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		ses, err := m.start(ctx, cfg, load)
 		if err == nil {
 			return ses, nil
@@ -451,14 +464,22 @@ func (m *Manager) dialSession(ctx context.Context, ses *session, network string)
 	return m.dial(ctx, n, ses.localAddr)
 }
 
-func (m *Manager) purgeLocked() {
+func (m *Manager) purgeLocked() []*cacheEntry {
 	now := m.now()
+	var stale []*cacheEntry
 	for key, ent := range m.cache {
 		if now.Sub(ent.lastUsed) <= m.ttl && ent.alive() {
 			continue
 		}
-		_ = ent.close()
 		delete(m.cache, key)
+		stale = append(stale, ent)
+	}
+	return stale
+}
+
+func closeEntries(entries []*cacheEntry) {
+	for _, ent := range entries {
+		_ = ent.close()
 	}
 }
 

--- a/internal/k8s/manager.go
+++ b/internal/k8s/manager.go
@@ -77,6 +77,12 @@ type cacheEntry struct {
 	lastUsed time.Time
 }
 
+type pendingClose struct {
+	key   sessionKey
+	ent   *cacheEntry
+	token chan struct{}
+}
+
 type session struct {
 	localAddr string
 	stopCh    chan struct{}
@@ -278,7 +284,7 @@ func (m *Manager) tryCachedSession(
 		ent.touch(m.now())
 		ses := ent.ses
 		m.mu.Unlock()
-		closeEntries(stale)
+		m.closeEntries(stale)
 
 		if ses.alive() {
 			ses.bindRequestDiag(ctx)
@@ -294,7 +300,7 @@ func (m *Manager) tryCachedSession(
 
 	waitCh, waiting := m.inflight[key]
 	m.mu.Unlock()
-	closeEntries(stale)
+	m.closeEntries(stale)
 	if !waiting {
 		return nil, cachedDialAcquire, nil
 	}
@@ -374,23 +380,29 @@ func (m *Manager) claimInflight(key sessionKey) (chan struct{}, cachedDialStep, 
 	stale := m.purgeLocked()
 	if m.cache[key] != nil || m.inflight[key] != nil {
 		m.mu.Unlock()
-		closeEntries(stale)
+		m.closeEntries(stale)
 		return nil, cachedDialRetry, nil
 	}
 
 	token := make(chan struct{})
 	m.inflight[key] = token
 	m.mu.Unlock()
-	closeEntries(stale)
+	m.closeEntries(stale)
 	return token, cachedDialAcquire, nil
 }
 
 func (m *Manager) evictCachedSession(key sessionKey, ent *cacheEntry) {
 	m.mu.Lock()
+	var pending *pendingClose
 	if cur := m.cache[key]; cur == ent {
-		delete(m.cache, key)
+		pending = m.reserveCloseLocked(key, ent)
 	}
 	m.mu.Unlock()
+
+	if pending != nil {
+		m.closeEntries([]*pendingClose{pending})
+		return
+	}
 	_ = ent.close()
 }
 
@@ -464,22 +476,40 @@ func (m *Manager) dialSession(ctx context.Context, ses *session, network string)
 	return m.dial(ctx, n, ses.localAddr)
 }
 
-func (m *Manager) purgeLocked() []*cacheEntry {
+func (m *Manager) purgeLocked() []*pendingClose {
 	now := m.now()
-	var stale []*cacheEntry
+	var stale []*pendingClose
 	for key, ent := range m.cache {
 		if now.Sub(ent.lastUsed) <= m.ttl && ent.alive() {
 			continue
 		}
-		delete(m.cache, key)
-		stale = append(stale, ent)
+		stale = append(stale, m.reserveCloseLocked(key, ent))
 	}
 	return stale
 }
 
-func closeEntries(entries []*cacheEntry) {
-	for _, ent := range entries {
-		_ = ent.close()
+func (m *Manager) reserveCloseLocked(key sessionKey, ent *cacheEntry) *pendingClose {
+	delete(m.cache, key)
+	if ent == nil {
+		return nil
+	}
+	if _, ok := m.inflight[key]; ok {
+		return &pendingClose{key: key, ent: ent}
+	}
+	token := make(chan struct{})
+	m.inflight[key] = token
+	return &pendingClose{key: key, ent: ent, token: token}
+}
+
+func (m *Manager) closeEntries(entries []*pendingClose) {
+	for _, pending := range entries {
+		if pending == nil {
+			continue
+		}
+		_ = pending.ent.close()
+		if pending.token != nil {
+			m.releaseInflight(pending.key, pending.token)
+		}
 	}
 }
 

--- a/internal/k8s/manager_test.go
+++ b/internal/k8s/manager_test.go
@@ -242,6 +242,117 @@ func TestDialPersistentReconnectsAfterDialFailure(t *testing.T) {
 	}
 }
 
+func TestEvictCachedSessionClosesOutsideManagerLock(t *testing.T) {
+	m := NewManager()
+	t.Cleanup(func() { _ = m.Close() })
+
+	cfg := podConfig("api", 8080)
+	cfg.Persist = true
+	otherCfg := podConfig("other", 8080)
+
+	load, err := m.loadSettings()
+	if err != nil {
+		t.Fatalf("load cfg err: %v", err)
+	}
+	execCfg, err := prepareExecConfig(cfg)
+	if err != nil {
+		t.Fatalf("prepare cfg err: %v", err)
+	}
+	key := sessionKeyFor(execCfg, load)
+
+	blocking, closeStarted, release := newBlockingCloseSession("127.0.0.1:18080")
+	defer release()
+
+	m.mu.Lock()
+	m.cache[key] = newCacheEntry(blocking, m.now())
+	m.mu.Unlock()
+
+	m.start = func(ctx context.Context, cfg execConfig, load loadSettings) (*session, error) {
+		return stubSession(cfg, "127.0.0.1:18081"), nil
+	}
+	m.dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if address == blocking.localAddr {
+			return nil, errBoom
+		}
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		return c1, nil
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := m.DialContext(context.Background(), cfg, "tcp", "")
+		if conn != nil {
+			_ = conn.Close()
+		}
+		errCh <- err
+	}()
+
+	waitForBlockingCloseStarted(t, closeStarted)
+	assertDialFinishes(t, m, otherCfg)
+
+	release()
+	if err := <-errCh; err != nil {
+		t.Fatalf("reconnect dial err: %v", err)
+	}
+}
+
+func TestPurgeClosesStaleSessionOutsideManagerLock(t *testing.T) {
+	m := NewManager()
+	t.Cleanup(func() { _ = m.Close() })
+
+	now := time.Unix(100, 0)
+	m.now = func() time.Time { return now }
+	m.ttl = time.Minute
+
+	cfg := podConfig("api", 8080)
+	cfg.Persist = true
+	otherCfg := podConfig("other", 8080)
+
+	load, err := m.loadSettings()
+	if err != nil {
+		t.Fatalf("load cfg err: %v", err)
+	}
+	execCfg, err := prepareExecConfig(cfg)
+	if err != nil {
+		t.Fatalf("prepare cfg err: %v", err)
+	}
+	key := sessionKeyFor(execCfg, load)
+
+	blocking, closeStarted, release := newBlockingCloseSession("127.0.0.1:18080")
+	defer release()
+
+	m.mu.Lock()
+	m.cache[key] = newCacheEntry(blocking, now.Add(-2*time.Minute))
+	m.mu.Unlock()
+
+	m.start = func(ctx context.Context, cfg execConfig, load loadSettings) (*session, error) {
+		return stubSession(cfg, "127.0.0.1:18081"), nil
+	}
+	m.dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		return c1, nil
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := m.DialContext(context.Background(), cfg, "tcp", "")
+		if conn != nil {
+			_ = conn.Close()
+		}
+		errCh <- err
+	}()
+
+	waitForBlockingCloseStarted(t, closeStarted)
+	assertDialFinishes(t, m, otherCfg)
+
+	release()
+	if err := <-errCh; err != nil {
+		t.Fatalf("purge dial err: %v", err)
+	}
+}
+
 func TestDialCachedUsesReplacedEntryWithoutReconnect(t *testing.T) {
 	m := NewManager()
 	t.Cleanup(func() { _ = m.Close() })
@@ -488,6 +599,26 @@ func TestDialRetryHonorsContextCancel(t *testing.T) {
 	}
 	if starts.Load() != 1 {
 		t.Fatalf("expected one start before cancel, got %d", starts.Load())
+	}
+}
+
+func TestDialRetryHonorsPreCancelledContext(t *testing.T) {
+	m := NewManager()
+	starts := atomic.Int32{}
+	m.start = func(ctx context.Context, cfg execConfig, load loadSettings) (*session, error) {
+		starts.Add(1)
+		return nil, errBoom
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.DialContext(ctx, podConfig("api", 8080), "tcp", "")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if starts.Load() != 0 {
+		t.Fatalf("expected no start after pre-cancel, got %d", starts.Load())
 	}
 }
 
@@ -1007,6 +1138,56 @@ func testResolveForwardTarget(
 		return forwardTarget{}, err
 	}
 	return testClusterResolver(cs, namespace).resolveForwardTarget(context.Background(), execCfg)
+}
+
+func newBlockingCloseSession(addr string) (*session, <-chan struct{}, func()) {
+	closeStarted := make(chan struct{})
+	closeRelease := make(chan struct{})
+	var startOnce sync.Once
+	var releaseOnce sync.Once
+
+	s := stubSessionWithClose(addr, func() {
+		startOnce.Do(func() {
+			close(closeStarted)
+		})
+		<-closeRelease
+	})
+	release := func() {
+		releaseOnce.Do(func() {
+			close(closeRelease)
+		})
+	}
+	return s, closeStarted, release
+}
+
+func waitForBlockingCloseStarted(t *testing.T, closeStarted <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-closeStarted:
+	case <-time.After(time.Second):
+		t.Fatalf("close did not start")
+	}
+}
+
+func assertDialFinishes(t *testing.T, m *Manager, cfg Config) {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := m.DialContext(context.Background(), cfg, "tcp", "")
+		if conn != nil {
+			_ = conn.Close()
+		}
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("dial err: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("dial blocked on manager lock")
+	}
 }
 
 func stubSession(_ any, addr string) *session {

--- a/internal/k8s/manager_test.go
+++ b/internal/k8s/manager_test.go
@@ -297,6 +297,69 @@ func TestEvictCachedSessionClosesOutsideManagerLock(t *testing.T) {
 	}
 }
 
+func TestEvictCachedSessionBlocksSameKeyUntilCloseCompletes(t *testing.T) {
+	m := NewManager()
+	t.Cleanup(func() { _ = m.Close() })
+
+	cfg := podConfig("api", 8080)
+	cfg.Persist = true
+	cfg.LocalPort = 18080
+
+	load, err := m.loadSettings()
+	if err != nil {
+		t.Fatalf("load cfg err: %v", err)
+	}
+	execCfg, err := prepareExecConfig(cfg)
+	if err != nil {
+		t.Fatalf("prepare cfg err: %v", err)
+	}
+	key := sessionKeyFor(execCfg, load)
+
+	blocking, closeStarted, release := newBlockingCloseSession("127.0.0.1:18080")
+	defer release()
+
+	m.mu.Lock()
+	m.cache[key] = newCacheEntry(blocking, m.now())
+	m.mu.Unlock()
+
+	released := atomic.Bool{}
+	starts := atomic.Int32{}
+	earlyStarts := atomic.Int32{}
+	m.start = func(ctx context.Context, cfg execConfig, load loadSettings) (*session, error) {
+		starts.Add(1)
+		if !released.Load() {
+			earlyStarts.Add(1)
+		}
+		return stubSession(cfg, "127.0.0.1:18081"), nil
+	}
+	m.dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if address == blocking.localAddr {
+			return nil, errBoom
+		}
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		return c1, nil
+	}
+
+	firstErr := dialAsync(m, cfg)
+	waitForBlockingCloseStarted(t, closeStarted)
+	secondErr := dialAsync(m, cfg)
+
+	time.Sleep(50 * time.Millisecond)
+	if got := earlyStarts.Load(); got != 0 {
+		t.Fatalf("expected same-key start to wait for close, got %d early starts", got)
+	}
+
+	released.Store(true)
+	release()
+	assertDialErr(t, firstErr, "first reconnect")
+	assertDialErr(t, secondErr, "same-key reconnect")
+
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("expected one replacement start, got %d", got)
+	}
+}
+
 func TestPurgeClosesStaleSessionOutsideManagerLock(t *testing.T) {
 	m := NewManager()
 	t.Cleanup(func() { _ = m.Close() })
@@ -350,6 +413,70 @@ func TestPurgeClosesStaleSessionOutsideManagerLock(t *testing.T) {
 	release()
 	if err := <-errCh; err != nil {
 		t.Fatalf("purge dial err: %v", err)
+	}
+}
+
+func TestPurgeBlocksSameKeyUntilCloseCompletes(t *testing.T) {
+	m := NewManager()
+	t.Cleanup(func() { _ = m.Close() })
+
+	now := time.Unix(100, 0)
+	m.now = func() time.Time { return now }
+	m.ttl = time.Minute
+
+	cfg := podConfig("api", 8080)
+	cfg.Persist = true
+	cfg.LocalPort = 18080
+
+	load, err := m.loadSettings()
+	if err != nil {
+		t.Fatalf("load cfg err: %v", err)
+	}
+	execCfg, err := prepareExecConfig(cfg)
+	if err != nil {
+		t.Fatalf("prepare cfg err: %v", err)
+	}
+	key := sessionKeyFor(execCfg, load)
+
+	blocking, closeStarted, release := newBlockingCloseSession("127.0.0.1:18080")
+	defer release()
+
+	m.mu.Lock()
+	m.cache[key] = newCacheEntry(blocking, now.Add(-2*time.Minute))
+	m.mu.Unlock()
+
+	released := atomic.Bool{}
+	starts := atomic.Int32{}
+	earlyStarts := atomic.Int32{}
+	m.start = func(ctx context.Context, cfg execConfig, load loadSettings) (*session, error) {
+		starts.Add(1)
+		if !released.Load() {
+			earlyStarts.Add(1)
+		}
+		return stubSession(cfg, "127.0.0.1:18081"), nil
+	}
+	m.dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		return c1, nil
+	}
+
+	firstErr := dialAsync(m, cfg)
+	waitForBlockingCloseStarted(t, closeStarted)
+	secondErr := dialAsync(m, cfg)
+
+	time.Sleep(50 * time.Millisecond)
+	if got := earlyStarts.Load(); got != 0 {
+		t.Fatalf("expected same-key start to wait for close, got %d early starts", got)
+	}
+
+	released.Store(true)
+	release()
+	assertDialErr(t, firstErr, "first purge reconnect")
+	assertDialErr(t, secondErr, "same-key purge reconnect")
+
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("expected one replacement start, got %d", got)
 	}
 }
 
@@ -1187,6 +1314,30 @@ func assertDialFinishes(t *testing.T, m *Manager, cfg Config) {
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("dial blocked on manager lock")
+	}
+}
+
+func dialAsync(m *Manager, cfg Config) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := m.DialContext(context.Background(), cfg, "tcp", "")
+		if conn != nil {
+			_ = conn.Close()
+		}
+		errCh <- err
+	}()
+	return errCh
+}
+
+func assertDialErr(t *testing.T, errCh <-chan error, label string) {
+	t.Helper()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("%s err: %v", label, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("%s timed out", label)
 	}
 }
 

--- a/internal/ssh/connector.go
+++ b/internal/ssh/connector.go
@@ -10,12 +10,7 @@ import (
 	xssh "golang.org/x/crypto/ssh"
 )
 
-func dialSSH(ctx context.Context, cfg Config) (Client, error) {
-	execCfg, err := prepareExecConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-
+func dialSSH(ctx context.Context, execCfg execConfig) (client, error) {
 	addr := execCfg.ep.addr()
 	base := &net.Dialer{Timeout: execCfg.Timeout}
 
@@ -71,21 +66,21 @@ func closeAuthConn(conn net.Conn, closeAuth func() error) error {
 }
 
 type clientWrap struct {
-	Client
+	client
 	closeFn func() error
 }
 
-func wrapClient(cli Client, closeFn func() error) Client {
+func wrapClient(cli client, closeFn func() error) client {
 	if closeFn == nil {
 		return cli
 	}
-	return &clientWrap{Client: cli, closeFn: closeFn}
+	return &clientWrap{client: cli, closeFn: closeFn}
 }
 
 func (c *clientWrap) Close() error {
 	var errs []error
-	if c.Client != nil {
-		if err := c.Client.Close(); err != nil {
+	if c.client != nil {
+		if err := c.client.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -17,7 +17,7 @@ var (
 	errManagerClosed      = errors.New("ssh: manager closed")
 )
 
-type Client interface {
+type client interface {
 	Dial(network, addr string) (net.Conn, error)
 	SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error)
 	Close() error
@@ -32,7 +32,7 @@ type Manager struct {
 
 	ttl        time.Duration
 	now        func() time.Time
-	dial       func(context.Context, Config) (Client, error)
+	dial       func(context.Context, execConfig) (client, error)
 	retryDelay time.Duration
 }
 
@@ -87,7 +87,6 @@ func (m *Manager) Close() error {
 	}
 
 	m.mu.Lock()
-	m.initLocked()
 	if m.closed {
 		m.mu.Unlock()
 		return nil
@@ -143,29 +142,10 @@ func (m *Manager) ready() error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.initLocked()
 	if m.closed {
 		return errManagerClosed
 	}
 	return nil
-}
-
-func (m *Manager) initLocked() {
-	if m.cache == nil {
-		m.cache = make(map[sessionKey]*entry)
-	}
-	if m.inflight == nil {
-		m.inflight = make(map[sessionKey]chan struct{})
-	}
-	if m.ttl == 0 {
-		m.ttl = defaultTTL
-	}
-	if m.now == nil {
-		m.now = time.Now
-	}
-	if m.retryDelay == 0 {
-		m.retryDelay = dialRetryDelay
-	}
 }
 
 func (m *Manager) dialOnce(
@@ -378,7 +358,7 @@ func (m *Manager) connect(ctx context.Context, cfg execConfig, cached bool) (*se
 		default:
 		}
 
-		cli, err := m.dial(ctx, cfg.Config)
+		cli, err := m.dial(ctx, cfg)
 		if err == nil {
 			keepAlive := time.Duration(0)
 			if cached {

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -132,7 +132,7 @@ func (b *blockingCloseClient) release() {
 	})
 }
 
-func newTestManager(dial func(context.Context, Config) (Client, error)) *Manager {
+func newTestManager(dial func(context.Context, execConfig) (client, error)) *Manager {
 	return &Manager{
 		cache:      make(map[sessionKey]*entry),
 		inflight:   make(map[sessionKey]chan struct{}),
@@ -198,7 +198,7 @@ func TestDialNonPersistent(t *testing.T) {
 	cfg := Config{Host: "h", Port: 22, User: "u", Pass: "p", Persist: false}
 	dials := atomic.Int32{}
 
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		dials.Add(1)
 		return &fakeClient{}, nil
 	})
@@ -219,7 +219,7 @@ func TestDialNonPersistentClosesSessionWhenManagerClosesDuringConnect(t *testing
 	started := make(chan struct{})
 	release := make(chan struct{})
 	fc := &fakeClient{}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		close(started)
 		<-release
 		return fc, nil
@@ -257,7 +257,7 @@ func TestDialPersistentCaches(t *testing.T) {
 	dials := atomic.Int32{}
 
 	fc := &fakeClient{}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		dials.Add(1)
 		return fc, nil
 	})
@@ -287,7 +287,7 @@ func TestDialPersistentReconnectsAfterCachedFailure(t *testing.T) {
 	second := &scriptedClient{}
 	dials := atomic.Int32{}
 
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		switch dials.Add(1) {
 		case 1:
 			return first, nil
@@ -339,7 +339,7 @@ func TestEvictCachedSessionClosesOutsideManagerLock(t *testing.T) {
 	defer blocking.release()
 
 	sshDials := atomic.Int32{}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		if cfg.Host == "h" && sshDials.Add(1) == 1 {
 			return blocking, nil
 		}
@@ -376,7 +376,7 @@ func TestPurgeClosesStaleSessionOutsideManagerLock(t *testing.T) {
 	blocking := newBlockingCloseClient(false)
 	defer blocking.release()
 
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		return &fakeClient{}, nil
 	})
 	m.cache[keyForTest(t, cfg)] = newEntry(
@@ -407,7 +407,7 @@ func TestDialPersistentConcurrentSharesClient(t *testing.T) {
 	dials := atomic.Int32{}
 	start := make(chan struct{})
 	fc := &fakeClient{}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		dials.Add(1)
 		<-start
 		return fc, nil
@@ -452,7 +452,7 @@ func TestDialRetry(t *testing.T) {
 	cfg := Config{Host: "h", Port: 22, User: "u", Pass: "p", Persist: false, Retries: 2}
 	count := atomic.Int32{}
 
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		if count.Add(1); count.Load() < 2 {
 			return nil, errBoom
 		}
@@ -487,7 +487,7 @@ func TestKeepAliveStops(t *testing.T) {
 	}
 	fc := &fakeClient{}
 
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		return fc, nil
 	})
 
@@ -517,7 +517,7 @@ func TestKeepAliveFailureReconnects(t *testing.T) {
 	first := &fakeClient{requestErr: errBoom}
 	second := &fakeClient{}
 	dials := atomic.Int32{}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		switch dials.Add(1) {
 		case 1:
 			return first, nil
@@ -553,7 +553,7 @@ func TestKeepAliveFailureReconnects(t *testing.T) {
 func TestPersistentTargetDialFailureClosesSession(t *testing.T) {
 	cfg := Config{Host: "h", Port: 22, User: "u", Pass: "p", Persist: true}
 	fc := &fakeClient{failDial: true}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		return fc, nil
 	})
 
@@ -577,7 +577,7 @@ func TestPersistentTargetDialFailureClosesSession(t *testing.T) {
 func TestManagerCloseIdempotent(t *testing.T) {
 	cfg := Config{Host: "h", Port: 22, User: "u", Pass: "p", Persist: true}
 	fc := &fakeClient{}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		return fc, nil
 	})
 
@@ -600,7 +600,7 @@ func TestManagerCloseIdempotent(t *testing.T) {
 
 func TestClosedManagerRejectsDial(t *testing.T) {
 	cfg := Config{Host: "h", Port: 22, User: "u", Pass: "p"}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		return &fakeClient{}, nil
 	})
 	if err := m.Close(); err != nil {
@@ -615,7 +615,7 @@ func TestClosedManagerRejectsDial(t *testing.T) {
 
 func TestDialRetryHonorsCancelledContext(t *testing.T) {
 	cfg := Config{Host: "h", Port: 22, User: "u", Pass: "p", Persist: false, Retries: 3}
-	m := newTestManager(func(ctx context.Context, cfg Config) (Client, error) {
+	m := newTestManager(func(ctx context.Context, cfg execConfig) (client, error) {
 		return nil, errBoom
 	})
 

--- a/internal/ssh/session.go
+++ b/internal/ssh/session.go
@@ -10,7 +10,7 @@ import (
 var errSessionClosed = errors.New("ssh: session closed")
 
 type session struct {
-	cli Client
+	cli client
 
 	stopCh chan struct{}
 	doneCh chan struct{}
@@ -20,7 +20,7 @@ type session struct {
 	closed sync.Once
 }
 
-func newSession(cli Client, keepAlive time.Duration) *session {
+func newSession(cli client, keepAlive time.Duration) *session {
 	s := &session{
 		cli:    cli,
 		stopCh: make(chan struct{}),


### PR DESCRIPTION
- keep stale/evicted K8s port-forward sessions closing outside the manager lock
- reserve the same K8s session key while the old port-forward shuts down
- add some extra tests