### PR TITLE
RST-297: nested variable expansion

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -1081,6 +1081,8 @@ Accept: application/json
 
 Values are taken verbatim which means that quotes are not special, so `# @file greeting "hello world"` stores the quotes as part of the value. If you need spaces, just write them directly: `# @file greeting hello world`.
 
+Declared values may reference other variables and dynamic helpers, so `# @request trace.id {{$uuid}}` works as expected. Nested references expand when the request runs, and a declared dynamic such as `{{$uuid}}` is generated once per execution, so every reference to `{{trace.id}}` in the same request sees the same value. Values captured at runtime (captures, script `vars.set`) are data and are never re-expanded. Self- or mutually-referencing variables fail the request with a `variable cycle` error that lists the reference chain.
+
 You can also use shorthand assignments outside comment blocks: `@requestId = {{$uuid}}`. Shorthand defaults to request scope while you're inside a request block and to file scope elsewhere; add a prefix to override (`@global api.token abc`, `@request trace.id {{$uuid}}`, or `@file base.url https://example.com`).
 
 Append `-secret` (`global-secret`, `file-secret`, `request-secret`) to mask stored values in summaries; this works for both comment directives and shorthand lines (`@global-secret token xyz`, `@file-secret base.url ...`, `@request-secret trace.id ...`).

--- a/internal/engine/headless/engine_test.go
+++ b/internal/engine/headless/engine_test.go
@@ -1,10 +1,13 @@
 package headless
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -596,4 +599,72 @@ func testDocumentRequest(url string) (*restfile.Document, *restfile.Request) {
 		Path:     "smoke.http",
 		Requests: []*restfile.Request{req},
 	}, req
