### PR TITLE
RST-268: fix multipart body parsing

### DIFF
--- a/internal/collection/refs.go
+++ b/internal/collection/refs.go
@@ -3,6 +3,7 @@ package collection
 import (
 	"strings"
 
+	"github.com/unkn0wn-root/resterm/internal/parser/bodyref"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -60,19 +61,9 @@ func bodyIncludes(body string) []string {
 	parts := strings.Split(body, "\n")
 	out := make([]string, 0, len(parts))
 	for _, ln := range parts {
-		// TrimSpace keeps CRLF and LF source files equivalent for include parsing.
-		t := strings.TrimSpace(ln)
-		if len(t) <= 1 {
-			continue
+		if p, ok := bodyref.IncludeLine(ln); ok {
+			out = append(out, p)
 		}
-		if !strings.HasPrefix(t, "@") || strings.HasPrefix(t, "@{") {
-			continue
-		}
-		p := strings.TrimSpace(t[1:])
-		if p == "" {
-			continue
-		}
-		out = append(out, p)
 	}
 	return out
 }

--- a/internal/httpclient/body.go
+++ b/internal/httpclient/body.go
@@ -51,11 +51,7 @@ func (c *Client) prepareBody(
 				)
 			}
 
-			processed, procErr := c.injectBodyIncludes(expanded, lookup)
-			if procErr != nil {
-				return bodyPlan{}, procErr
-			}
-			return bodyPlan{rd: strings.NewReader(processed)}, nil
+			return c.textBodyPlan(expanded, lookup, req)
 		}
 		return bodyPlan{rd: bytes.NewReader(data)}, nil
 	case req.Body.Text != "":
@@ -67,14 +63,33 @@ func (c *Client) prepareBody(
 				return bodyPlan{}, diag.WrapAs(diag.ClassProtocol, err, "expand body template")
 			}
 		}
-		processed, err := c.injectBodyIncludes(expanded, lookup)
-		if err != nil {
-			return bodyPlan{}, err
-		}
-		return bodyPlan{rd: strings.NewReader(processed)}, nil
+		return c.textBodyPlan(expanded, lookup, req)
 	default:
 		return bodyPlan{}, nil
 	}
+}
+
+func (c *Client) textBodyPlan(
+	body string,
+	lookup fileLookup,
+	req *restfile.Request,
+) (bodyPlan, error) {
+	processed, err := c.injectBodyIncludes(body, lookup, isMultipartRequest(req))
+	if err != nil {
+		return bodyPlan{}, err
+	}
+	return bodyPlan{rd: bytes.NewReader(processed)}, nil
+}
+
+// Multipart bodies need CRLF framing on the wire. The Content-Type header is
+// what is actually sent (scripts may rewrite it after parse); Body.MimeType is
+// the parse-time fallback.
+func isMultipartRequest(req *restfile.Request) bool {
+	ct := req.Headers.Get("Content-Type")
+	if ct == "" {
+		ct = req.Body.MimeType
+	}
+	return restfile.IsMultipartMime(ct)
 }
 
 // GET requests put everything in query params, POST uses JSON body.

--- a/internal/httpclient/executor_test.go
+++ b/internal/httpclient/executor_test.go
@@ -442,7 +442,7 @@ func TestBuildHTTPRequestMultipartUsesCRLFFramingAfterParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read multipart form: %v\nbody:\n%q", err, string(body))
 	}
-	defer form.RemoveAll()
+	t.Cleanup(func() { _ = form.RemoveAll() })
 	if got := form.Value["field1"]; len(got) != 1 || got[0] != "value1" {
 		t.Fatalf("unexpected field1 value: %v", got)
 	}
@@ -454,7 +454,7 @@ func TestBuildHTTPRequestMultipartUsesCRLFFramingAfterParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open file part: %v", err)
 	}
