### PR TITLE
RST-241: fix sgr highlight search

### DIFF
--- a/internal/ui/ansi_decorate.go
+++ b/internal/ui/ansi_decorate.go
@@ -1,0 +1,59 @@
+package ui
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// applyANSIAwareWrap wraps segment in prefix/suffix, re-applying prefix after
+// inner SGR sequences so embedded styles cannot cancel the outer decoration.
+// restore is appended after suffix to resume the style active after segment.
+func applyANSIAwareWrap(segment, prefix, suffix, restore string) string {
+	if prefix == "" {
+		return segment
+	}
+
+	trailing := suffix + restore
+	if segment == "" {
+		return prefix + trailing
+	}
+	if !ansiSequenceRegex.MatchString(segment) {
+		return prefix + segment + trailing
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(segment) + len(prefix)*2 + len(trailing))
+	builder.WriteString(prefix)
+	for i := 0; i < len(segment); {
+		if segment[i] == '\x1b' {
+			if seq, size := ansiSequenceAt(segment, i); size > 0 {
+				builder.WriteString(seq)
+				if isSGR(seq) {
+					builder.WriteString(prefix)
+				}
+				i += size
+				continue
+			}
+		}
+
+		_, size := utf8.DecodeRuneInString(segment[i:])
+		if size <= 0 {
+			size = 1
+		}
+		builder.WriteString(segment[i : i+size])
+		i += size
+	}
+	builder.WriteString(trailing)
+	return builder.String()
+}
+
+func ansiSequenceAt(content string, index int) (string, int) {
+	if index < 0 || index >= len(content) || content[index] != '\x1b' {
+		return "", 0
+	}
+	loc := ansiSequenceRegex.FindStringIndex(content[index:])
+	if loc == nil || loc[0] != 0 {
+		return "", 0
+	}
+	return content[index : index+loc[1]], loc[1]
+}

