### PR TITLE
RTS-210: parser and VM improvements

### DIFF
--- a/internal/rts/engine.go
+++ b/internal/rts/engine.go
@@ -31,6 +31,9 @@ type RT struct {
 	Extra       map[string]Value
 }
 
+// Eng evaluates RTS expressions and modules.
+// It is not safe for concurrent use because evaluation updates shared request
+// state that cached modules resolve dynamically.
 type Eng struct {
 	C      *ModCache
 	Lim    Limits

--- a/internal/rts/host.go
+++ b/internal/rts/host.go
@@ -2,7 +2,6 @@ package rts
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -29,10 +28,6 @@ func (o *mapObj) GetMember(name string) (Value, bool) {
 	}
 
 	return mapMember(o.m, name)
-}
-
-func (o *mapObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), fmt.Errorf("no member call: %s", name)
 }
 
 func (o *mapObj) Index(key Value) (Value, error) {
@@ -126,10 +121,6 @@ func (o *respObj) GetMember(name string) (Value, bool) {
 		return NativeNamed(o.name+".json", o.jsonFn), true
 	}
 	return Null(), false
-}
-
-func (o *respObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), fmt.Errorf("no member call: %s", name)
 }
 
 func (o *respObj) Index(key Value) (Value, error) {

--- a/internal/rts/modobj.go
+++ b/internal/rts/modobj.go
@@ -1,7 +1,5 @@
 package rts
 
-import "fmt"
-
 type ModObj struct {
 	name string
 	exp  map[string]Value
@@ -16,10 +14,6 @@ func (m *ModObj) TypeName() string { return "module:" + m.name }
 func (m *ModObj) GetMember(name string) (Value, bool) {
 	v, ok := m.exp[name]
 	return v, ok
-}
-
-func (m *ModObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), fmt.Errorf("module has no member call: %s", name)
 }
 
 func (m *ModObj) Index(key Value) (Value, error) {

--- a/internal/rts/parser.go
+++ b/internal/rts/parser.go
@@ -201,12 +201,18 @@ func (p *Parser) parseParams() []string {
 		return nil
 	}
 	var out []string
+	seen := map[string]struct{}{}
 	for {
 		if p.cur.K != IDENT {
 			p.fail(p.cur.P, "expected parameter name")
 		}
 
-		out = append(out, p.cur.Lit)
+		name := p.cur.Lit
+		if _, ok := seen[name]; ok {
+			p.fail(p.cur.P, fmt.Sprintf("duplicate parameter %q", name))
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
 		p.next()
 		if p.cur.K == COMMA {
 			p.next()

--- a/internal/rts/parser_test.go
+++ b/internal/rts/parser_test.go
@@ -20,6 +20,12 @@ func TestParseFnIf(t *testing.T) {
 	}
 }
 
+func TestParseDuplicateParamRejected(t *testing.T) {
+	if _, err := ParseModule("test", []byte("fn f(a, a) { return a }\n")); err == nil {
+		t.Fatalf("expected duplicate parameter error")
+	}
+}
+
 func TestParseDict(t *testing.T) {
 	src := "let x = {\"a\": 1, b: 2}\n"
 	m, err := ParseModule("test", []byte(src))

--- a/internal/rts/request.go
+++ b/internal/rts/request.go
@@ -1,7 +1,6 @@
 package rts
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 	"sync"
@@ -106,10 +105,6 @@ func (o *requestObj) GetMember(name string) (Value, bool) {
 		return NativeNamed(o.name+".setBody", o.setBodyFn), true
 	}
 	return Null(), false
-}
-
-func (o *requestObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), fmt.Errorf("no member call: %s", name)
 }
 
 func (o *requestObj) Index(key Value) (Value, error) {

--- a/internal/rts/result.go
+++ b/internal/rts/result.go
@@ -1,7 +1,5 @@
 package rts
 
-import "fmt"
-
 type resultObj struct {
 	ok  bool
 	val Value
@@ -36,10 +34,6 @@ func (o *resultObj) GetMember(name string) (Value, bool) {
 		return Str(o.err), true
 	}
 	return Null(), false
-}
-
-func (o *resultObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), fmt.Errorf("no member call: %s", name)
 }
 
 func (o *resultObj) Index(key Value) (Value, error) {

--- a/internal/rts/stdlib.go
+++ b/internal/rts/stdlib.go
@@ -1,9 +1,6 @@
 package rts
 
-import (
-	"fmt"
-	"maps"
-)
+import "maps"
 
 type nsSpec struct {
 	name string
@@ -37,10 +34,6 @@ func (o *objMap) TypeName() string { return o.name }
 func (o *objMap) GetMember(name string) (Value, bool) {
 	v, ok := o.m[name]
 	return v, ok
-}
-
-func (o *objMap) CallMember(name string, args []Value) (Value, error) {
-	return Null(), fmt.Errorf("no such member: %s", name)
 }
 
 func (o *objMap) Index(key Value) (Value, error) {

--- a/internal/rts/stream.go
+++ b/internal/rts/stream.go
@@ -32,10 +32,6 @@ func (o *streamObj) GetMember(name string) (Value, bool) {
 	return Null(), false
 }
 
-func (o *streamObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), rtErr(nil, Pos{}, "no member call: %s", name)
-}
-
 func (o *streamObj) Index(key Value) (Value, error) {
 	return Null(), nil
 }

--- a/internal/rts/trace.go
+++ b/internal/rts/trace.go
@@ -114,10 +114,6 @@ func (o *traceObj) GetMember(name string) (Value, bool) {
 	return Null(), false
 }
 
-func (o *traceObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), rtErr(nil, Pos{}, "no member call: %s", name)
-}
-
 func (o *traceObj) Index(key Value) (Value, error) {
 	return Null(), nil
 }

--- a/internal/rts/value.go
+++ b/internal/rts/value.go
@@ -39,7 +39,6 @@ type Func struct {
 type Object interface {
 	TypeName() string
 	GetMember(name string) (Value, bool)
-	CallMember(name string, args []Value) (Value, error)
 	Index(key Value) (Value, error)
 }
 

--- a/internal/rts/vars_obj.go
+++ b/internal/rts/vars_obj.go
@@ -72,10 +72,6 @@ func (o *varsObj) GetMember(name string) (Value, bool) {
 	return mapMember(o.m, name)
 }
 
-func (o *varsObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), rtErr(nil, Pos{}, "no member call: %s", name)
-}
-
 func (o *varsObj) Index(key Value) (Value, error) {
 	return mapIndex(o.m, key)
 }
@@ -130,10 +126,6 @@ func (o *globalObj) GetMember(name string) (Value, bool) {
 	}
 
 	return mapMember(o.m, name)
-}
-
-func (o *globalObj) CallMember(name string, args []Value) (Value, error) {
-	return Null(), rtErr(nil, Pos{}, "no member call: %s", name)
 }
 
 func (o *globalObj) Index(key Value) (Value, error) {

--- a/internal/rts/vm.go
+++ b/internal/rts/vm.go
@@ -452,6 +452,12 @@ func (vm *VM) eval(env *Env, ex Expr) (Value, error) {
 			if idx.K != VNum {
 				return Null(), rtErr(vm.ctx, e.Pos(), "list index must be number")
 			}
+			if math.IsNaN(idx.N) || math.IsInf(idx.N, 0) || math.Trunc(idx.N) != idx.N {
+				return Null(), rtErr(vm.ctx, e.Pos(), "list index must be integer")
+			}
+			if idx.N > maxI || idx.N < minI {
+				return Null(), rtErr(vm.ctx, e.Pos(), "list index out of range")
+			}
 			i := int(idx.N)
 			if i < 0 || i >= len(x.L) {
 				return Null(), nil

--- a/internal/rts/vm.go
+++ b/internal/rts/vm.go
@@ -449,16 +449,10 @@ func (vm *VM) eval(env *Env, ex Expr) (Value, error) {
 		}
 		switch x.K {
 		case VList:
-			if idx.K != VNum {
-				return Null(), rtErr(vm.ctx, e.Pos(), "list index must be number")
+			i, err := vm.listIndex(e.Pos(), idx)
+			if err != nil {
+				return Null(), err
 			}
-			if math.IsNaN(idx.N) || math.IsInf(idx.N, 0) || math.Trunc(idx.N) != idx.N {
-				return Null(), rtErr(vm.ctx, e.Pos(), "list index must be integer")
-			}
-			if idx.N > maxI || idx.N < minI {
-				return Null(), rtErr(vm.ctx, e.Pos(), "list index out of range")
-			}
-			i := int(idx.N)
 			if i < 0 || i >= len(x.L) {
 				return Null(), nil
 			}
@@ -538,6 +532,20 @@ func (vm *VM) eval(env *Env, ex Expr) (Value, error) {
 	default:
 		return Null(), rtErr(vm.ctx, ex.Pos(), "unknown expr")
 	}
+}
+
+func (vm *VM) listIndex(pos Pos, idx Value) (int, error) {
+	if idx.K != VNum {
+		return 0, rtErr(vm.ctx, pos, "list index must be number")
+	}
+	n := idx.N
+	switch {
+	case math.IsNaN(n), math.IsInf(n, 0), math.Trunc(n) != n:
+		return 0, rtErr(vm.ctx, pos, "list index must be integer")
+	case n > maxI, n < minI:
+		return 0, rtErr(vm.ctx, pos, "list index out of range")
+	}
+	return int(n), nil
 }
 
 func (vm *VM) evalCall(env *Env, c *Call) (Value, error) {

--- a/internal/rts/vm_test.go
+++ b/internal/rts/vm_test.go
@@ -52,6 +52,20 @@ func TestEvalBasic(t *testing.T) {
 	}
 }
 
+func TestListIndexRequiresInteger(t *testing.T) {
+	ex, err := ParseExpr("test", 1, 1, "[10,20][1.2]")
+	if err != nil {
+		t.Fatalf("parse expr: %v", err)
+	}
+	ctx := NewCtx(context.Background(), Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
+	vm := &VM{ctx: ctx}
+	env := NewEnv(nil)
+	_, err = vm.eval(env, ex)
+	if err == nil || !strings.Contains(err.Error(), "list index must be integer") {
+		t.Fatalf("expected integer index error, got %v", err)
+	}
+}
+
 func TestEvalLogic(t *testing.T) {
 	v := evalExpr(t, "true and false")
 	if v.K != VBool || v.B != false {


### PR DESCRIPTION
- reject duplicate function parameters at parse time.
- validate list indices for NaN/Inf/non-integer values.
- remove unused CallMember from Object interface and all implementations.