-	defer file.Close()
+	t.Cleanup(func() { _ = file.Close() })
 	fileBody, err := io.ReadAll(file)
 	if err != nil {
 		t.Fatalf("read file part: %v", err)

--- a/internal/httpclient/executor_test.go
+++ b/internal/httpclient/executor_test.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -14,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -28,6 +30,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/httpver"
 	"github.com/unkn0wn-root/resterm/internal/k8s"
 	"github.com/unkn0wn-root/resterm/internal/nettrace"
+	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/ssh"
 	"github.com/unkn0wn-root/resterm/internal/stream"
@@ -82,14 +85,14 @@ func TestInjectBodyIncludes(t *testing.T) {
 
 	body := "part1\n@payload.json\n@{notIncluded}\n"
 	lookup := newFileLookup(baseDir, Options{})
-	processed, err := client.injectBodyIncludes(body, lookup)
+	processed, err := client.injectBodyIncludes(body, lookup, false)
 	if err != nil {
 		t.Fatalf("inject body includes: %v", err)
 	}
-	if !strings.Contains(processed, `{"status":"ok"}`) {
+	if !strings.Contains(string(processed), `{"status":"ok"}`) {
 		t.Fatalf("expected file contents to be embedded, got %q", processed)
 	}
-	if !strings.Contains(processed, "@{notIncluded}") {
+	if !strings.Contains(string(processed), "@{notIncluded}") {
 		t.Fatalf("expected handlebars directive to remain untouched")
 	}
 }
@@ -101,11 +104,11 @@ func TestInjectBodyIncludesFallback(t *testing.T) {
 		"/does/not/exist",
 		Options{FallbackBaseDirs: []string{"workspace"}},
 	)
-	processed, err := client.injectBodyIncludes(body, lookup)
+	processed, err := client.injectBodyIncludes(body, lookup, false)
 	if err != nil {
 		t.Fatalf("inject body includes with fallback: %v", err)
 	}
-	if processed != "hi" {
+	if string(processed) != "hi" {
 		t.Fatalf("expected fallback file contents, got %q", processed)
 	}
 }
@@ -389,6 +392,75 @@ func TestBuildHTTPRequestSendsXMLBodyRaw(t *testing.T) {
 	}
 	if got := httpReq.Header.Get("Content-Type"); got != "text/xml; charset=utf-8" {
 		t.Fatalf("unexpected content type %q", got)
+	}
+}
+
+func TestBuildHTTPRequestMultipartUsesCRLFFramingAfterParse(t *testing.T) {
+	const boundary = "resterm-test-boundary"
+	src := "" +
+		"POST https://example.com/upload\r\n" +
+		"Content-Type: multipart/form-data; boundary=" + boundary + "\r\n" +
+		"\r\n" +
+		"--" + boundary + "\r\n" +
+		"Content-Disposition: form-data; name=\"field1\"\r\n" +
+		"\r\n" +
+		"value1\r\n" +
+		"--" + boundary + "\r\n" +
+		"Content-Disposition: form-data; name=\"file\"; filename=\"testfile.txt\"\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"@testfile.txt\r\n" +
+		"--" + boundary + "--\r\n"
+
+	doc := parser.Parse("upload.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected one request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if strings.Contains(req.Body.Text, "\r") {
+		t.Fatalf("parser should expose normalized body text before send, got %q", req.Body.Text)
+	}
+
+	client := NewClient(mapFS{"testfile.txt": []byte("hello\n")})
+	httpReq, _, body, err := client.BuildHTTPRequest(context.Background(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if got := httpReq.Header.Get("Content-Type"); got != "multipart/form-data; boundary="+boundary {
+		t.Fatalf("unexpected content type %q", got)
+	}
+	if bytes.Contains(body, []byte("--"+boundary+"\nContent-Disposition")) {
+		t.Fatalf("multipart delimiter was framed with LF only:\n%q", string(body))
+	}
+	wantFileFraming := "\r\n\r\nhello\n\r\n--" + boundary + "--"
+	if !bytes.Contains(body, []byte(wantFileFraming)) {
+		t.Fatalf("expected CRLF framing around unchanged file bytes %q, got:\n%q", wantFileFraming, string(body))
+	}
+
+	mr := multipart.NewReader(bytes.NewReader(body), boundary)
+	form, err := mr.ReadForm(1024)
+	if err != nil {
+		t.Fatalf("read multipart form: %v\nbody:\n%q", err, string(body))
+	}
+	defer form.RemoveAll()
+	if got := form.Value["field1"]; len(got) != 1 || got[0] != "value1" {
+		t.Fatalf("unexpected field1 value: %v", got)
+	}
+	files := form.File["file"]
+	if len(files) != 1 {
+		t.Fatalf("expected one file part, got %d", len(files))
+	}
+	file, err := files[0].Open()
+	if err != nil {
+		t.Fatalf("open file part: %v", err)
+	}
+	defer file.Close()
+	fileBody, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("read file part: %v", err)
+	}
+	if string(fileBody) != "hello\n" {
+		t.Fatalf("unexpected file body %q", string(fileBody))
 	}
 }
 

--- a/internal/httpclient/fs.go
+++ b/internal/httpclient/fs.go
@@ -1,7 +1,7 @@
 package httpclient
 
 import (
-	"bufio"
+	"bytes"
 	"errors"
 	"io/fs"
 	"os"
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/parser/bodyref"
 	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
@@ -62,7 +63,8 @@ func (c *Client) readFileWithFallback(
 		if err == nil {
 			return data, path, nil
 		}
-		return nil, "", diag.WrapAsf(diag.ClassFilesystem, err,
+		return nil, "", diag.WrapAsf(
+			diag.ClassFilesystem, err,
 			"read %s %s",
 			strings.ToLower(label),
 			path,
@@ -79,7 +81,8 @@ func (c *Client) readFileWithFallback(
 			return data, candidate, nil
 		}
 		if stopReadFallback(err) {
-			return nil, "", diag.WrapAsf(diag.ClassFilesystem, err,
+			return nil, "", diag.WrapAsf(
+				diag.ClassFilesystem, err,
 				"read %s %s",
 				strings.ToLower(label),
 				candidate,
@@ -93,7 +96,8 @@ func (c *Client) readFileWithFallback(
 		lastErr = os.ErrNotExist
 		lastPath = path
 	}
-	return nil, "", diag.WrapAsf(diag.ClassFilesystem, lastErr,
+	return nil, "", diag.WrapAsf(
+		diag.ClassFilesystem, lastErr,
 		"read %s %s (last tried %s)",
 		strings.ToLower(label),
 		path,
@@ -101,44 +105,37 @@ func (c *Client) readFileWithFallback(
 	)
 }
 
-// Lines starting with @ get replaced with the file contents.
-// @{variable} syntax is left alone so template expansion can handle it.
-func (c *Client) injectBodyIncludes(
-	body string,
-	lookup fileLookup,
-) (string, error) {
-	scanner := bufio.NewScanner(strings.NewReader(body))
-	scanner.Buffer(make([]byte, 0, 1024), 1024*1024)
+// injectBodyIncludes replaces each "@path" line with the referenced file's
+// bytes. "@{...}" template lines are left alone. crlf rejoins lines with CRLF
+// and always terminates the body with CRLF, like curl -F: readline-based
+// multipart parsers (e.g. Python's cgi) block without it.
+func (c *Client) injectBodyIncludes(body string, lookup fileLookup, crlf bool) ([]byte, error) {
+	eol := "\n"
+	if crlf {
+		eol = "\r\n"
+	}
 
-	var b strings.Builder
-	first := true
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !first {
-			b.WriteByte('\n')
+	var b bytes.Buffer
+	b.Grow(len(body))
+	for i, line := range strings.Split(strings.TrimSuffix(body, "\n"), "\n") {
+		if i > 0 {
+			b.WriteString(eol)
 		}
-
-		first = false
-		trimmed := strings.TrimSpace(line)
-		if len(trimmed) > 1 && strings.HasPrefix(trimmed, "@") &&
-			!strings.HasPrefix(trimmed, "@{") {
-			includePath := strings.TrimSpace(trimmed[1:])
-			if includePath != "" {
-				data, _, err := lookup.read(c, includePath, "include body file")
-				if err != nil {
-					return "", err
-				}
-				b.WriteString(string(data))
-				continue
+		line = strings.TrimSuffix(line, "\r")
+		if path, ok := bodyref.IncludeLine(line); ok {
+			data, _, err := lookup.read(c, path, "include body file")
+			if err != nil {
+				return nil, err
 			}
+			b.Write(data)
+			continue
 		}
 		b.WriteString(line)
 	}
-
-	if err := scanner.Err(); err != nil {
-		return "", diag.WrapAs(diag.ClassFilesystem, err, "scan body includes")
+	if crlf {
+		b.WriteString(eol)
 	}
-	return b.String(), nil
+	return b.Bytes(), nil
 }
 
 func buildPathCandidates(path, baseDir string, fallbacks []string, allowRaw bool) []string {

--- a/internal/httpclient/multipart_test.go
+++ b/internal/httpclient/multipart_test.go
@@ -1,0 +1,269 @@
+package httpclient_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/curl/importer"
+	"github.com/unkn0wn-root/resterm/internal/httpclient"
+	"github.com/unkn0wn-root/resterm/internal/parser"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+type recordedRequest struct {
+	body []byte
+	ct   string
+}
+
+func newRecordServer(t *testing.T) (*httptest.Server, *recordedRequest) {
+	t.Helper()
+	rec := &recordedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rec.body = data
+		rec.ct = r.Header.Get("Content-Type")
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+func (r *recordedRequest) boundary(t *testing.T) string {
+	t.Helper()
+	_, params, err := mime.ParseMediaType(r.ct)
+	if err != nil {
+		t.Fatalf("parse content type %q: %v", r.ct, err)
+	}
+	return params["boundary"]
+}
+
+func (r *recordedRequest) form(t *testing.T) (map[string]string, map[string][]byte) {
+	t.Helper()
+	mr := multipart.NewReader(bytes.NewReader(r.body), r.boundary(t))
+	values := map[string]string{}
+	files := map[string][]byte{}
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			return values, files
+		}
+		if err != nil {
+			t.Fatalf("parse multipart body: %v\nwire: %q", err, r.body)
+		}
+		data, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		if part.FileName() != "" {
+			files[part.FormName()] = data
+		} else {
+			values[part.FormName()] = string(data)
+		}
+	}
+}
+
+func executeRequest(t *testing.T, req *restfile.Request, resolver *vars.Resolver, baseDir string) {
+	t.Helper()
+	client := httpclient.NewClient(httpclient.OSFileSystem{})
+	resp, err := client.Execute(context.Background(), req, resolver, httpclient.Options{BaseDir: baseDir})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
+	}
+}
+
+func parseSingleRequest(t *testing.T, path string, src []byte) *restfile.Request {
+	t.Helper()
+	doc := parser.Parse(path, src)
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d (errors: %+v)", len(doc.Requests), doc.Errors)
+	}
+	return doc.Requests[0]
+}
+
+// Reproduces the reported bug end to end: curl -F import, parse, execute,
+// then assert the wire bytes carry curl-equivalent CRLF framing.
+func TestExecuteMultipartFromCurlImport(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "testfile.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, rec := newRecordServer(t)
+	cmd := `curl -s -F "field1=value1" -F "file=@testfile.txt;type=text/plain" ` + srv.URL + `/upload`
+	out := filepath.Join(dir, "curl.http")
+	svc := importer.Service{Writer: importer.NewFileWriter()}
+	if err := svc.GenerateHTTPFile(context.Background(), cmd, out, importer.WriterOptions{}); err != nil {
+		t.Fatalf("generate http file: %v", err)
+	}
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := parseSingleRequest(t, out, raw)
+	executeRequest(t, req, vars.NewResolver(), dir)
+
+	b := rec.boundary(t)
+	want := "--" + b + "\r\n" +
+		"Content-Disposition: form-data; name=\"field1\"\r\n" +
+		"\r\n" +
+		"value1\r\n" +
+		"--" + b + "\r\n" +
+		"Content-Disposition: form-data; name=\"file\"; filename=\"testfile.txt\"\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"hello\n\r\n" +
+		"--" + b + "--\r\n"
+	if string(rec.body) != want {
+		t.Errorf("unexpected wire body:\nwant %q\n got %q", want, rec.body)
+	}
+
+	values, files := rec.form(t)
+	if values["field1"] != "value1" {
+		t.Errorf("field1 = %q", values["field1"])
+	}
+	if string(files["file"]) != "hello\n" {
+		t.Errorf("file = %q", files["file"])
+	}
+}
+
+// Hand-written multipart bodies must produce identical wire framing whether the
+// .http file was authored with LF or CRLF line endings.
+func TestExecuteMultipartAuthoredLineEndings(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		eol  string
+	}{{"LF", "\n"}, {"CRLF", "\r\n"}} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, rec := newRecordServer(t)
+			src := strings.Join([]string{
+				"POST " + srv.URL + "/upload",
+				"Content-Type: multipart/form-data; boundary=xxBOUNDxx",
+				"",
+				"--xxBOUNDxx",
+				`Content-Disposition: form-data; name="a"`,
+				"",
+				"va",
+				"--xxBOUNDxx",
+				`Content-Disposition: form-data; name="note"`,
+				"",
+				"# comment-like part content",
+				"--xxBOUNDxx--",
+				"",
+			}, tc.eol)
+
+			req := parseSingleRequest(t, "upload.http", []byte(src))
+			executeRequest(t, req, vars.NewResolver(), "")
+
+			values, _ := rec.form(t)
+			if values["a"] != "va" {
+				t.Errorf("a = %q, wire: %q", values["a"], rec.body)
+			}
+			if values["note"] != "# comment-like part content" {
+				t.Errorf("note = %q, wire: %q", values["note"], rec.body)
+			}
+		})
+	}
+}
+
+// Included file bytes must pass through verbatim; CRLF framing applies only to
+// the surrounding multipart structure.
+func TestExecuteMultipartIncludeKeepsFileBytes(t *testing.T) {
+	dir := t.TempDir()
+	blob := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x00, '\n', '\r', 0xff, '\n'}
+	if err := os.WriteFile(filepath.Join(dir, "blob.bin"), blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, rec := newRecordServer(t)
+	src := "POST " + srv.URL + "/upload\n" +
+		"Content-Type: multipart/form-data; boundary=xxBOUNDxx\n" +
+		"\n" +
+		"--xxBOUNDxx\n" +
+		"Content-Disposition: form-data; name=\"f\"; filename=\"blob.bin\"\n" +
+		"Content-Type: application/octet-stream\n" +
+		"\n" +
+		"@blob.bin\n" +
+		"--xxBOUNDxx--\n"
+
+	req := parseSingleRequest(t, "blob.http", []byte(src))
+	executeRequest(t, req, vars.NewResolver(), dir)
+
+	_, files := rec.form(t)
+	if !bytes.Equal(files["f"], blob) {
+		t.Errorf("file bytes corrupted:\nwant %q\n got %q", blob, files["f"])
+	}
+}
+
+// CRLF framing applies to every multipart subtype, not only form-data.
+func TestExecuteMultipartMixedUsesCRLFFraming(t *testing.T) {
+	srv, rec := newRecordServer(t)
+	src := "POST " + srv.URL + "/batch\n" +
+		"Content-Type: multipart/mixed; boundary=xxBOUNDxx\n" +
+		"\n" +
+		"--xxBOUNDxx\n" +
+		"Content-Type: application/json\n" +
+		"\n" +
+		"{\"id\": 1}\n" +
+		"--xxBOUNDxx--\n"
+
+	req := parseSingleRequest(t, "batch.http", []byte(src))
+	executeRequest(t, req, vars.NewResolver(), "")
+
+	mr := multipart.NewReader(bytes.NewReader(rec.body), "xxBOUNDxx")
+	part, err := mr.NextPart()
+	if err != nil {
+		t.Fatalf("parse multipart body: %v\nwire: %q", err, rec.body)
+	}
+	if got := part.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("part content type = %q", got)
+	}
+	data, err := io.ReadAll(part)
+	if err != nil {
+		t.Fatalf("read part: %v", err)
+	}
+	if string(data) != `{"id": 1}` {
+		t.Errorf("part body = %q", data)
+	}
+	if _, err := mr.NextPart(); err != io.EOF {
+		t.Errorf("expected single part, got err %v", err)
+	}
+}
+
+// Template expansion runs before CRLF framing and include injection.
+func TestExecuteMultipartExpandsTemplates(t *testing.T) {
+	srv, rec := newRecordServer(t)
+	src := "POST " + srv.URL + "/upload\n" +
+		"Content-Type: multipart/form-data; boundary=xxBOUNDxx\n" +
+		"\n" +
+		"--xxBOUNDxx\n" +
+		"Content-Disposition: form-data; name=\"greet\"\n" +
+		"\n" +
+		"hello {{who}}\n" +
+		"--xxBOUNDxx--\n"
+
+	req := parseSingleRequest(t, "tpl.http", []byte(src))
+	resolver := vars.NewResolver(vars.NewMapProvider("test", map[string]string{"who": "world"}))
+	executeRequest(t, req, resolver, "")
+
+	values, _ := rec.form(t)
+	if values["greet"] != "hello world" {
+		t.Errorf("greet = %q", values["greet"])
+	}
+}

--- a/internal/parser/bodyref/ref.go
+++ b/internal/parser/bodyref/ref.go
@@ -55,6 +55,17 @@ func ParseBodyFile(line string, forceInline bool) (string, bool) {
 	return Parse(line, opt)
 }
 
+// IncludeLine returns the file path from an "@path" body include line.
+// "@{...}" template markers are not includes.
+func IncludeLine(line string) (string, bool) {
+	t := strings.TrimSpace(line)
+	if len(t) <= 1 || !strings.HasPrefix(t, "@") || strings.HasPrefix(t, "@{") {
+		return "", false
+	}
+	p := strings.TrimSpace(t[1:])
+	return p, p != ""
+}
+
 func parsePath(s string) (string, bool) {
 	if !hasLeadingSpace(s) {
 		return "", false

--- a/internal/parser/bodyref/ref_test.go
+++ b/internal/parser/bodyref/ref_test.go
@@ -97,3 +97,28 @@ func TestParseBodyFileChecksLineAndInlineForms(t *testing.T) {
 		})
 	}
 }
+
+func TestIncludeLine(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{in: "@payload.json", want: "payload.json", ok: true},
+		{in: "  @ payload.json  ", want: "payload.json", ok: true},
+		{in: "@my file.json", want: "my file.json", ok: true},
+		{in: "@{template}"},
+		{in: "@"},
+		{in: "@   "},
+		{in: "plain text"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, ok := IncludeLine(tt.in)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("IncludeLine(%q)=(%q,%v), want (%q,%v)", tt.in, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/internal/parser/document.go
+++ b/internal/parser/document.go
@@ -91,10 +91,13 @@ func (b *documentBuilder) processLine(lineNumber int, line string) {
 
 	b.flushScriptIfNeeded(trimmed)
 
-	if b.handleBlockComment(lineNumber, line, trimmed) {
+	if b.handleSeparator(lineNumber, trimmed) {
 		return
 	}
-	if b.handleSeparator(lineNumber, trimmed) {
+	if b.handleMultipartBodyLine(line, trimmed) {
+		return
+	}
+	if b.handleBlockComment(lineNumber, line, trimmed) {
 		return
 	}
 	if b.handleCommentLine(lineNumber, line, trimmed) {
@@ -262,6 +265,18 @@ func (b *documentBuilder) handleBodyContinuation(line string) bool {
 		return true
 	}
 	return false
+}
+
+// Blank lines fall through to handleBlankLine, which appends them to the body
+// with their whitespace normalized away.
+func (b *documentBuilder) handleMultipartBodyLine(line, trimmed string) bool {
+	if trimmed == "" || !b.inRequest || b.request.multipart == nil ||
+		!b.request.multipart.bodyLine(trimmed) {
+		return false
+	}
+	b.request.http.AppendBodyLine(line)
+	b.appendLine(line)
+	return true
 }
 
 func (b *documentBuilder) handleMethodLine(lineNumber int, line string) bool {

--- a/internal/parser/multipart.go
+++ b/internal/parser/multipart.go
@@ -1,0 +1,50 @@
+package parser
+
+import "strings"
+
+// multipartSpan tracks the region between the first multipart delimiter and
+// the close delimiter. Lines inside it are body content and must bypass the
+// comment, script, and variable handlers, which would otherwise consume them
+// (the "--" comment marker eats boundary lines, "#" eats part content, ...).
+type multipartSpan struct {
+	delimiter string // "--" + boundary; empty when Content-Type has no boundary param
+	open      bool
+	closed    bool
+}
+
+func newMultipartSpan(ct string) *multipartSpan {
+	return &multipartSpan{delimiter: "--" + boundaryParam(ct)}
+}
+
+// bodyLine reports whether trimmed is multipart body content: a delimiter
+// line, or any line between the first delimiter and the close delimiter.
+// Without a known boundary only "--" lines count, so comment-like part
+// content is not protected but boundary lines still survive.
+func (s *multipartSpan) bodyLine(trimmed string) bool {
+	if s.delimiter == "--" {
+		return strings.HasPrefix(trimmed, "--")
+	}
+	switch {
+	case s.closed:
+		return false
+	case trimmed == s.delimiter+"--":
+		s.closed = true
+		return true
+	case trimmed == s.delimiter:
+		s.open = true
+		return true
+	default:
+		return s.open
+	}
+}
+
+func boundaryParam(ct string) string {
+	params := strings.Split(ct, ";")
+	for _, p := range params[1:] {
+		k, v, ok := strings.Cut(p, "=")
+		if ok && strings.EqualFold(strings.TrimSpace(k), "boundary") {
+			return strings.Trim(strings.TrimSpace(v), `"`)
+		}
+	}
+	return ""
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -2427,6 +2427,119 @@ Content-Type: application/xml
 	}
 }
 
+func TestParseMultipartBodyPreservesBoundaryLines(t *testing.T) {
+	src := `POST https://example.com/api
+Content-Type: multipart/form-data; boundary=multipart-boundary
+
+--multipart-boundary
+Content-Disposition: form-data; name="field"
+
+value
+--multipart-boundary--
+`
+
+	doc := Parse("multipart-boundary-body.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	want := "--multipart-boundary\n" +
+		"Content-Disposition: form-data; name=\"field\"\n" +
+		"\n" +
+		"value\n" +
+		"--multipart-boundary--"
+	if got := doc.Requests[0].Body.Text; got != want {
+		t.Fatalf("unexpected body text:\nwant %q\n got %q", want, got)
+	}
+}
+
+func TestParseMultipartBodyKeepsPartContentVerbatim(t *testing.T) {
+	src := `POST https://example.com/api
+Content-Type: multipart/form-data; boundary=B
+
+--B
+Content-Disposition: form-data; name="script"; filename="run.sh"
+
+#!/bin/sh
+// not a comment
+> not a script
+@x = not a variable
+-- dashes
+--B--
+# @name upload
+`
+
+	doc := Parse("multipart-verbatim.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	want := "--B\n" +
+		"Content-Disposition: form-data; name=\"script\"; filename=\"run.sh\"\n" +
+		"\n" +
+		"#!/bin/sh\n" +
+		"// not a comment\n" +
+		"> not a script\n" +
+		"@x = not a variable\n" +
+		"-- dashes\n" +
+		"--B--"
+	if req.Body.Text != want {
+		t.Fatalf("unexpected body text:\nwant %q\n got %q", want, req.Body.Text)
+	}
+	if req.Metadata.Name != "upload" {
+		t.Fatalf("expected directive after close delimiter to parse, got name %q", req.Metadata.Name)
+	}
+	if len(req.Variables) != 0 {
+		t.Fatalf("expected no variables from part content, got %+v", req.Variables)
+	}
+	if len(req.Metadata.Scripts) != 0 {
+		t.Fatalf("expected no scripts from part content, got %d", len(req.Metadata.Scripts))
+	}
+}
+
+func TestParseMultipartWithoutBoundaryParamKeepsDashLines(t *testing.T) {
+	src := `POST https://example.com/api
+Content-Type: multipart/form-data
+
+--x
+value
+--x--
+`
+
+	doc := Parse("multipart-no-boundary.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	want := "--x\nvalue\n--x--"
+	if got := doc.Requests[0].Body.Text; got != want {
+		t.Fatalf("unexpected body text:\nwant %q\n got %q", want, got)
+	}
+}
+
+func TestParseMultipartQuotedBoundary(t *testing.T) {
+	src := `POST https://example.com/api
+Content-Type: multipart/form-data; boundary="B b"
+
+--B b
+Content-Disposition: form-data; name="note"
+
+# kept
+--B b--
+`
+
+	doc := Parse("multipart-quoted-boundary.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	want := "--B b\n" +
+		"Content-Disposition: form-data; name=\"note\"\n" +
+		"\n" +
+		"# kept\n" +
+		"--B b--"
+	if got := doc.Requests[0].Body.Text; got != want {
+		t.Fatalf("unexpected body text:\nwant %q\n got %q", want, got)
+	}
+}
+
 func TestParsePlainAngleNameWithoutContentTypeStaysInlineBody(t *testing.T) {
 	src := `POST https://example.com/api
 

--- a/internal/parser/request.go
+++ b/internal/parser/request.go
@@ -72,6 +72,7 @@ type requestBuilder struct {
 	sse               *ssebuilder.Builder
 	websocket         *wsbuilder.Builder
 	bodyOptions       restfile.BodyOptions
+	multipart         *multipartSpan
 	ssh               *restfile.SSHSpec
 	k8s               *restfile.K8sSpec
 }
@@ -199,6 +200,9 @@ func (r *requestBuilder) markHeadersDone() {
 		return
 	}
 	r.http.MarkHeadersDone()
+	if ct := r.http.MimeType(); restfile.IsMultipartMime(ct) {
+		r.multipart = newMultipartSpan(ct)
+	}
 }
 
 func (r *requestBuilder) applyHTTPBody(req *restfile.Request) {

--- a/internal/restfile/mime.go
+++ b/internal/restfile/mime.go
@@ -1,0 +1,11 @@
+package restfile
+
+import "strings"
+
+// IsMultipartMime reports whether ct names a multipart media type. ct may be a
+// raw header value with parameters, e.g. "multipart/form-data; boundary=x".
+func IsMultipartMime(ct string) bool {
+	ct = strings.TrimSpace(ct)
+	const prefix = "multipart/"
+	return len(ct) >= len(prefix) && strings.EqualFold(ct[:len(prefix)], prefix)
+}

--- a/internal/restfile/mime_test.go
+++ b/internal/restfile/mime_test.go
@@ -1,0 +1,24 @@
+package restfile
+
+import "testing"
+
+func TestIsMultipartMime(t *testing.T) {
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{"multipart/form-data; boundary=x", true},
+		{"multipart/mixed", true},
+		{"MULTIPART/Related", true},
+		{"  multipart/form-data", true},
+		{"application/json", false},
+		{"{{ct}}", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := IsMultipartMime(tt.ct); got != tt.want {
+			t.Errorf("IsMultipartMime(%q) = %v, want %v", tt.ct, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
This fixes: #310 where multipart requests were unusable: the parser ate boundary lines as "--" comments, CRLF was normalized away filewide and include injection stripped any CR that survived so servers could not parse the form.

- parser: track the multipart boundary span; everything between the first delimiter and the close delimiter is verbatim body content (directives after the close delimiter still parse)
- httpclient: reframe multipart/* bodies with CRLF at send time; `@file` includes are injected as verbatim bytes
- detect multipart from the live Content-Type header first (scripts may rewrite it after parse), shared via `restfile.IsMultipartMime`
- dedupe the `@path` include grammar into `bodyref.IncludeLine`