--- a/internal/ui/ansi_sgr.go
+++ b/internal/ui/ansi_sgr.go
@@ -1,0 +1,205 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+)
+
+const (
+	sgrExtForeground = 38
+	sgrExtBackground = 48
+	sgrExtUnderline  = 58
+	sgrExtPalette    = 5
+	sgrExtRGB        = 2
+)
+
+type sgrState struct {
+	bold          bool
+	faint         bool
+	italic        bool
+	underline     bool
+	blink         bool
+	reverse       bool
+	strikethrough bool
+	fg            []int
+	bg            []int
+	ul            []int
+}
+
+func isSGR(seq string) bool {
+	_, ok := parseSGRParams(seq)
+	return ok
+}
+
+func parseSGRParams(seq string) ([]int, bool) {
+	if len(seq) < 3 || !strings.HasPrefix(seq, "\x1b[") || seq[len(seq)-1] != 'm' {
+		return nil, false
+	}
+	params := seq[2 : len(seq)-1]
+	if params == "" {
+		return []int{0}, true
+	}
+
+	parts := strings.Split(params, ";")
+	out := make([]int, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			out = append(out, 0)
+			continue
+		}
+		if !asciiDigits(part) {
+			return nil, false
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	return out, true
+}
+
+func asciiDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *sgrState) apply(seq string) bool {
+	params, ok := parseSGRParams(seq)
+	if !ok {
+		return false
+	}
+	s.applyParams(params)
+	return true
+}
+
+func (s *sgrState) applyParams(params []int) {
+	for i := 0; i < len(params); {
+		p := params[i]
+		switch {
+		case p == 0:
+			*s = sgrState{}
+		case p == 1:
+			s.bold = true
+		case p == 2:
+			s.faint = true
+		case p == 3:
+			s.italic = true
+		case p == 4:
+			s.underline = true
+		case p == 5 || p == 6:
+			s.blink = true
+		case p == 7:
+			s.reverse = true
+		case p == 9:
+			s.strikethrough = true
+		case p == 22:
+			s.bold = false
+			s.faint = false
+		case p == 23:
+			s.italic = false
+		case p == 24:
+			s.underline = false
+		case p == 25:
+			s.blink = false
+		case p == 27:
+			s.reverse = false
+		case p == 29:
+			s.strikethrough = false
+		case p >= 30 && p <= 37 || p >= 90 && p <= 97:
+			s.fg = []int{p}
+		case p == 39:
+			s.fg = nil
+		case p >= 40 && p <= 47 || p >= 100 && p <= 107:
+			s.bg = []int{p}
+		case p == 49:
+			s.bg = nil
+		case p == 59:
+			s.ul = nil
+		case p == sgrExtForeground || p == sgrExtBackground || p == sgrExtUnderline:
+			i += s.applyExtColor(params[i:])
+			continue
+		}
+		i++
+	}
+}
+
+func (s *sgrState) applyExtColor(params []int) int {
+	if len(params) < 2 {
+		return 1
+	}
+
+	target := &s.fg
+	switch params[0] {
+	case sgrExtBackground:
+		target = &s.bg
+	case sgrExtUnderline:
+		target = &s.ul
+	}
+
+	switch params[1] {
+	case sgrExtPalette:
+		if len(params) >= 3 {
+			*target = append((*target)[:0], params[:3]...)
+			return 3
+		}
+		return len(params)
+	case sgrExtRGB:
+		if len(params) >= 5 {
+			*target = append((*target)[:0], params[:5]...)
+			return 5
+		}
+		return len(params)
+	default:
+		return 2
+	}
+}
+
+func (s sgrState) String() string {
+	params := make([]int, 0, 16)
+	if s.bold {
+		params = append(params, 1)
+	}
+	if s.faint {
+		params = append(params, 2)
+	}
+	if s.italic {
+		params = append(params, 3)
+	}
+	if s.underline {
+		params = append(params, 4)
+	}
+	if s.blink {
+		params = append(params, 5)
+	}
+	if s.reverse {
+		params = append(params, 7)
+	}
+	if s.strikethrough {
+		params = append(params, 9)
+	}
+	params = append(params, s.fg...)
+	params = append(params, s.bg...)
+	params = append(params, s.ul...)
+	if len(params) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\x1b[")
+	for i, p := range params {
+		if i > 0 {
+			b.WriteByte(';')
+		}
+		b.WriteString(strconv.Itoa(p))
+	}
+	b.WriteByte('m')
+	return b.String()
+}

--- a/internal/ui/ansi_sgr_test.go
+++ b/internal/ui/ansi_sgr_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestParseSGRParamsRejectsPrivateCSI(t *testing.T) {
+	if isSGR("\x1b[?m") {
+		t.Fatal("expected private CSI parameters not to be treated as SGR")
+	}
+	if _, ok := parseSGRParams("\x1b[?25m"); ok {
+		t.Fatal("expected private CSI with digits not to parse as SGR")
+	}
+}
+
+func TestParseSGRParamsHandlesEmptyAndTrailingDefaults(t *testing.T) {
+	tests := []struct {
+		seq  string
+		want []int
+	}{
+		{seq: "\x1b[m", want: []int{0}},
+		{seq: "\x1b[31;m", want: []int{31, 0}},
+		{seq: "\x1b[31;;1m", want: []int{31, 0, 1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q", tt.seq), func(t *testing.T) {
+			got, ok := parseSGRParams(tt.seq)
+			if !ok {
+				t.Fatalf("expected %q to parse", tt.seq)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("parseSGRParams(%q)=%v, want %v", tt.seq, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResponseSearchBoundariesIgnorePrivateCSIInRestore(t *testing.T) {
+	bounds := responseSearchBoundaries("\x1b[31mred\x1b[?mX")
+	if len(bounds) != 5 {
+		t.Fatalf("expected 4 visible runes plus initial boundary, got %d", len(bounds))
+	}
+	restore := bounds[len(bounds)-1].sgr
+	if strings.Contains(restore, "?") {
+		t.Fatalf("expected private CSI to be ignored in restore state, got %q", restore)
+	}
+	if restore != "\x1b[31m" {
+		t.Fatalf("expected red foreground restore, got %q", restore)
+	}
+}
+
+func TestResponseSearchBoundariesCompactSGRRestore(t *testing.T) {
+	bounds := responseSearchBoundaries("\x1b[31m\x1b[32m\x1b[33mX")
+	if len(bounds) != 2 {
+		t.Fatalf("expected one visible rune plus initial boundary, got %d", len(bounds))
+	}
+	if got := bounds[1].sgr; got != "\x1b[33m" {
+		t.Fatalf("expected compact latest foreground restore, got %q", got)
+	}
+}
+
+func TestResponseSearchBoundariesPreserveCompositeSGRRestore(t *testing.T) {
+	content := "\x1b[1m\x1b[3m\x1b[38;2;0;0;0m\x1b[48;5;244mX"
+	bounds := responseSearchBoundaries(content)
+	if len(bounds) != 2 {
+		t.Fatalf("expected one visible rune plus initial boundary, got %d", len(bounds))
+	}
+	want := "\x1b[1;3;38;2;0;0;0;48;5;244m"
+	if got := bounds[1].sgr; got != want {
+		t.Fatalf("expected composite restore %q, got %q", want, got)
+	}
+}
+
+func TestResponseSearchBoundariesClearAttributesWithoutClearingColors(t *testing.T) {
+	bounds := responseSearchBoundaries("\x1b[1;31m\x1b[22mX")
+	if len(bounds) != 2 {
+		t.Fatalf("expected one visible rune plus initial boundary, got %d", len(bounds))
+	}
+	if got := bounds[1].sgr; got != "\x1b[31m" {
+		t.Fatalf("expected intensity reset to keep foreground only, got %q", got)
+	}
+}

--- a/internal/ui/explain_render.go
+++ b/internal/ui/explain_render.go
@@ -386,7 +386,7 @@ func (m *Model) syncExplainPane(
 		responseTabExplain,
 		decorated,
 		width,
-		snapshot.ready,
+		true,
 		snapshot.id,
 	)
 	pane.viewport.SetContent(decorated)

--- a/internal/ui/explain_render.go
+++ b/internal/ui/explain_render.go
@@ -407,7 +407,9 @@ func (m *Model) explainStyledContent(snapshot *responseSnapshot, width int) stri
 	content := snapshot.explain.cache.styled
 	if content == "" || snapshot.explain.cache.width != width ||
 		snapshot.explain.cache.themeKey != key {
-		content = displayContent(renderExplainStyledView(snapshot.explain.ensureView(), width, m.theme))
+		content = displayContent(
+			renderExplainStyledView(snapshot.explain.ensureView(), width, m.theme),
+		)
 		snapshot.explain.cache = explainRenderCache{
 			styled:   content,
 			width:    width,

--- a/internal/ui/explain_render.go
+++ b/internal/ui/explain_render.go
@@ -376,6 +376,30 @@ func (m *Model) syncExplainPane(
 	if pane == nil || snapshot == nil || snapshot.explain.report == nil {
 		return nil
 	}
+	content := m.explainStyledContent(snapshot, width)
+	if strings.TrimSpace(content) == "" {
+		content = "<no explain>\n"
+	}
+	decorated := m.applyResponseContentStyles(responseTabExplain, content)
+	decorated = m.decorateResponseContentForPane(
+		pane,
+		responseTabExplain,
+		decorated,
+		width,
+		snapshot.ready,
+		snapshot.id,
+	)
+	pane.viewport.SetContent(decorated)
+	pane.restoreScrollForActiveTab()
+	ensureResponseMatchInView(pane, content)
+	pane.setCurrPosition()
+	return nil
+}
+
+func (m *Model) explainStyledContent(snapshot *responseSnapshot, width int) string {
+	if snapshot == nil || snapshot.explain.report == nil {
+		return ""
+	}
 	key := strings.TrimSpace(m.activeThemeKey)
 	if key == "" {
 		key = "default"
@@ -383,19 +407,12 @@ func (m *Model) syncExplainPane(
 	content := snapshot.explain.cache.styled
 	if content == "" || snapshot.explain.cache.width != width ||
 		snapshot.explain.cache.themeKey != key {
-		content = renderExplainStyledView(snapshot.explain.ensureView(), width, m.theme)
+		content = displayContent(renderExplainStyledView(snapshot.explain.ensureView(), width, m.theme))
 		snapshot.explain.cache = explainRenderCache{
 			styled:   content,
 			width:    width,
 			themeKey: key,
 		}
 	}
-	if strings.TrimSpace(content) == "" {
-		content = "<no explain>\n"
-	}
-	decorated := m.applyResponseContentStyles(responseTabExplain, content)
-	pane.viewport.SetContent(decorated)
-	pane.restoreScrollForActiveTab()
-	pane.setCurrPosition()
-	return nil
+	return content
 }

--- a/internal/ui/explain_test.go
+++ b/internal/ui/explain_test.go
@@ -325,7 +325,7 @@ func TestSyncResponsePaneExplainUsesStyledRenderer(t *testing.T) {
 	}
 }
 
-func TestSyncResponsePaneExplainFallsBackToPlainWhileSearching(t *testing.T) {
+func TestSyncResponsePaneExplainKeepsStyledRenderingWhileSearching(t *testing.T) {
 	t.Parallel()
 
 	model := New(Config{})
@@ -356,12 +356,58 @@ func TestSyncResponsePaneExplainFallsBackToPlainWhileSearching(t *testing.T) {
 		collectMsgs(cmd)
 	}
 
-	view := pane.viewport.View()
-	if strings.Contains(view, "\x1b[") {
-		t.Fatalf("expected search mode to use plain explain rendering, got %q", view)
+	view := ansi.Strip(pane.viewport.View())
+	if strings.Contains(view, "Summary\n======") {
+		t.Fatalf("expected search mode to keep styled explain rendering, got %q", view)
 	}
-	if !strings.Contains(view, "Decision") {
-		t.Fatalf("expected plain explain content during search, got %q", view)
+	if !strings.Contains(view, "DECISION") {
+		t.Fatalf("expected styled explain content during search, got %q", view)
+	}
+}
+
+func TestExplainSearchUsesSameStyledDisplayContentAsPane(t *testing.T) {
+	t.Parallel()
+
+	model := New(Config{})
+	model.ready = true
+	model.width = 120
+	model.height = 40
+	if cmd := model.applyLayout(); cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	pane := &model.responsePanes[responsePanePrimary]
+	pane.activeTab = responseTabExplain
+	pane.viewport.Width = 80
+	pane.snapshot = &responseSnapshot{
+		id:    "snap-explain-search-display",
+		ready: true,
+		explain: explainState{
+			report: &xplain.Report{
+				Status:   xplain.StatusReady,
+				Method:   "GET",
+				URL:      "https://example.com",
+				Decision: "Request prepared",
+			},
+		},
+	}
+
+	styled := model.explainStyledContent(pane.snapshot, pane.viewport.Width)
+	searchContent, tab, wrapped := model.responseSearchContent(
+		responsePanePrimary,
+		responseTabExplain,
+		pane.viewport.Width,
+	)
+	if tab != responseTabExplain {
+		t.Fatalf("expected explain search tab, got %v", tab)
+	}
+	if searchContent != styled || wrapped != styled {
+		t.Fatalf(
+			"expected explain search content to match pane display content\nstyled=%q\nsearch=%q\nwrapped=%q",
+			styled,
+			searchContent,
+			wrapped,
+		)
 	}
 }
 

--- a/internal/ui/explain_test.go
+++ b/internal/ui/explain_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	xplain "github.com/unkn0wn-root/resterm/internal/explain"
+	"github.com/unkn0wn-root/resterm/internal/httpclient"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/theme"
 )
@@ -325,6 +326,96 @@ func TestSyncResponsePaneExplainUsesStyledRenderer(t *testing.T) {
 	}
 }
 
+func TestSyncResponsePaneExplainDoesNotWaitForResponseFormatting(t *testing.T) {
+	t.Parallel()
+
+	model := New(Config{})
+	model.ready = true
+	model.width = 120
+	model.height = 40
+	if cmd := model.applyLayout(); cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	pane := &model.responsePanes[responsePanePrimary]
+	pane.activeTab = responseTabExplain
+	pane.snapshot = &responseSnapshot{
+		id:    "snap-explain-before-formatting",
+		ready: false,
+		explain: explainState{
+			report: &xplain.Report{
+				Status:   xplain.StatusReady,
+				Method:   "GET",
+				URL:      "https://example.com",
+				Decision: "HTTP request sent",
+			},
+		},
+	}
+
+	if cmd := model.syncResponsePane(responsePanePrimary); cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	plain := ansi.Strip(pane.viewport.View())
+	if strings.Contains(plain, responseFormattingBase) {
+		t.Fatalf("did not expect explain tab to wait for response formatting, got %q", plain)
+	}
+	if !strings.Contains(plain, "SUMMARY") || !strings.Contains(plain, "HTTP request sent") {
+		t.Fatalf("expected explain report before response formatting completes, got %q", plain)
+	}
+}
+
+func TestConsumeHTTPResponseActiveExplainRendersBeforeResponseFormatting(t *testing.T) {
+	t.Parallel()
+
+	model := New(Config{})
+	model.ready = true
+	model.width = 120
+	model.height = 40
+	if cmd := model.applyLayout(); cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	pane := model.pane(responsePanePrimary)
+	if pane == nil {
+		t.Fatal("expected response pane")
+	}
+	pane.activeTab = responseTabExplain
+
+	cmd := model.consumeHTTPResponse(
+		&httpclient.Response{
+			Status:       "200 OK",
+			StatusCode:   200,
+			ReqMethod:    "GET",
+			EffectiveURL: "https://example.com",
+			Body:         []byte("ok"),
+		},
+		nil,
+		nil,
+		"",
+		&xplain.Report{
+			Status:   xplain.StatusReady,
+			Method:   "GET",
+			URL:      "https://example.com",
+			Decision: "HTTP request sent",
+		},
+	)
+	if cmd == nil {
+		t.Fatal("expected async response render command")
+	}
+	if !model.responseLoading {
+		t.Fatal("expected response formatting to still be active")
+	}
+
+	plain := ansi.Strip(model.renderResponseColumn(responsePanePrimary, true, 120))
+	if strings.Contains(plain, responseFormattingBase) {
+		t.Fatalf("did not expect explain tab to show formatting overlay, got %q", plain)
+	}
+	if !strings.Contains(plain, "SUMMARY") || !strings.Contains(plain, "HTTP request sent") {
+		t.Fatalf("expected explain report before response formatting completes, got %q", plain)
+	}
+}
+
 func TestSyncResponsePaneExplainKeepsStyledRenderingWhileSearching(t *testing.T) {
 	t.Parallel()
 
@@ -466,7 +557,7 @@ func TestRenderExplainStyledWrapsCleanlyInNarrowWidth(t *testing.T) {
 	}
 }
 
-func TestApplyResponseSearchOnExplainUsesPlainContent(t *testing.T) {
+func TestApplyResponseSearchOnExplainDoesNotWaitForResponseFormatting(t *testing.T) {
 	t.Parallel()
 
 	model := New(Config{})
@@ -486,7 +577,7 @@ func TestApplyResponseSearchOnExplainUsesPlainContent(t *testing.T) {
 	pane.viewport.Width = 80
 	pane.snapshot = &responseSnapshot{
 		id:    "snap-explain-search-content",
-		ready: true,
+		ready: false,
 		explain: explainState{
 			report: &xplain.Report{
 				Status: xplain.StatusReady,

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -344,6 +344,7 @@ type Model struct {
 	ready                  bool
 	dirty                  bool
 	sending                bool
+	sendingOverlayBase     string
 	sendCancel             context.CancelFunc
 	suppressEditorKey      bool
 	editorInsertMode       bool

--- a/internal/ui/model_exec.go
+++ b/internal/ui/model_exec.go
@@ -357,6 +357,7 @@ func (m *Model) explainActiveRequest() tea.Cmd {
 	}
 
 	spin := m.startSending()
+	m.sendingOverlayBase = responseExplainPreviewBase
 	target := m.statusRequestTarget(st.doc, st.req, "")
 	base := "Preparing explain preview"
 	if trimmed := strings.TrimSpace(target); trimmed != "" {
@@ -442,11 +443,13 @@ const (
 
 func (m *Model) startSending() tea.Cmd {
 	m.sending = true
+	m.sendingOverlayBase = ""
 	return m.startTabSpin()
 }
 
 func (m *Model) stopSending() {
 	m.sending = false
+	m.sendingOverlayBase = ""
 	m.stopTabSpinIfIdle()
 }
 

--- a/internal/ui/model_exec_explain_test.go
+++ b/internal/ui/model_exec_explain_test.go
@@ -122,6 +122,35 @@ func TestExecuteExplainReturnsPreviewWithoutSending(t *testing.T) {
 	}
 }
 
+func TestExplainActiveRequestUsesPreviewSpinnerLabel(t *testing.T) {
+	t.Parallel()
+
+	model := New(Config{})
+	model.editor.SetValue("GET https://example.com/api\n")
+
+	cmd := model.explainActiveRequest()
+	if cmd == nil {
+		t.Fatal("expected explain request command")
+	}
+	if !model.sending {
+		t.Fatal("expected explain preview to keep active-run spinner state")
+	}
+	if model.sendingOverlayBase != responseExplainPreviewBase {
+		t.Fatalf(
+			"expected explain preview overlay %q, got %q",
+			responseExplainPreviewBase,
+			model.sendingOverlayBase,
+		)
+	}
+	view := model.sendingView(model.pane(responsePanePrimary), 40, 8)
+	if !strings.Contains(view, responseExplainPreviewBase) {
+		t.Fatalf("expected explain preview spinner to use %q, got %q", responseExplainPreviewBase, view)
+	}
+	if strings.Contains(view, responseSendingBase) {
+		t.Fatalf("did not expect explain preview spinner to use %q", responseSendingBase)
+	}
+}
+
 func TestHandleResponseMessagePreviewOpensExplainTab(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/model_exec_test.go
+++ b/internal/ui/model_exec_test.go
@@ -1764,6 +1764,7 @@ func TestExecuteRequestRejectsSSHAndK8sBeforeResolve(t *testing.T) {
 func TestCancelActiveRunsStopsSend(t *testing.T) {
 	model := New(Config{})
 	model.sending = true
+	model.sendingOverlayBase = responseExplainPreviewBase
 	model.statusPulseBase = "Sending test"
 	model.statusPulseFrame = 2
 	model.statusPulseOn = true
@@ -1777,6 +1778,9 @@ func TestCancelActiveRunsStopsSend(t *testing.T) {
 	}
 	if model.sending {
 		t.Fatalf("expected sending flag to reset")
+	}
+	if model.sendingOverlayBase != "" {
+		t.Fatalf("expected sending overlay label to reset, got %q", model.sendingOverlayBase)
 	}
 	if model.statusPulseBase != "" || model.statusPulseFrame != 0 {
 		t.Fatalf(

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -552,7 +552,15 @@ func (m *Model) consumeHTTPResponse(
 	formatCtx, cancel := context.WithCancel(context.Background())
 	m.responseRenderCancel = cancel
 
-	return m.respCmd(m.respFmtCmd(formatCtx, token, resp, tests, scriptErr, primaryWidth))
+	renderCmd := m.respCmd(m.respFmtCmd(formatCtx, token, resp, tests, scriptErr, primaryWidth))
+	if pane := m.pane(target); pane != nil &&
+		pane.activeTab == responseTabExplain &&
+		pane.hasExplainReport() {
+		if cmd := m.syncResponsePane(target); cmd != nil {
+			return tea.Batch(cmd, renderCmd)
+		}
+	}
+	return renderCmd
 }
 
 func (m *Model) responseLoadingMessage() string {
@@ -757,6 +765,9 @@ func (m *Model) handleResponseLoadingTick() tea.Cmd {
 	for _, id := range m.visiblePaneIDs() {
 		pane := m.pane(id)
 		if pane == nil || pane.snapshot == nil || pane.snapshot.ready {
+			continue
+		}
+		if pane.activeTab == responseTabExplain && pane.hasExplainReport() {
 			continue
 		}
 		pane.viewport.SetContent(message)

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1116,7 +1116,11 @@ func sanitizePaneTitle(title string) string {
 	return strings.Join(strings.Fields(title), " ")
 }
 
-func (m Model) paneTitleStyle(base lipgloss.Style, frame lipgloss.Style, active bool) lipgloss.Style {
+func (m Model) paneTitleStyle(
+	base lipgloss.Style,
+	frame lipgloss.Style,
+	active bool,
+) lipgloss.Style {
 	st := base.Inherit(m.theme.PaneTitle)
 	if !active {
 		return st

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1581,6 +1581,9 @@ func (m Model) sendingView(pane *responsePaneState, width, height int) string {
 }
 
 func (m Model) formattingView(pane *responsePaneState, width, height int) string {
+	if pane != nil && pane.activeTab == responseTabExplain && pane.hasExplainReport() {
+		return ""
+	}
 	return m.spinnerView(pane, width, height, responseFormattingBase, m.responseLoading)
 }
 

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1538,7 +1538,10 @@ var tabSpinFrames = []string{
 	"⠏",
 }
 
-const responseSendingBase = "Sending request"
+const (
+	responseSendingBase        = "Sending request"
+	responseExplainPreviewBase = "Preparing explain preview"
+)
 
 func (m Model) tabSpinner() string {
 	if !m.spinnerActive() || len(tabSpinFrames) == 0 {
@@ -1570,7 +1573,11 @@ func (m Model) spinnerView(
 }
 
 func (m Model) sendingView(pane *responsePaneState, width, height int) string {
-	return m.spinnerView(pane, width, height, responseSendingBase, m.sending)
+	base := m.sendingOverlayBase
+	if base == "" {
+		base = responseSendingBase
+	}
+	return m.spinnerView(pane, width, height, base, m.sending)
 }
 
 func (m Model) formattingView(pane *responsePaneState, width, height int) string {

--- a/internal/ui/model_render_test.go
+++ b/internal/ui/model_render_test.go
@@ -691,6 +691,32 @@ func TestResponsePaneShowsSendingSpinner(t *testing.T) {
 	}
 }
 
+func TestResponsePaneShowsExplainPreviewSpinner(t *testing.T) {
+	if len(tabSpinFrames) < 2 {
+		t.Fatalf("expected tab spinner frames")
+	}
+	snap := &responseSnapshot{pretty: withTrailingNewline("ok"), ready: true}
+	model := newModelWithResponseTab(responseTabExplain, snap)
+	model.sending = true
+	model.sendingOverlayBase = responseExplainPreviewBase
+	model.tabSpinIdx = 1
+	pane := model.pane(responsePanePrimary)
+	pane.viewport.Width = 40
+	pane.viewport.Height = 10
+
+	view := model.renderResponseColumn(responsePanePrimary, true, 40)
+	plain := ansi.Strip(view)
+	if strings.Contains(plain, responseSendingBase) {
+		t.Fatalf("did not expect send spinner message during explain preview, got %q", plain)
+	}
+	if !strings.Contains(plain, responseExplainPreviewBase) {
+		t.Fatalf("expected explain preview spinner message, got %q", plain)
+	}
+	if !strings.Contains(plain, tabSpinFrames[1]) {
+		t.Fatalf("expected spinner frame, got %q", plain)
+	}
+}
+
 func TestResponseSearchPromptRendersAtColumnBottom(t *testing.T) {
 	snap := &responseSnapshot{pretty: withTrailingNewline("short-body"), ready: true}
 	model := newModelWithResponseTab(responseTabPretty, snap)

--- a/internal/ui/model_render_test.go
+++ b/internal/ui/model_render_test.go
@@ -893,7 +893,10 @@ func TestPaneTitleStyleUsesFocusedFrameColor(t *testing.T) {
 		t.Fatalf("expected inactive title to keep pane title color, got %v", got)
 	}
 	if theme.ColorDefined(inactive.GetBackground()) {
-		t.Fatalf("expected inactive title background to stay unset, got %v", inactive.GetBackground())
+		t.Fatalf(
+			"expected inactive title background to stay unset, got %v",
+			inactive.GetBackground(),
+		)
 	}
 
 	active := model.paneTitleStyle(model.theme.PaneTitleEditor, frame, true)
@@ -939,7 +942,11 @@ func TestTitledPaneFrameRendersTitleOnTopBorder(t *testing.T) {
 			if !strings.HasSuffix(lines[0], "╮") {
 				t.Fatalf("expected top border to keep right corner, got %q", lines[0])
 			}
-			if got, want := ansi.StringWidth(lines[0]), lipgloss.Width(frame.Render("body")); got != want {
+			if got, want := ansi.StringWidth(
+				lines[0],
+			), lipgloss.Width(
+				frame.Render("body"),
+			); got != want {
 				t.Fatalf("expected titled top border width %d, got %d", want, got)
 			}
 		})

--- a/internal/ui/model_search.go
+++ b/internal/ui/model_search.go
@@ -141,7 +141,7 @@ func (m *Model) responseSearchContent(
 ) (string, responseTab, string) {
 	switch tab {
 	case responseTabExplain:
-		if pane := m.pane(paneID); pane.hasReadyExplain() {
+		if pane := m.pane(paneID); pane.hasExplainReport() {
 			content := m.explainStyledContent(pane.snapshot, width)
 			return content, responseTabExplain, content
 		}
@@ -198,15 +198,15 @@ func (m *Model) applyResponseSearch(query string, isRegex bool) tea.Cmd {
 
 	_, cacheKey, wrapped := m.responseSearchContent(paneID, tab, width)
 	snapshotID := ""
-	snapshotReady := false
+	contentReady := false
 	if pane.snapshot != nil {
 		snapshotID = pane.snapshot.id
-		snapshotReady = pane.snapshot.ready
+		contentReady = pane.searchContentReady(tab)
 	}
 
 	pane.search.prepare(query, isRegex, cacheKey, snapshotID, width)
 
-	if !snapshotReady {
+	if !contentReady {
 		pane.search.computed = false
 		pane.search.active = false
 		status := statusCmd(
@@ -273,12 +273,12 @@ func (m *Model) advanceResponseSearch() tea.Cmd {
 
 	_, cacheKey, wrapped := m.responseSearchContent(paneID, tab, width)
 	snapshotID := ""
-	snapshotReady := false
+	contentReady := false
 	if pane.snapshot != nil {
 		snapshotID = pane.snapshot.id
-		snapshotReady = pane.snapshot.ready
+		contentReady = pane.searchContentReady(tab)
 	}
-	if !snapshotReady {
+	if !contentReady {
 		return statusCmd(statusWarn, "Response not ready")
 	}
 
@@ -348,12 +348,12 @@ func (m *Model) retreatResponseSearch() tea.Cmd {
 
 	_, cacheKey, wrapped := m.responseSearchContent(paneID, tab, width)
 	snapshotID := ""
-	snapshotReady := false
+	contentReady := false
 	if pane.snapshot != nil {
 		snapshotID = pane.snapshot.id
-		snapshotReady = pane.snapshot.ready
+		contentReady = pane.searchContentReady(tab)
 	}
-	if !snapshotReady {
+	if !contentReady {
 		return statusCmd(statusWarn, "Response not ready")
 	}
 

--- a/internal/ui/model_search.go
+++ b/internal/ui/model_search.go
@@ -139,17 +139,24 @@ func (m *Model) responseSearchContent(
 	tab responseTab,
 	width int,
 ) (string, responseTab, string) {
-	content, cacheKey := m.paneDisplayContent(paneID, tab, width)
-	if tab == responseTabStats {
+	switch tab {
+	case responseTabExplain:
+		if pane := m.pane(paneID); pane.hasReadyExplain() {
+			content := m.explainStyledContent(pane.snapshot, width)
+			return content, responseTabExplain, content
+		}
+		// Fall back to paneDisplayContent so the normal "<no explain>" message is searchable.
+	case responseTabStats:
 		if pane := m.pane(paneID); pane != nil {
 			if stats := workflowStatsFromPane(pane); stats != nil {
 				render := stats.render(width, pane.viewport.Height)
-				content = displayContent(render.content)
-				cacheKey = responseTabStats
-				return content, cacheKey, content
+				content := displayContent(render.content)
+				return content, responseTabStats, content
 			}
 		}
 	}
+
+	content, cacheKey := m.paneDisplayContent(paneID, tab, width)
 	return content, cacheKey, wrapContentForTab(cacheKey, content, width)
 }
 
@@ -233,7 +240,7 @@ func (m *Model) applyResponseSearch(query string, isRegex bool) tea.Cmd {
 	pane.search.active = true
 	pane.search.index = 0
 	match := pane.search.matches[pane.search.index]
-	ensureResponseMatchVisible(&pane.viewport, wrapped, match)
+	ensureResponseMatchVisible(&pane.viewport, pane.search.contentIndexFor(wrapped), match)
 	status := statusCmd(
 		statusInfo,
 		searchStatusText(pane.search.index, len(pane.search.matches), query, false),
@@ -308,7 +315,7 @@ func (m *Model) advanceResponseSearch() tea.Cmd {
 	}
 	pane.search.index = next
 	match := pane.search.matches[next]
-	ensureResponseMatchVisible(&pane.viewport, wrapped, match)
+	ensureResponseMatchVisible(&pane.viewport, pane.search.contentIndexFor(wrapped), match)
 	pane.search.active = true
 
 	statusText := searchStatusText(next, len(pane.search.matches), pane.search.query, wrappedAround)
@@ -383,7 +390,7 @@ func (m *Model) retreatResponseSearch() tea.Cmd {
 	}
 	pane.search.index = prev
 	match := pane.search.matches[prev]
-	ensureResponseMatchVisible(&pane.viewport, wrapped, match)
+	ensureResponseMatchVisible(&pane.viewport, pane.search.contentIndexFor(wrapped), match)
 	pane.search.active = true
 
 	statusText := searchStatusText(prev, len(pane.search.matches), pane.search.query, wrappedAround)

--- a/internal/ui/model_search_test.go
+++ b/internal/ui/model_search_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+
+	xplain "github.com/unkn0wn-root/resterm/internal/explain"
 )
 
 func TestRetreatResponseSearchWrap(t *testing.T) {
@@ -318,6 +321,156 @@ func TestResponseSearchAppliesWhileTyping(t *testing.T) {
 	}
 	if pane == nil || !pane.search.active || pane.search.query != "foo" {
 		t.Fatalf("expected esc to keep live response search active, got %+v", pane)
+	}
+}
+
+func TestResponseSearchIgnoresANSIParametersInPretty(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.focus = focusResponse
+	model.responsePaneFocus = responsePanePrimary
+
+	pane := model.pane(responsePanePrimary)
+	if pane == nil {
+		t.Fatal("expected response pane to be available")
+	}
+	pane.activeTab = responseTabPretty
+	pane.viewport.Width = 80
+	pane.viewport.Height = 8
+	colored := "\x1b[38;5;244m\"X-Amzn-Trace-Id\"\x1b[0m: " +
+		"\x1b[48;2;248;242;240m\"Root=abc\"\x1b[0m"
+	pane.snapshot = &responseSnapshot{
+		id:      "snap-colored-no-visible-4",
+		pretty:  withTrailingNewline(colored),
+		raw:     withTrailingNewline(stripANSIEscape(colored)),
+		headers: withTrailingNewline("Status: 200 OK"),
+		ready:   true,
+	}
+
+	status := statusFromCmd(t, model.applyResponseSearch("4", false))
+	if status == nil {
+		t.Fatal("expected search status")
+	}
+	if status.level != statusWarn || !strings.Contains(status.text, "No matches") {
+		t.Fatalf("expected no visible matches, got %+v", status)
+	}
+	if len(pane.search.matches) != 0 || pane.search.active {
+		t.Fatalf(
+			"expected ANSI-only digits to be ignored, active=%v matches=%d",
+			pane.search.active,
+			len(pane.search.matches),
+		)
+	}
+}
+
+func TestResponseSearchHighlightPreservesANSIColoredPretty(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.focus = focusResponse
+	model.responsePaneFocus = responsePanePrimary
+
+	pane := model.pane(responsePanePrimary)
+	if pane == nil {
+		t.Fatal("expected response pane to be available")
+	}
+	pane.activeTab = responseTabPretty
+	pane.viewport.Width = 80
+	pane.viewport.Height = 8
+	colored := "\x1b[38;5;244m\"count\"\x1b[0m: \x1b[38;5;114m4\x1b[0m"
+	pane.snapshot = &responseSnapshot{
+		id:      "snap-colored-visible-4",
+		pretty:  withTrailingNewline(colored),
+		raw:     withTrailingNewline(stripANSIEscape(colored)),
+		headers: withTrailingNewline("Status: 200 OK"),
+		ready:   true,
+	}
+
+	status := statusFromCmd(t, model.applyResponseSearch("4", false))
+	if status == nil {
+		t.Fatal("expected search status")
+	}
+	if status.level != statusInfo {
+		t.Fatalf("expected visible match, got %+v", status)
+	}
+	if len(pane.search.matches) != 1 {
+		t.Fatalf("expected one visible match, got %d", len(pane.search.matches))
+	}
+
+	rendered := pane.viewport.View()
+	plain := stripANSIEscape(rendered)
+	if strings.Contains(plain, "38;5") || strings.Contains(plain, "48;2") {
+		t.Fatalf("expected ANSI sequences to stay hidden after highlight, got %q", plain)
+	}
+	if !strings.Contains(plain, `"count": 4`) {
+		t.Fatalf("expected highlighted view to preserve visible content, got %q", plain)
+	}
+}
+
+func TestResponseSearchKeepsExplainStyledRenderer(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.focus = focusResponse
+	model.responsePaneFocus = responsePanePrimary
+
+	pane := model.pane(responsePanePrimary)
+	if pane == nil {
+		t.Fatal("expected response pane to be available")
+	}
+	pane.activeTab = responseTabExplain
+	pane.viewport.Width = 80
+	pane.viewport.Height = 12
+	pane.snapshot = &responseSnapshot{
+		id:    "snap-explain-styled-search",
+		ready: true,
+		explain: explainState{
+			report: &xplain.Report{
+				Status: xplain.StatusReady,
+				Stages: []xplain.Stage{
+					{Name: "route", Status: xplain.StageOK, Summary: "direct connection"},
+				},
+			},
+		},
+	}
+
+	status := statusFromCmd(t, model.applyResponseSearch("direct", false))
+	if status == nil {
+		t.Fatal("expected search status")
+	}
+	if !pane.search.active || len(pane.search.matches) == 0 {
+		t.Fatalf(
+			"expected explain search matches, active=%v matches=%d",
+			pane.search.active,
+			len(pane.search.matches),
+		)
+	}
+
+	plain := stripANSIEscape(pane.viewport.View())
+	if strings.Contains(plain, "Summary\n======") {
+		t.Fatalf("expected styled explain view, got plain report %q", plain)
+	}
+	if !strings.Contains(plain, "SUMMARY") || !strings.Contains(plain, "direct connection") {
+		t.Fatalf("expected styled explain content to remain visible, got %q", plain)
+	}
+}
+
+func TestEnsureResponseMatchVisibleTargetsActualMatchLine(t *testing.T) {
+	content := "\x1b[38;5;244mzero\x1b[0m\none\ntwo"
+	visible := stripANSIEscape(content)
+	start := len([]rune("zero\n"))
+	end := start + len([]rune("one"))
+
+	vp := viewport.New(20, 1)
+	vp.SetContent(content)
+	index := buildResponseSearchContentIndex(content)
+	ensureResponseMatchVisible(&vp, &index, searchMatch{start: start, end: end})
+
+	if vp.YOffset != 1 {
+		t.Fatalf(
+			"expected match line %q in one-line viewport at offset 1, got offset %d for %q",
+			"one",
+			vp.YOffset,
+			visible,
+		)
 	}
 }
 

--- a/internal/ui/response_search.go
+++ b/internal/ui/response_search.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
@@ -19,6 +20,21 @@ type responseSearchState struct {
 	snapshotID string
 	width      int
 	computed   bool
+	content    responseSearchContentIndex
+}
+
+type responseSearchBoundary struct {
+	raw  int
+	sgr  string
+	line int
+}
+
+type responseSearchContentIndex struct {
+	raw        string
+	visible    string
+	bounds     []responseSearchBoundary
+	totalLines int
+	valid      bool
 }
 
 func (s *responseSearchState) invalidate() {
@@ -28,10 +44,12 @@ func (s *responseSearchState) invalidate() {
 	s.snapshotID = ""
 	s.width = 0
 	s.computed = false
+	s.content = responseSearchContentIndex{}
 }
 
 func (s *responseSearchState) markStale() {
 	s.computed = false
+	s.content = responseSearchContentIndex{}
 }
 
 func (s *responseSearchState) clear() bool {
@@ -45,6 +63,7 @@ func (s *responseSearchState) clear() bool {
 	s.snapshotID = ""
 	s.width = 0
 	s.computed = false
+	s.content = responseSearchContentIndex{}
 	return hadState
 }
 
@@ -59,6 +78,9 @@ func (s *responseSearchState) prepare(
 	snapshotID string,
 	width int,
 ) {
+	if s.tab != tab || s.snapshotID != snapshotID || s.width != width {
+		s.content = responseSearchContentIndex{}
+	}
 	s.query = query
 	s.isRegex = isRegex
 	s.tab = tab
@@ -81,6 +103,10 @@ func (s *responseSearchState) needsRefresh(snapshotID string, tab responseTab, w
 }
 
 func (s *responseSearchState) computeMatches(content string) error {
+	return s.computeMatchesFromIndex(s.contentIndexFor(content))
+}
+
+func (s *responseSearchState) computeMatchesFromIndex(index *responseSearchContentIndex) error {
 	if !s.hasQuery() {
 		s.matches = nil
 		s.index = -1
@@ -88,8 +114,11 @@ func (s *responseSearchState) computeMatches(content string) error {
 		s.computed = false
 		return nil
 	}
+	if index == nil {
+		index = &responseSearchContentIndex{}
+	}
 
-	matches, err := buildSearchMatches(content, s.query, s.isRegex)
+	matches, err := buildSearchMatches(index.visible, s.query, s.isRegex)
 	if err != nil {
 		return err
 	}
@@ -105,8 +134,21 @@ func (s *responseSearchState) computeMatches(content string) error {
 	return nil
 }
 
+func (s *responseSearchState) contentIndexFor(content string) *responseSearchContentIndex {
+	if s.content.valid && s.content.raw == content {
+		return &s.content
+	}
+	s.content = buildResponseSearchContentIndex(content)
+	return &s.content
+}
+
+// decorateResponseContent applies match highlights by visible-rune offsets while
+// preserving the original ANSI stream. Search matches must never split escape
+// sequences, and highlight resets must restore the SGR state that was active at
+// the end of the match.
 func decorateResponseContent(
 	content string,
+	index *responseSearchContentIndex,
 	matches []searchMatch,
 	highlight lipgloss.Style,
 	active lipgloss.Style,
@@ -118,34 +160,114 @@ func decorateResponseContent(
 	highlight = ensureResponseHighlight(highlight, false)
 	active = ensureResponseHighlight(active, true)
 
-	runes := []rune(content)
-	if len(runes) == 0 {
+	if index == nil || !index.valid || index.raw != content {
+		built := buildResponseSearchContentIndex(content)
+		index = &built
+	}
+	bounds := index.bounds
+	visibleLen := len(bounds) - 1
+	if visibleLen <= 0 {
 		return content
 	}
 
+	highlightPrefix, highlightSuffix := styleSGR(highlight)
+	activePrefix, activeSuffix := styleSGR(active)
+
 	var builder strings.Builder
 	builder.Grow(len(content) + len(matches)*8)
-	last := 0
+	lastRaw := 0
+	lastVisible := 0
 	for idx, match := range matches {
-		start := clamp(match.start, 0, len(runes))
-		end := clamp(match.end, 0, len(runes))
+		start := clamp(match.start, 0, visibleLen)
+		end := clamp(match.end, 0, visibleLen)
 		if end <= start {
 			continue
 		}
-		if start > last {
-			builder.WriteString(string(runes[last:start]))
+		if end <= lastVisible {
+			continue
 		}
-		style := highlight
+		if start < lastVisible {
+			start = lastVisible
+		}
+
+		rawStart := bounds[start].raw
+		rawEnd := bounds[end].raw
+		if rawEnd <= rawStart {
+			continue
+		}
+		if rawStart > lastRaw {
+			builder.WriteString(content[lastRaw:rawStart])
+		}
+		prefix := highlightPrefix
+		suffix := highlightSuffix
 		if current >= 0 && idx == current {
-			style = active
+			prefix = activePrefix
+			suffix = activeSuffix
 		}
-		builder.WriteString(style.Render(string(runes[start:end])))
-		last = end
+		builder.WriteString(applyANSIAwareWrap(content[rawStart:rawEnd], prefix, suffix, bounds[end].sgr))
+		lastRaw = rawEnd
+		lastVisible = end
 	}
-	if last < len(runes) {
-		builder.WriteString(string(runes[last:]))
+	if lastRaw < len(content) {
+		builder.WriteString(content[lastRaw:])
 	}
 	return builder.String()
+}
+
+// responseSearchBoundaries maps visible-rune boundaries to raw byte offsets and
+// active SGR prefixes. bounds[0] is always the boundary before the first visible
+// rune, so len(bounds) is visible rune count plus one.
+func responseSearchBoundaries(content string) []responseSearchBoundary {
+	return buildResponseSearchContentIndex(content).bounds
+}
+
+func buildResponseSearchContentIndex(content string) responseSearchContentIndex {
+	index := responseSearchContentIndex{
+		raw:    content,
+		bounds: []responseSearchBoundary{{raw: 0}},
+		valid:  true,
+	}
+	if content == "" {
+		return index
+	}
+
+	var sgr sgrState
+	var visible strings.Builder
+	visible.Grow(len(content))
+	restore := ""
+	line := 0
+	for i := 0; i < len(content); {
+		if content[i] == '\x1b' {
+			if seq, size := ansiSequenceAt(content, i); size > 0 {
+				if sgr.apply(seq) {
+					restore = sgr.String()
+				}
+				i += size
+				continue
+			}
+		}
+
+		r, size := utf8.DecodeRuneInString(content[i:])
+		if size <= 0 {
+			size = 1
+			r = rune(content[i])
+		}
+		visible.WriteRune(r)
+		if r == '\n' {
+			line++
+		}
+		i += size
+		index.bounds = append(index.bounds, responseSearchBoundary{
+			raw:  i,
+			sgr:  restore,
+			line: line,
+		})
+	}
+	index.visible = visible.String()
+	if index.visible != "" {
+		index.totalLines = line + 1
+	}
+	return index
 }
 
 func clamp(value, min, max int) int {
@@ -158,27 +280,26 @@ func clamp(value, min, max int) int {
 	return value
 }
 
-func ensureResponseMatchVisible(v *viewport.Model, content string, match searchMatch) {
+func ensureResponseMatchVisible(
+	v *viewport.Model,
+	index *responseSearchContentIndex,
+	match searchMatch,
+) {
 	if v == nil {
 		return
 	}
-	runes := []rune(content)
-	if len(runes) == 0 {
+	if index == nil || !index.valid || len(index.bounds) <= 1 {
 		return
 	}
-	start := clamp(match.start, 0, len(runes))
-	prefix := string(runes[:start])
-	line := strings.Count(prefix, "\n")
-	if line > 0 {
-		line--
-	}
+	start := clamp(match.start, 0, len(index.bounds)-1)
+	line := index.bounds[start].line
 	h := v.Height
 	if h <= 0 {
 		h = v.VisibleLineCount()
 	}
 	total := v.TotalLineCount()
 	if total == 0 {
-		total = strings.Count(content, "\n") + 1
+		total = index.totalLines
 	}
 	target := scroll.Align(line, v.YOffset, h, total)
 	v.SetYOffset(target)

--- a/internal/ui/response_search.go
+++ b/internal/ui/response_search.go
@@ -204,7 +204,9 @@ func decorateResponseContent(
 			prefix = activePrefix
 			suffix = activeSuffix
 		}
-		builder.WriteString(applyANSIAwareWrap(content[rawStart:rawEnd], prefix, suffix, bounds[end].sgr))
+		builder.WriteString(
+			applyANSIAwareWrap(content[rawStart:rawEnd], prefix, suffix, bounds[end].sgr),
+		)
 		lastRaw = rawEnd
 		lastVisible = end
 	}

--- a/internal/ui/response_selection.go
+++ b/internal/ui/response_selection.go
@@ -1148,40 +1148,7 @@ func toTermenvColor(profile termenv.Profile, c lipgloss.TerminalColor) termenv.C
 // selection prefix after every SGR sequence so the highlight doesn't get "canceled"
 // by styles that appear inside the line.
 func applySelectionToLine(line, prefix, suffix string) string {
-	if prefix == "" {
-		return line
-	}
-	if line == "" {
-		return prefix + suffix
-	}
-	if !ansiSequenceRegex.MatchString(line) {
-		return prefix + line + suffix
-	}
-	indices := ansiSequenceRegex.FindAllStringIndex(line, -1)
-	if len(indices) == 0 {
-		return prefix + line + suffix
-	}
-
-	var builder strings.Builder
-	builder.Grow(len(line) + len(prefix)*(len(indices)+1) + len(suffix))
-	builder.WriteString(prefix)
-	last := 0
-	for _, idx := range indices {
-		if idx[0] > last {
-			builder.WriteString(line[last:idx[0]])
-		}
-		seq := line[idx[0]:idx[1]]
-		builder.WriteString(seq)
-		if isSGR(seq) {
-			builder.WriteString(prefix)
-		}
-		last = idx[1]
-	}
-	if last < len(line) {
-		builder.WriteString(line[last:])
-	}
-	builder.WriteString(suffix)
-	return builder.String()
+	return applyANSIAwareWrap(line, prefix, suffix, "")
 }
 
 // Cursor highlighting targets the first visible rune. We preserve any leading ANSI
@@ -1271,16 +1238,6 @@ func splitFirstVisibleRune(line string) (string, string, string, bool) {
 		return line[:index], line[index : index+size], line[index+size:], true
 	}
 	return line, "", "", false
-}
-
-func isSGR(seq string) bool {
-	if len(seq) == 0 {
-		return false
-	}
-	if seq[len(seq)-1] != 'm' {
-		return false
-	}
-	return strings.HasPrefix(seq, "\x1b[")
 }
 
 func moveDir(prev, next int) int {

--- a/internal/ui/response_split.go
+++ b/internal/ui/response_split.go
@@ -845,7 +845,14 @@ func (m *Model) decorateResponseContentForPane(
 	}
 	highlight := m.theme.ResponseSearchHighlight
 	active := m.theme.ResponseSearchHighlightActive
-	return decorateResponseContent(base, index, pane.search.matches, highlight, active, pane.search.index)
+	return decorateResponseContent(
+		base,
+		index,
+		pane.search.matches,
+		highlight,
+		active,
+		pane.search.index,
+	)
 }
 
 func (m *Model) applyResponseContentStyles(tab responseTab, content string) string {
@@ -867,7 +874,11 @@ func ensureResponseMatchInView(pane *responsePaneState, base string) {
 		idx = 0
 		pane.search.index = idx
 	}
-	ensureResponseMatchVisible(&pane.viewport, pane.search.contentIndexFor(base), pane.search.matches[idx])
+	ensureResponseMatchVisible(
+		&pane.viewport,
+		pane.search.contentIndexFor(base),
+		pane.search.matches[idx],
+	)
 }
 
 func (m *Model) paneContentBase(

--- a/internal/ui/response_split.go
+++ b/internal/ui/response_split.go
@@ -130,6 +130,13 @@ func newResponsePaneState(vp viewport.Model, followLatest bool) responsePaneStat
 	}
 }
 
+func (pane *responsePaneState) hasReadyExplain() bool {
+	return pane != nil &&
+		pane.snapshot != nil &&
+		pane.snapshot.ready &&
+		pane.snapshot.explain.report != nil
+}
+
 func (pane *responsePaneState) stashCursor() {
 	if pane == nil || !pane.cursor.on {
 		return
@@ -515,20 +522,22 @@ func (m *Model) applyPaneContent(
 	if pane == nil {
 		return
 	}
+	// Apply the base style first so search highlights can restore the active SGR
+	// state after their own reset sequences.
+	base := m.applyResponseContentStyles(tab, content)
 	decorated := m.decorateResponseContentForPane(
 		pane,
 		tab,
-		content,
+		base,
 		width,
 		snapshotReady,
 		snapshotID,
 	)
-	decorated = m.applyResponseContentStyles(tab, decorated)
 	decorated = m.decorateResponseSelection(pane, tab, decorated)
 	decorated = m.decorateResponseCursor(pane, tab, decorated)
 	pane.viewport.SetContent(decorated)
 	pane.restoreScrollForActiveTab()
-	ensureResponseMatchInView(pane, content)
+	ensureResponseMatchInView(pane, base)
 	pane.setCurrPosition()
 }
 
@@ -616,10 +625,9 @@ func (m *Model) syncResponsePane(id responsePaneID) tea.Cmd {
 			return m.syncWorkflowStatsPane(pane, w, h, snapshot)
 		}
 	}
-	if tab == responseTabExplain && !pane.search.hasQuery() {
-		snapshot := pane.snapshot
-		if snapshot != nil && snapshot.explain.report != nil {
-			return m.syncExplainPane(pane, ww, snapshot)
+	if tab == responseTabExplain {
+		if pane.hasReadyExplain() {
+			return m.syncExplainPane(pane, ww, pane.snapshot)
 		}
 	}
 
@@ -776,17 +784,19 @@ func (m *Model) syncWorkflowStatsPane(
 		content: render.content,
 		valid:   true,
 	})
+	// Apply the base style first so search highlights can restore the active SGR
+	// state after their own reset sequences.
+	base := m.applyResponseContentStyles(responseTabStats, render.content)
 	decorated := m.decorateResponseContentForPane(
 		pane,
 		responseTabStats,
-		render.content,
+		base,
 		width,
 		snapshot.ready,
 		snapshot.id,
 	)
-	decorated = m.applyResponseContentStyles(responseTabStats, decorated)
 	pane.viewport.SetContent(decorated)
-	ensureResponseMatchInView(pane, render.content)
+	ensureResponseMatchInView(pane, base)
 	pane.viewport.SetYOffset(0)
 	pane.setCurrPosition()
 	return nil
@@ -810,10 +820,12 @@ func (m *Model) decorateResponseContentForPane(
 		return base
 	}
 
+	index := pane.search.contentIndexFor(base)
 	if pane.search.needsRefresh(snapshotID, tab, width) {
 		prevIndex := pane.search.index
 		pane.search.prepare(pane.search.query, pane.search.isRegex, tab, snapshotID, width)
-		if err := pane.search.computeMatches(base); err != nil {
+		index = pane.search.contentIndexFor(base)
+		if err := pane.search.computeMatchesFromIndex(index); err != nil {
 			pane.search.invalidate()
 			return base
 		}
@@ -833,7 +845,7 @@ func (m *Model) decorateResponseContentForPane(
 	}
 	highlight := m.theme.ResponseSearchHighlight
 	active := m.theme.ResponseSearchHighlightActive
-	return decorateResponseContent(base, pane.search.matches, highlight, active, pane.search.index)
+	return decorateResponseContent(base, index, pane.search.matches, highlight, active, pane.search.index)
 }
 
 func (m *Model) applyResponseContentStyles(tab responseTab, content string) string {
@@ -855,7 +867,7 @@ func ensureResponseMatchInView(pane *responsePaneState, base string) {
 		idx = 0
 		pane.search.index = idx
 	}
-	ensureResponseMatchVisible(&pane.viewport, base, pane.search.matches[idx])
+	ensureResponseMatchVisible(&pane.viewport, pane.search.contentIndexFor(base), pane.search.matches[idx])
 }
 
 func (m *Model) paneContentBase(
@@ -890,7 +902,7 @@ func (m *Model) paneContentBase(
 	case responseTabHeaders:
 		return m.headerContent(pane, w), tab
 	case responseTabExplain:
-		if snapshot.explain.report == nil {
+		if !pane.hasReadyExplain() {
 			return "<no explain>\n", tab
 		}
 		if strings.TrimSpace(snapshot.explain.plain) == "" {

--- a/internal/ui/response_split.go
+++ b/internal/ui/response_split.go
@@ -130,11 +130,20 @@ func newResponsePaneState(vp viewport.Model, followLatest bool) responsePaneStat
 	}
 }
 
-func (pane *responsePaneState) hasReadyExplain() bool {
+func (pane *responsePaneState) hasExplainReport() bool {
 	return pane != nil &&
 		pane.snapshot != nil &&
-		pane.snapshot.ready &&
 		pane.snapshot.explain.report != nil
+}
+
+func (pane *responsePaneState) searchContentReady(tab responseTab) bool {
+	if pane == nil || pane.snapshot == nil {
+		return false
+	}
+	if tab == responseTabExplain {
+		return pane.hasExplainReport()
+	}
+	return pane.snapshot.ready
 }
 
 func (pane *responsePaneState) stashCursor() {
@@ -626,7 +635,7 @@ func (m *Model) syncResponsePane(id responsePaneID) tea.Cmd {
 		}
 	}
 	if tab == responseTabExplain {
-		if pane.hasReadyExplain() {
+		if pane.hasExplainReport() {
 			return m.syncExplainPane(pane, ww, pane.snapshot)
 		}
 	}
@@ -901,7 +910,7 @@ func (m *Model) paneContentBase(
 	if snapshot == nil {
 		return "", tab
 	}
-	if !snapshot.ready {
+	if !snapshot.ready && (tab != responseTabExplain || !pane.hasExplainReport()) {
 		return m.responseLoadingMessage(), tab
 	}
 
@@ -913,7 +922,7 @@ func (m *Model) paneContentBase(
 	case responseTabHeaders:
 		return m.headerContent(pane, w), tab
 	case responseTabExplain:
-		if !pane.hasReadyExplain() {
+		if !pane.hasExplainReport() {
 			return "<no explain>\n", tab
 		}
 		if strings.TrimSpace(snapshot.explain.plain) == "" {


### PR DESCRIPTION
- fix response search so matches are computed against visible text, not raw ANSI escape sequences.
- preserve existing ANSI colors/styles when applying search highlights in Pretty, Stats, and Explain response views.
- add ANSI SGR parsing/restoration so highlight resets do not break surrounding terminal styling.
- keep Explain search on the styled Explain renderer instead of falling back to the plain report layout.
- make response search reuse the same rendered content that the pane displays for Explain and workflow Stats.
- improve match scrolling by mapping visible match offsets back to actual rendered line positions.
- share ANSI aware wrapping logic between search highlighting and response selection highlighting.
