### PR TITLE
RST-212: improve parser and add js, graphql and json read files

### DIFF
--- a/internal/filesvc/list.go
+++ b/internal/filesvc/list.go
@@ -12,6 +12,12 @@ const (
 	extHTTP              = ".http"
 	extREST              = ".rest"
 	extRTS               = ".rts"
+	extGraphQL           = ".graphql"
+	extGQL               = ".gql"
+	extJSON              = ".json"
+	extJS                = ".js"
+	extMJS               = ".mjs"
+	extCJS               = ".cjs"
 	defaultEnvSourceFile = "resterm.env.json"
 	altEnvSourceFile     = "rest-client.env.json"
 )
@@ -22,6 +28,9 @@ const (
 	FileKindRequest FileKind = iota
 	FileKindScript
 	FileKindEnv
+	FileKindGraphQL
+	FileKindJSON
+	FileKindJavaScript
 )
 
 func (k FileKind) String() string {
@@ -32,8 +41,31 @@ func (k FileKind) String() string {
 		return "script"
 	case FileKindEnv:
 		return "env"
+	case FileKindGraphQL:
+		return "graphql"
+	case FileKindJSON:
+		return "json"
+	case FileKindJavaScript:
+		return "javascript"
 	default:
 		return "unknown"
+	}
+}
+
+func (k FileKind) BadgeLabel() string {
+	switch k {
+	case FileKindScript:
+		return "RTS"
+	case FileKindEnv:
+		return "ENV"
+	case FileKindGraphQL:
+		return "GQL"
+	case FileKindJSON:
+		return "JSON"
+	case FileKindJavaScript:
+		return "JS"
+	default:
+		return ""
 	}
 }
 
@@ -56,20 +88,31 @@ func IsRTSFile(path string) bool {
 	return fileExt(path) == extRTS
 }
 
+func IsGraphQLFile(path string) bool {
+	ext := fileExt(path)
+	return ext == extGraphQL || ext == extGQL
+}
+
+func IsJSONFile(path string) bool {
+	return fileExt(path) == extJSON
+}
+
+func IsJavaScriptFile(path string) bool {
+	ext := fileExt(path)
+	return ext == extJS || ext == extMJS || ext == extCJS
+}
+
 func IsEnvJSONFile(path string) bool {
 	base := strings.ToLower(filepath.Base(strings.TrimSpace(path)))
 	return base == defaultEnvSourceFile || base == altEnvSourceFile
 }
 