+}
+
+func TestEngineExpandsDeclaredVariableTemplates(t *testing.T) {
+	type observedRequest struct {
+		body  string
+		trace string
+		err   error
+	}
+	observed := make(chan observedRequest, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			observed <- observedRequest{err: fmt.Errorf("read request body: %w", err)}
+			return
+		}
+		if _, err := fmt.Fprint(w, `{"ok":true}`); err != nil {
+			observed <- observedRequest{err: fmt.Errorf("write response: %w", err)}
+			return
+		}
+		observed <- observedRequest{body: string(data), trace: r.Header.Get("X-Trace-Id")}
+	}))
+	defer srv.Close()
+
+	src := strings.Join([]string{
+		"# @name nested",
+		"# @request trace.id {{$uuid}}",
+		"POST " + srv.URL,
+		"X-Trace-Id: {{trace.id}}",
+		"Content-Type: application/json",
+		"",
+		`{"request_id": "{{trace.id}}", "inline": "{{$uuid}}"}`,
+		"",
+	}, "\n")
+	doc := parser.Parse("nested.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+
+	res, err := New(engine.Config{}).ExecuteRequest(doc, doc.Requests[0], testSelection(""))
+	if err != nil {
+		t.Fatalf("ExecuteRequest: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("unexpected request error: %v", res.Err)
+	}
+	got := <-observed
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+
+	uuidRe := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	if !uuidRe.MatchString(got.trace) {
+		t.Fatalf("expected header to carry expanded uuid, got %q", got.trace)
+	}
+
+	var payload struct {
+		RequestID string `json:"request_id"`
+		Inline    string `json:"inline"`
+	}
+	if err := json.Unmarshal([]byte(got.body), &payload); err != nil {
+		t.Fatalf("parse sent body %q: %v", got.body, err)
+	}
+	if payload.RequestID != got.trace {
+		t.Fatalf("expected body and header to share one value, got %q vs %q", payload.RequestID, got.trace)
+	}
+	if !uuidRe.MatchString(payload.Inline) || payload.Inline == got.trace {
+		t.Fatalf("expected inline dynamic to stay fresh, got %q vs %q", payload.Inline, got.trace)
+	}
 }

--- a/internal/engine/request/vars.go
+++ b/internal/engine/request/vars.go
@@ -215,7 +215,7 @@ func (e *Engine) providers(
 		for _, c := range doc.Constants {
 			vals[c.Name] = c.Value
 		}
-		ps = append(ps, vars.NewMapProvider("const", vals))
+		ps = append(ps, vars.NewTemplateProvider("const", vals))
 	}
 	for _, extra := range extras {
 		if len(extra) > 0 {
@@ -231,7 +231,7 @@ func (e *Engine) providers(
 			vals[v.Name] = v.Value
 		}
 		if len(vals) > 0 {
-			ps = append(ps, vars.NewMapProvider("request", vals))
+			ps = append(ps, vars.NewTemplateProvider("request", vals))
 		}
 	}
 	if vals := globalValueMap(globs); len(vals) > 0 {
@@ -246,8 +246,13 @@ func (e *Engine) providers(
 			vals[v.Name] = v.Value
 		}
 		if len(vals) > 0 {
-			ps = append(ps, vars.NewMapProvider("document-global", vals))
+			ps = append(ps, vars.NewTemplateProvider("document-global", vals))
 		}
+	}
+	rv := make(map[string]string)
+	e.mergeFileRuntimeVars(rv, doc, env, sec)
+	if len(rv) > 0 {
+		ps = append(ps, vars.NewMapProvider("file", rv))
 	}
 	fv := make(map[string]string)
 	if doc != nil {
@@ -258,9 +263,8 @@ func (e *Engine) providers(
 			fv[v.Name] = v.Value
 		}
 	}
-	e.mergeFileRuntimeVars(fv, doc, env, sec)
 	if len(fv) > 0 {
-		ps = append(ps, vars.NewMapProvider("file", fv))
+		ps = append(ps, vars.NewTemplateProvider("file", fv))
 	}
 	if values := env.Values(); len(values) > 0 {
 		ps = append(ps, vars.NewMapProvider("environment", values))

--- a/internal/engine/request/vars_test.go
+++ b/internal/engine/request/vars_test.go
@@ -2,12 +2,14 @@ package request
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/httpclient"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 func TestResolveHTTPOptionsFallbackEnvEnable(t *testing.T) {
@@ -141,5 +143,54 @@ func TestRunRTSApplyUsesDocumentGlobalPatchProfiles(t *testing.T) {
 	}
 	if got := req.Headers.Get("Authorization"); got != "Bearer abc" {
 		t.Fatalf("runRTSApply() authorization = %q, want %q", got, "Bearer abc")
+	}
+}
+
+func TestProvidersExpandDeclaredVariableTemplates(t *testing.T) {
+	t.Parallel()
+
+	e := New(engcfg.Config{}, nil)
+	doc := &restfile.Document{
+		Variables: []restfile.Variable{{Name: "file.greeting", Value: "hello {{name}}"}},
+	}
+	req := &restfile.Request{
+		Variables: []restfile.Variable{{Name: "trace.id", Value: "{{$uuid}}"}},
+	}
+	globs := map[string]vars.GlobalMutation{
+		"captured": {Name: "captured", Value: "{{file.greeting}}"},
+	}
+	res := vars.NewResolver(
+		e.providers(doc, req, testEnv("dev"), globs, keepSecrets, map[string]string{"name": "resterm"})...,
+	)
+
+	greeting, err := res.ExpandTemplates("{{file.greeting}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if greeting != "hello resterm" {
+		t.Fatalf("expected nested file variable expansion, got %q", greeting)
+	}
+
+	first, err := res.ExpandTemplates("{{trace.id}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	second, err := res.ExpandTemplates("{{trace.id}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if first == "" || first != second {
+		t.Fatalf("expected stable request variable value, got %q vs %q", first, second)
+	}
+	if strings.Contains(first, "{{") {
+		t.Fatalf("expected dynamic to expand, got %q", first)
+	}
+
+	captured, err := res.ExpandTemplates("{{captured}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if captured != "{{file.greeting}}" {
+		t.Fatalf("expected runtime global to stay verbatim, got %q", captured)
 	}
 }

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,81 +32,245 @@ type Resolver struct {
 	expr      ExprEval
 	exprPos   ExprPos
 	trace     *Trace
+
+	mu   sync.Mutex
+	memo map[memoKey]memoEntry
+}
+
+// memoEntry pins the first expansion of a template-valued variable so every
+// later reference in the same resolver sees the same value, which is what
+// makes a declared {{$uuid}} stable across one request execution.
+type memoEntry struct {
+	value string
+	found bool
+}
+
+// variableKey identifies the declaration selected by provider precedence.
+// Keeping the provider index prevents a qualified lower-precedence variable
+// from sharing a cached value with an unqualified higher-precedence variable.
+type variableKey struct {
+	provider int
+	name     string
+}
+
+type memoKey struct {
+	variable     variableKey
+	allowDynamic bool
+	allowExpr    bool
+}
+
+const maxExpandDepth = 16
+
+// expandState tracks the chain of variables being expanded in one render so
+// cycles and runaway nesting fail with the full reference chain.
+type expandState struct {
+	names map[variableKey]bool
+	stack []string
 }
 
 func NewResolver(providers ...Provider) *Resolver {
 	return &Resolver{providers: providers}
 }
 
-// First tries direct lookup across all providers.
-// If that fails and the name has a dot, tries to match a provider prefix -
-// so "production.api_key" looks for a provider labeled "production" then asks for "api_key".
 func (r *Resolver) Resolve(name string) (string, bool) {
+	value, ok, err := r.resolve(name, r.exprPos, true, true, nil)
+	if err != nil {
+		return "", false
+	}
+	return value, ok
+}
+
+// resolve looks the name up and, when the winning provider holds authored
+// template text, expands nested placeholders before refs apply. A non-nil
+// error means expansion failed (cycle, depth, or an unresolvable nested
+// placeholder) and the value is unusable.
+func (r *Resolver) resolve(
+	name string,
+	pos ExprPos,
+	allowDynamic, allowExpr bool,
+	st *expandState,
+) (string, bool, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "", false
+		return "", false, nil
 	}
 
-	raw, sources, ok := r.lookup(func(p Provider) (string, bool) { return p.Resolve(name) })
-	if !ok && strings.Contains(name, ".") {
-		raw, sources, ok = r.lookup(func(p Provider) (string, bool) { return lookupPrefixed(p, name) })
-	}
+	hit, ok := r.lookupValue(name)
 	if !ok {
-		return "", false
+		return "", false, nil
 	}
 
-	resolved, found := r.applyRefs(raw)
-	if len(sources) > 0 {
+	var resolved string
+	var found bool
+	if expandableProvider(hit.prov) && strings.Contains(hit.raw, "{{") {
+		variable := hit.key()
+		if err := checkExpandState(name, variable, st); err != nil {
+			return "", false, err
+		}
+
+		key := memoKey{
+			variable:     variable,
+			allowDynamic: allowDynamic,
+			allowExpr:    allowExpr,
+		}
+		entry, cached := r.memoized(key)
+		if !cached {
+			expanded, err := r.expandValue(name, hit.raw, variable, pos, allowDynamic, allowExpr, st)
+			if err != nil {
+				return "", false, err
+			}
+			value, valueFound := r.applyRefs(expanded)
+			entry = r.memoize(key, memoEntry{value: value, found: valueFound})
+		}
+		resolved, found = entry.value, entry.found
+	} else {
+		resolved, found = r.applyRefs(hit.raw)
+	}
+
+	if len(hit.sources) > 0 {
 		r.traceVar(ResolveTrace{
 			Name:     name,
-			Source:   sources[0],
+			Source:   hit.sources[0],
 			Value:    resolved,
-			Shadowed: sources[1:],
+			Shadowed: hit.sources[1:],
 			Uses:     1,
 			Missing:  !found,
 		})
 	}
-	return resolved, found
+	return resolved, found, nil
+}
+
+func (r *Resolver) expandValue(
+	name, raw string,
+	key variableKey,
+	pos ExprPos,
+	allowDynamic, allowExpr bool,
+	st *expandState,
+) (string, error) {
+	if st == nil {
+		st = &expandState{names: make(map[variableKey]bool)}
+	}
+
+	st.names[key] = true
+	st.stack = append(st.stack, name)
+	out, err := CompileTemplate(raw).render(r, pos, allowDynamic, allowExpr, st)
+	st.stack = st.stack[:len(st.stack)-1]
+	delete(st.names, key)
+
+	if err != nil {
+		return "", fmt.Errorf("expand %s: %w", name, err)
+	}
+	return out, nil
+}
+
+func checkExpandState(name string, key variableKey, st *expandState) error {
+	if st == nil {
+		return nil
+	}
+	chain := strings.Join(append(st.stack, name), " -> ")
+	if st.names[key] {
+		return fmt.Errorf("variable cycle: %s", chain)
+	}
+	if len(st.stack) >= maxExpandDepth {
+		return fmt.Errorf("variable nesting deeper than %d: %s", maxExpandDepth, chain)
+	}
+	return nil
+}
+
+func (r *Resolver) memoized(key memoKey) (memoEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.memo[key]
+	return entry, ok
+}
+
+// memoize returns the first value stored for key. Multiple goroutines may do
+// the expansion work concurrently, but every caller observes the same winner.
+// Avoiding a wait on another variable's expansion also keeps concurrent roots
+// of a cyclic graph from deadlocking each other.
+func (r *Resolver) memoize(key memoKey, candidate memoEntry) memoEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.memo == nil {
+		r.memo = make(map[memoKey]memoEntry)
+	}
+	if entry, ok := r.memo[key]; ok {
+		return entry
+	}
+	r.memo[key] = candidate
+	return candidate
+}
+
+// lookupHit is the provider match a lookup selected. subject is the name the
+// winning provider actually resolved, which differs from the requested name
+// for prefixed lookups.
+type lookupHit struct {
+	raw     string
+	prov    Provider
+	idx     int
+	subject string
+	sources []string
+}
+
+func (h lookupHit) key() variableKey {
+	return variableKey{provider: h.idx, name: strings.ToLower(h.subject)}
+}
+
+// lookupValue first tries direct lookup across all providers.
+// If that fails and the name has a dot, tries to match a provider prefix -
+// so "production.api_key" looks for a provider labeled "production" then asks for "api_key".
+func (r *Resolver) lookupValue(name string) (lookupHit, bool) {
+	hit, ok := r.lookup(func(p Provider) (string, string, bool) {
+		value, found := p.Resolve(name)
+		return value, name, found
+	})
+	if !ok && strings.Contains(name, ".") {
+		hit, ok = r.lookup(func(p Provider) (string, string, bool) {
+			return lookupPrefixed(p, name)
+		})
+	}
+	return hit, ok
 }
 
 // lookup returns the first value find yields across providers. Without tracing
 // it stops at the first hit. With tracing it keeps scanning and collects every
 // matching provider label so shadowed sources can be reported.
-func (r *Resolver) lookup(find func(Provider) (string, bool)) (string, []string, bool) {
-	var raw string
-	var sources []string
-	hit := false
-	for _, p := range r.providers {
-		value, ok := find(p)
+func (r *Resolver) lookup(find func(Provider) (string, string, bool)) (lookupHit, bool) {
+	var hit lookupHit
+	matched := false
+	for idx, p := range r.providers {
+		value, subject, ok := find(p)
 		if !ok {
 			continue
 		}
-		if !hit {
-			raw, hit = value, true
+		if !matched {
+			hit = lookupHit{raw: value, prov: p, idx: idx, subject: subject}
+			matched = true
 			if r.trace == nil {
-				return raw, nil, true
+				return hit, true
 			}
 		}
-		sources = append(sources, providerLabel(p))
+		hit.sources = append(hit.sources, providerLabel(p))
 	}
-	return raw, sources, hit
+	return hit, matched
 }
 
 // lookupPrefixed matches "label.name" against the provider label, with any
 // ":detail" suffix stripped, and resolves the remainder against that provider.
-func lookupPrefixed(p Provider, name string) (string, bool) {
+func lookupPrefixed(p Provider, name string) (string, string, bool) {
 	label := strings.TrimSpace(strings.ToLower(p.Label()))
 	if before, _, ok := strings.Cut(label, ":"); ok {
 		label = strings.TrimSpace(before)
 	}
 	if label == "" || !strings.HasPrefix(strings.ToLower(name), label+".") {
-		return "", false
+		return "", "", false
 	}
 	subject := strings.TrimSpace(name[len(label)+1:])
 	if subject == "" {
-		return "", false
+		return "", "", false
 	}
-	return p.Resolve(subject)
+	value, ok := p.Resolve(subject)
+	return value, subject, ok
 }
 
 // applyRefs runs the value through registered ref resolvers. The first
@@ -133,15 +298,15 @@ func providerLabel(p Provider) string {
 }
 
 func (r *Resolver) ExpandTemplates(input string) (string, error) {
-	return CompileTemplate(input).render(r, r.exprPos, true, true)
+	return CompileTemplate(input).render(r, r.exprPos, true, true, nil)
 }
 
 func (r *Resolver) ExpandTemplatesAt(input string, pos ExprPos) (string, error) {
-	return CompileTemplate(input).render(r, pos, true, true)
+	return CompileTemplate(input).render(r, pos, true, true, nil)
 }
 
 func (r *Resolver) ExpandTemplatesStatic(input string) (string, error) {
-	return CompileTemplate(input).render(r, r.exprPos, false, false)
+	return CompileTemplate(input).render(r, r.exprPos, false, false, nil)
 }
 
 func (r *Resolver) AddRefResolver(fn RefResolver) {
@@ -162,7 +327,12 @@ func (r *Resolver) SetExprPos(pos ExprPos) {
 
 // resolveName resolves one placeholder name. A non-nil error means the
 // placeholder cannot be resolved and callers keep it as literal text.
-func (r *Resolver) resolveName(name string, pos ExprPos, allowDynamic, allowExpr bool) (string, error) {
+func (r *Resolver) resolveName(
+	name string,
+	pos ExprPos,
+	allowDynamic, allowExpr bool,
+	st *expandState,
+) (string, error) {
 	if strings.HasPrefix(name, "=") {
 		if !allowExpr {
 			return "", fmt.Errorf("expressions not allowed")
@@ -177,7 +347,11 @@ func (r *Resolver) resolveName(name string, pos ExprPos, allowDynamic, allowExpr
 		return r.expr(expr, pos)
 	}
 	if allowDynamic && strings.HasPrefix(name, "$") {
-		if value, ok := r.Resolve(name); ok {
+		value, ok, err := r.resolve(name, pos, allowDynamic, allowExpr, st)
+		if err != nil {
+			return "", err
+		}
+		if ok {
 			return value, nil
 		}
 		if dynamic, ok := resolveDynamic(name); ok {
@@ -191,7 +365,11 @@ func (r *Resolver) resolveName(name string, pos ExprPos, allowDynamic, allowExpr
 			return dynamic, nil
 		}
 	}
-	if value, ok := r.Resolve(name); ok {
+	value, ok, err := r.resolve(name, pos, allowDynamic, allowExpr, st)
+	if err != nil {
+		return "", err
+	}
+	if ok {
 		return value, nil
 	}
 	r.traceVar(ResolveTrace{Name: name, Missing: true, Uses: 1})
@@ -284,17 +462,43 @@ func splitDynamicOffset(name string) (string, time.Duration, bool) {
 }
 
 type MapProvider struct {
-	values map[string]string
-	label  string
+	values   map[string]string
+	label    string
+	template bool
 }
 
 // Keys get lowercased so lookups are case-insensitive
 func NewMapProvider(label string, values map[string]string) Provider {
+	return newMapProvider(label, values, false)
+}
+
+// NewTemplateProvider is a MapProvider whose values are authored template
+// text, so a value containing {{...}} is expanded when the variable resolves.
+// Use it only for values written in source files, never for runtime data such
+// as captured responses.
+func NewTemplateProvider(label string, values map[string]string) Provider {
+	return newMapProvider(label, values, true)
+}
+
+func newMapProvider(label string, values map[string]string, template bool) Provider {
 	normalized := make(map[string]string, len(values))
 	for k, v := range values {
 		normalized[strings.ToLower(k)] = v
 	}
-	return &MapProvider{values: normalized, label: label}
+	return &MapProvider{values: normalized, label: label, template: template}
+}
+
+type templateValueProvider interface {
+	templateValues() bool
+}
+
+func (p *MapProvider) templateValues() bool {
+	return p.template
+}
+
+func expandableProvider(p Provider) bool {
+	tp, ok := p.(templateValueProvider)
+	return ok && tp.templateValues()
 }
 
 func (p *MapProvider) Resolve(name string) (string, bool) {

--- a/internal/vars/resolver_nested_test.go
+++ b/internal/vars/resolver_nested_test.go
@@ -1,0 +1,351 @@
+package vars
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func TestNestedExpansionBasic(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "{{b}}",
+		"b": "value",
+		"c": "pre-{{b}}-post",
+	}))
+
+	out, err := r.ExpandTemplates("{{a}} {{c}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if out != "value pre-value-post" {
+		t.Fatalf("unexpected expansion: %q", out)
+	}
+}
+
+func TestNestedExpansionChain(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "{{b}}",
+		"b": "{{c}}",
+		"c": "leaf",
+	}))
+
+	out, err := r.ExpandTemplates("{{a}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if out != "leaf" {
+		t.Fatalf("unexpected expansion: %q", out)
+	}
+}
+
+func TestNestedExpansionAcrossProviders(t *testing.T) {
+	r := NewResolver(
+		NewTemplateProvider("request", map[string]string{"url": "{{base}}/v2"}),
+		NewMapProvider("environment", map[string]string{"base": "https://api.example.com"}),
+	)
+
+	out, err := r.ExpandTemplates("{{url}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if out != "https://api.example.com/v2" {
+		t.Fatalf("unexpected expansion: %q", out)
+	}
+}
+
+func TestNestedExpansionDynamicStablePerResolver(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"trace.id": "{{$uuid}}",
+	}))
+
+	out, err := r.ExpandTemplates("{{trace.id}} {{trace.id}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	parts := strings.Fields(out)
+	if len(parts) != 2 || parts[0] != parts[1] {
+		t.Fatalf("expected stable value across references, got %q", out)
+	}
+	if !uuidPattern.MatchString(parts[0]) {
+		t.Fatalf("expected uuid, got %q", parts[0])
+	}
+
+	again, err := r.ExpandTemplates("{{trace.id}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if again != parts[0] {
+		t.Fatalf("expected stable value across renders, got %q vs %q", again, parts[0])
+	}
+}
+
+func TestNestedExpansionDynamicDoesNotLeakIntoStaticExpansion(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"trace.id": "{{$uuid}}",
+	}))
+
+	dynamic, err := r.ExpandTemplates("{{trace.id}}")
+	if err != nil {
+		t.Fatalf("dynamic expansion: %v", err)
+	}
+	if !uuidPattern.MatchString(dynamic) {
+		t.Fatalf("dynamic expansion = %q, want UUID", dynamic)
+	}
+
+	static, err := r.ExpandTemplatesStatic("{{trace.id}}")
+	if err == nil {
+		t.Fatal("static expansion unexpectedly accepted a nested dynamic")
+	}
+	if static != "{{trace.id}}" {
+		t.Fatalf("static expansion = %q, want unresolved placeholder", static)
+	}
+}
+
+func TestNestedExpansionProviderAliasSharesMemoizedValue(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver(
+		NewTemplateProvider("request", map[string]string{"trace.id": "{{$uuid}}"}),
+		NewTemplateProvider("file", map[string]string{"trace.id": "{{$uuid}}"}),
+	)
+
+	direct, err := r.ExpandTemplates("{{trace.id}}")
+	if err != nil {
+		t.Fatalf("direct expansion: %v", err)
+	}
+	qualified, err := r.ExpandTemplates("{{request.trace.id}}")
+	if err != nil {
+		t.Fatalf("qualified expansion: %v", err)
+	}
+	if direct != qualified {
+		t.Fatalf("aliases expanded to different values: %q and %q", direct, qualified)
+	}
+	fileValue, err := r.ExpandTemplates("{{file.trace.id}}")
+	if err != nil {
+		t.Fatalf("qualified file expansion: %v", err)
+	}
+	if fileValue == direct {
+		t.Fatalf("qualified lower-precedence variable reused request value %q", direct)
+	}
+}
+
+func TestNestedExpansionDistinctVariablesDiffer(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"trace.id": "{{$uuid}}",
+		"span.id":  "{{$uuid}}",
+	}))
+
+	a, err := r.ExpandTemplates("{{trace.id}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	b, err := r.ExpandTemplates("{{span.id}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if a == b {
+		t.Fatalf("expected distinct variables to expand independently, both %q", a)
+	}
+}
+
+func TestInlineDynamicStaysFreshPerOccurrence(t *testing.T) {
+	r := NewResolver()
+	out, err := r.ExpandTemplates("{{$uuid}} {{$uuid}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	parts := strings.Fields(out)
+	if len(parts) != 2 || parts[0] == parts[1] {
+		t.Fatalf("expected fresh inline dynamics, got %q", out)
+	}
+}
+
+func TestNestedExpansionCycle(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "{{b}}",
+		"b": "{{a}}",
+	}))
+
+	out, err := r.ExpandTemplates("{{a}}")
+	if err == nil || !strings.Contains(err.Error(), "variable cycle") {
+		t.Fatalf("expected cycle error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "a -> b -> a") {
+		t.Fatalf("expected cycle chain in error, got %v", err)
+	}
+	if out != "{{a}}" {
+		t.Fatalf("expected placeholder to stay literal on cycle, got %q", out)
+	}
+}
+
+func TestNestedExpansionSelfCycle(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "x{{a}}y",
+	}))
+
+	_, err := r.ExpandTemplates("{{a}}")
+	if err == nil || !strings.Contains(err.Error(), "variable cycle") {
+		t.Fatalf("expected self cycle error, got %v", err)
+	}
+}
+
+func TestNestedExpansionDepthLimit(t *testing.T) {
+	values := make(map[string]string)
+	for i := range 20 {
+		values[fmt.Sprintf("v%d", i)] = fmt.Sprintf("{{v%d}}", i+1)
+	}
+	values["v20"] = "leaf"
+	r := NewResolver(NewTemplateProvider("request", values))
+
+	_, err := r.ExpandTemplates("{{v0}}")
+	if err == nil || !strings.Contains(err.Error(), "nesting deeper") {
+		t.Fatalf("expected depth limit error, got %v", err)
+	}
+}
+
+func TestDataProviderValuesStayVerbatim(t *testing.T) {
+	r := NewResolver(
+		NewMapProvider("global", map[string]string{"captured": "{{secret}}"}),
+		NewTemplateProvider("file", map[string]string{"secret": "hunter2"}),
+	)
+
+	out, err := r.ExpandTemplates("{{captured}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if out != "{{secret}}" {
+		t.Fatalf("expected captured data to stay verbatim, got %q", out)
+	}
+}
+
+func TestNestedExpansionUndefinedFails(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "{{missing}}",
+	}))
+
+	out, err := r.ExpandTemplates("{{a}}")
+	if err == nil {
+		t.Fatalf("expected error for undefined nested variable")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "expand a") || !strings.Contains(msg, "undefined variable: missing") {
+		t.Fatalf("expected error naming both variables, got %q", msg)
+	}
+	if out != "{{a}}" {
+		t.Fatalf("expected placeholder to stay literal, got %q", out)
+	}
+}
+
+func TestNestedExpansionComposesWithEnvRef(t *testing.T) {
+	t.Setenv("RESTERM_TEST_NESTED", "from-os")
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a":   "env:{{key}}",
+		"key": "RESTERM_TEST_NESTED",
+	}))
+	r.AddRefResolver(EnvRefResolver)
+
+	out, err := r.ExpandTemplates("{{a}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if out != "from-os" {
+		t.Fatalf("expected env ref to resolve after expansion, got %q", out)
+	}
+}
+
+func TestEnvRefResultNotExpanded(t *testing.T) {
+	t.Setenv("RESTERM_TEST_NESTED", "{{secret}}")
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a":      "env:RESTERM_TEST_NESTED",
+		"secret": "hunter2",
+	}))
+	r.AddRefResolver(EnvRefResolver)
+
+	out, err := r.ExpandTemplates("{{a}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if out != "{{secret}}" {
+		t.Fatalf("expected OS env content to stay verbatim, got %q", out)
+	}
+}
+
+func TestNestedExpansionCaseInsensitive(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"trace.id": "{{$uuid}}",
+	}))
+
+	a, err := r.ExpandTemplates("{{Trace.ID}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	b, err := r.ExpandTemplates("{{trace.id}}")
+	if err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+	if a != b {
+		t.Fatalf("expected case-insensitive references to share one value, got %q vs %q", a, b)
+	}
+}
+
+func TestNestedExpansionStaticContextRejectsDynamics(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "{{$uuid}}",
+	}))
+
+	out, err := r.ExpandTemplatesStatic("{{a}}")
+	if err == nil {
+		t.Fatalf("expected error for dynamic in static context")
+	}
+	if out != "{{a}}" {
+		t.Fatalf("expected placeholder to stay literal, got %q", out)
+	}
+}
+
+func TestPublicResolveExpands(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "{{b}}",
+		"b": "value",
+	}))
+
+	got, ok := r.Resolve("a")
+	if !ok || got != "value" {
+		t.Fatalf("Resolve(a) = %q, %v", got, ok)
+	}
+}
+
+func TestPublicResolveCycleReportsUnresolved(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "{{a}}",
+	}))
+
+	if got, ok := r.Resolve("a"); ok {
+		t.Fatalf("expected cycle to resolve as missing, got %q", got)
+	}
+}
+
+func TestNestedExpansionTraceIncludesInner(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("request", map[string]string{
+		"a": "{{b}}",
+		"b": "value",
+	}))
+	tr := NewTrace()
+	r.SetTrace(tr)
+
+	if _, err := r.ExpandTemplates("{{a}}"); err != nil {
+		t.Fatalf("expand err: %v", err)
+	}
+
+	names := make(map[string]bool)
+	for _, it := range tr.Items() {
+		names[strings.ToLower(it.Name)] = true
+	}
+	if !names["a"] || !names["b"] {
+		t.Fatalf("expected trace to include both outer and inner variables, got %v", names)
+	}
+}

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -53,16 +53,21 @@ func CompileTemplate(input string) Template {
 // unresolvable or blank placeholder stays literal and only the first error
 // is reported.
 func (t Template) Render(r *Resolver) (string, error) {
-	return t.render(r, r.exprPos, true, true)
+	return t.render(r, r.exprPos, true, true, nil)
 }
 
-func (t Template) render(r *Resolver, pos ExprPos, allowDynamic, allowExpr bool) (string, error) {
+func (t Template) render(
+	r *Resolver,
+	pos ExprPos,
+	allowDynamic, allowExpr bool,
+	st *expandState,
+) (string, error) {
 	var firstErr error
 	out := t.replace(func(match, name string) string {
 		if name == "" {
 			return match
 		}
-		value, err := r.resolveName(name, pos, allowDynamic, allowExpr)
+		value, err := r.resolveName(name, pos, allowDynamic, allowExpr, st)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err


### PR DESCRIPTION
Declared variable values (`{{$uuid}}` in `@var request`, `@const`, `@global`, `@file`) now expand when referenced instead of rendering as literal text. Expansion is recursive with cycle detection and a depth cap, memoized per execution so every reference to a variable sees one value, and gated to authored sources so runtime data (captures, script vars, OSenv) is never re-expanded and cannot inject templates.