### PR TITLE
RST-267: vim cmdline

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Quick links: [Screenshots](#screenshot-tour), [Installation](#installation), [Qu
 - **Multi-step workflows** with `@workflow` / `@step`.
 - **Captures, variables, and assertions** (`@capture`, `@var`, `@assert`).
 - **RestermScript** - a small, safe expression language purpose.
+- **Vim-style TUI controls** with familiar motions, `/` search and command-line actions like `:w`, `:q`, `:q!`, `:wq`, `:x`, `:e`, `:help` and `:noh`.
 - **OAuth 2.0** (client credentials, password, auth code + PKCE), **command-backed auth** via existing CLIs, **SSH tunnels**, and **Kubernetes port-forwards** are built in - no extra tools.
 - **CLI** with `resterm run` for requests, workflows, JSON/JUnit output, and reusable run artifacts.
 - **Timeline tracing**, **profiling**, and **compare runs** across environments.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -174,6 +174,8 @@ Once the files exist, run `resterm` in the same directory to open the workspace.
 
 The editor supports familiar Vim motions (`h`, `j`, `k`, `l`, `w`, `b`, `gg`, `G`, etc.), insert entries (`i`, `a`, `I`, `A`, `o`, `O`; `I` moves to the first non-blank character), visual selections with `v` / `V`, yank and delete/change operations, undo/redo (`u` / `Ctrl+r`), and a search palette (`Shift+F` or `/`, toggle regex with `Ctrl+R` and `n` moves cursor forward and `p` backwards).
 
+Press `:` from normal mode panes to open a Vim-style command line. Supported actions include `:w`, `:q`, `:q!`, `:wq`, `:x`, `:e`, `:help` and `:noh`.
+
 ### Editor completions (IntelliSense)
 
 While the editor is in insert mode, Resterm suggests completions based on where the

--- a/internal/ui/help_modal.go
+++ b/internal/ui/help_modal.go
@@ -373,6 +373,19 @@ func (m Model) helpSections() []helpSection {
 			},
 		},
 		{
+			title: "Command line",
+			entries: []helpEntry{
+				{":", "Open Vim-style command line"},
+				{":w / :write", "Save current file"},
+				{":q / :qa", "Quit when there are no unsaved changes"},
+				{":q! / :qa!", "Quit without saving"},
+				{":wq / :x", "Save and quit"},
+				{":e / :edit", "Open file or folder prompt"},
+				{":noh", "Clear search highlights"},
+				{":help", "Open this help"},
+			},
+		},
+		{
 			title: "Response selection",
 			entries: []helpEntry{
 				{"v / V", "Response: show cursor / start selection"},

--- a/internal/ui/model_commandline.go
+++ b/internal/ui/model_commandline.go
@@ -1,0 +1,204 @@
+package ui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type exCommandKind int
+
+const (
+	exCommandUnknown exCommandKind = iota
+	exCommandEmpty
+	exCommandTrailing
+	exCommandWrite
+	exCommandQuit
+	exCommandWriteQuit
+	exCommandExit
+	exCommandEdit
+	exCommandHelp
+	exCommandNoHighlight
+)
+
+type exCommand struct {
+	kind exCommandKind
+	name string
+	bang bool
+}
+
+func isCommandLineTriggerKey(msg tea.KeyMsg) bool {
+	return msg.String() == ":"
+}
+
+// Modals, help, the search prompt and the navigator/history filters are already
+// gated before handleKeyWithChord runs; only states reachable there are checked.
+func (m *Model) canOpenCommandLine(msg tea.KeyMsg) bool {
+	return isCommandLineTriggerKey(msg) &&
+		!m.streamFilterActive &&
+		!m.websocketConsoleCapturesInput() &&
+		(m.focus != focusEditor || (!m.editorInsertMode && !m.editor.awaitingFindTarget()))
+}
+
+func (m *Model) openCommandLine() tea.Cmd {
+	m.resetChordState()
+	m.clearOperatorState()
+	m.editor.pendingMotion = ""
+	m.closeSearchPrompt()
+	m.showCommandLine = true
+	m.commandLineJustOpened = true
+	m.commandLineInput.SetValue("")
+	m.commandLineInput.CursorEnd()
+	return m.commandLineInput.Focus()
+}
+
+func (m *Model) closeCommandLine() {
+	m.showCommandLine = false
+	m.commandLineJustOpened = false
+	m.commandLineInput.Blur()
+	m.commandLineInput.SetValue("")
+}
+
+func (m *Model) handleCommandLineKey(msg tea.KeyMsg) tea.Cmd {
+	keyStr := msg.String()
+	if m.commandLineJustOpened {
+		m.commandLineJustOpened = false
+		if isCommandLineTriggerKey(msg) {
+			return nil
+		}
+	}
+
+	switch keyStr {
+	case "esc", "ctrl+c", "ctrl+g":
+		m.closeCommandLine()
+		return nil
+	case "ctrl+q", "ctrl+d":
+		return tea.Quit
+	case "enter":
+		value := m.commandLineInput.Value()
+		m.closeCommandLine()
+		return m.executeExCommand(value)
+	}
+
+	var cmd tea.Cmd
+	m.commandLineInput, cmd = m.commandLineInput.Update(msg)
+	return cmd
+}
+
+func parseExCommand(input string) exCommand {
+	fields := strings.Fields(strings.TrimPrefix(strings.TrimSpace(input), ":"))
+	if len(fields) == 0 {
+		return exCommand{kind: exCommandEmpty}
+	}
+
+	name := fields[0]
+	bang := strings.HasSuffix(name, "!")
+	kind := exCommandKindFor(strings.ToLower(strings.TrimSuffix(name, "!")))
+	if kind == exCommandUnknown {
+		return exCommand{kind: exCommandUnknown, name: strings.Join(fields, " ")}
+	}
+	if len(fields) > 1 {
+		return exCommand{kind: exCommandTrailing, name: strings.Join(fields[1:], " ")}
+	}
+	return exCommand{kind: kind, bang: bang}
+}
+
+func exCommandKindFor(name string) exCommandKind {
+	switch name {
+	case "w", "write":
+		return exCommandWrite
+	case "q", "quit", "qa", "qall":
+		return exCommandQuit
+	case "wq":
+		return exCommandWriteQuit
+	case "x", "xit", "exit":
+		return exCommandExit
+	case "e", "edit":
+		return exCommandEdit
+	case "h", "help":
+		return exCommandHelp
+	case "noh", "nohlsearch":
+		return exCommandNoHighlight
+	default:
+		return exCommandUnknown
+	}
+}
+
+func (m *Model) executeExCommand(input string) tea.Cmd {
+	cmd := parseExCommand(input)
+	switch cmd.kind {
+	case exCommandEmpty:
+		return statusCmd(statusWarn, "Enter a command")
+	case exCommandTrailing:
+		return statusCmd(statusWarn, "Trailing characters: "+cmd.name)
+	case exCommandWrite:
+		return m.saveFile()
+	case exCommandQuit:
+		return m.quitFromEx(cmd.bang)
+	case exCommandWriteQuit:
+		return m.writeQuitFromEx()
+	case exCommandExit:
+		if m.dirty {
+			return m.writeQuitFromEx()
+		}
+		return tea.Quit
+	case exCommandEdit:
+		m.openOpenModal()
+		return nil
+	case exCommandHelp:
+		if !m.showHelp {
+			m.toggleHelp()
+		}
+		return nil
+	case exCommandNoHighlight:
+		return m.clearSearchHighlightsFromEx()
+	default:
+		return statusCmd(statusWarn, "Unknown command: "+cmd.name+" (try :help)")
+	}
+}
+
+func (m *Model) quitFromEx(force bool) tea.Cmd {
+	if !force && m.dirty {
+		return statusCmd(statusWarn, "No write since last change (add ! to quit)")
+	}
+	return tea.Quit
+}
+
+func (m *Model) writeQuitFromEx() tea.Cmd {
+	outcome, cmd := m.saveFileWithOutcome()
+	switch outcome {
+	case saveFileOutcomeSaved:
+		return batchCommands(cmd, tea.Quit)
+	case saveFileOutcomePending:
+		// Must be set after saveFileWithOutcome: opening the save-as modal resets saveAsFollowUp.
+		m.saveAsFollowUp = tea.Quit
+		return cmd
+	default:
+		return cmd
+	}
+}
+
+func (m *Model) clearSearchHighlightsFromEx() tea.Cmd {
+	hadSearch := m.editor.ExitSearchMode() != nil
+
+	var cmds []tea.Cmd
+	for _, id := range []responsePaneID{responsePanePrimary, responsePaneSecondary} {
+		pane := m.pane(id)
+		if pane == nil {
+			continue
+		}
+		if pane.search.clear() {
+			hadSearch = true
+			if cmd := m.syncResponsePane(id); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+
+	if hadSearch {
+		cmds = append(cmds, statusCmd(statusInfo, "Search cleared"))
+	} else {
+		cmds = append(cmds, statusCmd(statusInfo, "No search highlights"))
+	}
+	return batchCommands(cmds...)
+}

--- a/internal/ui/model_commandline_test.go
+++ b/internal/ui/model_commandline_test.go
@@ -1,0 +1,315 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestParseExCommand(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		kind  exCommandKind
+		bang  bool
+	}{
+		{name: "empty", input: "  :", kind: exCommandEmpty},
+		{name: "write", input: "w", kind: exCommandWrite},
+		{name: "write alias", input: ":write", kind: exCommandWrite},
+		{name: "quit", input: "q", kind: exCommandQuit},
+		{name: "quit bang", input: "q!", kind: exCommandQuit, bang: true},
+		{name: "quit all", input: "qa", kind: exCommandQuit},
+		{name: "quit all bang", input: "qall!", kind: exCommandQuit, bang: true},
+		{name: "write quit", input: "wq", kind: exCommandWriteQuit},
+		{name: "write quit bang", input: "wq!", kind: exCommandWriteQuit, bang: true},
+		{name: "exit", input: "x", kind: exCommandExit},
+		{name: "edit", input: "edit", kind: exCommandEdit},
+		{name: "help", input: "h", kind: exCommandHelp},
+		{name: "no highlight", input: "nohlsearch", kind: exCommandNoHighlight},
+		{name: "trailing args", input: "w other.http", kind: exCommandTrailing},
+		{name: "edit with path", input: "e file.http", kind: exCommandTrailing},
+		{name: "unknown", input: "set number", kind: exCommandUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseExCommand(tt.input)
+			if got.kind != tt.kind {
+				t.Fatalf("kind: want %v, got %v", tt.kind, got.kind)
+			}
+			if got.bang != tt.bang {
+				t.Fatalf("bang: want %v, got %v", tt.bang, got.bang)
+			}
+		})
+	}
+}
+
+func TestColonOpensCommandLineFromNormalModePanes(t *testing.T) {
+	tests := []struct {
+		name  string
+		focus paneFocus
+	}{
+		{name: "editor", focus: focusEditor},
+		{name: "response", focus: focusResponse},
+		{name: "requests", focus: focusRequests},
+		{name: "file", focus: focusFile},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := New(Config{})
+			model.ready = true
+			model.focus = tt.focus
+			_ = model.setInsertMode(false, false)
+
+			updated, _ := model.Update(colonKeyMsg())
+			model = updated.(Model)
+
+			if !model.showCommandLine {
+				t.Fatalf("expected command line to open for focus %v", tt.focus)
+			}
+			if got := model.commandLineInput.Value(); got != "" {
+				t.Fatalf("expected trigger colon to be consumed, got %q", got)
+			}
+		})
+	}
+}
+
+func TestColonDoesNotOpenCommandLineInEditorInsertMode(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	_ = model.setFocus(focusEditor)
+	_ = model.setInsertMode(true, false)
+
+	updated, _ := model.Update(colonKeyMsg())
+	model = updated.(Model)
+
+	if model.showCommandLine {
+		t.Fatal("did not expect command line in insert mode")
+	}
+	if !strings.Contains(model.editor.Value(), ":") {
+		t.Fatalf("expected insert mode colon to enter editor text, got %q", model.editor.Value())
+	}
+}
+
+func TestColonDoesNotOpenCommandLineInsideSearchPrompt(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.showSearchPrompt = true
+	model.searchInput.Focus()
+
+	updated, _ := model.Update(colonKeyMsg())
+	model = updated.(Model)
+
+	if model.showCommandLine {
+		t.Fatal("did not expect command line while search prompt is active")
+	}
+	if got := model.searchInput.Value(); got != ":" {
+		t.Fatalf("expected colon to remain search input, got %q", got)
+	}
+}
+
+func TestRenderCommandLinePrompt(t *testing.T) {
+	model := New(Config{})
+	model.width = 80
+	model.showCommandLine = true
+	model.commandLineInput.Focus()
+
+	out := ansi.Strip(model.renderCommandBar())
+	if !strings.HasPrefix(out, " :") {
+		t.Fatalf("expected command line to align with command bar gutter, got %q", out)
+	}
+	if !strings.Contains(out, "w q wq q! qa noh e help") {
+		t.Fatalf("expected command hints, got %q", out)
+	}
+}
+
+func TestRenderCommandLineKeepsCursorTailVisible(t *testing.T) {
+	model := New(Config{})
+	model.width = 24
+	model.showCommandLine = true
+	model.commandLineInput.SetValue(strings.Repeat("a", 30) + "TAIL")
+	model.commandLineInput.CursorEnd()
+	model.commandLineInput.Focus()
+
+	out := ansi.Strip(model.renderCommandBar())
+	if !strings.Contains(out, "TAIL") {
+		t.Fatalf("expected long command to render cursor tail, got %q", out)
+	}
+	if lipgloss.Width(out) > 24 {
+		t.Fatalf("expected command line width <= 24, got %d in %q", lipgloss.Width(out), out)
+	}
+}
+
+func TestExQuitGuardsDirtyBuffer(t *testing.T) {
+	model := New(Config{})
+	model.dirty = true
+
+	status, ok := statusMsgFromCmd(model.executeExCommand("q"))
+	if !ok {
+		t.Fatal("expected dirty quit warning")
+	}
+	if status.level != statusWarn || !strings.Contains(status.text, "No write since last change") {
+		t.Fatalf("unexpected dirty quit status: %+v", status)
+	}
+
+	if !commandHasQuit(model.executeExCommand("q!")) {
+		t.Fatal("expected q! to quit")
+	}
+}
+
+func TestExWriteSavesCurrentFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "request.http")
+	if err := os.WriteFile(path, []byte("GET https://old.example\n"), 0o644); err != nil {
+		t.Fatalf("write setup file: %v", err)
+	}
+
+	model := New(Config{
+		WorkspaceRoot:  dir,
+		FilePath:       path,
+		InitialContent: "GET https://old.example\n",
+	})
+	model.editor.SetValue("GET https://new.example\n")
+	model.markDirty()
+
+	collectMsgs(model.executeExCommand("w"))
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	if string(data) != "GET https://new.example\n" {
+		t.Fatalf("unexpected saved content: %q", string(data))
+	}
+	if model.dirty {
+		t.Fatal("expected write command to clear dirty state")
+	}
+}
+
+func TestExWriteQuitQuitsOnlyAfterSuccessfulSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "request.http")
+	if err := os.WriteFile(path, []byte("GET https://old.example\n"), 0o644); err != nil {
+		t.Fatalf("write setup file: %v", err)
+	}
+
+	model := New(Config{WorkspaceRoot: dir, FilePath: path, InitialContent: "old\n"})
+	model.editor.SetValue("new\n")
+	model.markDirty()
+
+	if !commandHasQuit(model.executeExCommand("wq")) {
+		t.Fatal("expected wq to save and quit")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	if string(data) != "new\n" {
+		t.Fatalf("unexpected saved content: %q", string(data))
+	}
+}
+
+func TestExWriteQuitDoesNotQuitAfterFailedSave(t *testing.T) {
+	dir := t.TempDir()
+	model := New(Config{})
+	model.currentFile = dir
+	model.editor.SetValue("new\n")
+	model.markDirty()
+
+	if commandHasQuit(model.executeExCommand("wq")) {
+		t.Fatal("did not expect wq to quit after failed save")
+	}
+}
+
+func TestExWriteQuitUnnamedBufferQuitsAfterSaveAsSubmit(t *testing.T) {
+	dir := t.TempDir()
+	model := New(Config{WorkspaceRoot: dir, InitialContent: "GET https://example.com\n"})
+
+	cmd := model.executeExCommand("wq")
+	if cmd != nil {
+		collectMsgs(cmd)
+	}
+	if !model.showNewFileModal {
+		t.Fatal("expected wq on unnamed buffer to open save-as modal")
+	}
+	if model.saveAsFollowUp == nil {
+		t.Fatal("expected save-as submit to be marked for quit")
+	}
+
+	model.newFileInput.SetValue("saved")
+	if !commandHasQuit(model.submitNewFile()) {
+		t.Fatal("expected successful save-as submit to quit")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "saved.http"))
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	if string(data) != "GET https://example.com\n" {
+		t.Fatalf("unexpected saved content: %q", string(data))
+	}
+}
+
+func TestExNoHighlightClearsEditorSearch(t *testing.T) {
+	model := New(Config{})
+	model.editor.SetValue("foo\nbar\nfoo\n")
+	updated, cmd := model.editor.ApplySearch("foo", false)
+	model.editor = updated
+	collectMsgs(cmd)
+	if !model.editor.SearchActive() {
+		t.Fatal("expected search to be active before noh")
+	}
+
+	collectMsgs(model.executeExCommand("noh"))
+
+	if model.editor.SearchActive() {
+		t.Fatal("expected noh to clear editor search")
+	}
+}
+
+func TestExEditAndHelpOpenExistingUI(t *testing.T) {
+	model := New(Config{})
+
+	model.executeExCommand("e")
+	if !model.showOpenModal {
+		t.Fatal("expected :e to open path modal")
+	}
+
+	model.closeOpenModal()
+	model.executeExCommand("help")
+	if !model.showHelp {
+		t.Fatal("expected :help to open help")
+	}
+}
+
+func colonKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{':'}}
+}
+
+func commandHasQuit(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	msg := cmd()
+	return messageHasQuit(msg)
+}
+
+func messageHasQuit(msg tea.Msg) bool {
+	switch typed := msg.(type) {
+	case nil:
+		return false
+	case tea.QuitMsg:
+		return true
+	case tea.BatchMsg:
+		for _, cmd := range typed {
+			if commandHasQuit(cmd) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -264,12 +264,15 @@ type Model struct {
 	requestDetailViewport  *viewport.Model
 	helpViewport           *viewport.Model
 
-	showSearchPrompt   bool
-	searchInput        textinput.Model
-	searchIsRegex      bool
-	searchJustOpened   bool
-	searchTarget       searchTarget
-	searchResponsePane responsePaneID
+	showSearchPrompt      bool
+	searchInput           textinput.Model
+	searchIsRegex         bool
+	searchJustOpened      bool
+	searchTarget          searchTarget
+	searchResponsePane    responsePaneID
+	showCommandLine       bool
+	commandLineInput      textinput.Model
+	commandLineJustOpened bool
 
 	statusMessage    statusMsg
 	statusUser       string
@@ -359,6 +362,7 @@ type Model struct {
 	newFileExtIndex        int
 	newFileError           string
 	newFileFromSave        bool
+	saveAsFollowUp         tea.Cmd
 	openPathInput          textinput.Model
 	openPathError          string
 	responseSaveInput      textinput.Model
@@ -402,6 +406,13 @@ type Model struct {
 type navDocCache struct {
 	doc *restfile.Document
 	mod time.Time
+}
+
+func newPromptInput(placeholder, prompt string) textinput.Model {
+	in := textinput.New()
+	in.Placeholder = placeholder
+	in.Prompt = prompt
+	return in
 }
 
 func New(cfg Config) Model {
@@ -490,46 +501,16 @@ func New(cfg Config) Model {
 	editor.KeyMap = viewKeyMap
 	editor.Cursor.SetMode(cursor.CursorStatic)
 
-	newFileInput := textinput.New()
-	newFileInput.Placeholder = "new-request"
-	newFileInput.CharLimit = 0
-	newFileInput.Prompt = ""
-	newFileInput.SetCursor(0)
-
-	openPathInput := textinput.New()
-	openPathInput.Placeholder = "./examples/basic.http"
-	openPathInput.CharLimit = 0
-	openPathInput.Prompt = ""
-	openPathInput.SetCursor(0)
-
-	responseSaveInput := textinput.New()
-	responseSaveInput.Placeholder = "~/Downloads/response.bin"
-	responseSaveInput.CharLimit = 0
-	responseSaveInput.Prompt = ""
-	responseSaveInput.SetCursor(0)
-
-	searchInput := textinput.New()
-	searchInput.Placeholder = "pattern"
-	searchInput.CharLimit = 0
-	searchInput.Prompt = "/"
-	searchInput.SetCursor(0)
-	searchInput.Blur()
+	newFileInput := newPromptInput("new-request", "")
+	openPathInput := newPromptInput("./examples/basic.http", "")
+	responseSaveInput := newPromptInput("~/Downloads/response.bin", "")
+	searchInput := newPromptInput("pattern", "/")
+	commandLineInput := newPromptInput("command", "")
 
 	navFilter := newNavigatorFilterInput()
 
-	helpFilter := textinput.New()
-	helpFilter.Placeholder = "Search..."
-	helpFilter.CharLimit = 0
-	helpFilter.Prompt = ""
-	helpFilter.SetCursor(0)
-	helpFilter.Blur()
-
-	historyFilter := textinput.New()
-	historyFilter.Placeholder = "method:GET date:05-Jun-2024 users"
-	historyFilter.CharLimit = 0
-	historyFilter.Prompt = "Filter: "
-	historyFilter.SetCursor(0)
-	historyFilter.Blur()
+	helpFilter := newPromptInput("Search...", "")
+	historyFilter := newPromptInput("method:GET date:05-Jun-2024 users", "Filter: ")
 
 	primaryViewport := viewport.New(0, 0)
 	primaryViewport.SetContent(logoPlaceholder(0, 0))
@@ -706,6 +687,7 @@ func New(cfg Config) Model {
 		responseSaveInput:        responseSaveInput,
 		searchInput:              searchInput,
 		searchTarget:             searchTargetEditor,
+		commandLineInput:         commandLineInput,
 		streamMgr:                stream.NewManager(),
 		streamMsgChan:            make(chan tea.Msg, 128),
 		streamBatchWindow:        defaultStreamBatchWindow,

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -504,7 +504,7 @@ func New(cfg Config) Model {
 	newFileInput := newPromptInput("new-request", "")
 	openPathInput := newPromptInput("./examples/basic.http", "")
 	responseSaveInput := newPromptInput("~/Downloads/response.bin", "")
-	searchInput := newPromptInput("pattern", "/")
+	searchInput := newPromptInput("pattern", "")
 	commandLineInput := newPromptInput("command", "")
 
 	navFilter := newNavigatorFilterInput()

--- a/internal/ui/model_files.go
+++ b/internal/ui/model_files.go
@@ -30,6 +30,14 @@ type editorDocumentReplacement struct {
 	reportWorkspaceErrors bool
 }
 
+type saveFileOutcome int
+
+const (
+	saveFileOutcomeFailed saveFileOutcome = iota
+	saveFileOutcomeSaved
+	saveFileOutcomePending
+)
+
 func (m *Model) openSelectedFile() tea.Cmd {
 	path := selectedFilePath(m.fileList.SelectedItem())
 	if path == "" {
@@ -84,31 +92,27 @@ func (m *Model) openTemporaryDocument() tea.Cmd {
 }
 
 func (m *Model) saveFile() tea.Cmd {
+	_, cmd := m.saveFileWithOutcome()
+	return cmd
+}
+
+func (m *Model) saveFileWithOutcome() (saveFileOutcome, tea.Cmd) {
 	if m.currentFile == "" {
 		if strings.TrimSpace(m.editor.Value()) == "" {
-			return func() tea.Msg {
-				return statusMsg{text: "No file selected", level: statusWarn}
-			}
+			return saveFileOutcomeFailed, statusCmd(statusWarn, "No file selected")
 		}
 		m.openSaveAsModal()
-		return nil
+		return saveFileOutcomePending, nil
 	}
 	content := []byte(m.editor.Value())
 	if err := os.WriteFile(m.currentFile, content, 0o644); err != nil {
-		return func() tea.Msg {
-			return statusMsg{text: fmt.Sprintf("save failed: %v", err), level: statusError}
-		}
+		return saveFileOutcomeFailed, statusCmd(statusError, fmt.Sprintf("save failed: %v", err))
 	}
 	m.watchFile(m.currentFile, content)
 	m.refreshCurrentDocument(content)
-	return batchCommands(
+	return saveFileOutcomeSaved, batchCommands(
 		m.refreshGitStatusCmd(),
-		func() tea.Msg {
-			return statusMsg{
-				text:  fmt.Sprintf("Saved %s", filepath.Base(m.currentFile)),
-				level: statusSuccess,
-			}
-		},
+		statusCmd(statusSuccess, fmt.Sprintf("Saved %s", filepath.Base(m.currentFile))),
 	)
 }
 

--- a/internal/ui/model_files_test.go
+++ b/internal/ui/model_files_test.go
@@ -19,6 +19,9 @@ func statusMsgFromCmd(cmd tea.Cmd) (statusMsg, bool) {
 	if status, ok := msg.(statusMsg); ok {
 		return status, true
 	}
+	if evt, ok := msg.(editorEvent); ok && evt.status != nil {
+		return *evt.status, true
+	}
 	if batch, ok := msg.(tea.BatchMsg); ok {
 		for _, item := range batch {
 			if status, ok := statusMsgFromCmd(item); ok {

--- a/internal/ui/model_mouse.go
+++ b/internal/ui/model_mouse.go
@@ -117,7 +117,7 @@ func (m *Model) consumeMouseClick(area mouseArea, target string, x, y int) bool 
 }
 
 func (m *Model) mouseModalActive() bool {
-	return m.modalCapturesGlobalKeys() || m.showHelp || m.showSearchPrompt
+	return m.modalCapturesGlobalKeys() || m.showHelp || m.showSearchPrompt || m.showCommandLine
 }
 
 func (m *Model) handleMouseClick(msg tea.MouseMsg) (tea.Cmd, bool) {

--- a/internal/ui/model_newfile.go
+++ b/internal/ui/model_newfile.go
@@ -30,6 +30,7 @@ func (m *Model) prepareNewFileModal(fromSave bool) {
 	m.showThemeSelector = false
 	m.closeOpenModal()
 	m.newFileFromSave = fromSave
+	m.saveAsFollowUp = nil
 }
 
 func (m *Model) closeNewFileModal() {
@@ -38,6 +39,7 @@ func (m *Model) closeNewFileModal() {
 	m.newFileInput.Blur()
 	m.newFileInput.SetValue("")
 	m.newFileFromSave = false
+	m.saveAsFollowUp = nil
 }
 
 func (m *Model) cycleNewFileExtension(delta int) {
@@ -113,6 +115,7 @@ func (m *Model) submitNewFile() tea.Cmd {
 	}
 
 	fromSave := m.newFileFromSave
+	followUp := m.saveAsFollowUp
 	m.closeNewFileModal()
 	focusCmd := m.setFocus(focusEditor)
 	cmd := m.openFile(finalPath)
@@ -126,5 +129,8 @@ func (m *Model) submitNewFile() tea.Cmd {
 			level: statusSuccess,
 		},
 	)
+	if followUp != nil {
+		return batchCommands(focusCmd, cmd, followUp)
+	}
 	return batchCommands(focusCmd, cmd)
 }

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1910,30 +1910,7 @@ func (m Model) renderSearchPrompt() string {
 }
 
 func (m Model) renderCommandLinePrompt() string {
-	style := m.theme.CommandBar.Width(m.width)
-	subtle := m.themeRuntime.subtleTextStyle(m.theme)
-	label := lipgloss.NewStyle().Bold(true).Render(":")
-
-	reserved := lipgloss.Width(label)
-	hints := ""
-	if m.commandLineInput.Value() == "" {
-		hints = subtle.
-			PaddingLeft(1).
-			Render("w q wq q! qa noh e help")
-		reserved += lipgloss.Width(hints)
-	}
-
-	segments := []string{
-		label,
-		renderPromptInput(m.commandLineInput, commandBarContentWidth(style)-reserved),
-	}
-	if hints != "" {
-		segments = append(segments, hints)
-	}
-	return renderCommandBarContainer(
-		style,
-		lipgloss.JoinHorizontal(lipgloss.Top, segments...),
-	)
+	return m.renderPromptBar(m.theme.CommandBar.Width(m.width), ":", m.commandLineInput, "w q wq q! qa noh e help")
 }
 
 func (m Model) renderResponseSearchPrompt(width int) string {
@@ -1944,59 +1921,32 @@ func (m Model) renderResponseSearchPrompt(width int) string {
 	return m.renderSearchCommandBar(style)
 }
 
-const (
-	searchPromptIcon = "⌕"
-)
-
 func (m Model) renderSearchCommandBar(style lipgloss.Style) string {
-	subtle := m.themeRuntime.subtleTextStyle(m.theme)
-	label := renderSearchPromptLabel("Search")
+	mode, hint := "LITERAL", "^R regex"
+	if m.searchIsRegex {
+		mode, hint = "REGEX", "^R literal"
+	}
+	return m.renderPromptBar(style, "/", m.searchInput, mode, hint)
+}
 
+// guides are subtle helper segments shown only while the input is empty.
+func (m Model) renderPromptBar(style lipgloss.Style, prompt string, input textinput.Model, guides ...string) string {
+	label := lipgloss.NewStyle().Bold(true).Render(prompt)
 	reserved := lipgloss.Width(label)
-	showGuide := m.searchInput.Value() == ""
-	modeBadge := ""
-	hints := ""
-	if showGuide {
-		modeBadge = subtle.
-			PaddingLeft(1).
-			Render(strings.ToUpper(m.searchPromptMode()))
-		reserved += lipgloss.Width(modeBadge)
 
-		hints = subtle.
-			PaddingLeft(1).
-			Render(m.searchPromptHints())
-		reserved += lipgloss.Width(hints)
+	var extras []string
+	if input.Value() == "" {
+		subtle := m.themeRuntime.subtleTextStyle(m.theme).PaddingLeft(1)
+		for _, guide := range guides {
+			seg := subtle.Render(guide)
+			reserved += lipgloss.Width(seg)
+			extras = append(extras, seg)
+		}
 	}
 
-	segments := []string{
-		label,
-		renderPromptInput(m.searchInput, commandBarContentWidth(style)-reserved),
-	}
-	if modeBadge != "" {
-		segments = append(segments, modeBadge)
-	}
-	if hints != "" {
-		segments = append(segments, hints)
-	}
-
-	return renderCommandBarContainer(
-		style,
-		lipgloss.JoinHorizontal(lipgloss.Top, segments...),
-	)
-}
-
-func (m Model) searchPromptMode() string {
-	if m.searchIsRegex {
-		return "regex"
-	}
-	return "literal"
-}
-
-func (m Model) searchPromptHints() string {
-	if m.searchIsRegex {
-		return "^R literal"
-	}
-	return "^R regex"
+	segments := []string{label, renderPromptInput(input, commandBarContentWidth(style)-reserved)}
+	segments = append(segments, extras...)
+	return renderCommandBarContainer(style, lipgloss.JoinHorizontal(lipgloss.Top, segments...))
 }
 
 // input is received as a copy, so Width can be adjusted without mutating the real model.
@@ -2019,10 +1969,6 @@ func renderPromptInput(input textinput.Model, width int) string {
 		input.SetCursor(pos)
 	}
 	return lipgloss.NewStyle().MaxWidth(width).Render(input.View())
-}
-
-func renderSearchPromptLabel(text string) string {
-	return lipgloss.NewStyle().Bold(true).Render(searchPromptIcon + " " + text + " ")
 }
 
 func commandBarContentWidth(style lipgloss.Style) int {

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/cellbuf"
@@ -1857,6 +1858,9 @@ func clampPositive(value, maxValue int) int {
 }
 
 func (m Model) renderCommandBar() string {
+	if m.showCommandLine {
+		return m.renderCommandLinePrompt()
+	}
 	if m.showSearchPrompt && m.searchTarget != searchTargetResponse {
 		return m.renderSearchPrompt()
 	}
@@ -1905,6 +1909,33 @@ func (m Model) renderSearchPrompt() string {
 	return m.renderSearchCommandBar(m.theme.CommandBar.Width(m.width))
 }
 
+func (m Model) renderCommandLinePrompt() string {
+	style := m.theme.CommandBar.Width(m.width)
+	subtle := m.themeRuntime.subtleTextStyle(m.theme)
+	label := lipgloss.NewStyle().Bold(true).Render(":")
+
+	reserved := lipgloss.Width(label)
+	hints := ""
+	if m.commandLineInput.Value() == "" {
+		hints = subtle.
+			PaddingLeft(1).
+			Render("w q wq q! qa noh e help")
+		reserved += lipgloss.Width(hints)
+	}
+
+	segments := []string{
+		label,
+		renderPromptInput(m.commandLineInput, commandBarContentWidth(style)-reserved),
+	}
+	if hints != "" {
+		segments = append(segments, hints)
+	}
+	return renderCommandBarContainer(
+		style,
+		lipgloss.JoinHorizontal(lipgloss.Top, segments...),
+	)
+}
+
 func (m Model) renderResponseSearchPrompt(width int) string {
 	if width <= 0 {
 		width = defaultResponseViewportWidth
@@ -1939,7 +1970,7 @@ func (m Model) renderSearchCommandBar(style lipgloss.Style) string {
 
 	segments := []string{
 		label,
-		m.renderSearchPromptInput(commandBarContentWidth(style) - reserved),
+		renderPromptInput(m.searchInput, commandBarContentWidth(style)-reserved),
 	}
 	if modeBadge != "" {
 		segments = append(segments, modeBadge)
@@ -1968,30 +1999,26 @@ func (m Model) searchPromptHints() string {
 	return "^R regex"
 }
 
-func (m Model) renderSearchPromptInput(width int) string {
-	if width < 4 {
-		width = 4
-	}
-	// Copy so we can adjust Width without mutating the real input.
-	inputModel := m.searchInput
-	inputModel.Width = 0
-	if inputModel.Value() == "" {
+// input is received as a copy, so Width can be adjusted without mutating the real model.
+func renderPromptInput(input textinput.Model, width int) string {
+	width = max(width, 4)
+	input.Width = 0
+	if input.Value() == "" {
 		// With a zero width, textinput renders only the first placeholder rune.
 		// Set just enough width for the placeholder without padding the gap to the next segment.
-		placeholderWidth := lipgloss.Width(inputModel.Placeholder)
-		if placeholderWidth > 1 {
-			inputModel.Width = placeholderWidth - 1
+		if placeholderWidth := lipgloss.Width(input.Placeholder); placeholderWidth > 1 {
+			input.Width = placeholderWidth - 1
 		}
 	} else {
-		inputModel.Width = max(width-lipgloss.Width(inputModel.Prompt), 1)
-		value := inputModel.Value()
-		pos := inputModel.Position()
+		input.Width = max(width-lipgloss.Width(input.Prompt), 1)
+		value := input.Value()
+		pos := input.Position()
 		// Rebuild the copy's overflow window after assigning a render-only width.
-		inputModel.Reset()
-		inputModel.SetValue(value)
-		inputModel.SetCursor(pos)
+		input.Reset()
+		input.SetValue(value)
+		input.SetCursor(pos)
 	}
-	return lipgloss.NewStyle().MaxWidth(width).Render(inputModel.View())
+	return lipgloss.NewStyle().MaxWidth(width).Render(input.View())
 }
 
 func renderSearchPromptLabel(text string) string {

--- a/internal/ui/model_render_commandbar_test.go
+++ b/internal/ui/model_render_commandbar_test.go
@@ -53,7 +53,7 @@ func TestRenderSearchPromptAlignsToCommandBarStart(t *testing.T) {
 
 	out := ansi.Strip(model.renderSearchPrompt())
 
-	if !strings.HasPrefix(out, " "+searchPromptIcon+" Search") {
+	if !strings.HasPrefix(out, " /pattern") {
 		t.Fatalf("expected search prompt to align with command bar gutter, got %q", out)
 	}
 }
@@ -65,7 +65,7 @@ func TestRenderSearchPromptShowsLiteralGuideWhenEmpty(t *testing.T) {
 	model.searchInput.Focus()
 
 	out := ansi.Strip(model.renderSearchPrompt())
-	expected := searchPromptIcon + " Search /pattern LITERAL " + model.searchPromptHints()
+	expected := "/pattern LITERAL ^R regex"
 
 	if !strings.Contains(out, expected) {
 		t.Fatalf("expected empty literal editor search guide %q, got %q", expected, out)
@@ -83,7 +83,7 @@ func TestRenderSearchPromptShowsRegexGuideWhenEmpty(t *testing.T) {
 	model.searchInput.Focus()
 
 	out := ansi.Strip(model.renderSearchPrompt())
-	expected := searchPromptIcon + " Search /pattern REGEX " + model.searchPromptHints()
+	expected := "/pattern REGEX ^R literal"
 
 	if !strings.Contains(out, expected) {
 		t.Fatalf("expected empty regex editor search guide %q, got %q", expected, out)
@@ -143,7 +143,7 @@ func TestRenderResponseSearchPromptShowsLiteralGuideWhenEmpty(t *testing.T) {
 	model.searchInput.Focus()
 
 	out := ansi.Strip(model.renderResponseSearchPrompt(96))
-	expected := searchPromptIcon + " Search /pattern LITERAL " + model.searchPromptHints()
+	expected := "/pattern LITERAL ^R regex"
 
 	if !strings.Contains(out, expected) {
 		t.Fatalf("expected empty literal response search guide %q, got %q", expected, out)
@@ -160,7 +160,7 @@ func TestRenderResponseSearchPromptShowsRegexGuideWhenEmpty(t *testing.T) {
 	model.searchInput.Focus()
 
 	out := ansi.Strip(model.renderResponseSearchPrompt(96))
-	expected := searchPromptIcon + " Search /pattern REGEX " + model.searchPromptHints()
+	expected := "/pattern REGEX ^R literal"
 
 	if !strings.Contains(out, expected) {
 		t.Fatalf("expected empty regex response search guide %q, got %q", expected, out)
@@ -178,13 +178,8 @@ func TestRenderResponseSearchPromptHidesGuideAfterTyping(t *testing.T) {
 
 	out := ansi.Strip(model.renderResponseSearchPrompt(48))
 
-	if !strings.HasPrefix(out, searchPromptIcon+" Search") {
+	if !strings.HasPrefix(out, "/pattern") {
 		t.Fatalf("expected response search prompt to start at pane edge, got %q", out)
-	}
-
-	const value = "/pattern"
-	if !strings.Contains(out, value) {
-		t.Fatalf("expected response search input value, got %q", out)
 	}
 	assertSearchGuideHidden(t, out)
 }

--- a/internal/ui/model_render_test.go
+++ b/internal/ui/model_render_test.go
@@ -1394,7 +1394,7 @@ func TestResponseSearchPromptRendersAtColumnBottom(t *testing.T) {
 	view := model.renderResponseColumn(responsePanePrimary, true, 36)
 	lines := strings.Split(ansi.Strip(view), "\n")
 	bodyLine := lineIndexContaining(lines, "short-body")
-	searchLine := lineIndexContaining(lines, searchPromptIcon+" Search")
+	searchLine := lineIndexContaining(lines, "/needle")
 	if bodyLine < 0 {
 		t.Fatalf("expected response body in column, got %q", ansi.Strip(view))
 	}
@@ -1441,18 +1441,18 @@ func TestResponseSearchPromptOnlyRendersInTargetSplitPane(t *testing.T) {
 	secondary.viewport.SetContent("secondary-body")
 
 	primaryView := model.renderResponseColumn(responsePanePrimary, true, 32)
-	if strings.Contains(ansi.Strip(primaryView), searchPromptIcon+" Search") {
+	if strings.Contains(ansi.Strip(primaryView), "/needle") {
 		t.Fatalf("did not expect search prompt in primary pane, got %q", ansi.Strip(primaryView))
 	}
 
 	secondaryView := model.renderResponseColumn(responsePaneSecondary, false, 32)
 	secondaryPlain := ansi.Strip(secondaryView)
-	if !strings.Contains(secondaryPlain, searchPromptIcon+" Search") {
+	if !strings.Contains(secondaryPlain, "/needle") {
 		t.Fatalf("expected search prompt in secondary pane, got %q", secondaryPlain)
 	}
 	secondaryLines := strings.Split(secondaryPlain, "\n")
 	bodyLine := lineIndexContaining(secondaryLines, "secondary-body")
-	searchLine := lineIndexContaining(secondaryLines, searchPromptIcon+" Search")
+	searchLine := lineIndexContaining(secondaryLines, "/needle")
 	if bodyLine < 0 || searchLine < 0 {
 		t.Fatalf("expected secondary body and search prompt, got %q", secondaryPlain)
 	}

--- a/internal/ui/model_search.go
+++ b/internal/ui/model_search.go
@@ -54,16 +54,13 @@ func (m *Model) openSearchPrompt() tea.Cmd {
 		m.searchTarget = searchTargetResponse
 		m.searchResponsePane = m.responsePaneFocus
 		m.searchIsRegex = pane.search.isRegex
-		if pane.search.hasQuery() {
-			m.searchInput.SetValue(pane.search.query)
-		} else {
-			m.searchInput.SetValue("")
-		}
 	default:
 		m.prepareEditorSearchContext()
 	}
 
-	m.searchInput.CursorEnd()
+	// Like Vim, "/" always opens an empty prompt; the previous query stays
+	// available to n/N via the target's search state.
+	m.searchInput.Reset()
 	return m.searchInput.Focus()
 }
 
@@ -144,7 +141,6 @@ func (m *Model) clearLiveSearchTarget() tea.Cmd {
 func (m *Model) prepareEditorSearchContext() {
 	m.searchTarget = searchTargetEditor
 	m.searchIsRegex = m.editor.search.isRegex
-	m.searchInput.SetValue(m.editor.search.query)
 }
 
 func (m *Model) responseSearchContent(

--- a/internal/ui/model_search_test.go
+++ b/internal/ui/model_search_test.go
@@ -152,6 +152,40 @@ func TestSlashOpensResponseSearchPromptWithoutTypingSlash(t *testing.T) {
 	}
 }
 
+func TestSearchPromptReopensEmptyAfterEscape(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.focus = focusEditor
+	model.editorInsertMode = false
+	model.editor.SetValue("one\ntwo\nthree two")
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = updated.(Model)
+	for _, r := range "two" {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		model = updated.(Model)
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+	if model.editor.SearchActive() {
+		t.Fatal("expected esc to clear search highlights")
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = updated.(Model)
+	if !model.showSearchPrompt {
+		t.Fatal("expected search prompt to reopen")
+	}
+	if got := model.searchInput.Value(); got != "" {
+		t.Fatalf("expected reopened search prompt to be empty, got %q", got)
+	}
+	if model.editor.search.query != "two" {
+		t.Fatalf("expected retained query for n/N, got %q", model.editor.search.query)
+	}
+}
+
 func TestSlashStillOpensHistoryFilter(t *testing.T) {
 	model := New(Config{})
 	model.ready = true
@@ -521,10 +555,10 @@ func TestLiveSearchEmptyQueryClearsCurrentTarget(t *testing.T) {
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	model = updated.(Model)
-	for range "foo" {
-		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
-		model = updated.(Model)
-	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	model = updated.(Model)
 
 	pane = model.pane(responsePanePrimary)
 	if pane == nil {

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -61,7 +61,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.setStatusMessage(*typed.status)
 		}
 	case tea.KeyMsg:
-		if !m.showSearchPrompt && !m.showEnvSelector && !m.showFileChangeModal {
+		if !m.showSearchPrompt && !m.showCommandLine {
 			if cmd := m.handleKey(typed); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -432,6 +432,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, m.applyLiveSearchPrompt())
 			}
 			return m, batchCommands(cmds...)
+		}
+		return m, batchCommands(cmds...)
+	}
+
+	if m.showCommandLine {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			cmd := m.handleCommandLineKey(keyMsg)
+			return m, batchCommands(append(cmds, cmd)...)
 		}
 		return m, batchCommands(cmds...)
 	}
@@ -1263,6 +1271,10 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 	if cmd, handled := m.handleHistoryFilterKey(msg); handled {
 		m.resetChordState()
 		return combine(cmd)
+	}
+
+	if m.canOpenCommandLine(msg) {
+		return combine(m.openCommandLine())
 	}
 
 	if m.operator.active {

--- a/internal/ui/theme_runtime.go
+++ b/internal/ui/theme_runtime.go
@@ -255,6 +255,7 @@ func (m *Model) applyThemeDefinition(def theme.Definition) {
 func (m *Model) applyThemeToInputs() {
 	m.themeRuntime.applyRequestEditor(&m.editor, m.theme)
 	m.themeRuntime.applyTextInput(&m.searchInput, m.theme, textInputKindGeneric)
+	m.themeRuntime.applyTextInput(&m.commandLineInput, m.theme, textInputKindGeneric)
 	m.themeRuntime.applyTextInput(&m.helpFilter, m.theme, textInputKindHelp)
 	m.themeRuntime.applyTextInput(&m.newFileInput, m.theme, textInputKindGeneric)
 	m.themeRuntime.applyTextInput(&m.openPathInput, m.theme, textInputKindGeneric)

--- a/internal/ui/theme_runtime_test.go
+++ b/internal/ui/theme_runtime_test.go
@@ -89,6 +89,15 @@ func TestApplyThemeDefinitionStylesFiltersUseDistinctPromptAndTextColors(t *test
 	if got := model.searchInput.TextStyle.GetForeground(); got != lipgloss.Color("#0f172a") {
 		t.Fatalf("expected light input text foreground, got %v", got)
 	}
+	if got := model.commandLineInput.PromptStyle.GetForeground(); got != lipgloss.Color("#1e40af") {
+		t.Fatalf("expected light command prompt foreground, got %v", got)
+	}
+	if got := model.commandLineInput.TextStyle.GetForeground(); got != lipgloss.Color("#0f172a") {
+		t.Fatalf("expected light command text foreground, got %v", got)
+	}
+	if got := model.commandLineInput.Cursor.Style.GetForeground(); got != lipgloss.Color("#1e40af") {
+		t.Fatalf("expected light command cursor foreground, got %v", got)
+	}
 	if got := model.helpFilter.TextStyle.GetForeground(); got != lipgloss.Color("#0f172a") {
 		t.Fatalf("expected light help filter text foreground, got %v", got)
 	}


### PR DESCRIPTION
Adds a Vim-style command line to the TUI, opened with `:`, with support for common commands like :w, :q, :q!, :wq, :x, :e, :help, and :noh.

Also updates search UX to behave more like Vim: opening/starts with an empty prompt while keeping the previous search available for navigation and clearing the live search input clears current highlights. The search command bar was simplified by removing the extra search icon.

Includes UI/theming updates for the new command-line input and adds/updates tests covering command parsing, command execution, search prompt behavior, rendering, save-as :wq, and theme styling.