### PR TITLE
RST-225: changes tracking refactor

### DIFF
--- a/internal/history/sqlite/io.go
+++ b/internal/history/sqlite/io.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/errdef"
 	"github.com/unkn0wn-root/resterm/internal/history"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 func (s *Store) ExportJSON(path string) (int, error) {
@@ -99,7 +100,7 @@ func (s *Store) Backup(path string) error {
 
 	// The destination must be different from the live database path.
 	// Removing an existing file is part of backup preparation.
-	if samePath(path, s.p) {
+	if util.SamePath(path, s.p) {
 		return errdef.Wrap(
 			errdef.CodeHistory,
 			errors.New("backup path must differ from history db path"),
@@ -159,17 +160,4 @@ func writeFileAtom(path string, data []byte, perm os.FileMode) error {
 		return errdef.Wrap(errdef.CodeFilesystem, err, "replace export file")
 	}
 	return nil
-}
-
-func samePath(a, b string) bool {
-	if a == "" || b == "" {
-		return false
-	}
-	if p, err := filepath.Abs(a); err == nil {
-		a = p
-	}
-	if p, err := filepath.Abs(b); err == nil {
-		b = p
-	}
-	return a == b
 }

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -255,9 +255,11 @@ func (e *requestEditor) noteContentChanged() {
 }
 
 func (e *requestEditor) SetValue(value string) {
-	if e.Value() != value {
-		e.noteContentChanged()
+	if e.Value() == value {
+		return
 	}
+
+	e.noteContentChanged()
 	e.Model.SetValue(value)
 }
 

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -86,6 +86,7 @@ func statusCmd(level statusLevel, text string) tea.Cmd {
 
 type requestEditor struct {
 	textarea.Model
+	revision             uint64
 	selection            selectionState
 	mode                 selectionMode
 	pendingMotion        string
@@ -244,6 +245,21 @@ func newRequestEditor() requestEditor {
 		motionsEnabled: true,
 		hintManager:    hint.NewManager(hint.MetaSource()),
 	}
+}
+
+func (e requestEditor) Revision() uint64 {
+	return e.revision
+}
+
+func (e *requestEditor) noteContentChanged() {
+	e.revision++
+}
+
+func (e *requestEditor) SetValue(value string) {
+	if e.Value() != value {
+		e.noteContentChanged()
+	}
+	e.Model.SetValue(value)
 }
 
 func (e *requestEditor) SetMotionsEnabled(enabled bool) {
@@ -615,10 +631,15 @@ func (e *requestEditor) applyMetadataHintSelection() tea.Cmd {
 }
 
 func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
+	beforeValue := e.Value()
+	beforeRevision := e.revision
 	keyMsg, isKey := msg.(tea.KeyMsg)
 	if !isKey {
 		var innerCmd tea.Cmd
 		e.Model, innerCmd = e.Model.Update(msg)
+		if e.Value() != beforeValue && e.revision == beforeRevision {
+			e.noteContentChanged()
+		}
 		return e, innerCmd
 	}
 
@@ -824,6 +845,9 @@ func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 		}
 		var innerCmd tea.Cmd
 		e.Model, innerCmd = e.Model.Update(transformed)
+		if e.Value() != beforeValue && e.revision == beforeRevision {
+			e.noteContentChanged()
+		}
 		if innerCmd != nil {
 			cmds = append(cmds, innerCmd)
 		}

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -65,7 +65,6 @@ func (s selectionState) Caret() cursorPosition {
 }
 
 type editorEvent struct {
-	dirty  bool
 	status *statusMsg
 }
 
@@ -627,7 +626,7 @@ func (e *requestEditor) applyMetadataHintSelection() tea.Cmd {
 	e.moveCursorTo(line, col)
 	e.applySelectionHighlight()
 	e.metadataHints.deactivate()
-	return toEditorEventCmd(editorEvent{dirty: true})
+	return nil
 }
 
 func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
@@ -680,9 +679,7 @@ func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 	case "ctrl+x":
 		if text := e.selectedText(); text != "" {
 			cmds = append(cmds, (&e).copyToClipboard(text, ""))
-			if _, removed := (&e).removeSelection(); removed {
-				cmds = append(cmds, toEditorEventCmd(editorEvent{dirty: true}))
-			}
+			(&e).removeSelection()
 		}
 		handled = true
 	case " ":
@@ -691,15 +688,11 @@ func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 		}
 	case "ctrl+v":
 		if e.hasSelection() {
-			if _, removed := (&e).removeSelection(); removed {
-				cmds = append(cmds, toEditorEventCmd(editorEvent{dirty: true}))
-			}
+			(&e).removeSelection()
 		}
 	case "backspace", "ctrl+h", "delete":
 		if e.hasSelection() {
-			if _, removed := (&e).removeSelection(); removed {
-				cmds = append(cmds, toEditorEventCmd(editorEvent{dirty: true}))
-			}
+			(&e).removeSelection()
 			handled = true
 		}
 	case "gg":
@@ -830,9 +823,6 @@ func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 						cmds = append(cmds, warnCmd)
 					}
 				}
-
-				dirtyCmd := toEditorEventCmd(editorEvent{dirty: true})
-				cmds = append(cmds, dirtyCmd)
 			}
 		}
 	}
@@ -955,7 +945,7 @@ func (e requestEditor) DeleteSelection() (requestEditor, tea.Cmd) {
 		if status.level == statusInfo && status.text == "Deleted selection" {
 			status.text = "Selection deleted"
 		}
-		return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+		return e, toEditorEventCmd(editorEvent{status: &status})
 	}
 	return e, nil
 }
