### PR TITLE
RST-255: rts annotation and modal refactor

### DIFF
--- a/internal/engine/request/capture.go
+++ b/internal/engine/request/capture.go
@@ -214,8 +214,7 @@ func (e *Engine) captureRTSValue(in captureRTSIn) (string, error) {
 		res:  in.rr,
 		st:   in.rs,
 	})
-	v, err := e.re.EvalStr(context.Background(), rt, in.ex, ps)
-	return v, e.rtsErr(err, in.doc)
+	return e.evalRTSString(context.Background(), in.doc, rt, in.ex, ps)
 }
 
 func parseCaptureExpr(raw string, mode restfile.CaptureExprMode) captureExpr {

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -259,8 +259,30 @@ func (e *Engine) rtsEval(
 			site: "{{= " + expr + " }}",
 			x:    extra,
 		})
-		return e.re.EvalStr(ctx, rt, expr, rts.Pos{Path: pos.Path, Line: pos.Line, Col: pos.Col})
+		return e.evalRTSString(ctx, doc, rt, expr, rts.Pos{Path: pos.Path, Line: pos.Line, Col: pos.Col})
 	}
+}
+
+func (e *Engine) evalRTSValue(
+	ctx context.Context,
+	doc *restfile.Document,
+	rt rts.RT,
+	expr string,
+	pos rts.Pos,
+) (rts.Value, error) {
+	v, err := e.re.Eval(ctx, rt, expr, pos)
+	return v, e.rtsErr(err, doc)
+}
+
+func (e *Engine) evalRTSString(
+	ctx context.Context,
+	doc *restfile.Document,
+	rt rts.RT,
+	expr string,
+	pos rts.Pos,
+) (string, error) {
+	s, err := e.re.EvalStr(ctx, rt, expr, pos)
+	return s, e.rtsErr(err, doc)
 }
 
 func (e *Engine) rtsEvalValue(
@@ -275,7 +297,7 @@ func (e *Engine) rtsEvalValue(
 	if vv == nil {
 		vv = e.collectVariables(doc, req, env)
 	}
-	return e.re.Eval(ctx, e.buildRT(rtIn{
+	rt := e.buildRT(rtIn{
 		doc:  doc,
 		req:  req,
 		env:  env,
@@ -283,7 +305,8 @@ func (e *Engine) rtsEvalValue(
 		vars: vv,
 		site: site,
 		x:    extra,
-	}), expr, pos)
+	})
+	return e.evalRTSValue(ctx, doc, rt, expr, pos)
 }
 
 func (e *Engine) PosForLine(doc *restfile.Document, req *restfile.Request, line int) rts.Pos {
@@ -350,7 +373,7 @@ func (e *Engine) EvalCondition(
 		extra,
 	)
 	if err != nil {
-		return false, "", e.rtsErr(err, doc)
+		return false, "", err
 	}
 	truthy := val.IsTruthy()
 	shouldRun := truthy
@@ -452,9 +475,9 @@ func (e *Engine) runAsserts(
 		}
 		rt.Site = "@assert " + expr
 		start := time.Now()
-		val, err := e.re.Eval(ctx, rt, expr, e.rtsPosForLineCol(doc, req, as.Line, as.Col))
+		val, err := e.evalRTSValue(ctx, doc, rt, expr, e.rtsPosForLineCol(doc, req, as.Line, as.Col))
 		if err != nil {
-			return out, e.rtsErr(err, doc)
+			return out, err
 		}
 		out = append(out, scripts.TestResult{
 			Name:    expr,
@@ -1048,7 +1071,7 @@ func (e *Engine) runRTSApply(
 			}
 			val, err := e.rtsEvalValue(ctx, doc, req, env, base, ex.ex, ex.st, ex.ps, vv, nil)
 			if err != nil {
-				return e.rtsErr(err, doc)
+				return err
 			}
 			patch, err := e.parseApplyPatch(ctx, ex.ps, val)
 			if err != nil {

--- a/internal/engine/request/rts_test.go
+++ b/internal/engine/request/rts_test.go
@@ -49,3 +49,42 @@ GET https://example.com
 		}
 	}
 }
+
+func TestEvalForEachErrorCarriesSource(t *testing.T) {
+	eng := New(engcfg.Config{SourceDiagnostics: true}, nil)
+	src := `### Req
+# @for-each item in missing.value
+GET https://example.com
+`
+	doc := parser.Parse("sample.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+
+	_, err := eng.EvalForEachItems(
+		context.Background(),
+		doc,
+		doc.Requests[0],
+		"",
+		"",
+		ForEachSpec{Expr: "missing.value", Line: 2},
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatalf("expected for-each error")
+	}
+
+	out := diag.Render(err)
+	checks := []string{
+		`error[script]: undefined name "missing"`,
+		"--> sample.http:2:1",
+		"   2 | # @for-each item in missing.value", // source snippet, attached via rtsErr
+		"in @for-each missing.value",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected rendered for-each error to contain %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -57,8 +57,9 @@ type responseMsg struct {
 }
 
 type statusMsg struct {
-	text  string
-	level statusLevel
+	text    string
+	level   statusLevel
+	noModal bool // error shown elsewhere (e.g. response pane); don't also pop the modal
 }
 
 type updateCheckMsg struct {

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -265,7 +265,6 @@ type Model struct {
 	requestDetailFields    []requestDetailField
 	requestDetailViewport  *viewport.Model
 	helpViewport           *viewport.Model
-	suppressNextErrorModal bool
 
 	showSearchPrompt   bool
 	searchInput        textinput.Model

--- a/internal/ui/model_exec_test.go
+++ b/internal/ui/model_exec_test.go
@@ -520,9 +520,6 @@ func TestHandleResponseMsgShowsHTTPErrorInPane(t *testing.T) {
 		model.statusMessage.level != statusError {
 		t.Fatalf("unexpected request error status: %+v", model.statusMessage)
 	}
-	if model.suppressNextErrorModal {
-		t.Fatalf("expected suppress flag to reset after status update")
-	}
 }
 
 func TestHandleResponseMsgShowsRequestCauseWithoutNotes(t *testing.T) {
@@ -601,9 +598,6 @@ func TestHandleResponseMsgShowsScriptErrorInPane(t *testing.T) {
 	viewport := model.pane(responsePanePrimary).viewport.View()
 	if !strings.Contains(viewport, "pre-request script") {
 		t.Fatalf("expected viewport to include script error details, got %q", viewport)
-	}
-	if model.suppressNextErrorModal {
-		t.Fatalf("expected suppress flag to reset after script error")
 	}
 }
 

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -120,7 +120,6 @@ func (m *Model) handleResponseMessage(msg responseMsg) tea.Cmd {
 		m.lastGRPC = nil
 
 		cmd := m.consumeRequestError(msg.err, msg.explain)
-		m.suppressNextErrorModal = true
 		m.setStatusMessage(requestErrorStatus(canceled))
 		return cmd
 	}
@@ -150,7 +149,8 @@ func requestErrorStatus(canceled bool) statusMsg {
 	if canceled {
 		return statusMsg{text: "Request canceled", level: statusInfo}
 	}
-	return statusMsg{text: "Request failed ✗", level: statusError}
+	// error is already rendered in the response pane
+	return statusMsg{text: "Request failed ✗", level: statusError, noModal: true}
 }
 
 func (m *Model) recordResponseLatency(msg responseMsg) {
@@ -501,8 +501,7 @@ func (m *Model) consumeHTTPResponse(
 
 	// A response (incl. 4xx/5xx API errors) is already shown in the response tab and
 	// status line so don't also pop the error modal - it would just duplicate it.
-	m.suppressNextErrorModal = true
-	m.setStatusMessage(statusMsg{text: statusText, level: statusLevel})
+	m.setStatusMessage(statusMsg{text: statusText, level: statusLevel, noModal: true})
 
 	token := nextResponseRenderToken()
 	snapshot := &responseSnapshot{

--- a/internal/ui/model_orchestration_test.go
+++ b/internal/ui/model_orchestration_test.go
@@ -1057,10 +1057,6 @@ func TestWorkflowRunHTTPServerErrorDoesNotOpenErrorModal(t *testing.T) {
 			m.errorModalMessage,
 		)
 	}
-	if m.suppressNextErrorModal {
-		t.Fatal("expected modal suppression to be consumed by the step status update")
-	}
-
 	applyRunEvt(t, &m, core.WfStepDone{
 		Meta: core.NewMeta(pl.Run, at.Add(9*time.Millisecond)),
 		Step: core.StepMeta{

--- a/internal/ui/model_status.go
+++ b/internal/ui/model_status.go
@@ -23,9 +23,7 @@ func (m *Model) syncPulseBase(msg statusMsg) {
 }
 
 func (m *Model) handleStatusModal(msg statusMsg) {
-	show := msg.level == statusError && strings.TrimSpace(msg.text) != "" &&
-		!m.suppressNextErrorModal
-	m.suppressNextErrorModal = false
+	show := msg.level == statusError && strings.TrimSpace(msg.text) != "" && !msg.noModal
 	if show {
 		m.openErrorModal(msg.text)
 	}

--- a/internal/ui/model_workflow_run.go
+++ b/internal/ui/model_workflow_run.go
@@ -1314,7 +1314,6 @@ func (m *Model) wfConsume(st *workflowState, msg responseMsg) []tea.Cmd {
 			cmds = append(cmds, cmd)
 		}
 	case msg.response != nil:
-		m.suppressNextErrorModal = true
 		if cmd := m.consumeHTTPResponse(
 			msg.response,
 			msg.tests,


### PR DESCRIPTION
- add evalRTSValue/evalRTSString helpers that always apply rtsErr
- annotate `@for-each` and `{{= }}` template eval errors (previously missed)
- drop redundant rtsErr at `@when/@assert/@apply` at callers
- guard `@for-each` error source annotation
- carry error modal suppression on the status message
- remove temporal suppressNextErrorModal flag