### PR TITLE
RST-292: env-less workspace reopen

### DIFF
--- a/internal/ui/model_workspace_change_test.go
+++ b/internal/ui/model_workspace_change_test.go
@@ -185,6 +185,27 @@ func TestReopeningSameWorkspaceKeepsRuntimeState(t *testing.T) {
 	}
 }
 
+// A workspace with no environment file has nothing to compare a move against,
+// so reopening it once looked like a move between two env-less workspaces.
+func TestReopeningEnvlessWorkspaceKeepsRuntimeState(t *testing.T) {
+	base := workspaceFixture(t)
+	m := workspaceModel(t, base, "", "")
+	m.applyOpenDirectory(filepath.Join(base, "C"))
+
+	scope := m.ws.active.Scope()
+	m.globalsStore().Set(scope, "captured.token", "KEEP", false)
+	m.fileStore().Set(scope, filepath.Join(base, "C", "req.http"), "file.token", "KEEP", false)
+
+	m.applyOpenDirectory(filepath.Join(base, "C"))
+
+	if snap := m.globalsStore().Snapshot(scope); len(snap) == 0 {
+		t.Fatal("reopening the same env-less workspace discarded globals")
+	}
+	if got := m.fileStore().Entries(); len(got) == 0 {
+		t.Fatal("reopening the same env-less workspace discarded file values")
+	}
+}
+
 func TestOpenWorkspaceWithoutEnvironmentClearsIt(t *testing.T) {
 	base := workspaceFixture(t)
 	m := workspaceModel(t, base, "", "")

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -102,7 +102,7 @@ func (w workspace) plan(root string) (wsMove, error) {
 		root:    root,
 		cat:     cat,
 		envFile: envFile,
-		reset:   !sameEnvFile(envFile, w.envFile),
+		reset:   !w.sameEnv(root, envFile),
 		status:  statusMsg{text: text, level: statusInfo},
 	}
 	if cat.Empty() {
@@ -136,8 +136,17 @@ func (w workspace) plan(root string) (wsMove, error) {
 	return mv, nil
 }
 
-// Two workspaces without an environment file share nothing nameable, so a
-// move between them still crosses a boundary and resets.
+// sameEnv reports whether a move to root keeps the environment the runtime
+// values were captured under. Two workspaces without an environment file share
+// nothing nameable, so a move between them still crosses a boundary and resets,
+// but reopening the same root is not a crossing at all.
+func (w workspace) sameEnv(root, envFile string) bool {
+	if sameEnvFile(envFile, w.envFile) {
+		return true
+	}
+	return envFile == "" && w.envFile == "" && util.SameFile(root, w.root)
+}
+
 func sameEnvFile(a, b string) bool {
 	return a != "" && b != "" && util.SameFile(a, b)
 }


### PR DESCRIPTION
A workspace with no environment file compared as different from itself, because sameEnvFile treats an empty path as unknown. Reopening that root planned a reset and wiped globals, file values, cookies and cached tokenscaptured during the session.

Moves compare the root as well when neither side has an environment file, so a real crossing between two env-less workspaces still resets.