### PR TITLE
RST-280: mock ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ Quick links: [Screenshots](#screenshot-tour), [Installation](#installation), [Qu
 
 - **HTTP, GraphQL, gRPC, WebSocket, and SSE** are supported out of the box.
 - Requests live in plain `.http` / `.rest` files.
-- **Conditional logic** - `@when`, `@skip-if`, `@if`/`@elif`/`@else`, `@switch`/`@case`, and `@for-each`.
-- **Multi-step workflows** with `@workflow` / `@step`.
-- **Captures, variables, and assertions** (`@capture`, `@var`, `@assert`).
-- **RestermScript** - a small, safe expression language purpose.
+- **File-native automation** - conditional logic (`@when`, `@if`/`@elif`/`@else`, `@for-each`), multi-step workflows (`@workflow` / `@step`), captures, variables and assertions (`@capture`, `@var`, `@assert`).
+- **RestermScript** - a small, safe expression language purpose-built for Resterm.
 - **Vim-style TUI controls** with familiar motions, `/` search and command-line actions like `:w`, `:q`, `:q!`, `:wq`, `:x`, `:e`, `:help` and `:noh`.
 - **OAuth 2.0** (client credentials, password, auth code + PKCE), **command-backed auth** via existing CLIs, **SSH tunnels**, and **Kubernetes port-forwards** are built in - no extra tools.
 - **CLI** with `resterm run` for requests, workflows, JSON/JUnit output, and reusable run artifacts.
@@ -119,7 +117,7 @@ See the full [CLI documentation](docs/cli.md) for usage, selectors, output forma
 
 ## Mock Servers
 
-Resterm can serve mock responses straight from the same `.http` / `.rest` files your requests live in. A route can hold several named scenarios: `@match` picks one by query values, headers, or a subset of the JSON body, and the `default` scenario answers everything else.
+Resterm can serve mock responses straight from the same `.http` / `.rest` files your requests live in. A route can hold several named scenarios: `@match` picks one by query values, headers, or a subset of the JSON body, and the `default` scenario answers everything else. Responses can interpolate request data like `{{path.id}}` or `{{body.user.email}}` and a `sequence` scenario returns a different response on each call.
 
 ```http
 ### Payment accepted
@@ -160,19 +158,10 @@ The public Go API lives in the [`headless`](./headless) package and can run requ
 
 ## Quick Start
 
-1. Install Resterm using the command that matches your OS.
+1. Install Resterm (see [Installation](#installation) for install scripts, Windows, and manual installs).
 
    ```bash
-   # Linux/macOS (Homebrew)
    brew install resterm
-
-   # Linux (install script)
-   curl -fsSL https://raw.githubusercontent.com/unkn0wn-root/resterm/main/install.sh | bash
-   ```
-
-   ```powershell
-   # Windows (PowerShell)
-   iwr -useb https://raw.githubusercontent.com/unkn0wn-root/resterm/main/install.ps1 | iex
    ```
 
 2. Bootstrap a tiny workspace.
@@ -209,7 +198,7 @@ A few keys that make Resterm feel “native” quickly:
     - When editor/response are stacked: change editor/response height.
     - When the navigator is focused: collapse/expand the selected branch.
   - `g+v` / `g+s` - toggle response pane between inline and stacked layout.
-  - `g+1`, `g+2`, `g+3` + minimize/restore sidebar, editor, response.
+  - `g+1`, `g+2`, `g+3` - minimize/restore sidebar, editor, response.
   - `g+z` / `g+Z` - zoom the focused pane / clear zoom.
 
 - **Environments & globals**
@@ -321,55 +310,26 @@ The next update replaces it once no process is still running the old version.
 
 ## Collections
 
-You can export a workspace into a Git-friendly Resterm bundle. The exported bundle always includes a `manifest.json` with checksums, so imports can verify file integrity before writing anything.
-
-When Resterm sees `resterm.env.example.json` in your workspace, it includes that file as-is. If only `resterm.env.json` exists, Resterm generates `resterm.env.example.json` automatically and replaces values with `REPLACE_ME` placeholders so secrets are not exported.
-
-### Export a bundle
+Export a workspace into a Git-friendly Resterm bundle and import it into another workspace. Bundles carry a `manifest.json` with checksums so imports verify file integrity first, and environment values are replaced with `REPLACE_ME` placeholders on export so secrets stay out of the bundle.
 
 ```bash
-resterm collection export \
-  --workspace ./my-api \
-  --out ./shared/my-api-bundle \
-  --recursive \
-  --name "my-api-v1"
+resterm collection export --workspace ./my-api --out ./shared/my-api-bundle
+resterm collection import --in ./shared/my-api-bundle --workspace ./my-local-api
 ```
 
-### Import a bundle
-
-```bash
-resterm collection import \
-  --in ./shared/my-api-bundle \
-  --workspace ./my-local-api
-```
-
-If you want to preview actions first, you can run:
-
-```bash
-resterm collection import \
-  --in ./shared/my-api-bundle \
-  --workspace ./my-local-api \
-  --dry-run
-```
-
-If files already exist and should be replaced intentionally, add `--force`.
+Add `--dry-run` to preview an import and `--force` to overwrite existing files intentionally. Docs: [`docs/resterm.md#collection-sharing`](./docs/resterm.md#collection-sharing).
 
 ## Inline curl import
 
 Paste a curl command into the editor and press `Ctrl+Enter` to convert it into a structured request. Resterm understands common flags, merges repeated data segments, and keeps multipart uploads intact.
 
 ```bash
-curl \
-  --compressed \
-  --url "https://httpbin.org/post?source=resterm&case=multipart" \
+curl --compressed \
+  --url "https://httpbin.org/post?source=resterm" \
   --request POST \
   -H "Accept: application/json" \
-  -H "X-Client: resterm-dev" \
   --user resterm:test123 \
-  -F file=@README.md \
-  --form-string memo='Testing resterm inline curl
-with multiline value' \
-  --form-string meta='{"env":"test","attempt":1}'
+  -F file=@README.md
 ```
 
 If you copied the command from a shell, prefixes like `sudo` or `$` are ignored automatically.
@@ -427,10 +387,6 @@ Resterm supports unary and streaming calls with transcripts, metadata, and body 
 #### OpenAPI import
 
 Convert OpenAPI 3 specs into Resterm `.http` collections from the CLI with `--from-openapi`, passing either a local file or an `http(s)` URL (e.g. `--from-openapi https://api.example.com/openapi.json`). Use `--openapi-mode requests`, `mocks`, or `both` to choose generated blocks. Remote fetches respect the global `--insecure` and `--proxy` flags. Docs: [`docs/cli.md#import-examples`](./docs/cli.md#import-examples).
-
-#### Collection sharing
-
-Export a portable Resterm-native bundle with `resterm collection export` and import it into another workspace with `resterm collection import`. Docs: [`docs/resterm.md#collection-sharing`](./docs/resterm.md#collection-sharing).
 
 #### Curl import
 

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -759,7 +759,7 @@ Ordinary requests advance atomically through the sequence. Once the final respon
 
 `X-Resterm-Mock: polling` selects the sequence. `X-Resterm-Mock-Status: 200` pins the first sequence response with that status without advancing the cursor, and it can be combined with the name selector. Sequence progress appears in CLI and TUI request logs as `polling 2/3`.
 
-A no-op hot reload keeps the active handler and its cursors. Any source or fixture change that produces a new compiled handler resets every sequence to its first response. In a sequence's inline body, a line whose trimmed content is exactly `---` is reserved as the response delimiter; use a file-backed body when the payload must contain such a line. Outside a sequence, `---` remains ordinary body text.
+A no-op hot reload keeps the active handler and its cursors. Any source or fixture change that produces a new compiled handler resets every sequence to its first response. In a sequence's inline body, a line whose trimmed content is exactly `---` is reserved as the response delimiter; use a file-backed body when the payload must contain such a line. Outside a sequence, `---` remains ordinary body text. A `---` with no response after it at the end of the block is reported as a dangling delimiter.
 
 ### Conditional scenarios
 

--- a/internal/mock/compile.go
+++ b/internal/mock/compile.go
@@ -77,7 +77,6 @@ func (c *compiler) addMock(doc *restfile.Document, spec *restfile.Mock) error {
 	}
 	rt := &route{
 		method:   spec.Method,
-		path:     spec.Path,
 		pattern:  key,
 		label:    spec.Method + " " + spec.Path,
 		variants: []*variant{v},
@@ -117,11 +116,9 @@ func (c *compiler) newVariant(
 			return nil, err
 		}
 		if !spec.DisableInterpolation {
-			interpolate, err := validateResponseTemplates(resp, pathParams)
-			if err != nil {
+			if err := resp.compileTemplates(pathParams); err != nil {
 				return nil, err
 			}
-			resp.interpolate = interpolate
 		}
 		responses = append(responses, resp)
 	}
@@ -131,15 +128,10 @@ func (c *compiler) newVariant(
 		return nil, err
 	}
 
-	name := spec.Name
-	if spec.Sequence != "" {
-		name = spec.Sequence
-	}
 	return &variant{
-		name:       name,
+		name:       cmp.Or(spec.Sequence, spec.Name),
 		def:        spec.Default,
 		latency:    spec.Latency,
-		match:      spec.Match,
 		matchers:   ms,
 		responses:  responses,
 		pathParams: pathParams,
@@ -279,9 +271,10 @@ func (rt *route) validate() error {
 	names := make(map[string]loc)
 	var def *loc
 	for _, v := range rt.variants {
-		if prev, ok := names[v.name]; v.name != "" && ok {
-			return fmt.Errorf("%s: mock scenario name %q is already used at %s", v.src, v.name, prev)
-		} else if v.name != "" {
+		if v.name != "" {
+			if prev, ok := names[v.name]; ok {
+				return fmt.Errorf("%s: mock scenario name %q is already used at %s", v.src, v.name, prev)
+			}
 			names[v.name] = v.src
 		}
 		if !v.def {
@@ -290,8 +283,7 @@ func (rt *route) validate() error {
 		if def != nil {
 			return fmt.Errorf("%s: mock route already has a default at %s", v.src, *def)
 		}
-		src := v.src
-		def = &src
+		def = &v.src
 	}
 	return nil
 }

--- a/internal/mock/digest.go
+++ b/internal/mock/digest.go
@@ -9,13 +9,18 @@ import (
 )
 
 // digest fingerprints the effective mock configuration so reloads can skip
-// no-op handler swaps. It hashes the parsed specs - so any new field is covered
-// automatically - plus the resolved fixture bytes each response was built from,
-// so editing a fixture file (or pointing a response at a different one) reloads.
+// no-op handler swaps. It hashes each source path and its parsed specs, which
+// automatically covers any field added to the spec later. It also hashes the
+// fixture bytes each response was built from, so editing a fixture file or
+// pointing a response at a different one still reloads.
 func digest(docs []*restfile.Document, routes []*route) string {
 	h := sha256.New()
 	enc := json.NewEncoder(h)
 	for _, doc := range docs {
+		if len(doc.Mocks) == 0 {
+			continue
+		}
+		_ = enc.Encode(doc.Path)
 		for _, m := range doc.Mocks {
 			if m != nil {
 				_ = enc.Encode(m)
@@ -26,8 +31,10 @@ func digest(docs []*restfile.Document, routes []*route) string {
 		for _, v := range rt.variants {
 			for _, resp := range v.responses {
 				if resp.fixture != "" {
-					_, _ = h.Write([]byte(resp.fixture))
-					_, _ = h.Write(resp.body)
+					_ = enc.Encode(struct {
+						Fixture string
+						Body    []byte
+					}{resp.fixture, resp.body})
 				}
 			}
 		}

--- a/internal/mock/digest_test.go
+++ b/internal/mock/digest_test.go
@@ -3,9 +3,31 @@ package mock
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 )
+
+// Renaming the source file keeps the parsed specs byte-identical, but served
+// events report their source path, so the reload must swap in a fresh handler.
+func TestReloadDetectsSourceFileRename(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.http"), "# @mock method=GET path=/x\nHTTP/1.1 200 OK\n\nok")
+
+	reloader := NewReloader(root, false)
+	if _, err := reloader.Reload("", nil); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+
+	if err := os.Rename(filepath.Join(root, "a.http"), filepath.Join(root, "b.http")); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := reloader.Reload("", nil)
+	if err != nil || reloaded == nil {
+		t.Fatalf("rename reload = %v, %v; want a fresh handler", reloaded, err)
+	}
+	assertResponse(t, reloaded, httptest.NewRequest(http.MethodGet, "/x", nil), http.StatusOK, "ok")
+}
 
 // Swapping a response to a different fixture file that currently holds identical
 // bytes still changes the configuration, so the reload must not be skipped.

--- a/internal/mock/match.go
+++ b/internal/mock/match.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"mime"
 	"net/http"
 	"net/url"
@@ -54,20 +55,25 @@ func queryMatcher(want map[string][]string) matcher {
 func headerMatcher(want map[string][]string) matcher {
 	return func(p *probe) (bool, *problem) {
 		for k, vals := range want {
-			var got []string
-			if strings.EqualFold(k, "Host") {
-				if p.r.Host != "" {
-					got = []string{p.r.Host}
-				}
-			} else {
-				got = p.r.Header.Values(k)
-			}
+			got := headerValues(p.r, k)
 			if got == nil || !slices.Equal(got, vals) {
 				return false, nil
 			}
 		}
 		return true, nil
 	}
+}
+
+// headerValues reads a request header for mock config. net/http strips Host
+// out of the header map, so every header lookup needs the same special case.
+func headerValues(r *http.Request, name string) []string {
+	if strings.EqualFold(name, "Host") {
+		if r.Host == "" {
+			return nil
+		}
+		return []string{r.Host}
+	}
+	return r.Header.Values(name)
 }
 
 func jsonMatcher(want any) matcher {
@@ -200,20 +206,16 @@ func subset(want, got any) bool {
 	}
 }
 
-// equalJSONNumbers compares two JSON numbers by value so 100, 1e2 and 100.0 all
-// match. The int64 path keeps integers exact past float64's 2^53; the float64
-// fallback handles the rest and, unlike big.Rat, cannot be made to allocate
-// 10^exp by a hostile request - ParseFloat returns +Inf for a runaway exponent.
+// equalJSONNumbers compares two JSON numbers by value so 100, 1e2 and 100.0
+// all match. 256 bits keep mixed int/decimal forms exact far past float64's
+// 2^53. Unlike big.Rat, a hostile request cannot make this allocate 10^exp
+// bytes, because a runaway exponent just saturates to Inf and Inf never
+// matches anything.
 func equalJSONNumbers(want, got json.Number) bool {
 	if want == got {
 		return true
 	}
-	if a, err := want.Int64(); err == nil {
-		if b, err := got.Int64(); err == nil {
-			return a == b
-		}
-	}
-	a, aerr := want.Float64()
-	b, berr := got.Float64()
-	return aerr == nil && berr == nil && a == b
+	a, _, aerr := big.ParseFloat(string(want), 10, 256, big.ToNearestEven)
+	b, _, berr := big.ParseFloat(string(got), 10, 256, big.ToNearestEven)
+	return aerr == nil && berr == nil && !a.IsInf() && !b.IsInf() && a.Cmp(b) == 0
 }

--- a/internal/mock/match_test.go
+++ b/internal/mock/match_test.go
@@ -17,11 +17,14 @@ func TestEqualJSONNumbers(t *testing.T) {
 		{"100", "1e2", true},
 		{"1.5", "1.50", true},
 		{"9007199254740993", "9.007199254740993e15", true}, // same value, different form
-		{"9007199254740993", "9007199254740992", false},    // adjacent ints stay distinct (int64 path)
+		{"9007199254740993", "9007199254740992", false},    // adjacent ints stay distinct
+		{"9007199254740993", "9007199254740992.0", false},  // ...even when one side is a decimal
 		{"1e100", "10e99", true},
 		{"1", "2", false},
 		{"1", "1e999999999", false}, // runaway exponent stays cheap (ParseFloat -> +Inf)
 		{"1e999999999", "1", false},
+		{"1e999999999", "1e999999999", true},  // byte-identical short-circuits before Inf
+		{"1e999999999", "2e999999999", false}, // distinct overflows never compare equal
 	}
 	for _, tt := range tests {
 		t.Run(tt.a+"_"+tt.b, func(t *testing.T) {

--- a/internal/mock/route.go
+++ b/internal/mock/route.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 type loc struct {
@@ -30,7 +31,6 @@ type variant struct {
 	name       string
 	def        bool
 	latency    time.Duration
-	match      restfile.MockMatch // only feeds the digest, matching uses matchers
 	matchers   []matcher
 	responses  []response
 	pathParams map[string]string
@@ -39,16 +39,18 @@ type variant struct {
 }
 
 type response struct {
-	status      int
-	headers     http.Header
-	body        []byte
-	fixture     string
-	interpolate bool
+	status  int
+	headers http.Header
+	body    []byte
+	fixture string
+	// set at compile time so rendering only touches the parts with templates
+	interpHeaders bool
+	interpBody    bool
+	bodyTpl       vars.Template
 }
 
 type route struct {
 	method   string
-	path     string
 	pattern  string
 	label    string
 	variants []*variant
@@ -62,7 +64,7 @@ func (rt *route) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	event.Route = rt.label
 
 	p := &probe{r: r}
-	sel, err := rt.pick(r, p)
+	sel, err := rt.pick(p)
 	if err != nil {
 		event.Error = err.detail
 		writeProblem(w, err.status, err.detail)
@@ -90,7 +92,7 @@ func (rt *route) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	rendered, renderErr := renderMockResponse(v, resp, r, p)
+	rendered, renderErr := v.render(resp, p)
 	if renderErr != nil {
 		event.Error = renderErr.detail
 		writeProblem(w, renderErr.status, renderErr.detail)

--- a/internal/mock/select.go
+++ b/internal/mock/select.go
@@ -29,30 +29,34 @@ type selection struct {
 	step int
 }
 
-func (rt *route) pick(r *http.Request, p *probe) (selection, *problem) {
-	name := strings.TrimSpace(r.Header.Get(selectorNameHeader))
-	status, err := parseStatus(r.Header.Get(selectorStatusHeader))
+func (rt *route) pick(p *probe) (selection, *problem) {
+	name := strings.TrimSpace(p.r.Header.Get(selectorNameHeader))
+	status, err := parseStatus(p.r.Header.Get(selectorStatusHeader))
 	if err != nil {
 		return selection{}, err
 	}
+	v, err := rt.variantFor(name, status, p)
+	if err != nil {
+		return selection{}, err
+	}
+	return v.selectResponse(status), nil
+}
+
+func (rt *route) variantFor(name string, status int, p *probe) (*variant, *problem) {
 	if name != "" {
-		v, selectErr := rt.named(name, status)
-		if selectErr != nil {
-			return selection{}, selectErr
-		}
-		return v.selectResponse(status), nil
+		return rt.named(name, status)
 	}
 
 	vs := rt.variants
 	if status != 0 {
 		vs = make([]*variant, 0, len(rt.variants))
 		for _, v := range rt.variants {
-			if v.hasStatus(status) {
+			if _, ok := v.stepFor(status); ok {
 				vs = append(vs, v)
 			}
 		}
 		if len(vs) == 0 {
-			return selection{}, &problem{
+			return nil, &problem{
 				status: http.StatusNotFound,
 				detail: fmt.Sprintf("mock status %d was not found for this route", status),
 			}
@@ -63,25 +67,25 @@ func (rt *route) pick(r *http.Request, p *probe) (selection, *problem) {
 		if len(v.matchers) == 0 {
 			continue
 		}
-		matched, matchErr := v.matches(p)
-		if matchErr != nil {
-			return selection{}, matchErr
+		matched, err := v.matches(p)
+		if err != nil {
+			return nil, err
 		}
 		if matched {
-			return v.selectResponse(status), nil
+			return v, nil
 		}
 	}
 	for _, v := range vs {
 		if v.def {
-			return v.selectResponse(status), nil
+			return v, nil
 		}
 	}
 	for _, v := range vs {
 		if len(v.matchers) == 0 {
-			return v.selectResponse(status), nil
+			return v, nil
 		}
 	}
-	return selection{}, &problem{
+	return nil, &problem{
 		status: http.StatusNotFound,
 		detail: "no mock scenario matched the request",
 	}
@@ -92,10 +96,12 @@ func (rt *route) named(name string, status int) (*variant, *problem) {
 		if v.name != name {
 			continue
 		}
-		if status != 0 && !v.hasStatus(status) {
-			return nil, &problem{
-				status: http.StatusNotFound,
-				detail: fmt.Sprintf("mock scenario %q has no response with status %d", name, status),
+		if status != 0 {
+			if _, ok := v.stepFor(status); !ok {
+				return nil, &problem{
+					status: http.StatusNotFound,
+					detail: fmt.Sprintf("mock scenario %q has no response with status %d", name, status),
+				}
 			}
 		}
 		return v, nil
@@ -109,38 +115,30 @@ func (rt *route) named(name string, status int) (*variant, *problem) {
 func (v *variant) selectResponse(status int) selection {
 	step := 0
 	if status == 0 {
-		step = v.nextResponse()
-	} else {
-		for i := range v.responses {
-			if v.responses[i].status == status {
-				step = i
-				break
-			}
-		}
+		step = v.advance()
+	} else if i, ok := v.stepFor(status); ok {
+		step = i
 	}
 	return selection{v: v, step: step}
 }
 
-func (v *variant) nextResponse() int {
-	last := uint64(len(v.responses) - 1)
-	for {
-		current := v.next.Load()
-		if current >= last {
-			return int(last)
-		}
-		if v.next.CompareAndSwap(current, current+1) {
-			return int(current)
-		}
+// advance returns the next sequence step, sticking at the final response once
+// the sequence is exhausted.
+func (v *variant) advance() int {
+	last := len(v.responses) - 1
+	if n := v.next.Add(1) - 1; n < uint64(last) {
+		return int(n)
 	}
+	return last
 }
 
-func (v *variant) hasStatus(status int) bool {
-	for _, resp := range v.responses {
+func (v *variant) stepFor(status int) (int, bool) {
+	for i, resp := range v.responses {
 		if resp.status == status {
-			return true
+			return i, true
 		}
 	}
-	return false
+	return 0, false
 }
 
 func parseStatus(raw string) (int, *problem) {

--- a/internal/mock/template.go
+++ b/internal/mock/template.go
@@ -39,30 +39,40 @@ func parseRequestTemplate(name string) (requestTemplate, bool) {
 	return ref, true
 }
 
-func validateResponseTemplates(resp response, pathParams map[string]string) (bool, error) {
-	hasTemplates := false
-	for name, values := range resp.headers {
+// compileTemplates validates every placeholder against the route's path params
+// and records which parts of the response need per-request interpolation.
+func (r *response) compileTemplates(pathParams map[string]string) error {
+	for name, values := range r.headers {
 		for _, value := range values {
-			hasTemplate, err := validateTemplateString(value, pathParams)
+			has, err := validateTemplateString(value, pathParams)
 			if err != nil {
-				return false, fmt.Errorf("response header %q: %w", name, err)
+				return fmt.Errorf("response header %q: %w", name, err)
 			}
-			hasTemplates = hasTemplates || hasTemplate
+			r.interpHeaders = r.interpHeaders || has
 		}
 	}
-	bodyHasTemplate, err := validateTemplateString(string(resp.body), pathParams)
+	body := string(r.body)
+	has, err := validateTemplateString(body, pathParams)
 	if err != nil {
-		return false, fmt.Errorf("response body: %w", err)
+		return fmt.Errorf("response body: %w", err)
 	}
-	return hasTemplates || bodyHasTemplate, nil
+	if has {
+		r.interpBody = true
+		r.bodyTpl = vars.CompileTemplate(body)
+	}
+	return nil
 }
 
 // Use the same template scanner during validation and rendering so both paths
-// agree on what counts as a placeholder. An unterminated "{{" stays literal.
+// agree on what counts as a placeholder. An unterminated "{{" or a blank
+// "{{ }}" stays literal, exactly as the resolver renders it.
 func validateTemplateString(input string, pathParams map[string]string) (bool, error) {
 	has := false
 	var err error
 	vars.ReplaceTemplateVars(input, func(match, name string) string {
+		if name == "" {
+			return match
+		}
 		has = true
 		if err == nil {
 			err = validateTemplateName(name, pathParams)
@@ -73,9 +83,6 @@ func validateTemplateString(input string, pathParams map[string]string) (bool, e
 }
 
 func validateTemplateName(name string, pathParams map[string]string) error {
-	if name == "" {
-		return fmt.Errorf("response template name cannot be empty")
-	}
 	if strings.HasPrefix(name, "=") {
 		return fmt.Errorf("response templates do not support expressions")
 	}
@@ -120,46 +127,47 @@ func invalidTemplateSubject(subject string) bool {
 	}) >= 0
 }
 
-func renderMockResponse(
-	v *variant,
-	resp *response,
-	r *http.Request,
-	p *probe,
-) (renderedResponse, *problem) {
-	if !resp.interpolate {
-		return renderedResponse{headers: resp.headers, body: resp.body}, nil
+func (v *variant) render(resp *response, p *probe) (renderedResponse, *problem) {
+	out := renderedResponse{headers: resp.headers, body: resp.body}
+	if !resp.interpHeaders && !resp.interpBody {
+		return out, nil
 	}
 
-	provider := &requestProvider{request: r, probe: p, pathParams: v.pathParams}
+	provider := &requestProvider{probe: p, pathParams: v.pathParams}
 	resolver := vars.NewResolver(provider)
-	headers := make(http.Header, len(resp.headers))
-	for name, values := range resp.headers {
-		for _, value := range values {
-			expanded, err := resolver.ExpandTemplates(value)
-			if err != nil {
-				return renderedResponse{}, provider.renderProblem(err)
-			}
-			if !httpguts.ValidHeaderFieldValue(expanded) {
-				return renderedResponse{}, &problem{
-					status: http.StatusInternalServerError,
-					detail: fmt.Sprintf(
-						"mock response interpolation produced an invalid value for header %q",
-						name,
-					),
+	if resp.interpHeaders {
+		headers := make(http.Header, len(resp.headers))
+		for name, values := range resp.headers {
+			for _, value := range values {
+				expanded, err := resolver.ExpandTemplates(value)
+				if err != nil {
+					return renderedResponse{}, provider.renderProblem(err)
 				}
+				if !httpguts.ValidHeaderFieldValue(expanded) {
+					return renderedResponse{}, &problem{
+						status: http.StatusInternalServerError,
+						detail: fmt.Sprintf(
+							"mock response interpolation produced an invalid value for header %q",
+							name,
+						),
+					}
+				}
+				headers.Add(name, expanded)
 			}
-			headers.Add(name, expanded)
 		}
+		out.headers = headers
 	}
-	body, err := resolver.ExpandTemplates(string(resp.body))
-	if err != nil {
-		return renderedResponse{}, provider.renderProblem(err)
+	if resp.interpBody {
+		body, err := resp.bodyTpl.Render(resolver)
+		if err != nil {
+			return renderedResponse{}, provider.renderProblem(err)
+		}
+		out.body = []byte(body)
 	}
-	return renderedResponse{headers: headers, body: []byte(body)}, nil
+	return out, nil
 }
 
 type requestProvider struct {
-	request    *http.Request
 	probe      *probe
 	pathParams map[string]string
 	problem    *problem
@@ -174,10 +182,8 @@ func (p *requestProvider) Resolve(name string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	if !ref.encodeJSON {
-		if text, ok := value.(string); ok {
-			return text, true
-		}
+	if text, ok := value.(string); ok && !ref.encodeJSON {
+		return text, true
 	}
 	data, err := json.Marshal(value)
 	if err != nil {
@@ -214,7 +220,7 @@ func (p *requestProvider) resolvePath(name string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return p.request.PathValue(wildcard), true
+	return p.probe.r.PathValue(wildcard), true
 }
 
 func (p *requestProvider) resolveQuery(name string) (string, bool) {
@@ -227,14 +233,7 @@ func (p *requestProvider) resolveQuery(name string) (string, bool) {
 }
 
 func (p *requestProvider) resolveHeader(name string) (string, bool) {
-	if strings.EqualFold(name, "Host") {
-		if p.request.Host == "" {
-			p.missing("request header", name)
-			return "", false
-		}
-		return p.request.Host, true
-	}
-	values := p.request.Header.Values(name)
+	values := headerValues(p.probe.r, name)
 	if len(values) == 0 {
 		p.missing("request header", name)
 		return "", false

--- a/internal/mock/template_test.go
+++ b/internal/mock/template_test.go
@@ -346,6 +346,15 @@ HTTP/1.1 200 OK
 	assertResponse(t, handler, req, http.StatusOK, "expanded {{oops")
 }
 
+func TestResponseInterpolationServesBlankPlaceholderLiterally(t *testing.T) {
+	handler := compileSource(t, `# @mock method=GET path=/x
+HTTP/1.1 200 OK
+
+{{}} {{ }} {{query.v}}`)
+	req := httptest.NewRequest(http.MethodGet, "/x?v=expanded", nil)
+	assertResponse(t, handler, req, http.StatusOK, "{{}} {{ }} expanded")
+}
+
 func TestCompileRejectsInvalidResponseTemplates(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/parser/mock.go
+++ b/internal/parser/mock.go
@@ -140,13 +140,13 @@ func (b *documentBuilder) checkMockRoute(line int, m *mockBuilder) {
 }
 
 func (b *documentBuilder) handleMockBlockLine(ln int, line, trimmed string) {
+	m := b.mock
 	if strings.HasPrefix(trimmed, "###") {
-		b.mock.trimStructuralBlankLine()
+		m.trimStructuralBlankLine()
 		b.handleSeparator(ln, trimmed)
 		return
 	}
 
-	m := b.mock
 	m.endLine = ln
 	if m.sequence != "" && restfile.IsMockSequenceDelimiter(trimmed) {
 		if !m.started() {

--- a/internal/parser/mock.go
+++ b/internal/parser/mock.go
@@ -39,6 +39,7 @@ type mockBuilder struct {
 	headers              http.Header
 	inBody               bool
 	body                 []string
+	delimLine            int
 }
 
 func (b *documentBuilder) handleMockDirective(line int, key, raw string) bool {
@@ -149,6 +150,7 @@ func (b *documentBuilder) handleMockBlockLine(ln int, line, trimmed string) {
 
 	m.endLine = ln
 	if m.sequence != "" && restfile.IsMockSequenceDelimiter(trimmed) {
+		m.delimLine = ln
 		if !m.started() {
 			b.addMockError(ln, "@mock sequence has an empty response")
 			return
@@ -290,6 +292,9 @@ func (b *documentBuilder) flushMock() {
 		return
 	}
 	m := b.mock
+	if m.delimLine > 0 && !m.started() {
+		b.addMockError(m.delimLine, "@mock sequence ends with a dangling delimiter")
+	}
 	if m.started() || len(m.responses) == 0 {
 		m.finishResponse(b, m.endLine)
 	}
@@ -337,7 +342,7 @@ func (m *mockBuilder) finishResponse(b *documentBuilder, line int) {
 }
 
 // started reports whether the current response has begun accumulating, so a
-// trailing or stray '---' does not finalize a phantom empty response.
+// stray '---' is reported instead of finalizing a phantom empty response.
 func (m *mockBuilder) started() bool {
 	return m.status != 0 || len(m.body) > 0
 }

--- a/internal/parser/mock_test.go
+++ b/internal/parser/mock_test.go
@@ -129,7 +129,7 @@ after
 	}
 }
 
-func TestParseMockSequenceTrailingDelimiter(t *testing.T) {
+func TestParseMockSequenceTrailingDelimiterErrors(t *testing.T) {
 	src := `# @mock method=GET path=/x sequence=poll
 HTTP/1.1 503 Service Unavailable
 
@@ -141,8 +141,11 @@ done
 ---
 `
 	doc := Parse("mocks.http", []byte(src))
-	if len(doc.Errors) != 0 {
-		t.Fatalf("errors = %+v", doc.Errors)
+	if len(doc.Errors) != 1 || !strings.Contains(doc.Errors[0].Message, "dangling delimiter") {
+		t.Fatalf("errors = %+v, want one dangling delimiter error", doc.Errors)
+	}
+	if got := doc.Errors[0].Line; got != 9 {
+		t.Fatalf("error line = %d, want 9 (the trailing delimiter)", got)
 	}
 	if got := len(doc.Mocks[0].Responses); got != 2 {
 		t.Fatalf("responses = %d, want 2 (no phantom from trailing delimiter)", got)

--- a/internal/restwriter/writer.go
+++ b/internal/restwriter/writer.go
@@ -215,11 +215,8 @@ func NormalizeMockBody(body string) (string, error) {
 		return body, err
 	}
 	lines := strings.Split(body, "\n")
-	if _, isFile := bodyref.Parse(
-		lines[0],
-		bodyref.Options{Location: bodyref.Line},
-	); isFile &&
-		util.AllBlank(lines[1:]) {
+	_, isFile := bodyref.Parse(lines[0], bodyref.Options{Location: bodyref.Line})
+	if isFile && util.AllBlank(lines[1:]) {
 		return "", errors.New("mock body looks like a file reference")
 	}
 	return body, nil

--- a/internal/rts/jsonpath.go
+++ b/internal/rts/jsonpath.go
@@ -92,7 +92,6 @@ func ValidJSONPath(path string) bool {
 	}
 
 	needKey := true
-	allowBracket := true
 	for i := 0; i < len(p); {
 		switch p[i] {
 		case '.':
@@ -100,18 +99,13 @@ func ValidJSONPath(path string) bool {
 				return false
 			}
 			needKey = true
-			allowBracket = false
 			i++
 		case '[':
-			if !allowBracket {
-				return false
-			}
 			next, ok := validJSONPathBracket(p, i)
 			if !ok {
 				return false
 			}
 			needKey = false
-			allowBracket = true
 			i = next
 		default:
 			if !needKey {
@@ -132,7 +126,6 @@ func ValidJSONPath(path string) bool {
 				return false
 			}
 			needKey = false
-			allowBracket = true
 		}
 	}
 	return !needKey
@@ -148,7 +141,7 @@ func validJSONPathBracket(path string, start int) (int, bool) {
 		return end + 1, ok
 	}
 	res := readIdx(path, i)
-	return res.next + 1, res.ok && !res.stop && res.idx >= 0
+	return res.next + 1, res.ok && res.idx >= 0
 }
 
 func splitPath(p string) []jseg {

--- a/internal/rts/jsonpath_test.go
+++ b/internal/rts/jsonpath_test.go
@@ -9,6 +9,7 @@ func TestValidJSONPath(t *testing.T) {
 	}{
 		{path: "user.id", want: true},
 		{path: "items[0].id", want: true},
+		{path: "items.[0].id", want: true}, // JSONPathGet resolves this form too
 		{path: `$["display.name"]`, want: true},
 		{path: "user..id", want: false},
 		{path: "items[nope]", want: false},

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -5,15 +5,12 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/unkn0wn-root/resterm/internal/duration"
 )
-
-var templateVarPattern = regexp.MustCompile(`\{\{([^}]+)\}\}`)
 
 type Provider interface {
 	Resolve(name string) (string, bool)
@@ -155,15 +152,15 @@ func providerLabel(p Provider) string {
 }
 
 func (r *Resolver) ExpandTemplates(input string) (string, error) {
-	return r.expandTemplates(input, r.exprPos, true, true)
+	return CompileTemplate(input).render(r, r.exprPos, true, true)
 }
 
 func (r *Resolver) ExpandTemplatesAt(input string, pos ExprPos) (string, error) {
-	return r.expandTemplates(input, pos, true, true)
+	return CompileTemplate(input).render(r, pos, true, true)
 }
 
 func (r *Resolver) ExpandTemplatesStatic(input string) (string, error) {
-	return r.expandTemplates(input, r.exprPos, false, false)
+	return CompileTemplate(input).render(r, r.exprPos, false, false)
 }
 
 func (r *Resolver) AddRefResolver(fn RefResolver) {
@@ -182,70 +179,42 @@ func (r *Resolver) SetExprPos(pos ExprPos) {
 	r.exprPos = pos
 }
 
-func (r *Resolver) expandTemplates(
-	input string,
-	pos ExprPos,
-	allowDynamic, allowExpr bool,
-) (string, error) {
-	var firstErr error
-	result := ReplaceTemplateVars(input, func(match, name string) string {
-		if name == "" {
-			return match
+// resolveName resolves one placeholder name. A non-nil error means the
+// placeholder cannot be resolved and callers keep it as literal text.
+func (r *Resolver) resolveName(name string, pos ExprPos, allowDynamic, allowExpr bool) (string, error) {
+	if strings.HasPrefix(name, "=") {
+		if !allowExpr {
+			return "", fmt.Errorf("expressions not allowed")
 		}
-		if strings.HasPrefix(name, "=") {
-			if !allowExpr {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("expressions not allowed")
-				}
-				return match
-			}
-			expr := strings.TrimSpace(name[1:])
-			if expr == "" {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("empty expression")
-				}
-				return match
-			}
-			if r.expr == nil {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("expressions not enabled")
-				}
-				return match
-			}
-			val, err := r.expr(expr, pos)
-			if err != nil {
-				if firstErr == nil {
-					firstErr = err
-				}
-				return match
-			}
-			return val
+		expr := strings.TrimSpace(name[1:])
+		if expr == "" {
+			return "", fmt.Errorf("empty expression")
 		}
-		if allowDynamic && strings.HasPrefix(name, "$") {
-			if value, ok := r.Resolve(name); ok {
-				return value
-			}
-			if dynamic, ok := resolveDynamic(name); ok {
-				r.traceVar(ResolveTrace{
-					Name:    name,
-					Source:  "dynamic",
-					Value:   dynamic,
-					Dynamic: true,
-					Uses:    1,
-				})
-				return dynamic
-			}
+		if r.expr == nil {
+			return "", fmt.Errorf("expressions not enabled")
 		}
+		return r.expr(expr, pos)
+	}
+	if allowDynamic && strings.HasPrefix(name, "$") {
 		if value, ok := r.Resolve(name); ok {
-			return value
+			return value, nil
 		}
-		r.traceVar(ResolveTrace{Name: name, Missing: true, Uses: 1})
-		if firstErr == nil {
-			firstErr = fmt.Errorf("undefined variable: %s", name)
+		if dynamic, ok := resolveDynamic(name); ok {
+			r.traceVar(ResolveTrace{
+				Name:    name,
+				Source:  "dynamic",
+				Value:   dynamic,
+				Dynamic: true,
+				Uses:    1,
+			})
+			return dynamic, nil
 		}
-		return match
-	})
-	return result, firstErr
+	}
+	if value, ok := r.Resolve(name); ok {
+		return value, nil
+	}
+	r.traceVar(ResolveTrace{Name: name, Missing: true, Uses: 1})
+	return "", fmt.Errorf("undefined variable: %s", name)
 }
 
 func resolveDynamic(name string) (string, bool) {
@@ -374,15 +343,12 @@ func (EnvProvider) Label() string {
 	return "env"
 }
 
+// ReplaceTemplateVars rewrites every {{...}} in input through fn. The
+// callback gets the raw match and the trimmed name, which is empty for a
+// blank {{ }}.
 func ReplaceTemplateVars(input string, fn func(match, name string) string) string {
 	if fn == nil {
 		return input
 	}
-	return templateVarPattern.ReplaceAllStringFunc(input, func(match string) string {
-		sub := templateVarPattern.FindStringSubmatch(match)
-		if len(sub) < 2 {
-			return match
-		}
-		return fn(match, strings.TrimSpace(sub[1]))
-	})
+	return CompileTemplate(input).replace(fn)
 }

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -1,0 +1,95 @@
+package vars
+
+import (
+	"regexp"
+	"strings"
+)
+
+var templateVarPattern = regexp.MustCompile(`\{\{([^}]+)\}\}`)
+
+// Template is input pre-split into literal chunks and placeholders so hot
+// paths can render repeatedly without rescanning the text. It is the single
+// traversal implementation behind ExpandTemplates, Render and
+// ReplaceTemplateVars, so all of them agree on what counts as a placeholder.
+type Template struct {
+	segs []tplSeg
+}
+
+type tplSeg struct {
+	text string // literal text, or the raw {{...}} match when ph is set
+	name string // trimmed placeholder name, blank for literals and {{ }}
+	ph   bool
+}
+
+func CompileTemplate(input string) Template {
+	ms := templateVarPattern.FindAllStringSubmatchIndex(input, -1)
+	if len(ms) == 0 {
+		if input == "" {
+			return Template{}
+		}
+		return Template{segs: []tplSeg{{text: input}}}
+	}
+
+	segs := make([]tplSeg, 0, 2*len(ms)+1)
+	last := 0
+	for _, m := range ms {
+		if m[0] > last {
+			segs = append(segs, tplSeg{text: input[last:m[0]]})
+		}
+		segs = append(segs, tplSeg{
+			text: input[m[0]:m[1]],
+			name: strings.TrimSpace(input[m[2]:m[3]]),
+			ph:   true,
+		})
+		last = m[1]
+	}
+	if last < len(input) {
+		segs = append(segs, tplSeg{text: input[last:]})
+	}
+	return Template{segs: segs}
+}
+
+// Render expands the template the same way ExpandTemplates does. An
+// unresolvable or blank placeholder stays literal and only the first error
+// is reported.
+func (t Template) Render(r *Resolver) (string, error) {
+	return t.render(r, r.exprPos, true, true)
+}
+
+func (t Template) render(r *Resolver, pos ExprPos, allowDynamic, allowExpr bool) (string, error) {
+	var firstErr error
+	out := t.replace(func(match, name string) string {
+		if name == "" {
+			return match
+		}
+		value, err := r.resolveName(name, pos, allowDynamic, allowExpr)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			return match
+		}
+		return value
+	})
+	return out, firstErr
+}
+
+// replace rebuilds the input and passes every placeholder through fn, even a
+// blank {{ }}.
+func (t Template) replace(fn func(match, name string) string) string {
+	if len(t.segs) == 0 {
+		return ""
+	}
+	if len(t.segs) == 1 && !t.segs[0].ph {
+		return t.segs[0].text
+	}
+	var b strings.Builder
+	for _, s := range t.segs {
+		if s.ph {
+			b.WriteString(fn(s.text, s.name))
+		} else {
+			b.WriteString(s.text)
+		}
+	}
+	return b.String()
+}

--- a/internal/vars/template_test.go
+++ b/internal/vars/template_test.go
@@ -1,0 +1,70 @@
+package vars
+
+import (
+	"slices"
+	"strconv"
+	"testing"
+)
+
+// Callers rely on fn seeing every regex match, including a blank {{ }} with
+// an empty trimmed name. A bare {{}} and an unterminated {{ never match.
+func TestReplaceTemplateVarsCallbackContract(t *testing.T) {
+	var calls []string
+	out := ReplaceTemplateVars("a {{x}} b {{ }} c {{}} {{oops", func(match, name string) string {
+		calls = append(calls, match+"|"+name)
+		return "<" + name + ">"
+	})
+	if want := "a <x> b <> c {{}} {{oops"; out != want {
+		t.Fatalf("out = %q, want %q", out, want)
+	}
+	if want := []string{"{{x}}|x", "{{ }}|"}; !slices.Equal(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+// Render must stay byte-for-byte equivalent to ExpandTemplates, including how
+// unresolved placeholders stay literal while only the first error is reported.
+func TestCompileTemplateRenderMatchesExpandTemplates(t *testing.T) {
+	r := NewResolver(NewMapProvider("test", map[string]string{"name": "resterm", "empty": ""}))
+	inputs := []string{
+		"",
+		"plain text",
+		"{{name}}",
+		"pre {{name}} post",
+		"{{ name }} padded",
+		"{{name}}{{name}}",
+		"{{empty}}[]",
+		"{{missing}} tail",
+		"{{missing}} then {{other}}",
+		"{{}} blank stays literal",
+		"{{ }} blank stays literal",
+		"unterminated {{oops",
+		"{{= }} empty expression",
+		"{{=1+1}} expressions not enabled",
+		"{{$nosuchdynamic}}",
+		"mixed {{name}} {{missing}} {{ }} {{name}}",
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			want, wantErr := r.ExpandTemplates(input)
+			got, gotErr := CompileTemplate(input).Render(r)
+			if got != want {
+				t.Fatalf("Render = %q, ExpandTemplates = %q", got, want)
+			}
+			if (gotErr == nil) != (wantErr == nil) ||
+				(gotErr != nil && gotErr.Error() != wantErr.Error()) {
+				t.Fatalf("Render error = %v, ExpandTemplates error = %v", gotErr, wantErr)
+			}
+		})
+	}
+}
+
+func TestCompileTemplateRenderResolvesDynamics(t *testing.T) {
+	out, err := CompileTemplate("{{$timestamp}}").Render(NewResolver())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := strconv.ParseInt(out, 10, 64); err != nil {
+		t.Fatalf("Render($timestamp) = %q, want a unix timestamp", out)
+	}
+}


### PR DESCRIPTION
- match JSON numbers by value past 2^53 using big.Float, so a decimal form of an adjacent integer no longer matches
- include source paths in the reload digest, so renaming a mock file swaps the handler and log events stop pointing at the old file
- accept dot-then-bracket JSON paths in templates, the form JSONPathGet already resolves at runtime
- serve blank {{ }} placeholders literally instead of failing compile
- report a trailing --- in a mock sequence as a dangling delimiter parse error instead of silently dropping it
- precompile response body templates and unify all placeholder scanning behind vars.Template, one scanner and one dispatch for validation, rendering, expansion and capture
- render only the response parts that actually contain templates
- drop dead variant.match and route.path, share the Host header special case, simplify sequence step selection
- small readme improvements