@@ -1058,7 +1048,7 @@ func (e requestEditor) DeleteMotion(
 	}
 
 	status := editorPtr.writeClipboardWithFallback(removed, summary)
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func (e *requestEditor) changeLines(startLine, endLine int) (string, bool) {
@@ -1149,7 +1139,7 @@ func (e requestEditor) ChangeMotion(
 	}
 
 	status := editorPtr.writeClipboardWithFallback(removed, summary)
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func classifyMotion(keys []string, action string) (deleteMotionSpec, error) {
@@ -1301,7 +1291,7 @@ func (e requestEditor) DeleteCurrentLine() (requestEditor, tea.Cmd) {
 	editorPtr.moveCursorTo(target, 0)
 	e.applySelectionHighlight()
 	status := editorPtr.writeClipboardWithFallback(clip, "Deleted line")
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func (e requestEditor) DeleteToLineEnd() (requestEditor, tea.Cmd) {
@@ -1342,7 +1332,7 @@ func (e requestEditor) DeleteToLineEnd() (requestEditor, tea.Cmd) {
 	editorPtr.moveCursorTo(cursor.Line, cursor.Column)
 	e.applySelectionHighlight()
 	status := (&e).writeClipboardWithFallback(segment, "Deleted to end of line")
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func (e requestEditor) DeleteCharAtCursor() (requestEditor, tea.Cmd) {
@@ -1357,7 +1347,7 @@ func (e requestEditor) DeleteCharAtCursor() (requestEditor, tea.Cmd) {
 		} else {
 			status = statusMsg{text: "Deleted selection", level: statusInfo}
 		}
-		return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+		return e, toEditorEventCmd(editorEvent{status: &status})
 	}
 
 	runes := []rune(e.Value())
@@ -1380,7 +1370,7 @@ func (e requestEditor) DeleteCharAtCursor() (requestEditor, tea.Cmd) {
 	e.applySelectionHighlight()
 	deletedChar := string([]rune{removed})
 	status := (&e).writeClipboardWithFallback(deletedChar, "Deleted character")
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func (e requestEditor) ChangeCurrentLine() (requestEditor, tea.Cmd) {
@@ -1394,7 +1384,7 @@ func (e requestEditor) ChangeCurrentLine() (requestEditor, tea.Cmd) {
 		return e, statusCmd(statusWarn, "Nothing to change")
 	}
 	status := editorPtr.writeClipboardWithFallback(removed, "Changed line")
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func (e requestEditor) PasteClipboard(after bool) (requestEditor, tea.Cmd) {
@@ -1485,7 +1475,7 @@ func (e requestEditor) PasteClipboard(after bool) (requestEditor, tea.Cmd) {
 			text:  "Clipboard unavailable; pasted from editor register",
 		}
 	}
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func (e requestEditor) UndoLastChange() (requestEditor, tea.Cmd) {
@@ -1503,7 +1493,7 @@ func (e requestEditor) UndoLastChange() (requestEditor, tea.Cmd) {
 		level: statusInfo,
 		text:  "Undid last change",
 	}
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func (e requestEditor) RedoLastChange() (requestEditor, tea.Cmd) {
@@ -1521,7 +1511,7 @@ func (e requestEditor) RedoLastChange() (requestEditor, tea.Cmd) {
 		level: statusInfo,
 		text:  "Redid last change",
 	}
-	return e, toEditorEventCmd(editorEvent{dirty: true, status: &status})
+	return e, toEditorEventCmd(editorEvent{status: &status})
 }
 
 func (e requestEditor) lineBounds(requested int) (start int, end int, idx int) {

--- a/internal/ui/editor_state_test.go
+++ b/internal/ui/editor_state_test.go
@@ -72,6 +72,25 @@ func collectHintLabels(options []hint.Hint) map[string]bool {
 	return labels
 }
 
+func TestRequestEditorSetValueNoopsWhenUnchanged(t *testing.T) {
+	content := "alpha\nbeta\ngamma"
+	editor := newTestEditor(content)
+	editorPtr := &editor
+	editorPtr.moveCursorTo(1, 2)
+
+	beforeCursor := editor.caretPosition()
+	beforeRevision := editor.Revision()
+
+	editorPtr.SetValue(content)
+
+	if got := editor.caretPosition(); got != beforeCursor {
+		t.Fatalf("expected cursor to remain at %+v, got %+v", beforeCursor, got)
+	}
+	if got := editor.Revision(); got != beforeRevision {
+		t.Fatalf("expected revision to remain %d, got %d", beforeRevision, got)
+	}
+}
+
 const clipboardFallbackStatus = "Clipboard unavailable; saved in editor register"
 
 func expectStatusWithClipboardFallback(t *testing.T, status *statusMsg, want string) {

--- a/internal/ui/editor_state_test.go
+++ b/internal/ui/editor_state_test.go
@@ -328,10 +328,11 @@ func TestRequestEditorDeleteSelectionRemovesText(t *testing.T) {
 	editorPtr.selection.Update(cursorPosition{Line: 0, Column: 5, Offset: 5})
 	editorPtr.applySelectionHighlight()
 
+	beforeRevision := editor.Revision()
 	updated, cmd := editor.DeleteSelection()
 	evt := editorEventFromCmd(t, cmd)
-	if !evt.dirty {
-		t.Fatalf("expected delete selection to mark editor dirty")
+	if updated.Revision() == beforeRevision {
+		t.Fatalf("expected delete selection to change editor revision")
 	}
 	expectStatusWithClipboardFallback(t, evt.status, "Selection deleted")
 	if got := updated.Value(); got != "" {
@@ -344,10 +345,11 @@ func TestRequestEditorDeleteSelectionRemovesText(t *testing.T) {
 
 func TestRequestEditorDeleteSelectionRequiresSelection(t *testing.T) {
 	editor := newTestEditor("alpha")
+	beforeRevision := editor.Revision()
 	updated, cmd := editor.DeleteSelection()
 	evt := editorEventFromCmd(t, cmd)
-	if evt.dirty {
-		t.Fatalf("expected no dirty flag when nothing deleted")
+	if updated.Revision() != beforeRevision {
+		t.Fatalf("expected editor revision to remain unchanged when nothing deleted")
 	}
 	if evt.status == nil || evt.status.text != "No selection to delete" {
 		t.Fatalf("expected warning about missing selection, got %+v", evt.status)
@@ -404,10 +406,11 @@ func TestRequestEditorUndoRestoresDeletion(t *testing.T) {
 	editorPtr.applySelectionHighlight()
 
 	editor, _ = editor.DeleteSelection()
+	beforeRevision := editor.Revision()
 	editor, cmd := editor.UndoLastChange()
 	evt := editorEventFromCmd(t, cmd)
-	if !evt.dirty {
-		t.Fatalf("expected undo to mark editor dirty")
+	if editor.Revision() == beforeRevision {
+		t.Fatalf("expected undo to change editor revision")
 	}
 	if evt.status == nil || evt.status.text != "Undid last change" {
 		t.Fatalf("expected undo status message, got %+v", evt.status)
@@ -422,10 +425,11 @@ func TestRequestEditorUndoRestoresDeletion(t *testing.T) {
 
 func TestRequestEditorUndoWhenEmpty(t *testing.T) {
 	editor := newTestEditor("alpha")
+	beforeRevision := editor.Revision()
 	editor, cmd := editor.UndoLastChange()
 	evt := editorEventFromCmd(t, cmd)
-	if evt.dirty {
-		t.Fatalf("expected no dirty flag when nothing to undo")
+	if editor.Revision() != beforeRevision {
+		t.Fatalf("expected editor revision to remain unchanged when nothing to undo")
 	}
 	if evt.status == nil || evt.status.text != "Nothing to undo" {
 		t.Fatalf("expected no-undo status message, got %+v", evt.status)
@@ -1036,10 +1040,10 @@ func TestRequestEditorMetadataHintsSuggestAndAccept(t *testing.T) {
 	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 
-	editor, cmd := editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	evt := editorEventFromCmd(t, cmd)
-	if !evt.dirty {
-		t.Fatal("expected autocomplete acceptance to mark editor dirty")
+	beforeRevision := editor.Revision()
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if editor.Revision() == beforeRevision {
+		t.Fatal("expected autocomplete acceptance to change editor revision")
 	}
 	if got := editor.Value(); !strings.HasPrefix(got, "# @name ") {
 		t.Fatalf("expected @name completion, got %q", got)
@@ -1072,10 +1076,10 @@ func TestRequestEditorMetadataHintsSecondLineAnchor(t *testing.T) {
 		t.Fatal("expected metadata hints to activate on the second line")
 	}
 
-	editor, cmd := editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	evt := editorEventFromCmd(t, cmd)
-	if !evt.dirty {
-		t.Fatal("expected autocomplete acceptance to mark editor dirty")
+	beforeRevision := editor.Revision()
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if editor.Revision() == beforeRevision {
+		t.Fatal("expected autocomplete acceptance to change editor revision")
 	}
 	if got := editor.Value(); got != "GET https://example.com\n# @name " {
 		t.Fatalf("expected @name completion on second line, got %q", got)
@@ -1127,10 +1131,10 @@ func TestRequestEditorMetadataHintsSuggestWsSubcommands(t *testing.T) {
 		t.Fatalf("expected first suggestion to be send, got %q", got)
 	}
 
-	editor, cmd := editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	evt := editorEventFromCmd(t, cmd)
-	if !evt.dirty {
-		t.Fatal("expected accepting subcommand hint to mark editor dirty")
+	beforeRevision := editor.Revision()
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if editor.Revision() == beforeRevision {
+		t.Fatal("expected accepting subcommand hint to change editor revision")
 	}
 	if got := editor.Value(); !strings.HasPrefix(got, "# @ws send ") {
 		t.Fatalf("expected editor content to include ws subcommand, got %q", got)
@@ -1184,10 +1188,10 @@ func TestRequestEditorMetadataHintsSuggestAuthSubcommands(t *testing.T) {
 		t.Fatalf("expected first suggestion to be command, got %q", got)
 	}
 
-	editor, cmd := editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	evt := editorEventFromCmd(t, cmd)
-	if !evt.dirty {
-		t.Fatal("expected accepting auth hint to mark editor dirty")
+	beforeRevision := editor.Revision()
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if editor.Revision() == beforeRevision {
+		t.Fatal("expected accepting auth hint to change editor revision")
 	}
 	if got := editor.Value(); !strings.HasPrefix(got, "# @auth command argv=") {
 		t.Fatalf("expected editor content to include auth command skeleton, got %q", got)
@@ -1228,10 +1232,10 @@ func TestRequestEditorMetadataHintsTracePlaceholder(t *testing.T) {
 		t.Fatalf("expected subcommand mode, got %v", editor.metadataHints.ctx.Mode)
 	}
 
-	editor, cmd := editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	evt := editorEventFromCmd(t, cmd)
-	if !evt.dirty {
-		t.Fatal("expected accepting trace hint to mark editor dirty")
+	beforeRevision := editor.Revision()
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if editor.Revision() == beforeRevision {
+		t.Fatal("expected accepting trace hint to change editor revision")
 	}
 	if editor.metadataHints.active {
 		t.Fatal("expected metadata hints to close after acceptance")

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -367,9 +367,7 @@ type Model struct {
 	doc                *restfile.Document
 	currentFile        string
 	currentRequest     *restfile.Request
-	lastCursorLine     int
-	lastCursorFile     string
-	lastCursorDoc      *restfile.Document
+	lastCursorSync     cursorSyncState
 	compareBundle      *compareBundle
 	compareRun         *compareState
 	profileRun         *profileState
@@ -685,7 +683,7 @@ func New(cfg Config) Model {
 		historyScope:             historyScopeGlobal,
 		historySort:              historySortNewest,
 		currentFile:              cfg.FilePath,
-		lastCursorLine:           -1,
+		lastCursorSync:           cursorSyncState{line: -1},
 		statusMessage:            initialStatus,
 		latencySeries:            newLatencySeries(latCap),
 		scriptRunner:             scripts.NewRunner(nil),

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -345,7 +345,6 @@ type Model struct {
 	sending                bool
 	sendCancel             context.CancelFunc
 	suppressEditorKey      bool
-	skipEditorCursorSync   bool
 	editorInsertMode       bool
 	editorWriteKeyMap      textarea.KeyMap
 	editorViewKeyMap       textarea.KeyMap

--- a/internal/ui/model_files.go
+++ b/internal/ui/model_files.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/filesvc"
 	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 func (m *Model) openSelectedFile() tea.Cmd {
@@ -143,7 +144,7 @@ func (m *Model) selectFileByPath(path string) bool {
 	items := m.fileList.Items()
 	for i, item := range items {
 		if fi, ok := item.(fileItem); ok {
-			if samePath(fi.entry.Path, path) {
+			if util.SamePath(fi.entry.Path, path) {
 				m.fileList.Select(i)
 				return true
 			}

--- a/internal/ui/model_files.go
+++ b/internal/ui/model_files.go
@@ -54,7 +54,7 @@ func (m *Model) openFile(path string) tea.Cmd {
 		}
 	}
 	m.rebuildNavigator(entries)
-	m.dirty = false
+	m.markClean()
 	m.watchFile(path, data)
 	m.setHistoryScopeForFile(path)
 	m.syncHistory()
@@ -92,7 +92,7 @@ func (m *Model) openTemporaryDocument() tea.Cmd {
 	m.syncRequestList(m.doc)
 	entries := m.syncWorkspaceEntriesStatus()
 	m.rebuildNavigator(entries)
-	m.dirty = false
+	m.markClean()
 	m.syncHistory()
 	focusCmd := m.setFocus(focusEditor)
 	m.setStatusMessage(statusMsg{text: "Temporary document", level: statusInfo})
@@ -228,7 +228,17 @@ func (m *Model) refreshCurrentDocument(content []byte) {
 	if req := m.findRequestByKey(m.activeRequestKey); req != nil {
 		m.currentRequest = req
 	}
+	m.markClean()
+}
+
+func (m *Model) markDirty() {
+	m.dirty = true
+	m.clearPendingCrossFileNavigation()
+}
+
+func (m *Model) markClean() {
 	m.dirty = false
+	m.clearPendingCrossFileNavigation()
 }
 
 func (m *Model) updateEditorStyler(path string) {

--- a/internal/ui/model_files_test.go
+++ b/internal/ui/model_files_test.go
@@ -147,7 +147,7 @@ func TestReparseDocumentPreservesDirtyState(t *testing.T) {
 	})
 	m := &model
 	m.editor.SetValue("GET https://changed.example\n")
-	m.dirty = true
+	m.markDirty()
 
 	if cmd := m.reparseDocument(); cmd != nil {
 		cmd()
@@ -208,7 +208,7 @@ func TestReloadWarnUpdatesFileChangeModal(t *testing.T) {
 
 	model := New(Config{WorkspaceRoot: tmp, Theme: &th, FilePath: path, InitialContent: "body"})
 	m := &model
-	m.dirty = true
+	m.markDirty()
 	m.handleFileChangeEvent(fileChangedMsg{path: path, kind: watcher.EventChanged})
 	if !m.showFileChangeModal {
 		t.Fatalf("expected file change modal to be visible")

--- a/internal/ui/model_filewatch.go
+++ b/internal/ui/model_filewatch.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/unkn0wn-root/resterm/internal/bindings"
+	"github.com/unkn0wn-root/resterm/internal/util"
 	"github.com/unkn0wn-root/resterm/internal/watcher"
 )
 
@@ -70,7 +71,7 @@ func (m *Model) nextFileWatchMsgCmd() tea.Cmd {
 }
 
 func (m *Model) handleFileChangeEvent(msg fileChangedMsg) {
-	if msg.path == "" || !samePath(msg.path, m.currentFile) {
+	if msg.path == "" || !util.SamePath(msg.path, m.currentFile) {
 		return
 	}
 	m.fileStale = true

--- a/internal/ui/model_navigator.go
+++ b/internal/ui/model_navigator.go
@@ -356,7 +356,6 @@ func requestBadges(req *restfile.Request) []string {
 		b = append(b, "WS")
 	case req.SSE != nil:
 		b = append(b, "SSE")
-	default:
 	}
 
 	if req.Metadata.Compare != nil {
@@ -434,8 +433,6 @@ func (m *Model) syncNavigatorSelection() {
 			_ = m.selectFileByPath(path)
 		}
 		m.clearNavigatorRequestSelection()
-	case navigator.KindDir:
-		m.clearNavigatorRequestSelection()
 	default:
 		m.clearNavigatorRequestSelection()
 	}
@@ -479,10 +476,41 @@ func (m *Model) applyCursorRequest(req *restfile.Request) {
 	m.setActiveRequest(req)
 }
 
+type cursorSyncState struct {
+	line int
+	file string
+	doc  *restfile.Document
+}
+
 func (m *Model) resetCursorSync() {
-	m.lastCursorLine = -1
-	m.lastCursorFile = ""
-	m.lastCursorDoc = nil
+	m.lastCursorSync = cursorSyncState{line: -1}
+}
+
+func (m *Model) markCursorSynced(line int) {
+	m.lastCursorSync = m.currentCursorSyncState(line)
+}
+
+func (m *Model) currentCursorSyncState(line int) cursorSyncState {
+	return cursorSyncState{
+		line: line,
+		file: m.currentFile,
+		doc:  m.doc,
+	}
+}
+
+func (m *Model) cursorSyncChanged(line int, targetID string) bool {
+	// Doc pointer comparison intentionally detects reparses as a change.
+	if m.lastCursorSync != m.currentCursorSyncState(line) {
+		return true
+	}
+
+	currentID := ""
+	if m.navigator != nil {
+		if sel := m.navigator.Selected(); sel != nil {
+			currentID = sel.ID
+		}
+	}
+	return currentID != targetID
 }
 
 func (m *Model) syncNavigatorWithEditorCursor() {
@@ -494,9 +522,6 @@ func (m *Model) syncNavigatorWithEditorCursor() {
 	}
 
 	line := currentCursorLine(m.editor)
-	if line == m.lastCursorLine && m.lastCursorFile == m.currentFile && m.lastCursorDoc == m.doc {
-		return
-	}
 
 	if wf, wfIdx := workflowAtLine(m.doc, line); wf != nil {
 		m.syncNavigatorWorkflowAtCursor(wf, wfIdx, line)
@@ -514,37 +539,23 @@ func (m *Model) syncNavigatorWithEditorCursor() {
 	}
 
 	if req == nil {
-		m.lastCursorLine = line
-		m.lastCursorFile = m.currentFile
-		m.lastCursorDoc = m.doc
+		m.markCursorSynced(line)
 		return
 	}
 
 	targetID := navigatorRequestID(m.currentFile, reqIdx)
-	currentID := ""
-	if sel := m.navigator.Selected(); sel != nil {
-		currentID = sel.ID
-	}
-	// Doc pointer comparison intentionally detects reparses as a change.
-	if line == m.lastCursorLine &&
-		m.lastCursorFile == m.currentFile &&
-		m.lastCursorDoc == m.doc &&
-		currentID == targetID {
+	if !m.cursorSyncChanged(line, targetID) {
 		return
 	}
 
 	m.ensureNavigatorRequestsForFile(m.currentFile)
 	if !m.navigator.SelectByID(targetID) {
-		m.lastCursorLine = line
-		m.lastCursorFile = m.currentFile
-		m.lastCursorDoc = m.doc
+		m.markCursorSynced(line)
 		return
 	}
 
 	m.applyCursorRequest(req)
-	m.lastCursorLine = line
-	m.lastCursorFile = m.currentFile
-	m.lastCursorDoc = m.doc
+	m.markCursorSynced(line)
 }
 
 func (m *Model) syncNavigatorWorkflowAtCursor(wf *restfile.Workflow, wfIdx int, line int) {
@@ -553,22 +564,13 @@ func (m *Model) syncNavigatorWorkflowAtCursor(wf *restfile.Workflow, wfIdx int, 
 	}
 
 	targetID := navigatorWorkflowID(m.currentFile, wfIdx)
-	currentID := ""
-	if sel := m.navigator.Selected(); sel != nil {
-		currentID = sel.ID
-	}
-	if line == m.lastCursorLine &&
-		m.lastCursorFile == m.currentFile &&
-		m.lastCursorDoc == m.doc &&
-		currentID == targetID {
+	if !m.cursorSyncChanged(line, targetID) {
 		return
 	}
 
 	m.ensureNavigatorRequestsForFile(m.currentFile)
 	if !m.navigator.SelectByID(targetID) {
-		m.lastCursorLine = line
-		m.lastCursorFile = m.currentFile
-		m.lastCursorDoc = m.doc
+		m.markCursorSynced(line)
 		return
 	}
 
@@ -578,9 +580,7 @@ func (m *Model) syncNavigatorWorkflowAtCursor(wf *restfile.Workflow, wfIdx int, 
 		}
 	}
 	m.workflowSelectionKey = workflowKey(wf)
-	m.lastCursorLine = line
-	m.lastCursorFile = m.currentFile
-	m.lastCursorDoc = m.doc
+	m.markCursorSynced(line)
 }
 
 func workflowAtLine(doc *restfile.Document, line int) (*restfile.Workflow, int) {

--- a/internal/ui/model_navigator.go
+++ b/internal/ui/model_navigator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/ui/navigator"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 func (m *Model) rebuildNavigator(entries []filesvc.FileEntry) {
@@ -111,7 +112,7 @@ func (m *Model) buildFileNode(entry filesvc.FileEntry) *navigator.Node[any] {
 	if doc, ok := m.cachedDoc(entry.Path); ok && doc != nil {
 		node.Count = len(doc.Requests)
 		node.Children = m.buildRequestNodes(doc, entry.Path)
-		if samePath(entry.Path, m.currentFile) && navHasKids(node) {
+		if util.SamePath(entry.Path, m.currentFile) && navHasKids(node) {
 			node.Expanded = true
 		}
 	}
@@ -124,7 +125,7 @@ func fileEntryBadges(entry filesvc.FileEntry, activeEnvFile string) []string {
 		badges = append(badges, label)
 	}
 
-	if entry.Kind == filesvc.FileKindEnv && samePath(entry.Path, activeEnvFile) {
+	if entry.Kind == filesvc.FileKindEnv && util.SamePath(entry.Path, activeEnvFile) {
 		badges = append(badges, "ACTIVE")
 	}
 	return badges
@@ -390,7 +391,7 @@ func (m *Model) syncNavigatorSelection() {
 			if path != "" {
 				_ = m.selectFileByPath(path)
 			}
-			if samePath(path, m.currentFile) {
+			if util.SamePath(path, m.currentFile) {
 				m.setActiveRequest(req)
 			} else {
 				if m.pendingCrossFile.nodeID == n.ID {
@@ -409,7 +410,7 @@ func (m *Model) syncNavigatorSelection() {
 			if path != "" {
 				_ = m.selectFileByPath(path)
 			}
-			if samePath(path, m.currentFile) {
+			if util.SamePath(path, m.currentFile) {
 				if m.selectWorkflowForNode(wf, n.ID) {
 					if item, ok := m.workflowList.SelectedItem().(workflowListItem); ok && item.workflow != nil {
 						wf = item.workflow
@@ -628,25 +629,6 @@ func applyNavigatorExpansion(nodes []*navigator.Node[any], prev *navigator.Model
 
 func navHasKids(n *navigator.Node[any]) bool {
 	return n != nil && len(n.Children) > 0
-}
-
-func samePath(a, b string) bool {
-	if a == "" || b == "" {
-		return false
-	}
-
-	cleanA := filepath.Clean(a)
-	cleanB := filepath.Clean(b)
-	if cleanA == cleanB {
-		return true
-	}
-
-	absA, errA := filepath.Abs(cleanA)
-	absB, errB := filepath.Abs(cleanB)
-	if errA != nil || errB != nil {
-		return false
-	}
-	return absA == absB
 }
 
 func sortNavNodes(nodes []*navigator.Node[any]) {

--- a/internal/ui/model_navigator.go
+++ b/internal/ui/model_navigator.go
@@ -43,6 +43,10 @@ func navigatorRequestID(path string, idx int) string {
 	return fmt.Sprintf("req:%s:%d", path, idx)
 }
 
+func navigatorWorkflowID(path string, idx int) string {
+	return fmt.Sprintf("wf:%s:%d", path, idx)
+}
+
 func (m *Model) buildNavTree(entries []filesvc.FileEntry) []*navigator.Node[any] {
 	if len(entries) == 0 {
 		return nil
@@ -167,7 +171,7 @@ func (m *Model) buildRequestNodes(doc *restfile.Document, filePath string) []*na
 		desc := condense(strings.TrimSpace(wf.Description), 80)
 		badges := []string{fmt.Sprintf("%d steps", len(wf.Steps))}
 		nodes = append(nodes, &navigator.Node[any]{
-			ID:      fmt.Sprintf("wf:%s:%d", filePath, idx),
+			ID:      navigatorWorkflowID(filePath, idx),
 			Title:   title,
 			Desc:    desc,
 			Kind:    navigator.KindWorkflow,
@@ -493,6 +497,11 @@ func (m *Model) syncNavigatorWithEditorCursor() {
 		return
 	}
 
+	if wf, wfIdx := workflowAtLine(m.doc, line); wf != nil {
+		m.syncNavigatorWorkflowAtCursor(wf, wfIdx, line)
+		return
+	}
+
 	req, reqIdx := requestAtLine(m.doc, line)
 	if req == nil && len(m.doc.Requests) > 0 {
 		lastIdx := len(m.doc.Requests) - 1
@@ -535,6 +544,63 @@ func (m *Model) syncNavigatorWithEditorCursor() {
 	m.lastCursorLine = line
 	m.lastCursorFile = m.currentFile
 	m.lastCursorDoc = m.doc
+}
+
+func (m *Model) syncNavigatorWorkflowAtCursor(wf *restfile.Workflow, wfIdx int, line int) {
+	if wf == nil || wfIdx < 0 {
+		return
+	}
+
+	targetID := navigatorWorkflowID(m.currentFile, wfIdx)
+	currentID := ""
+	if sel := m.navigator.Selected(); sel != nil {
+		currentID = sel.ID
+	}
+	if line == m.lastCursorLine &&
+		m.lastCursorFile == m.currentFile &&
+		m.lastCursorDoc == m.doc &&
+		currentID == targetID {
+		return
+	}
+
+	m.ensureNavigatorRequestsForFile(m.currentFile)
+	if !m.navigator.SelectByID(targetID) {
+		m.lastCursorLine = line
+		m.lastCursorFile = m.currentFile
+		m.lastCursorDoc = m.doc
+		return
+	}
+
+	if m.selectWorkflowForNode(wf, targetID) {
+		if item, ok := m.workflowList.SelectedItem().(workflowListItem); ok && item.workflow != nil {
+			wf = item.workflow
+		}
+	}
+	m.workflowSelectionKey = workflowKey(wf)
+	m.lastCursorLine = line
+	m.lastCursorFile = m.currentFile
+	m.lastCursorDoc = m.doc
+}
+
+func workflowAtLine(doc *restfile.Document, line int) (*restfile.Workflow, int) {
+	if doc == nil || line < 1 {
+		return nil, -1
+	}
+	for idx := range doc.Workflows {
+		wf := &doc.Workflows[idx]
+		start := wf.LineRange.Start
+		end := wf.LineRange.End
+		if start < 1 {
+			continue
+		}
+		if end < start {
+			end = start
+		}
+		if line >= start && line <= end {
+			return wf, idx
+		}
+	}
+	return nil, -1
 }
 
 // applyNavigatorExpansion copies expanded state from the previous navigator tree.

--- a/internal/ui/model_navigator_test.go
+++ b/internal/ui/model_navigator_test.go
@@ -98,6 +98,35 @@ func TestNavigatorFollowsEditorCursor(t *testing.T) {
 	}
 }
 
+func TestNavigatorResyncsSelectionWhenCursorUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "sample.http")
+	content := "### first\nGET https://example.com/one\n\n### second\nGET https://example.com/two\n"
+	writeSampleFile(t, file, content)
+
+	model := New(Config{WorkspaceRoot: tmp, FilePath: file, InitialContent: content})
+	m := &model
+
+	_ = m.setFocus(focusEditor)
+
+	secondStart := m.doc.Requests[1].LineRange.Start
+	secondID := navigatorRequestID(file, 1)
+	m.moveCursorToLine(secondStart)
+	if sel := m.navigator.Selected(); sel == nil || sel.ID != secondID {
+		t.Fatalf("expected navigator to select second request, got %#v", sel)
+	}
+
+	firstID := navigatorRequestID(file, 0)
+	if !m.navigator.SelectByID(firstID) {
+		t.Fatalf("expected navigator to select first request")
+	}
+
+	m.syncNavigatorWithEditorCursor()
+	if sel := m.navigator.Selected(); sel == nil || sel.ID != secondID {
+		t.Fatalf("expected navigator to resync second request, got %#v", sel)
+	}
+}
+
 func TestNavigatorIgnoresLinesOutsideRequests(t *testing.T) {
 	tmp := t.TempDir()
 	file := filepath.Join(tmp, "preface.http")
@@ -391,6 +420,37 @@ func TestNavigatorRightDoesNotCollapseFile(t *testing.T) {
 	}
 	if !node.Expanded {
 		t.Fatalf("expected %s to stay expanded after second right", fileB)
+	}
+}
+
+func TestNavigatorSpaceExpandsUnloadedFile(t *testing.T) {
+	tmp := t.TempDir()
+	fileA := filepath.Join(tmp, "a.http")
+	fileB := filepath.Join(tmp, "b.http")
+	content := "### req\n# @name sample\nGET https://example.com\n"
+	writeSampleFile(t, fileA, content)
+	writeSampleFile(t, fileB, content)
+
+	model := New(Config{WorkspaceRoot: tmp, FilePath: fileA})
+	m := &model
+	if cmd := m.openFile(fileA); cmd != nil {
+		cmd()
+	}
+
+	selectNavigatorID(t, m, "file:"+fileB)
+	if cmd := m.updateNavigator(tea.KeyMsg{Type: tea.KeySpace}); cmd != nil {
+		cmd()
+	}
+
+	node := m.navigator.Find("file:" + fileB)
+	if node == nil {
+		t.Fatalf("expected node for %s", fileB)
+	}
+	if !node.Expanded {
+		t.Fatalf("expected %s to expand after space", fileB)
+	}
+	if len(node.Children) == 0 {
+		t.Fatalf("expected requests to load for %s", fileB)
 	}
 }
 

--- a/internal/ui/model_navigator_test.go
+++ b/internal/ui/model_navigator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/ui/navigator"
+	"github.com/unkn0wn-root/resterm/internal/util"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -1035,7 +1036,7 @@ func TestNavigatorRequestEnterSendsFromSidebar(t *testing.T) {
 			m.navigator.Selected().Payload.Data,
 		)
 	}
-	if sel := m.navigator.Selected(); sel == nil || !samePath(sel.Payload.FilePath, m.currentFile) {
+	if sel := m.navigator.Selected(); sel == nil || !util.SamePath(sel.Payload.FilePath, m.currentFile) {
 		t.Fatalf(
 			"expected navigator selection to target current file, got %v vs %q",
 			sel,
@@ -1467,7 +1468,7 @@ GET https://remote.test
 	m.markDirty()
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
-	if !samePath(m.currentFile, fileA) {
+	if !util.SamePath(m.currentFile, fileA) {
 		t.Fatalf("expected first jump press to keep current file %q, got %q", fileA, m.currentFile)
 	}
 	if !strings.Contains(m.statusMessage.text, "Press l again to jump.") {
@@ -1475,7 +1476,7 @@ GET https://remote.test
 	}
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	if !samePath(m.currentFile, fileA) {
+	if !util.SamePath(m.currentFile, fileA) {
 		t.Fatalf("expected enter not to reuse jump confirmation, got current file %q", m.currentFile)
 	}
 	if m.workflowRun != nil {
@@ -1505,7 +1506,7 @@ func TestNavigatorCrossFilePreviewConfirmationIsNotReusedForRequestSend(t *testi
 	m.markDirty()
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
-	if !samePath(m.currentFile, fileA) {
+	if !util.SamePath(m.currentFile, fileA) {
 		t.Fatalf("expected first preview press to keep current file %q, got %q", fileA, m.currentFile)
 	}
 	if !strings.Contains(m.statusMessage.text, "Press Space again to preview.") {
@@ -1513,7 +1514,7 @@ func TestNavigatorCrossFilePreviewConfirmationIsNotReusedForRequestSend(t *testi
 	}
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	if !samePath(m.currentFile, fileA) {
+	if !util.SamePath(m.currentFile, fileA) {
 		t.Fatalf("expected enter not to reuse preview confirmation, got current file %q", m.currentFile)
 	}
 	if !strings.Contains(m.statusMessage.text, "Press Enter again to send.") {
@@ -1542,7 +1543,7 @@ func TestNavigatorCrossFileConfirmationIsBoundToSourceBuffer(t *testing.T) {
 	m.markDirty()
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
-	if !samePath(m.currentFile, fileA) {
+	if !util.SamePath(m.currentFile, fileA) {
 		t.Fatalf("expected first preview press to keep current file %q, got %q", fileA, m.currentFile)
 	}
 	if !strings.Contains(m.statusMessage.text, "Press Space again to preview.") {
@@ -1558,7 +1559,7 @@ func TestNavigatorCrossFileConfirmationIsBoundToSourceBuffer(t *testing.T) {
 	m.markDirty()
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
-	if !samePath(m.currentFile, fileC) {
+	if !util.SamePath(m.currentFile, fileC) {
 		t.Fatalf("expected stale confirmation not to open %q, got current file %q", fileB, m.currentFile)
 	}
 	if !strings.Contains(m.statusMessage.text, "Press Space again to preview.") {
@@ -1585,7 +1586,7 @@ func TestNavigatorCrossFileConfirmationIsInvalidatedByFurtherEdits(t *testing.T)
 	m.markDirty()
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
-	if !samePath(m.currentFile, fileA) {
+	if !util.SamePath(m.currentFile, fileA) {
 		t.Fatalf("expected first preview press to keep current file %q, got %q", fileA, m.currentFile)
 	}
 
@@ -1594,7 +1595,7 @@ func TestNavigatorCrossFileConfirmationIsInvalidatedByFurtherEdits(t *testing.T)
 	m.editor.SetValue(original)
 	m.markDirty()
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
-	if !samePath(m.currentFile, fileA) {
+	if !util.SamePath(m.currentFile, fileA) {
 		t.Fatalf("expected edited-then-restored buffer to require fresh confirmation, got current file %q", m.currentFile)
 	}
 	if !strings.Contains(m.statusMessage.text, "Press Space again to preview.") {
@@ -1619,7 +1620,7 @@ func TestNavigatorFileOpenRequiresDirtyConfirmation(t *testing.T) {
 	m.markDirty()
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	if !samePath(m.currentFile, fileA) {
+	if !util.SamePath(m.currentFile, fileA) {
 		t.Fatalf("expected first enter to keep dirty file %q, got %q", fileA, m.currentFile)
 	}
 	if !strings.Contains(m.statusMessage.text, "Press Enter again to open.") {
@@ -1627,7 +1628,7 @@ func TestNavigatorFileOpenRequiresDirtyConfirmation(t *testing.T) {
 	}
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	if !samePath(m.currentFile, fileB) {
+	if !util.SamePath(m.currentFile, fileB) {
 		t.Fatalf("expected repeated enter to open %q, got %q", fileB, m.currentFile)
 	}
 	if m.dirty {

--- a/internal/ui/model_navigator_test.go
+++ b/internal/ui/model_navigator_test.go
@@ -1380,8 +1380,65 @@ GET https://example.com
 	if sel := m.navigator.Selected(); sel == nil || sel.ID != wfID {
 		t.Fatalf("expected workflow selection to survive full update, got %#v", sel)
 	}
-	if m.suppressEditorKey || m.skipEditorCursorSync {
-		t.Fatalf("expected jump suppression flags to be consumed after full update")
+	if m.suppressEditorKey {
+		t.Fatalf("expected editor key suppression to be consumed after full update")
+	}
+}
+
+func TestNavigatorWorkflowJumpSurvivesNextEditorSync(t *testing.T) {
+	content := `### Fetch
+# @name FetchExample
+GET https://example.com
+
+# @workflow sample-order
+# @step Fetch using=FetchExample
+`
+	model := newTestModelWithDoc(content)
+	m := model
+	m.currentFile = "/tmp/workflow-stable.http"
+	m.cfg.FilePath = m.currentFile
+	m.syncRequestList(m.doc)
+
+	wf := &m.doc.Workflows[0]
+	wfID := navigatorWorkflowID(m.currentFile, 0)
+	activeReq := m.currentRequest
+	activeReqKey := m.activeRequestKey
+	m.navigator = navigator.New[any]([]*navigator.Node[any]{
+		{
+			ID:      navigatorRequestID(m.currentFile, 0),
+			Kind:    navigator.KindRequest,
+			Payload: navigator.Payload[any]{FilePath: m.currentFile, Data: m.doc.Requests[0]},
+		},
+		{
+			ID:      wfID,
+			Kind:    navigator.KindWorkflow,
+			Payload: navigator.Payload[any]{FilePath: m.currentFile, Data: wf},
+		},
+	})
+	selectNavigatorID(t, m, wfID)
+	m.focus = focusWorkflows
+
+	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if got := currentCursorLine(m.editor); got != wf.LineRange.Start {
+		t.Fatalf("expected cursor to jump to workflow line %d, got %d", wf.LineRange.Start, got)
+	}
+	if sel := m.navigator.Selected(); sel == nil || sel.ID != wfID {
+		t.Fatalf("expected workflow selected after jump, got %#v", sel)
+	}
+
+	m = applyModelUpdate(t, m, tea.WindowSizeMsg{Width: 100, Height: 32})
+	if got := currentCursorLine(m.editor); got != wf.LineRange.Start {
+		t.Fatalf("expected cursor to remain on workflow line %d, got %d", wf.LineRange.Start, got)
+	}
+	if sel := m.navigator.Selected(); sel == nil || sel.ID != wfID {
+		t.Fatalf("expected workflow selection to survive next editor sync, got %#v", sel)
+	}
+	if m.currentRequest != activeReq || m.activeRequestKey != activeReqKey {
+		t.Fatalf(
+			"expected active request %q to survive workflow cursor sync, got %q",
+			activeReqKey,
+			m.activeRequestKey,
+		)
 	}
 }
 
@@ -1407,7 +1464,7 @@ GET https://remote.test
 	wfID := "wf:" + fileB + ":0"
 	selectNavigatorID(t, m, wfID)
 	m.focus = focusWorkflows
-	m.dirty = true
+	m.markDirty()
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
 	if !samePath(m.currentFile, fileA) {
@@ -1445,7 +1502,7 @@ func TestNavigatorCrossFilePreviewConfirmationIsNotReusedForRequestSend(t *testi
 	reqID := navigatorRequestID(fileB, 0)
 	selectNavigatorID(t, m, reqID)
 	m.focus = focusRequests
-	m.dirty = true
+	m.markDirty()
 
 	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
 	if !samePath(m.currentFile, fileA) {
@@ -1461,6 +1518,120 @@ func TestNavigatorCrossFilePreviewConfirmationIsNotReusedForRequestSend(t *testi
 	}
 	if !strings.Contains(m.statusMessage.text, "Press Enter again to send.") {
 		t.Fatalf("expected send-specific warning, got %q", m.statusMessage.text)
+	}
+}
+
+func TestNavigatorCrossFileConfirmationIsBoundToSourceBuffer(t *testing.T) {
+	tmp := t.TempDir()
+	fileA := filepath.Join(tmp, "current.http")
+	fileB := filepath.Join(tmp, "remote.http")
+	fileC := filepath.Join(tmp, "other.http")
+	writeSampleFile(t, fileA, "### Local\n# @name Local\nGET https://local.test\n")
+	writeSampleFile(t, fileB, "### Remote\n# @name Remote\nGET https://remote.test\n")
+	writeSampleFile(t, fileC, "### Other\n# @name Other\nGET https://other.test\n")
+
+	model := New(Config{WorkspaceRoot: tmp, FilePath: fileA})
+	m := &model
+	if cmd := m.openFile(fileA); cmd != nil {
+		cmd()
+	}
+	m.expandNavigatorFile(fileB)
+	reqID := navigatorRequestID(fileB, 0)
+	selectNavigatorID(t, m, reqID)
+	m.focus = focusRequests
+	m.markDirty()
+
+	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
+	if !samePath(m.currentFile, fileA) {
+		t.Fatalf("expected first preview press to keep current file %q, got %q", fileA, m.currentFile)
+	}
+	if !strings.Contains(m.statusMessage.text, "Press Space again to preview.") {
+		t.Fatalf("expected preview-specific warning, got %q", m.statusMessage.text)
+	}
+
+	if cmd := m.openFile(fileC); cmd != nil {
+		cmd()
+	}
+	m.expandNavigatorFile(fileB)
+	selectNavigatorID(t, m, reqID)
+	m.focus = focusRequests
+	m.markDirty()
+
+	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
+	if !samePath(m.currentFile, fileC) {
+		t.Fatalf("expected stale confirmation not to open %q, got current file %q", fileB, m.currentFile)
+	}
+	if !strings.Contains(m.statusMessage.text, "Press Space again to preview.") {
+		t.Fatalf("expected a fresh preview warning for new source buffer, got %q", m.statusMessage.text)
+	}
+}
+
+func TestNavigatorCrossFileConfirmationIsInvalidatedByFurtherEdits(t *testing.T) {
+	tmp := t.TempDir()
+	fileA := filepath.Join(tmp, "current.http")
+	fileB := filepath.Join(tmp, "remote.http")
+	writeSampleFile(t, fileA, "### Local\n# @name Local\nGET https://local.test\n")
+	writeSampleFile(t, fileB, "### Remote\n# @name Remote\nGET https://remote.test\n")
+
+	model := New(Config{WorkspaceRoot: tmp, FilePath: fileA})
+	m := &model
+	if cmd := m.openFile(fileA); cmd != nil {
+		cmd()
+	}
+	m.expandNavigatorFile(fileB)
+	reqID := navigatorRequestID(fileB, 0)
+	selectNavigatorID(t, m, reqID)
+	m.focus = focusRequests
+	m.markDirty()
+
+	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
+	if !samePath(m.currentFile, fileA) {
+		t.Fatalf("expected first preview press to keep current file %q, got %q", fileA, m.currentFile)
+	}
+
+	original := m.editor.Value()
+	m.editor.SetValue(original + "\n# changed after warning")
+	m.editor.SetValue(original)
+	m.markDirty()
+	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeySpace})
+	if !samePath(m.currentFile, fileA) {
+		t.Fatalf("expected edited-then-restored buffer to require fresh confirmation, got current file %q", m.currentFile)
+	}
+	if !strings.Contains(m.statusMessage.text, "Press Space again to preview.") {
+		t.Fatalf("expected fresh preview warning after restoring an edit, got %q", m.statusMessage.text)
+	}
+}
+
+func TestNavigatorFileOpenRequiresDirtyConfirmation(t *testing.T) {
+	tmp := t.TempDir()
+	fileA := filepath.Join(tmp, "current.http")
+	fileB := filepath.Join(tmp, "remote.http")
+	writeSampleFile(t, fileA, "### Local\n# @name Local\nGET https://local.test\n")
+	writeSampleFile(t, fileB, "### Remote\n# @name Remote\nGET https://remote.test\n")
+
+	model := New(Config{WorkspaceRoot: tmp, FilePath: fileA})
+	m := &model
+	if cmd := m.openFile(fileA); cmd != nil {
+		cmd()
+	}
+	selectNavigatorID(t, m, "file:"+fileB)
+	m.focus = focusFile
+	m.markDirty()
+
+	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !samePath(m.currentFile, fileA) {
+		t.Fatalf("expected first enter to keep dirty file %q, got %q", fileA, m.currentFile)
+	}
+	if !strings.Contains(m.statusMessage.text, "Press Enter again to open.") {
+		t.Fatalf("expected file-open warning, got %q", m.statusMessage.text)
+	}
+
+	m = applyModelUpdate(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !samePath(m.currentFile, fileB) {
+		t.Fatalf("expected repeated enter to open %q, got %q", fileB, m.currentFile)
+	}
+	if m.dirty {
+		t.Fatalf("expected opened file to be clean")
 	}
 }
 

--- a/internal/ui/model_open.go
+++ b/internal/ui/model_open.go
@@ -95,6 +95,7 @@ func (m *Model) applyOpenDirectory(dir string) tea.Cmd {
 	m.doc = nil
 	m.editor.SetValue("")
 	m.editor.SetCursor(0)
+	m.markClean()
 	focusCmd := m.setFocus(focusFile)
 	m.requestList.SetItems(nil)
 	m.requestItems = nil

--- a/internal/ui/model_open.go
+++ b/internal/ui/model_open.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/unkn0wn-root/resterm/internal/filesvc"
+	"github.com/unkn0wn-root/resterm/internal/util"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -143,7 +144,7 @@ func (m *Model) isSupportedOpenPath(path string) bool {
 		return true
 	case vars.IsDotEnvPath(path):
 		return true
-	case samePath(path, m.cfg.EnvironmentFile):
+	case util.SamePath(path, m.cfg.EnvironmentFile):
 		return true
 	default:
 		return false

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -13,6 +13,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/bindings"
 	"github.com/unkn0wn-root/resterm/internal/theme"
 	"github.com/unkn0wn-root/resterm/internal/ui/navigator"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 const (
@@ -428,7 +429,7 @@ func (m Model) navigatorFileNode(path string) *navigator.Node[any] {
 		if n == nil || n.Kind != navigator.KindFile {
 			continue
 		}
-		if samePath(n.Payload.FilePath, path) {
+		if util.SamePath(n.Payload.FilePath, path) {
 			return n
 		}
 	}

--- a/internal/ui/model_request_details.go
+++ b/internal/ui/model_request_details.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/theme"
 	"github.com/unkn0wn-root/resterm/internal/ui/navigator"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 type requestDetailField struct {
@@ -74,7 +75,7 @@ func (m *Model) navigatorRequestContext() (*restfile.Request, *restfile.Document
 	}
 	path := n.Payload.FilePath
 	doc := m.doc
-	if path != "" && !samePath(path, m.currentFile) {
+	if path != "" && !util.SamePath(path, m.currentFile) {
 		doc = m.loadDocFor(path)
 	}
 	if path == "" {

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -53,12 +53,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 	case editorEvent:
-		if typed.dirty {
-			// Content changes are observed synchronously through the editor revision.
-			// Dirty events may arrive later with status messages, so they should not
-			// clear a newer pending navigation confirmation.
-			m.dirty = true
-		}
 		if typed.status != nil {
 			m.setStatusMessage(*typed.status)
 		}
@@ -488,18 +482,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.suppressEditorKey {
 			m.suppressEditorKey = false
 		} else {
-			filtered := m.filterEditorMessage(msg)
-			beforeValue := m.editor.Value()
-			beforeRevision := m.editor.Revision()
-			var editorCmd tea.Cmd
-			m.editor, editorCmd = m.editor.Update(filtered)
-			if m.editor.Revision() != beforeRevision || m.editor.Value() != beforeValue {
-				if m.editor.Revision() == beforeRevision {
-					m.editor.noteContentChanged()
-				}
-				m.markDirty()
-			}
-			cmds = append(cmds, editorCmd)
+			cmds = append(cmds, m.updateEditor(m.filterEditorMessage(msg)))
 		}
 		if m.focus == focusEditor {
 			m.syncNavigatorWithEditorCursor()
@@ -1933,13 +1916,13 @@ func (m *Model) handleOperatorKey(msg tea.KeyMsg) tea.Cmd {
 	switch op {
 	case "c":
 		actionCmd = batchCommands(
-			m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+			m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 				return ed.ChangeMotion(anchor, spec)
 			}),
 			m.setInsertMode(true, true),
 		)
 	default:
-		actionCmd = m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+		actionCmd = m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 			return ed.DeleteMotion(anchor, spec)
 		})
 	}
@@ -2046,64 +2029,70 @@ func (m *Model) runWorkflowResize(delta float64) tea.Cmd {
 	return nil
 }
 
-func (m *Model) applyEditorMutation(op func(requestEditor) (requestEditor, tea.Cmd)) tea.Cmd {
-	before := m.editor.Value()
+func (m *Model) updateEditor(msg tea.Msg) tea.Cmd {
 	beforeRevision := m.editor.Revision()
-	editor, cmd := op(m.editor)
-	if editor.Revision() != beforeRevision || editor.Value() != before {
-		if editor.Revision() == beforeRevision {
-			editor.noteContentChanged()
-		}
+	var cmd tea.Cmd
+	m.editor, cmd = m.editor.Update(msg)
+	if m.editor.Revision() != beforeRevision {
 		m.markDirty()
 	}
+	return cmd
+}
+
+func (m *Model) mutateEditor(op func(requestEditor) (requestEditor, tea.Cmd)) tea.Cmd {
+	beforeRevision := m.editor.Revision()
+	editor, cmd := op(m.editor)
 	m.editor = editor
+	if editor.Revision() != beforeRevision {
+		m.markDirty()
+	}
 	return cmd
 }
 
 func (m *Model) runDeleteSelection() tea.Cmd {
-	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+	return m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 		return ed.DeleteSelection()
 	})
 }
 
 func (m *Model) runUndoLastChange() tea.Cmd {
-	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+	return m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 		return ed.UndoLastChange()
 	})
 }
 
 func (m *Model) runDeleteCurrentLine() tea.Cmd {
-	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+	return m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 		return ed.DeleteCurrentLine()
 	})
 }
 
 func (m *Model) runDeleteToLineEnd() tea.Cmd {
-	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+	return m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 		return ed.DeleteToLineEnd()
 	})
 }
 
 func (m *Model) runDeleteCharAtCursor() tea.Cmd {
-	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+	return m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 		return ed.DeleteCharAtCursor()
 	})
 }
 
 func (m *Model) runChangeCurrentLine() tea.Cmd {
-	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+	return m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 		return ed.ChangeCurrentLine()
 	})
 }
 
 func (m *Model) runPasteClipboard(after bool) tea.Cmd {
-	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+	return m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 		return ed.PasteClipboard(after)
 	})
 }
 
 func (m *Model) runRedoLastChange() tea.Cmd {
-	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+	return m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
 		return ed.RedoLastChange()
 	})
 }

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/ui/navigator"
 	"github.com/unkn0wn-root/resterm/internal/ui/scroll"
 	"github.com/unkn0wn-root/resterm/internal/ui/textarea"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 func (m Model) Init() tea.Cmd {
@@ -657,7 +658,7 @@ func (m *Model) navGate(kind navigator.Kind, warn string) bool {
 	if sel.Kind != kind {
 		return false
 	}
-	if !samePath(sel.Payload.FilePath, m.currentFile) {
+	if !util.SamePath(sel.Payload.FilePath, m.currentFile) {
 		if warn != "" {
 			m.setStatusMessage(statusMsg{text: warn, level: statusInfo})
 		}
@@ -696,7 +697,7 @@ func (m *Model) confirmCrossFileNavigation(
 		return true
 	}
 	path := n.Payload.FilePath
-	if path == "" || samePath(path, m.currentFile) || !m.dirty {
+	if path == "" || util.SamePath(path, m.currentFile) || !m.dirty {
 		m.clearPendingCrossFileNavigation()
 		return true
 	}
@@ -740,17 +741,10 @@ func (p pendingCrossFileNavigation) matches(
 	if p.nodeID != nodeID || p.action != action || p.sourceRevision != sourceRevision {
 		return false
 	}
-	if !samePathOrBothEmpty(p.sourcePath, sourcePath) {
+	if !util.SamePathOrBothEmpty(p.sourcePath, sourcePath) {
 		return false
 	}
-	return samePathOrBothEmpty(p.targetPath, targetPath)
-}
-
-func samePathOrBothEmpty(a, b string) bool {
-	if a == "" || b == "" {
-		return a == b
-	}
-	return samePath(a, b)
+	return util.SamePathOrBothEmpty(p.targetPath, targetPath)
 }
 
 func (m *Model) ensureNavigatorFile(n *navigator.Node[any]) ([]tea.Cmd, bool) {
@@ -758,14 +752,14 @@ func (m *Model) ensureNavigatorFile(n *navigator.Node[any]) ([]tea.Cmd, bool) {
 		return nil, true
 	}
 	path := n.Payload.FilePath
-	if path == "" || samePath(path, m.currentFile) {
+	if path == "" || util.SamePath(path, m.currentFile) {
 		return nil, true
 	}
 	var cmds []tea.Cmd
 	if cmd := m.openFile(path); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
-	if samePath(path, m.currentFile) {
+	if util.SamePath(path, m.currentFile) {
 		return cmds, true
 	}
 	return cmds, false

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -53,6 +53,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case editorEvent:
 		if typed.dirty {
+			// Content changes are observed synchronously through the editor revision.
+			// Dirty events may arrive later with status messages, so they should not
+			// clear a newer pending navigation confirmation.
 			m.dirty = true
 		}
 		if typed.status != nil {
@@ -485,16 +488,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.suppressEditorKey = false
 		} else {
 			filtered := m.filterEditorMessage(msg)
+			beforeValue := m.editor.Value()
+			beforeRevision := m.editor.Revision()
 			var editorCmd tea.Cmd
 			m.editor, editorCmd = m.editor.Update(filtered)
+			if m.editor.Revision() != beforeRevision || m.editor.Value() != beforeValue {
+				if m.editor.Revision() == beforeRevision {
+					m.editor.noteContentChanged()
+				}
+				m.markDirty()
+			}
 			cmds = append(cmds, editorCmd)
 		}
 		if m.focus == focusEditor {
-			if m.skipEditorCursorSync {
-				m.skipEditorCursorSync = false
-			} else {
-				m.syncNavigatorWithEditorCursor()
-			}
+			m.syncNavigatorWithEditorCursor()
 		}
 	}
 
@@ -660,13 +667,17 @@ func (m *Model) navGate(kind navigator.Kind, warn string) bool {
 }
 
 type pendingCrossFileNavigation struct {
-	nodeID string
-	action string
+	nodeID         string
+	action         string
+	sourcePath     string
+	targetPath     string
+	sourceRevision uint64
 }
 
 const (
 	navActionJumpL          = "navigator:jump:l"
 	navActionJumpR          = "navigator:jump:r"
+	navActionOpenFile       = "navigator:file:open"
 	navActionRequestSend    = "request:send"
 	navActionRequestPreview = "request:preview"
 	navActionWorkflowRun    = "workflow:run"
@@ -684,16 +695,23 @@ func (m *Model) confirmCrossFileNavigation(
 	if n == nil {
 		return true
 	}
-	path := strings.TrimSpace(n.Payload.FilePath)
+	path := n.Payload.FilePath
 	if path == "" || samePath(path, m.currentFile) || !m.dirty {
 		m.clearPendingCrossFileNavigation()
 		return true
 	}
-	if m.pendingCrossFile.nodeID == n.ID && m.pendingCrossFile.action == action {
+	sourceRevision := m.editor.Revision()
+	if m.pendingCrossFile.matches(n.ID, action, m.currentFile, path, sourceRevision) {
 		m.clearPendingCrossFileNavigation()
 		return true
 	}
-	m.pendingCrossFile = pendingCrossFileNavigation{nodeID: n.ID, action: action}
+	m.pendingCrossFile = pendingCrossFileNavigation{
+		nodeID:         n.ID,
+		action:         action,
+		sourcePath:     m.currentFile,
+		targetPath:     path,
+		sourceRevision: sourceRevision,
+	}
 	base := filepath.Base(path)
 	if base == "" {
 		base = path
@@ -712,11 +730,34 @@ func (m *Model) confirmCrossFileNavigation(
 	return false
 }
 
+func (p pendingCrossFileNavigation) matches(
+	nodeID string,
+	action string,
+	sourcePath string,
+	targetPath string,
+	sourceRevision uint64,
+) bool {
+	if p.nodeID != nodeID || p.action != action || p.sourceRevision != sourceRevision {
+		return false
+	}
+	if !samePathOrBothEmpty(p.sourcePath, sourcePath) {
+		return false
+	}
+	return samePathOrBothEmpty(p.targetPath, targetPath)
+}
+
+func samePathOrBothEmpty(a, b string) bool {
+	if a == "" || b == "" {
+		return a == b
+	}
+	return samePath(a, b)
+}
+
 func (m *Model) ensureNavigatorFile(n *navigator.Node[any]) ([]tea.Cmd, bool) {
 	if n == nil {
 		return nil, true
 	}
-	path := strings.TrimSpace(n.Payload.FilePath)
+	path := n.Payload.FilePath
 	if path == "" || samePath(path, m.currentFile) {
 		return nil, true
 	}
@@ -1319,8 +1360,7 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 				m.suppressEditorKey = true
 				return combine(cmd)
 			case "u":
-				var cmd tea.Cmd
-				m.editor, cmd = m.editor.UndoLastChange()
+				cmd := m.runUndoLastChange()
 				m.suppressEditorKey = true
 				return combine(cmd)
 			case "ctrl+r":
@@ -1329,8 +1369,7 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 				return combine(cmd)
 			case "d":
 				if m.editor.hasSelection() {
-					var cmd tea.Cmd
-					m.editor, cmd = m.editor.DeleteSelection()
+					cmd := m.runDeleteSelection()
 					m.suppressEditorKey = true
 					return combine(cmd)
 				}
@@ -1349,8 +1388,7 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 				return combine(cmd)
 			case "c":
 				if m.editor.hasSelection() {
-					var cmd tea.Cmd
-					m.editor, cmd = m.editor.DeleteSelection()
+					cmd := m.runDeleteSelection()
 					cmd = batchCommands(cmd, m.setInsertMode(true, true))
 					m.suppressEditorKey = true
 					return combine(cmd)
@@ -1420,15 +1458,6 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 		if m.shouldSendEditorRequest(msg, m.editorInsertMode) {
 			m.suppressEditorKey = true
 			return combine(m.sendActiveRequest())
-		}
-		if m.editorInsertMode {
-			km := msg
-			switch km.Type {
-			case tea.KeyBackspace, tea.KeyDelete, tea.KeyRunes, tea.KeyEnter:
-				if km.Type != tea.KeyRunes || len(km.Runes) > 0 {
-					m.dirty = true
-				}
-			}
 		}
 	}
 
@@ -2025,12 +2054,28 @@ func (m *Model) runWorkflowResize(delta float64) tea.Cmd {
 
 func (m *Model) applyEditorMutation(op func(requestEditor) (requestEditor, tea.Cmd)) tea.Cmd {
 	before := m.editor.Value()
+	beforeRevision := m.editor.Revision()
 	editor, cmd := op(m.editor)
-	if editor.Value() != before {
-		m.dirty = true
+	if editor.Revision() != beforeRevision || editor.Value() != before {
+		if editor.Revision() == beforeRevision {
+			editor.noteContentChanged()
+		}
+		m.markDirty()
 	}
 	m.editor = editor
 	return cmd
+}
+
+func (m *Model) runDeleteSelection() tea.Cmd {
+	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+		return ed.DeleteSelection()
+	})
+}
+
+func (m *Model) runUndoLastChange() tea.Cmd {
+	return m.applyEditorMutation(func(ed requestEditor) (requestEditor, tea.Cmd) {
+		return ed.UndoLastChange()
+	})
 }
 
 func (m *Model) runDeleteCurrentLine() tea.Cmd {

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -685,17 +685,18 @@ func (m *Model) confirmCrossFileNavigation(
 		return true
 	}
 	sourceRevision := m.editor.Revision()
-	if m.pendingCrossFile.matches(n.ID, action, m.currentFile, path, sourceRevision) {
-		m.clearPendingCrossFileNavigation()
-		return true
-	}
-	m.pendingCrossFile = pendingCrossFileNavigation{
+	pending := pendingCrossFileNavigation{
 		nodeID:         n.ID,
 		action:         action,
 		sourcePath:     m.currentFile,
 		targetPath:     path,
 		sourceRevision: sourceRevision,
 	}
+	if m.pendingCrossFile.matches(pending) {
+		m.clearPendingCrossFileNavigation()
+		return true
+	}
+	m.pendingCrossFile = pending
 	base := filepath.Base(path)
 	if base == "" {
 		base = path
@@ -714,20 +715,20 @@ func (m *Model) confirmCrossFileNavigation(
 	return false
 }
 
-func (p pendingCrossFileNavigation) matches(
-	nodeID string,
-	action string,
-	sourcePath string,
-	targetPath string,
-	sourceRevision uint64,
-) bool {
-	if p.nodeID != nodeID || p.action != action || p.sourceRevision != sourceRevision {
+func (p pendingCrossFileNavigation) matches(other pendingCrossFileNavigation) bool {
+	if p.nodeID != other.nodeID {
 		return false
 	}
-	if !util.SamePathOrBothEmpty(p.sourcePath, sourcePath) {
+	if p.action != other.action {
 		return false
 	}
-	return util.SamePathOrBothEmpty(p.targetPath, targetPath)
+	if p.sourceRevision != other.sourceRevision {
+		return false
+	}
+	if !util.SamePathOrBothEmpty(p.sourcePath, other.sourcePath) {
+		return false
+	}
+	return util.SamePathOrBothEmpty(p.targetPath, other.targetPath)
 }
 
 func (m *Model) ensureNavigatorFile(n *navigator.Node[any]) ([]tea.Cmd, bool) {

--- a/internal/ui/model_update_navigator.go
+++ b/internal/ui/model_update_navigator.go
@@ -125,7 +125,6 @@ func (m *Model) updateNavigator(msg tea.Msg) tea.Cmd {
 		focusCmd := m.setFocus(focusEditor)
 		if m.focus == focusEditor {
 			m.suppressEditorKey = true
-			m.skipEditorCursorSync = true
 		}
 		return batchCommands(out, focusCmd)
 	}
@@ -187,6 +186,13 @@ func (m *Model) updateNavigator(msg tea.Msg) tea.Cmd {
 			case navigator.KindFile:
 				path := n.Payload.FilePath
 				if path != "" && !samePath(path, m.currentFile) {
+					if !m.confirmCrossFileNavigation(
+						n,
+						navActionOpenFile,
+						navOpenFileRetryHint(ev.String()),
+					) {
+						return applyFilter(nil)
+					}
 					cmd = m.openFile(path)
 				}
 				if path != "" && !filesvc.IsRequestFile(path) {
@@ -211,6 +217,13 @@ func (m *Model) updateNavigator(msg tea.Msg) tea.Cmd {
 			case navigator.KindFile:
 				path := n.Payload.FilePath
 				if path != "" && !samePath(path, m.currentFile) {
+					if !m.confirmCrossFileNavigation(
+						n,
+						navActionOpenFile,
+						navOpenFileRetryHint(ev.String()),
+					) {
+						return applyFilter(nil)
+					}
 					cmd = m.openFile(path)
 				}
 				if path != "" && !filesvc.IsRequestFile(path) {
@@ -271,6 +284,19 @@ func (m *Model) updateNavigator(msg tea.Msg) tea.Cmd {
 
 func navJumpable(n *navigator.Node[any]) bool {
 	return n != nil && (n.Kind == navigator.KindRequest || n.Kind == navigator.KindWorkflow)
+}
+
+func navOpenFileRetryHint(key string) string {
+	switch key {
+	case "enter":
+		return "Press Enter again to open."
+	case "right":
+		return "Press Right again to open."
+	case "l":
+		return "Press l again to open."
+	default:
+		return "Repeat the open action to continue."
+	}
 }
 
 func (m *Model) navExpandFile(n *navigator.Node[any], toggle bool) {

--- a/internal/ui/model_update_navigator.go
+++ b/internal/ui/model_update_navigator.go
@@ -304,42 +304,36 @@ func (m *Model) navExpandFile(n *navigator.Node[any], toggle bool) {
 	if m.navigator == nil || n == nil {
 		return
 	}
-	has := len(n.Children) > 0
-	if !has {
+	loaded := len(n.Children) > 0
+	if !loaded {
 		m.expandNavigatorFile(n.Payload.FilePath)
 		if refreshed := m.navigator.Find(n.ID); refreshed != nil {
 			n = refreshed
 		}
 	}
-	if n == nil || len(n.Children) == 0 {
-		return
+
+	if !loaded {
+		toggle = false
 	}
-	changed := false
-	if toggle && has {
-		n.Expanded = !n.Expanded
-		changed = true
-	} else if !n.Expanded {
-		n.Expanded = true
-		changed = true
-	}
-	if changed {
-		m.navigator.Refresh()
-	}
+	m.navToggleExpand(n, toggle)
 }
 
 func (m *Model) navExpandDir(n *navigator.Node[any], toggle bool) {
+	m.navToggleExpand(n, toggle)
+}
+
+func (m *Model) navToggleExpand(n *navigator.Node[any], toggle bool) {
 	if m.navigator == nil || n == nil || len(n.Children) == 0 {
 		return
 	}
-	changed := false
+
+	expanded := n.Expanded
 	if toggle {
 		n.Expanded = !n.Expanded
-		changed = true
-	} else if !n.Expanded {
+	} else {
 		n.Expanded = true
-		changed = true
 	}
-	if changed {
+	if n.Expanded != expanded {
 		m.navigator.Refresh()
 	}
 }

--- a/internal/ui/model_update_navigator.go
+++ b/internal/ui/model_update_navigator.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/filesvc"
 	"github.com/unkn0wn-root/resterm/internal/ui/navigator"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 func navigatorFilterConsumesKey(msg tea.KeyMsg) bool {
@@ -185,7 +186,7 @@ func (m *Model) updateNavigator(msg tea.Msg) tea.Cmd {
 			switch n.Kind {
 			case navigator.KindFile:
 				path := n.Payload.FilePath
-				if path != "" && !samePath(path, m.currentFile) {
+				if path != "" && !util.SamePath(path, m.currentFile) {
 					if !m.confirmCrossFileNavigation(
 						n,
 						navActionOpenFile,
@@ -216,7 +217,7 @@ func (m *Model) updateNavigator(msg tea.Msg) tea.Cmd {
 			switch n.Kind {
 			case navigator.KindFile:
 				path := n.Payload.FilePath
-				if path != "" && !samePath(path, m.currentFile) {
+				if path != "" && !util.SamePath(path, m.currentFile) {
 					if !m.confirmCrossFileNavigation(
 						n,
 						navActionOpenFile,

--- a/internal/ui/model_update_test.go
+++ b/internal/ui/model_update_test.go
@@ -861,7 +861,7 @@ func TestHandleKeyUWithoutHistoryShowsStatus(t *testing.T) {
 	if evt.status == nil || evt.status.text != "Nothing to undo" {
 		t.Fatalf("expected no-history status, got %+v", evt.status)
 	}
-	if evt.dirty {
+	if model.dirty {
 		t.Fatalf("expected dirty to remain false when no undo")
 	}
 	if got := model.editor.Value(); got != "alpha" {

--- a/internal/ui/navigator/render.go
+++ b/internal/ui/navigator/render.go
@@ -2,7 +2,6 @@ package navigator
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/filesvc"
 	"github.com/unkn0wn-root/resterm/internal/theme"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 const (
@@ -296,17 +296,7 @@ func sameNavigatorPath(a, b string) bool {
 	if strings.TrimSpace(a) == "" || strings.TrimSpace(b) == "" {
 		return false
 	}
-	cleanA := filepath.Clean(a)
-	cleanB := filepath.Clean(b)
-	if cleanA == cleanB {
-		return true
-	}
-	absA, errA := filepath.Abs(cleanA)
-	absB, errB := filepath.Abs(cleanB)
-	if errA != nil || errB != nil {
-		return false
-	}
-	return absA == absB
+	return util.SamePath(a, b)
 }
 
 func fileKind(n *Node[any]) filesvc.FileKind {

--- a/internal/ui/navigator/render.go
+++ b/internal/ui/navigator/render.go
@@ -156,7 +156,7 @@ func rowActive(row Flat[any], state RenderState) bool {
 	if state.ActiveNodeID != "" && n.ID == state.ActiveNodeID {
 		return true
 	}
-	return n.Kind == KindFile && sameNavigatorPath(n.Payload.FilePath, state.ActiveFilePath)
+	return n.Kind == KindFile && util.SamePath(n.Payload.FilePath, state.ActiveFilePath)
 }
 
 func rowTextStyles(
@@ -290,13 +290,6 @@ func withActiveForeground(style lipgloss.Style, th theme.Theme) lipgloss.Style {
 		return style.Foreground(fg)
 	}
 	return style
-}
-
-func sameNavigatorPath(a, b string) bool {
-	if strings.TrimSpace(a) == "" || strings.TrimSpace(b) == "" {
-		return false
-	}
-	return util.SamePath(a, b)
 }
 
 func fileKind(n *Node[any]) filesvc.FileKind {

--- a/internal/ui/navigator/render_test.go
+++ b/internal/ui/navigator/render_test.go
@@ -44,12 +44,19 @@ func assertSelectedRow(t *testing.T, rendered string, width int) {
 	assertSelectedBackgroundSegments(t, rendered, 3)
 }
 
-func TestSameNavigatorPathMatchesRelativeAndAbsolute(t *testing.T) {
+func TestRowActiveMatchesRelativeAndAbsoluteFilePath(t *testing.T) {
 	abs, err := filepath.Abs("api.http")
 	if err != nil {
 		t.Fatalf("abs path: %v", err)
 	}
-	if !sameNavigatorPath("api.http", abs) {
+	row := Flat[any]{
+		Node: &Node[any]{
+			Kind:    KindFile,
+			Payload: Payload[any]{FilePath: "api.http"},
+		},
+	}
+
+	if !rowActive(row, RenderState{ActiveFilePath: abs}) {
 		t.Fatalf("expected relative path to match absolute path %q", abs)
 	}
 }

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -1,0 +1,34 @@
+package util
+
+import "path/filepath"
+
+// SamePath reports whether two non-empty paths resolve to the same lexical path.
+//
+// It does not stat files or resolve symlinks; use os.SameFile with os.Stat
+// results when physical file identity is required.
+func SamePath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+
+	cleanA := filepath.Clean(a)
+	cleanB := filepath.Clean(b)
+	if cleanA == cleanB {
+		return true
+	}
+
+	absA, errA := filepath.Abs(cleanA)
+	absB, errB := filepath.Abs(cleanB)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return absA == absB
+}
+
+// SamePathOrBothEmpty reports whether a and b are both empty or name the same path.
+func SamePathOrBothEmpty(a, b string) bool {
+	if a == "" || b == "" {
+		return a == b
+	}
+	return SamePath(a, b)
+}

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -11,14 +11,12 @@ func SamePath(a, b string) bool {
 		return false
 	}
 
-	cleanA := filepath.Clean(a)
-	cleanB := filepath.Clean(b)
-	if cleanA == cleanB {
+	if a == b {
 		return true
 	}
 
-	absA, errA := filepath.Abs(cleanA)
-	absB, errB := filepath.Abs(cleanB)
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
 	if errA != nil || errB != nil {
 		return false
 	}

--- a/internal/util/path_test.go
+++ b/internal/util/path_test.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSamePath(t *testing.T) {
+	abs, err := filepath.Abs(filepath.Join("internal", "util", "path.go"))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{
+			name: "relative absolute",
+			a:    filepath.Join("internal", "util", ".", "path.go"),
+			b:    abs,
+			want: true,
+		},
+		{
+			name: "clean equivalent",
+			a:    filepath.Join("internal", "util", "..", "util", "path.go"),
+			b:    filepath.Join("internal", "util", "path.go"),
+			want: true,
+		},
+		{
+			name: "empty does not match empty",
+			a:    "",
+			b:    "",
+			want: false,
+		},
+		{
+			name: "different",
+			a:    filepath.Join("internal", "util", "path.go"),
+			b:    filepath.Join("internal", "util", "string.go"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SamePath(tt.a, tt.b); got != tt.want {
+				t.Fatalf("SamePath(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSamePathOrBothEmpty(t *testing.T) {
+	abs, err := filepath.Abs(filepath.Join("internal", "util", "path.go"))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+
+	if !SamePathOrBothEmpty("", "") {
+		t.Fatal("expected two empty paths to match")
+	}
+	if SamePathOrBothEmpty("", abs) {
+		t.Fatal("expected one empty path not to match")
+	}
+	if !SamePathOrBothEmpty(filepath.Join("internal", "util", "path.go"), abs) {
+		t.Fatal("expected relative and absolute paths to match")
+	}
+}

--- a/internal/workspace/list.go
+++ b/internal/workspace/list.go
@@ -152,7 +152,7 @@ func (l *lister) addRTSModuleRefs(referrerPath string, e filesvc.FileEntry) {
 }
 
 func (l *lister) loadDoc(path string) *restfile.Document {
-	if l.opt.CurrentDoc != nil && samePath(path, l.opt.CurrentFile) {
+	if l.opt.CurrentDoc != nil && str.SamePath(str.Trim(path), str.Trim(l.opt.CurrentFile)) {
 		return l.opt.CurrentDoc
 	}
 
@@ -169,7 +169,7 @@ func (l *lister) addEntry(e filesvc.FileEntry) {
 
 func (l *lister) addDoc(e filesvc.FileEntry) {
 	for _, doc := range l.docs {
-		if samePath(doc.Path, e.Path) {
+		if str.SamePath(str.Trim(doc.Path), str.Trim(e.Path)) {
 			return
 		}
 	}
@@ -246,13 +246,6 @@ func (l *lister) sorted() []filesvc.FileEntry {
 		return out[i].Name < out[j].Name
 	})
 	return out
-}
-
-func samePath(a, b string) bool {
-	if str.Trim(a) == "" || str.Trim(b) == "" {
-		return false
-	}
-	return pathKey(a) == pathKey(b)
 }
 
 func pathKey(path string) string {

--- a/internal/workspace/list.go
+++ b/internal/workspace/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/filesvc"
 	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
-	str "github.com/unkn0wn-root/resterm/internal/util"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 const (
@@ -152,7 +152,7 @@ func (l *lister) addRTSModuleRefs(referrerPath string, e filesvc.FileEntry) {
 }
 
 func (l *lister) loadDoc(path string) *restfile.Document {
-	if l.opt.CurrentDoc != nil && str.SamePath(str.Trim(path), str.Trim(l.opt.CurrentFile)) {
+	if l.opt.CurrentDoc != nil && util.SamePath(util.Trim(path), util.Trim(l.opt.CurrentFile)) {
 		return l.opt.CurrentDoc
 	}
 
@@ -169,7 +169,7 @@ func (l *lister) addEntry(e filesvc.FileEntry) {
 
 func (l *lister) addDoc(e filesvc.FileEntry) {
 	for _, doc := range l.docs {
-		if str.SamePath(str.Trim(doc.Path), str.Trim(e.Path)) {
+		if util.SamePath(util.Trim(doc.Path), util.Trim(e.Path)) {
 			return
 		}
 	}
@@ -177,7 +177,7 @@ func (l *lister) addDoc(e filesvc.FileEntry) {
 }
 
 func (l *lister) currentEntry() (filesvc.FileEntry, bool) {
-	path := str.Trim(l.opt.CurrentFile)
+	path := util.Trim(l.opt.CurrentFile)
 	if path == "" {
 		return filesvc.FileEntry{}, false
 	}
@@ -189,7 +189,7 @@ func (l *lister) currentEntry() (filesvc.FileEntry, bool) {
 }
 
 func (l *lister) refEntry(src, ref string) (filesvc.FileEntry, bool) {
-	ref = str.Trim(ref)
+	ref = util.Trim(ref)
 	if ref == "" {
 		return filesvc.FileEntry{}, false
 	}
@@ -249,7 +249,7 @@ func (l *lister) sorted() []filesvc.FileEntry {
 }
 
 func pathKey(path string) string {
-	path = filepath.Clean(str.Trim(path))
+	path = filepath.Clean(util.Trim(path))
 	if abs, err := filepath.Abs(path); err == nil {
 		return abs
 	}
@@ -258,7 +258,7 @@ func pathKey(path string) string {
 
 func isDynamicRef(ref string) bool {
 	for _, marker := range templateMarkers {
-		if str.Contains(ref, marker) {
+		if util.Contains(ref, marker) {
 			return true
 		}
 	}
@@ -269,7 +269,7 @@ func relEscapesRoot(rel string) bool {
 	switch {
 	case rel == parentRel:
 		return true
-	case str.HasPrefix(rel, parentRel+string(filepath.Separator)):
+	case util.HasPrefix(rel, parentRel+string(filepath.Separator)):
 		return true
 	default:
 		return false
@@ -277,7 +277,7 @@ func relEscapesRoot(rel string) bool {
 }
 
 func rtsModuleRefScanKey(modulePath, referrerPath string) string {
-	rtbase := str.Trim(referrerPath)
+	rtbase := util.Trim(referrerPath)
 	if rtbase == "" {
 		rtbase = modulePath
 	}


### PR DESCRIPTION
- Removed `dirty` from `editorEvent`. Editor events now carry status only.
- Added centralized `updateEditor` and `mutateEditor` helpers that mark the model dirty when `requestEditor.Revision()` changes.
- Removed `Model`-side calls to `noteContentChanged()`.
- Kept content revision ownership inside `requestEditor`.
- Updated editor tests to assert revision changes instead of dirty editor events.
- Added path.go to utils package 