-func ListRequestFiles(root string, recursive bool) ([]FileEntry, error) {
-	return listFiles(root, recursive, classifyRequestFile, "")
+func IsWorkspaceFile(path string) bool {
+	_, ok := ClassifyWorkspacePath(path)
+	return ok
 }
 
-func ListWorkspaceFiles(root string, recursive bool, opts ListOptions) ([]FileEntry, error) {
-	return listFiles(root, recursive, classifyWorkspaceFile, opts.ExplicitEnvFile)
-}
-
-func classifyRequestFile(path string) (FileKind, bool) {
+func ClassifyRequestPath(path string) (FileKind, bool) {
 	switch {
 	case IsRequestFile(path):
 		return FileKindRequest, true
@@ -80,7 +123,7 @@ func classifyRequestFile(path string) (FileKind, bool) {
 	}
 }
 
-func classifyWorkspaceFile(path string) (FileKind, bool) {
+func ClassifyWorkspacePath(path string) (FileKind, bool) {
 	switch {
 	case IsRequestFile(path):
 		return FileKindRequest, true
@@ -88,9 +131,23 @@ func classifyWorkspaceFile(path string) (FileKind, bool) {
 		return FileKindScript, true
 	case IsEnvJSONFile(path):
 		return FileKindEnv, true
+	case IsGraphQLFile(path):
+		return FileKindGraphQL, true
+	case IsJSONFile(path):
+		return FileKindJSON, true
+	case IsJavaScriptFile(path):
+		return FileKindJavaScript, true
 	default:
 		return 0, false
 	}
+}
+
+func ListRequestFiles(root string, recursive bool) ([]FileEntry, error) {
+	return listFiles(root, recursive, ClassifyRequestPath, "")
+}
+
+func ListWorkspaceFiles(root string, recursive bool, opts ListOptions) ([]FileEntry, error) {
+	return listFiles(root, recursive, ClassifyWorkspacePath, opts.ExplicitEnvFile)
 }
 
 func listFiles(

--- a/internal/filesvc/list_test.go
+++ b/internal/filesvc/list_test.go
@@ -15,6 +15,9 @@ func TestFileKindString(t *testing.T) {
 		{name: "request", kind: FileKindRequest, want: "request"},
 		{name: "script", kind: FileKindScript, want: "script"},
 		{name: "env", kind: FileKindEnv, want: "env"},
+		{name: "graphql", kind: FileKindGraphQL, want: "graphql"},
+		{name: "json", kind: FileKindJSON, want: "json"},
+		{name: "javascript", kind: FileKindJavaScript, want: "javascript"},
 		{name: "unknown", kind: FileKind(99), want: "unknown"},
 	}
 
@@ -24,6 +27,27 @@ func TestFileKindString(t *testing.T) {
 				t.Fatalf("String() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFileKindBadgeLabel(t *testing.T) {
+	tests := []struct {
+		kind FileKind
+		want string
+	}{
+		{kind: FileKindRequest, want: ""},
+		{kind: FileKindScript, want: "RTS"},
+		{kind: FileKindEnv, want: "ENV"},
+		{kind: FileKindGraphQL, want: "GQL"},
+		{kind: FileKindJSON, want: "JSON"},
+		{kind: FileKindJavaScript, want: "JS"},
+		{kind: FileKind(99), want: ""},
+	}
+
+	for _, tt := range tests {
+		if got := tt.kind.BadgeLabel(); got != tt.want {
+			t.Fatalf("BadgeLabel(%v) = %q, want %q", tt.kind, got, tt.want)
+		}
 	}
 }
 
@@ -84,6 +108,12 @@ func TestListWorkspaceFilesIncludesEnvJSON(t *testing.T) {
 		"a.http",
 		"helpers.rts",
 		"resterm.env.json",
+		"query.graphql",
+		"short.gql",
+		"payload.json",
+		"pre.js",
+		"module.mjs",
+		"common.cjs",
 		"notes.txt",
 	}
 	for _, name := range files {
@@ -111,8 +141,57 @@ func TestListWorkspaceFilesIncludesEnvJSON(t *testing.T) {
 	if got["resterm.env.json"] != FileKindEnv {
 		t.Fatalf("expected resterm.env.json to be an env file, got %+v", entries)
 	}
+	if got["query.graphql"] != FileKindGraphQL {
+		t.Fatalf("expected query.graphql to be a graphql file, got %+v", entries)
+	}
+	if got["short.gql"] != FileKindGraphQL {
+		t.Fatalf("expected short.gql to be a graphql file, got %+v", entries)
+	}
+	if got["payload.json"] != FileKindJSON {
+		t.Fatalf("expected payload.json to be a json file, got %+v", entries)
+	}
+	if got["pre.js"] != FileKindJavaScript {
+		t.Fatalf("expected pre.js to be a javascript file, got %+v", entries)
+	}
+	if got["module.mjs"] != FileKindJavaScript {
+		t.Fatalf("expected module.mjs to be a javascript file, got %+v", entries)
+	}
+	if got["common.cjs"] != FileKindJavaScript {
+		t.Fatalf("expected common.cjs to be a javascript file, got %+v", entries)
+	}
 	if _, ok := got["notes.txt"]; ok {
 		t.Fatalf("did not expect notes.txt in workspace entries, got %+v", entries)
+	}
+}
+
+func TestClassifyWorkspacePathPrecedence(t *testing.T) {
+	tests := []struct {
+		path string
+		want FileKind
+		ok   bool
+	}{
+		{path: "requests.http", want: FileKindRequest, ok: true},
+		{path: "requests.rest", want: FileKindRequest, ok: true},
+		{path: "helpers.rts", want: FileKindScript, ok: true},
+		{path: "resterm.env.json", want: FileKindEnv, ok: true},
+		{path: "rest-client.env.json", want: FileKindEnv, ok: true},
+		{path: "payload.json", want: FileKindJSON, ok: true},
+		{path: "query.graphql", want: FileKindGraphQL, ok: true},
+		{path: "query.gql", want: FileKindGraphQL, ok: true},
+		{path: "pre.js", want: FileKindJavaScript, ok: true},
+		{path: "pre.mjs", want: FileKindJavaScript, ok: true},
+		{path: "pre.cjs", want: FileKindJavaScript, ok: true},
+		{path: "notes.txt", ok: false},
+	}
+
+	for _, tt := range tests {
+		got, ok := ClassifyWorkspacePath(tt.path)
+		if ok != tt.ok {
+			t.Fatalf("ClassifyWorkspacePath(%q) ok = %v, want %v", tt.path, ok, tt.ok)
+		}
+		if got != tt.want {
+			t.Fatalf("ClassifyWorkspacePath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
 	}
 }
 

--- a/internal/parser/bodyref/ref.go
+++ b/internal/parser/bodyref/ref.go
@@ -31,32 +31,28 @@ func Parse(line string, opt Options) (string, bool) {
 		return "", false
 	}
 	s := str.Trim(line)
-	t, ok := tail(s, opt.Location)
-	if !ok {
-		return "", false
-	}
-	return parsePath(t)
-}
-
-func tail(s string, loc Location) (string, bool) {
-	switch loc {
+	switch opt.Location {
 	case Line:
-		if !strings.HasPrefix(s, "<") {
-			return "", false
-		}
-		return s[1:], true
+		return parseLinePath(s)
 	case Inline:
-		if !strings.HasPrefix(s, "@") {
-			return "", false
-		}
-		_, after, ok := strings.Cut(s, "<")
-		if !ok {
-			return "", false
-		}
-		return after, true
+		return parseInlinePath(s)
 	default:
 		return "", false
 	}
+}
+
+// ParseBodyFile returns a body file path from a protocol body line. It accepts
+// standalone "< path" references and directive-style "@name < path" references.
+func ParseBodyFile(line string, forceInline bool) (string, bool) {
+	opt := Options{
+		Location:    Line,
+		ForceInline: forceInline,
+	}
+	if file, ok := Parse(line, opt); ok {
+		return file, true
+	}
+	opt.Location = Inline
+	return Parse(line, opt)
 }
 
 func parsePath(s string) (string, bool) {
@@ -70,10 +66,59 @@ func parsePath(s string) (string, bool) {
 	return p, true
 }
 
+func parseLinePath(s string) (string, bool) {
+	if !strings.HasPrefix(s, "<") {
+		return "", false
+	}
+	return parsePath(s[1:])
+}
+
+func parseInlinePath(s string) (string, bool) {
+	if !strings.HasPrefix(s, "@") {
+		return "", false
+	}
+
+	headEnd := strings.IndexFunc(s, unicode.IsSpace)
+	if headEnd <= 1 {
+		return "", false
+	}
+	if !isDirectiveHead(s[:headEnd]) {
+		return "", false
+	}
+
+	rest := str.TrimLeft(s[headEnd:])
+	if !strings.HasPrefix(rest, "<") {
+		return "", false
+	}
+	return parsePath(rest[1:])
+}
+
+func isDirectiveHead(s string) bool {
+	if !strings.HasPrefix(s, "@") || len(s) == 1 {
+		return false
+	}
+	for i, r := range s[1:] {
+		if i == 0 {
+			if !unicode.IsLetter(r) {
+				return false
+			}
+			continue
+		}
+		if !isDirectiveRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
 func hasLeadingSpace(s string) bool {
 	if s == "" {
 		return false
 	}
 	r, _ := utf8.DecodeRuneInString(s)
 	return unicode.IsSpace(r)
+}
+
+func isDirectiveRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || strings.ContainsRune("-_.", r)
 }

--- a/internal/parser/bodyref/ref_test.go
+++ b/internal/parser/bodyref/ref_test.go
@@ -9,6 +9,9 @@ func TestParseBodyFileReference(t *testing.T) {
 		ok   bool
 	}{
 		{in: "< ./payload.xml", want: "./payload.xml", ok: true},
+		{in: "  < ./payload.xml", want: "./payload.xml", ok: true},
+		{in: "<\t./payload.xml", want: "./payload.xml", ok: true},
+		{in: "<\u00a0./payload.xml", want: "./payload.xml", ok: true},
 		{in: "< ./payload>v1.xml", want: "./payload>v1.xml", ok: true},
 		{in: "<?xml version=\"1.0\"?>", ok: false},
 		{in: "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">", ok: false},
@@ -18,6 +21,7 @@ func TestParseBodyFileReference(t *testing.T) {
 		{in: "<payload.xml", ok: false},
 		{in: "<./payload.xml", ok: false},
 		{in: "<", ok: false},
+		{in: "< ", ok: false},
 	}
 
 	for _, tt := range tests {
@@ -31,28 +35,32 @@ func TestParseBodyFileReference(t *testing.T) {
 }
 
 func TestParseEmbeddedBodyFileReference(t *testing.T) {
-	got, ok := Parse("@body < ./payload.json", Options{
-		Location: Inline,
-	})
-	if !ok || got != "./payload.json" {
-		t.Fatalf("Parse()=(%q,%v), want body file", got, ok)
+	tests := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{in: "@body < ./payload.json", want: "./payload.json", ok: true},
+		{in: "@body\t<\t./payload.json", want: "./payload.json", ok: true},
+		{in: "@body < ./payload>v1.json", want: "./payload>v1.json", ok: true},
+		{in: "@body <soap:Envelope>", ok: false},
+		{in: "@body <./payload.json", ok: false},
+		{in: "@body< ./payload.json", ok: false},
+		{in: "@body text < ./payload.json", ok: false},
+		{in: "@{body} < ./payload.json", ok: false},
+		{in: "@1body < ./payload.json", ok: false},
+		{in: "@grpc-metadata < ./metadata.json", want: "./metadata.json", ok: true},
+		{in: "@body <", ok: false},
+		{in: "body < ./payload.json", ok: false},
 	}
 
-	if got, ok := Parse("@body < ./payload>v1.json", Options{
-		Location: Inline,
-	}); !ok ||
-		got != "./payload>v1.json" {
-		t.Fatalf("Parse()=(%q,%v), want explicit body file", got, ok)
-	}
-
-	if got, ok := Parse("@body <soap:Envelope>", Options{
-		Location: Inline,
-	}); ok || got != "" {
-		t.Fatalf("expected xml markup to remain body text, got (%q,%v)", got, ok)
-	}
-
-	if got, ok := Parse("@body <./payload.json", Options{Location: Inline}); ok || got != "" {
-		t.Fatalf("expected compact reference to remain body text, got (%q,%v)", got, ok)
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, ok := Parse(tt.in, Options{Location: Inline})
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("Parse(%q)=(%q,%v), want (%q,%v)", tt.in, got, ok, tt.want, tt.ok)
+			}
+		})
 	}
 }
 
@@ -62,5 +70,30 @@ func TestParseForceInlineRejectsBodyReferences(t *testing.T) {
 		ForceInline: true,
 	}); ok || got != "" {
 		t.Fatalf("expected forced inline body text, got (%q,%v)", got, ok)
+	}
+}
+
+func TestParseBodyFileChecksLineAndInlineForms(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		forceInline bool
+		want        string
+		ok          bool
+	}{
+		{name: "line", in: "< ./payload.json", want: "./payload.json", ok: true},
+		{name: "inline", in: "@query < ./query.graphql", want: "./query.graphql", ok: true},
+		{name: "template head", in: "@{payload} < ./payload.json"},
+		{name: "compact", in: "<./payload.json"},
+		{name: "force inline", in: "< ./payload.json", forceInline: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseBodyFile(tt.in, tt.forceInline)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("ParseBodyFile(%q)=(%q,%v), want (%q,%v)", tt.in, got, ok, tt.want, tt.ok)
+			}
+		})
 	}
 }

--- a/internal/parser/builder/graphql/builder.go
+++ b/internal/parser/builder/graphql/builder.go
@@ -86,17 +86,12 @@ func (b *Builder) disable() {
 	b.queryFile = ""
 }
 
-func (b *Builder) HandleBodyLine(line string) bool {
+func (b *Builder) HandleBodyLine(line string, forceInline bool) bool {
 	if !b.enabled {
 		return false
 	}
 	if b.collectVariables {
-		if file, ok := bodyref.Parse(line, bodyref.Options{Location: bodyref.Line}); ok {
-			b.variablesFile = file
-			b.variablesLines = nil
-			return true
-		}
-		if file, ok := bodyref.Parse(line, bodyref.Options{Location: bodyref.Inline}); ok {
+		if file, ok := bodyref.ParseBodyFile(line, forceInline); ok {
 			b.variablesFile = file
 			b.variablesLines = nil
 			return true
@@ -105,17 +100,12 @@ func (b *Builder) HandleBodyLine(line string) bool {
 		return true
 	}
 
-	if file, ok := bodyref.Parse(line, bodyref.Options{Location: bodyref.Line}); ok {
+	if file, ok := bodyref.ParseBodyFile(line, forceInline); ok {
 		b.queryFile = file
 		b.queryLines = nil
 		return true
 	}
 
-	if file, ok := bodyref.Parse(line, bodyref.Options{Location: bodyref.Inline}); ok {
-		b.queryFile = file
-		b.queryLines = nil
-		return true
-	}
 	b.queryLines = append(b.queryLines, line)
 	return true
 }

--- a/internal/parser/builder/grpc/builder.go
+++ b/internal/parser/builder/grpc/builder.go
@@ -111,7 +111,7 @@ func (b *Builder) HandleDirective(key, rest string) bool {
 	return false
 }
 
-func (b *Builder) HandleBodyLine(line string) bool {
+func (b *Builder) HandleBodyLine(line string, forceInline bool) bool {
 	if b.request == nil {
 		return false
 	}
@@ -121,17 +121,12 @@ func (b *Builder) HandleBodyLine(line string) bool {
 		return false
 	}
 
-	if file, ok := bodyref.Parse(line, bodyref.Options{Location: bodyref.Line}); ok {
+	if file, ok := bodyref.ParseBodyFile(line, forceInline); ok {
 		b.messageFromFile = file
 		b.messageLines = nil
 		return true
 	}
 
-	if file, ok := bodyref.Parse(line, bodyref.Options{Location: bodyref.Inline}); ok {
-		b.messageFromFile = file
-		b.messageLines = nil
-		return true
-	}
 	b.messageLines = append(b.messageLines, line)
 	return true
 }

--- a/internal/parser/document.go
+++ b/internal/parser/document.go
@@ -226,17 +226,30 @@ func (b *documentBuilder) handleBlankLine(line, trimmed string) bool {
 	if trimmed != "" {
 		return false
 	}
-	if b.inRequest {
-		if !b.request.http.HasMethod() {
-		} else if !b.request.http.HeaderDone() {
-			b.request.markHeadersDone()
-		} else if b.request.graphql.HandleBodyLine(line) {
-		} else if b.request.grpc.HandleBodyLine(line) {
-		} else {
-			b.request.http.AppendBodyLine("")
-		}
-		b.appendLine(line)
+	if !b.inRequest {
+		return true
 	}
+
+	if !b.request.http.HasMethod() {
+		b.appendLine(line)
+		return true
+	}
+	if !b.request.http.HeaderDone() {
+		b.request.markHeadersDone()
+		b.appendLine(line)
+		return true
+	}
+	if b.request.graphql.HandleBodyLine(line, b.request.bodyOptions.ForceInline) {
+		b.appendLine(line)
+		return true
+	}
+	if b.request.grpc.HandleBodyLine(line, b.request.bodyOptions.ForceInline) {
+		b.appendLine(line)
+		return true
+	}
+
+	b.request.http.AppendBodyLine("")
+	b.appendLine(line)
 	return true
 }
 
@@ -639,27 +652,25 @@ func (b *documentBuilder) addConstant(name, value string, line int) {
 }
 
 func (b *documentBuilder) handleBodyLine(line string) {
-	if b.request.graphql.HandleBodyLine(line) {
+	if b.request.graphql.HandleBodyLine(line, b.request.bodyOptions.ForceInline) {
 		return
 	}
-	if b.request.grpc.HandleBodyLine(line) {
+	if b.request.grpc.HandleBodyLine(line, b.request.bodyOptions.ForceInline) {
 		return
 	}
 
-	opt := bodyref.Options{
-		Location:    bodyref.Line,
-		ForceInline: b.request.bodyOptions.ForceInline,
-	}
-	if file, ok := bodyref.Parse(line, opt); ok {
-		b.request.http.SetBodyFromFile(file)
-		return
-	}
-	opt.Location = bodyref.Inline
-	if file, ok := bodyref.Parse(line, opt); ok {
+	if file, ok := parseHTTPBodyFile(line, b.request.bodyOptions.ForceInline); ok {
 		b.request.http.SetBodyFromFile(file)
 		return
 	}
 	b.request.http.AppendBodyLine(line)
+}
+
+func parseHTTPBodyFile(line string, forceInline bool) (string, bool) {
+	return bodyref.Parse(line, bodyref.Options{
+		Location:    bodyref.Line,
+		ForceInline: forceInline,
+	})
 }
 
 func (b *documentBuilder) ensureRequest(line int) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -46,6 +46,5 @@ func Parse(path string, data []byte) *restfile.Document {
 }
 
 func normalizeNewlines(data []byte) []byte {
-	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
-	return bytes.ReplaceAll(data, []byte("\r"), []byte("\n"))
+	return bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -46,5 +46,6 @@ func Parse(path string, data []byte) *restfile.Document {
 }
 
 func normalizeNewlines(data []byte) []byte {
-	return bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	return bytes.ReplaceAll(data, []byte("\r"), []byte("\n"))
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -2539,13 +2539,6 @@ func TestParseScannerError(t *testing.T) {
 	}
 }
 
-func TestNormalizeNewlinesHandlesBareCarriageReturn(t *testing.T) {
-	got := string(normalizeNewlines([]byte("first\rsecond\r\nthird\n")))
-	if got != "first\nsecond\nthird\n" {
-		t.Fatalf("unexpected normalized newlines %q", got)
-	}
-}
-
 func TestParseGraphQLRequest(t *testing.T) {
 	src := `# @name GraphQLExample
 # @graphql

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -2312,6 +2312,25 @@ ignored
 	}
 }
 
+func TestParseHTTPBodyAtPrefixedAngleLineStaysInlineText(t *testing.T) {
+	src := `POST https://example.com/api
+
+@{payload} < ./not-a-file-reference
+`
+
+	doc := Parse("http-at-angle-body.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if req.Body.FilePath != "" {
+		t.Fatalf("expected inline body text, got file path %q", req.Body.FilePath)
+	}
+	if req.Body.Text != "@{payload} < ./not-a-file-reference" {
+		t.Fatalf("unexpected inline body text %q", req.Body.Text)
+	}
+}
+
 func TestParseWorkflowDirectives(t *testing.T) {
 	src := `# @workflow provision-account on-failure=continue
 # @description Provision new account flow
@@ -2520,6 +2539,13 @@ func TestParseScannerError(t *testing.T) {
 	}
 }
 
+func TestNormalizeNewlinesHandlesBareCarriageReturn(t *testing.T) {
+	got := string(normalizeNewlines([]byte("first\rsecond\r\nthird\n")))
+	if got != "first\nsecond\nthird\n" {
+		t.Fatalf("unexpected normalized newlines %q", got)
+	}
+}
+
 func TestParseGraphQLRequest(t *testing.T) {
 	src := `# @name GraphQLExample
 # @graphql
@@ -2585,6 +2611,77 @@ POST https://example.com/graphql
 	}
 	if gql.VariablesFile != "./queries/workspace.variables.json" {
 		t.Fatalf("unexpected variables file %q", gql.VariablesFile)
+	}
+}
+
+func TestParseGraphQLDirectiveFileRefsIgnoreBodyInline(t *testing.T) {
+	src := `# @body inline
+# @graphql
+# @query < ./queries/workspace.graphql
+# @variables < ./queries/workspace.variables.json
+POST https://example.com/graphql
+`
+
+	doc := Parse("graphql-directive-files-inline.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	gql := doc.Requests[0].Body.GraphQL
+	if gql == nil {
+		t.Fatalf("expected GraphQL body")
+	}
+	if gql.QueryFile != "./queries/workspace.graphql" {
+		t.Fatalf("unexpected query file %q", gql.QueryFile)
+	}
+	if gql.VariablesFile != "./queries/workspace.variables.json" {
+		t.Fatalf("unexpected variables file %q", gql.VariablesFile)
+	}
+}
+
+func TestParseGraphQLBodyInlineForcesFileLikeLineToText(t *testing.T) {
+	src := `# @body inline
+# @graphql
+POST https://example.com/graphql
+
+< ./queries/workspace.graphql
+`
+
+	doc := Parse("graphql-inline-body-file-like.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	gql := doc.Requests[0].Body.GraphQL
+	if gql == nil {
+		t.Fatalf("expected GraphQL body")
+	}
+	if gql.QueryFile != "" {
+		t.Fatalf("expected inline query text, got query file %q", gql.QueryFile)
+	}
+	if gql.Query != "< ./queries/workspace.graphql" {
+		t.Fatalf("unexpected query text %q", gql.Query)
+	}
+}
+
+func TestParseGraphQLTemplateHeadAngleLineStaysInlineText(t *testing.T) {
+	src := `# @graphql
+POST https://example.com/graphql
+
+@{payload} < ./not-a-file-reference
+`
+
+	doc := Parse("graphql-template-head-angle.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	gql := doc.Requests[0].Body.GraphQL
+	if gql == nil {
+		t.Fatalf("expected GraphQL body")
+	}
+	if gql.QueryFile != "" {
+		t.Fatalf("expected inline query text, got query file %q", gql.QueryFile)
+	}
+	if gql.Query != "@{payload} < ./not-a-file-reference" {
+		t.Fatalf("unexpected query text %q", gql.Query)
 	}
 }
 
@@ -2726,6 +2823,34 @@ GRPC localhost:50051
 	}
 	if grpc.Message != "" {
 		t.Fatalf("expected no inline message, got %q", grpc.Message)
+	}
+}
+
+func TestParseGRPCBodyInlineForcesFileLikeLineToText(t *testing.T) {
+	src := `# @body inline
+# @grpc my.pkg.UserService/GetUser
+GRPC localhost:50051
+
+< ./payload.json
+`
+
+	doc := Parse("grpc-inline-body-file-like.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	grpc := req.GRPC
+	if grpc == nil {
+		t.Fatalf("expected grpc request")
+	}
+	if grpc.MessageFile != "" {
+		t.Fatalf("expected inline message text, got message file %q", grpc.MessageFile)
+	}
+	if grpc.Message != "< ./payload.json" {
+		t.Fatalf("unexpected inline message %q", grpc.Message)
+	}
+	if !req.Body.Options.ForceInline {
+		t.Fatalf("expected ForceInline option")
 	}
 }
 

--- a/internal/restwriter/writer.go
+++ b/internal/restwriter/writer.go
@@ -203,9 +203,7 @@ func bodyTextNeedsInlineDirective(req *restfile.Request) bool {
 	if _, ok := bodyref.Parse(line, opt); ok {
 		return true
 	}
-	opt.Location = bodyref.Inline
-	_, ok := bodyref.Parse(line, opt)
-	return ok
+	return false
 }
 
 func renderDescription(b *strings.Builder, desc string) {

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -23,7 +23,6 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/history"
 	"github.com/unkn0wn-root/resterm/internal/httpclient"
 	"github.com/unkn0wn-root/resterm/internal/k8s"
-	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/registry"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/rts"
@@ -723,7 +722,7 @@ func New(cfg Config) Model {
 	model.applyLayoutSettingsFromConfig(cfg.Settings.Layout)
 	_ = model.setInsertMode(false, false)
 
-	model.doc = parser.Parse(cfg.FilePath, []byte(cfg.InitialContent))
+	model.doc = parseEditableDocument(cfg.FilePath, []byte(cfg.InitialContent))
 	model.syncRegistry(model.doc)
 	model.syncRequestList(model.doc)
 	model.rebuildNavigator(entries)

--- a/internal/ui/model_files.go
+++ b/internal/ui/model_files.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/filesvc"
 	"github.com/unkn0wn-root/resterm/internal/parser"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
 func (m *Model) openSelectedFile() tea.Cmd {
@@ -43,7 +44,7 @@ func (m *Model) openFile(path string) tea.Cmd {
 	m.currentRequest = nil
 	m.activeRequestTitle = ""
 	m.activeRequestKey = ""
-	m.doc = parser.Parse(path, data)
+	m.doc = parseEditableDocument(path, data)
 	m.syncRegistry(m.doc)
 	m.syncRequestList(m.doc)
 	m.rebuildNavigator(nil)
@@ -158,7 +159,7 @@ func (m *Model) ensureWorkspaceFile(path string) bool {
 }
 
 func (m *Model) reparseDocument() tea.Cmd {
-	m.doc = parser.Parse(m.currentFile, []byte(m.editor.Value()))
+	m.doc = parseEditableDocument(m.currentFile, []byte(m.editor.Value()))
 	m.syncRegistry(m.doc)
 	m.syncRequestList(m.doc)
 	m.rebuildNavigator(nil)
@@ -213,7 +214,7 @@ func (m *Model) reloadFileFromDisk() tea.Cmd {
 }
 
 func (m *Model) refreshCurrentDocument(content []byte) {
-	m.doc = parser.Parse(m.currentFile, content)
+	m.doc = parseEditableDocument(m.currentFile, content)
 	m.syncRegistry(m.doc)
 	m.syncRequestList(m.doc)
 	m.rebuildNavigator(nil)
@@ -227,4 +228,11 @@ func (m *Model) refreshCurrentDocument(content []byte) {
 
 func (m *Model) updateEditorStyler(path string) {
 	m.editor.SetRuneStyler(selectEditorRuneStyler(path, m.theme.EditorMetadata))
+}
+
+func parseEditableDocument(path string, data []byte) *restfile.Document {
+	if !filesvc.IsRequestFile(path) {
+		return &restfile.Document{Path: path, Raw: append([]byte(nil), data...)}
+	}
+	return parser.Parse(path, data)
 }

--- a/internal/ui/model_navigator.go
+++ b/internal/ui/model_navigator.go
@@ -115,12 +115,12 @@ func (m *Model) buildFileNode(entry filesvc.FileEntry) *navigator.Node[any] {
 }
 
 func fileEntryBadges(entry filesvc.FileEntry, activeEnvFile string) []string {
-	if entry.Kind != filesvc.FileKindEnv {
-		return nil
+	var badges []string
+	if label := entry.Kind.BadgeLabel(); label != "" {
+		badges = append(badges, label)
 	}
 
-	badges := []string{"ENV"}
-	if samePath(entry.Path, activeEnvFile) {
+	if entry.Kind == filesvc.FileKindEnv && samePath(entry.Path, activeEnvFile) {
 		badges = append(badges, "ACTIVE")
 	}
 	return badges

--- a/internal/ui/model_navigator_test.go
+++ b/internal/ui/model_navigator_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/unkn0wn-root/resterm/internal/filesvc"
 	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/ui/navigator"
@@ -707,6 +708,56 @@ func TestNavigatorDirFirstSort(t *testing.T) {
 	}
 	if dirNode.Children[1].Kind != navigator.KindFile || dirNode.Children[1].Title != "a.http" {
 		t.Fatalf("expected file after dir under %s", dir)
+	}
+}
+
+func TestNavigatorIncludesAuxiliaryWorkspaceFiles(t *testing.T) {
+	tmp := t.TempDir()
+	queryFile := filepath.Join(tmp, "addNote.graphql")
+	varsFile := filepath.Join(tmp, "addNote.variables.json")
+	scriptFile := filepath.Join(tmp, "pre.js")
+
+	writeSampleFile(t, queryFile, "mutation AddNote { addNote { id } }\n")
+	writeSampleFile(t, varsFile, `{"id":"1"}`)
+	writeSampleFile(t, scriptFile, "request.setHeader('X-Test', '1');\n")
+
+	model := New(Config{WorkspaceRoot: tmp})
+	m := &model
+
+	tests := []struct {
+		path  string
+		kind  filesvc.FileKind
+		badge string
+	}{
+		{path: queryFile, kind: filesvc.FileKindGraphQL, badge: "GQL"},
+		{path: varsFile, kind: filesvc.FileKindJSON, badge: "JSON"},
+		{path: scriptFile, kind: filesvc.FileKindJavaScript, badge: "JS"},
+	}
+
+	for _, tt := range tests {
+		node := m.navigator.Find("file:" + tt.path)
+		if node == nil {
+			t.Fatalf("expected navigator node for %s", tt.path)
+		}
+		entry, ok := node.Payload.Data.(filesvc.FileEntry)
+		if !ok {
+			t.Fatalf("expected filesvc.FileEntry payload for %s, got %T", tt.path, node.Payload.Data)
+		}
+		if entry.Kind != tt.kind {
+			t.Fatalf("expected kind %v for %s, got %v", tt.kind, tt.path, entry.Kind)
+		}
+		if !containsString(node.Badges, tt.badge) {
+			t.Fatalf("expected badge %q for %s, got %+v", tt.badge, tt.path, node.Badges)
+		}
+		if len(node.Children) != 0 || node.Count != 0 {
+			t.Fatalf("expected auxiliary file to be a leaf node, got count=%d children=%d", node.Count, len(node.Children))
+		}
+	}
+
+	m.navigator.SetFilter("GQL")
+	rows := m.navigator.Rows()
+	if len(rows) != 1 || rows[0].Node == nil || rows[0].Node.ID != "file:"+queryFile {
+		t.Fatalf("expected GQL filter to find graphql file, got %+v", rows)
 	}
 }
 

--- a/internal/ui/model_open.go
+++ b/internal/ui/model_open.go
@@ -54,7 +54,7 @@ func (m *Model) submitOpenPath() tea.Cmd {
 	}
 
 	if !m.isSupportedOpenPath(resolved) {
-		m.openPathError = "Only request, RTS, or env files are supported"
+		m.openPathError = "Only Resterm-supported workspace files can be opened"
 		return nil
 	}
 
@@ -146,11 +146,7 @@ func (m *Model) applyOpenFilePath(path string) tea.Cmd {
 
 func (m *Model) isSupportedOpenPath(path string) bool {
 	switch {
-	case filesvc.IsRequestFile(path):
-		return true
-	case filesvc.IsRTSFile(path):
-		return true
-	case filesvc.IsEnvJSONFile(path):
+	case filesvc.IsWorkspaceFile(path):
 		return true
 	case vars.IsDotEnvPath(path):
 		return true

--- a/internal/ui/model_open_test.go
+++ b/internal/ui/model_open_test.go
@@ -114,3 +114,47 @@ func TestSubmitOpenPathOpensEnvFile(t *testing.T) {
 		t.Fatalf("expected current file %q, got %q", file, m.currentFile)
 	}
 }
+
+func TestSubmitOpenPathOpensAuxiliaryWorkspaceFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		file string
+		body string
+	}{
+		{name: "graphql", file: "query.graphql", body: "query { viewer { id } }"},
+		{name: "gql", file: "query.gql", body: "query { viewer { id } }"},
+		{name: "json", file: "variables.json", body: `{"id":"1"}`},
+		{name: "js", file: "pre.js", body: "request.setHeader('X-Test', '1');"},
+		{name: "mjs", file: "pre.mjs", body: "export const value = 1;"},
+		{name: "cjs", file: "pre.cjs", body: "module.exports = {};"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, tt.file)
+			if err := os.WriteFile(file, []byte(tt.body), 0o644); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+
+			th := theme.DefaultTheme()
+			model := New(Config{WorkspaceRoot: tmp, Theme: &th})
+			m := &model
+			m.openOpenModal()
+			m.openPathInput.SetValue(file)
+			if cmd := m.submitOpenPath(); cmd != nil {
+				cmd()
+			}
+
+			if m.currentFile != file {
+				t.Fatalf("expected current file %q, got %q", file, m.currentFile)
+			}
+			if got := m.editor.Value(); got != tt.body {
+				t.Fatalf("expected editor body %q, got %q", tt.body, got)
+			}
+			if len(m.requestItems) != 0 {
+				t.Fatalf("expected auxiliary file not to populate requests, got %+v", m.requestItems)
+			}
+		})
+	}
+}

--- a/internal/ui/model_update_navigator.go
+++ b/internal/ui/model_update_navigator.go
@@ -137,7 +137,7 @@ func (m *Model) updateNavigator(msg tea.Msg) tea.Cmd {
 				if path != "" && !samePath(path, m.currentFile) {
 					cmd = m.openFile(path)
 				}
-				if filesvc.IsRTSFile(path) {
+				if path != "" && !filesvc.IsRequestFile(path) {
 					return applyJump(cmd, true)
 				}
 				m.navExpandFile(n, false)
@@ -160,6 +160,9 @@ func (m *Model) updateNavigator(msg tea.Msg) tea.Cmd {
 				path := n.Payload.FilePath
 				if path != "" && !samePath(path, m.currentFile) {
 					cmd = m.openFile(path)
+				}
+				if path != "" && !filesvc.IsRequestFile(path) {
+					return applyJump(cmd, true)
 				}
 				m.navExpandFile(n, false)
 			case navigator.KindDir:

--- a/internal/ui/navigator/render.go
+++ b/internal/ui/navigator/render.go
@@ -19,6 +19,9 @@ const (
 	iconDirOpen     = "📂"
 	iconRTS         = "λ"
 	iconEnv         = "⚙"
+	iconGraphQL     = "◇"
+	iconJSON        = "{}"
+	iconJavaScript  = "JS"
 )
 
 // ListView renders the navigator list with an optional height constraint.
@@ -128,6 +131,12 @@ func rowIcon(n *Node[any]) string {
 			return iconRTS
 		case filesvc.FileKindEnv:
 			return iconEnv
+		case filesvc.FileKindGraphQL:
+			return iconGraphQL
+		case filesvc.FileKindJSON:
+			return iconJSON
+		case filesvc.FileKindJavaScript:
+			return iconJavaScript
 		}
 		return caret(n.Expanded)
 	default:
@@ -142,14 +151,10 @@ func fileKind(n *Node[any]) filesvc.FileKind {
 	if entry, ok := n.Payload.Data.(filesvc.FileEntry); ok {
 		return entry.Kind
 	}
-	switch {
-	case filesvc.IsRTSFile(n.Payload.FilePath):
-		return filesvc.FileKindScript
-	case filesvc.IsEnvJSONFile(n.Payload.FilePath):
-		return filesvc.FileKindEnv
-	default:
-		return filesvc.FileKindRequest
+	if kind, ok := filesvc.ClassifyWorkspacePath(n.Payload.FilePath); ok {
+		return kind
 	}
+	return filesvc.FileKindRequest
 }
 
 func caret(expanded bool) string {

--- a/internal/ui/navigator/render_test.go
+++ b/internal/ui/navigator/render_test.go
@@ -167,3 +167,93 @@ func TestRenderRowShowsEnvIcon(t *testing.T) {
 		t.Fatalf("expected env badges, got %q", clean)
 	}
 }
+
+func TestRenderRowShowsGraphQLIcon(t *testing.T) {
+	th := theme.DefaultTheme()
+	row := Flat[any]{
+		Node: &Node[any]{
+			Kind:   KindFile,
+			Title:  "query.graphql",
+			Badges: []string{"GQL"},
+			Payload: Payload[any]{
+				FilePath: "/tmp/query.graphql",
+				Data: filesvc.FileEntry{
+					Name: "query.graphql",
+					Path: "/tmp/query.graphql",
+					Kind: filesvc.FileKindGraphQL,
+				},
+			},
+		},
+	}
+	out := renderRow(row, false, th, 80, true, false, theme.AppearanceUnknown)
+	clean := ansi.Strip(out)
+	if !strings.Contains(clean, iconGraphQL) {
+		t.Fatalf("expected graphql icon, got %q", clean)
+	}
+	if strings.Contains(clean, iconCaretClosed) || strings.Contains(clean, iconCaretOpen) {
+		t.Fatalf("expected graphql row without caret, got %q", clean)
+	}
+	if !strings.Contains(clean, "GQL") {
+		t.Fatalf("expected graphql badge, got %q", clean)
+	}
+}
+
+func TestRenderRowShowsJSONIcon(t *testing.T) {
+	th := theme.DefaultTheme()
+	row := Flat[any]{
+		Node: &Node[any]{
+			Kind:   KindFile,
+			Title:  "variables.json",
+			Badges: []string{"JSON"},
+			Payload: Payload[any]{
+				FilePath: "/tmp/variables.json",
+				Data: filesvc.FileEntry{
+					Name: "variables.json",
+					Path: "/tmp/variables.json",
+					Kind: filesvc.FileKindJSON,
+				},
+			},
+		},
+	}
+	out := renderRow(row, false, th, 80, true, false, theme.AppearanceUnknown)
+	clean := ansi.Strip(out)
+	if !strings.Contains(clean, iconJSON) {
+		t.Fatalf("expected json icon, got %q", clean)
+	}
+	if strings.Contains(clean, iconCaretClosed) || strings.Contains(clean, iconCaretOpen) {
+		t.Fatalf("expected json row without caret, got %q", clean)
+	}
+	if !strings.Contains(clean, "JSON") {
+		t.Fatalf("expected json badge, got %q", clean)
+	}
+}
+
+func TestRenderRowShowsJavaScriptIcon(t *testing.T) {
+	th := theme.DefaultTheme()
+	row := Flat[any]{
+		Node: &Node[any]{
+			Kind:   KindFile,
+			Title:  "pre.js",
+			Badges: []string{"JS"},
+			Payload: Payload[any]{
+				FilePath: "/tmp/pre.js",
+				Data: filesvc.FileEntry{
+					Name: "pre.js",
+					Path: "/tmp/pre.js",
+					Kind: filesvc.FileKindJavaScript,
+				},
+			},
+		},
+	}
+	out := renderRow(row, false, th, 80, true, false, theme.AppearanceUnknown)
+	clean := ansi.Strip(out)
+	if !strings.Contains(clean, iconJavaScript) {
+		t.Fatalf("expected javascript icon, got %q", clean)
+	}
+	if strings.Contains(clean, iconCaretClosed) || strings.Contains(clean, iconCaretOpen) {
+		t.Fatalf("expected javascript row without caret, got %q", clean)
+	}
+	if !strings.Contains(clean, "JS") {
+		t.Fatalf("expected javascript badge, got %q", clean)
+	}
+}


### PR DESCRIPTION
- fix body file reference parser misidentifying `@`- prefixed body text as file paths when the line contains `<`
- thread `@body inline` (ForceInline) through GraphQL and gRPC body handling so it is respected everywhere
- fix missing source line tracking in blank line handling before the method line
- add js/json and grapql files into TUI.