### PR TITLE
RST-253: fix completion popup on esc

### DIFF
--- a/internal/intellisense/context.go
+++ b/internal/intellisense/context.go
@@ -69,7 +69,7 @@ func analyzeVariable(cur []rune, col int) (Context, bool) {
 		return Context{}, false
 	}
 	start := col
-	for start > open && isVarRune(cur[start-1]) {
+	for start > open && IsTokenRune(cur[start-1]) {
 		start--
 	}
 	return Context{
@@ -131,10 +131,7 @@ func analyzeDirectiveArea(area []rune) (Context, bool) {
 		return Context{}, false
 	}
 
-	base := normalizeKey(string(area[:firstSpace]))
-	if base == "" {
-		return Context{}, false
-	}
+	base := strings.ToLower(string(area[:firstSpace]))
 
 	start, token, ok := splitToken(area, skipSpaces(area, firstSpace))
 	if !ok {
@@ -285,8 +282,11 @@ func looksLikeRequestLine(line string) bool {
 	if t == "" {
 		return false
 	}
-	fields := strings.Fields(t)
-	if IsMethodKeyword(fields[0]) {
+	token := t
+	if i := strings.IndexFunc(t, unicode.IsSpace); i >= 0 {
+		token = t[:i]
+	}
+	if IsMethodKeyword(token) {
 		return true
 	}
 	lower := strings.ToLower(t)
@@ -373,14 +373,10 @@ func isSubcommandRune(r rune) bool {
 	}
 }
 
-func isVarRune(r rune) bool {
+func IsTokenRune(r rune) bool {
 	return isQueryRune(r) || r == '$' || r == '.'
 }
 
 func isMethodRune(r rune) bool {
 	return unicode.IsLetter(r)
-}
-
-func IsTokenRune(r rune) bool {
-	return isVarRune(r)
 }

--- a/internal/intellisense/item.go
+++ b/internal/intellisense/item.go
@@ -1,6 +1,9 @@
 package intellisense
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 type Item struct {
 	Label      string
@@ -15,7 +18,7 @@ func filter(opts []Item, q string) []Item {
 		return nil
 	}
 	if q == "" {
-		return clone(opts)
+		return slices.Clone(opts)
 	}
 	lq := strings.ToLower(q)
 	var out []Item
@@ -42,16 +45,4 @@ func match(it Item, q string) bool {
 func hasPrefix(label, q string) bool {
 	label = strings.TrimPrefix(label, "@")
 	return strings.HasPrefix(strings.ToLower(label), q)
-}
-
-func clone(opts []Item) []Item {
-	out := make([]Item, len(opts))
-	copy(out, opts)
-	return out
-}
-
-func normalizeKey(raw string) string {
-	raw = strings.TrimSpace(raw)
-	raw = strings.TrimPrefix(raw, "@")
-	return strings.ToLower(raw)
 }

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -535,6 +535,18 @@ func (e *requestEditor) handleCompletionKeys(msg tea.KeyMsg) (bool, tea.Cmd) {
 	}
 }
 
+func (e *requestEditor) dismissCompletion() bool {
+	if !e.completion.active {
+		return false
+	}
+	if e.completion.preview {
+		e.completion.setPreview(false)
+		return true
+	}
+	e.completion.deactivate()
+	return true
+}
+
 func (e *requestEditor) refreshCompletions() {
 	if !e.completionEnabled {
 		e.completion.deactivate()

--- a/internal/ui/model_completion_popup_test.go
+++ b/internal/ui/model_completion_popup_test.go
@@ -347,3 +347,29 @@ func runeIndex(s string, target rune) int {
 	}
 	return -1
 }
+
+func TestEscDismissesCompletionBeforeLeavingInsertMode(t *testing.T) {
+	m := newCompletionPopupModel(t, 120, 40)
+	setTestCompletions(&m, []intellisense.Item{
+		{Label: "@auth", Summary: "Configure authentication"},
+		{Label: "@name", Summary: "Assign a name"},
+	}, 0)
+	if !m.editor.completion.active {
+		t.Fatal("expected completion popup to be active")
+	}
+
+	// First esc retracts the popup but must stay in insert mode.
+	_ = m.handleKey(keyMsgFor("esc"))
+	if m.editor.completion.active {
+		t.Fatal("expected esc to dismiss the completion popup")
+	}
+	if !m.editorInsertMode {
+		t.Fatal("expected esc to keep the editor in insert mode while a popup was open")
+	}
+
+	// Second esc, with no popup, leaves insert mode as before.
+	_ = m.handleKey(keyMsgFor("esc"))
+	if m.editorInsertMode {
+		t.Fatal("expected esc to leave insert mode once the popup was closed")
+	}
+}

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -1470,6 +1470,10 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 		} else {
 			switch keyStr {
 			case "esc":
+				if m.editor.dismissCompletion() {
+					m.suppressEditorKey = true
+					return combine(nil)
+				}
 				cmd := m.setInsertMode(false, true)
 				m.suppressEditorKey = true
 				return combine(cmd)


### PR DESCRIPTION
Esc while the intellisense popup was open exited insert mode (to View mode) instead of only dismissing the popup. The model's insert mode Esc handler ran `setInsertMode(false)` before the editor's popup aware Esc logic could so the popup closed only as a side effect of leaving insert mode.