### PR TITLE
RST-300: fail closed on var expantion

### DIFF
--- a/_examples/auth_command.http
+++ b/_examples/auth_command.http
@@ -15,7 +15,7 @@ X-GitHub-Api-Version: 2022-11-28
 ### GitHub CLI Token Via @apply
 # @name GitHubCLITokenPatched
 # @tag auth command
-# @description Reuses command-backed bearer auth through a global apply profile.
+# @description Reuses command-backed bearer auth through a file-scoped apply profile.
 # @apply use=githubCliAuth
 GET https://api.github.com/user
 Accept: application/vnd.github+json
@@ -33,8 +33,8 @@ X-GitHub-Api-Version: 2022-11-28
 ### GitHub CLI Token Reuse
 # @name GitHubCLITokenReuse
 # @tag auth command
-# @description Reuses the seeded github-cli command auth slot without repeating argv.
-# @auth command cache_key=github-cli
+# @description Reuses the github-cli command auth slot and can also seed it on a cold start.
+# @auth command argv=["gh","auth","token"] cache_key=github-cli
 GET https://api.github.com/user/repos
 Accept: application/vnd.github+json
 X-GitHub-Api-Version: 2022-11-28

--- a/_examples/resterm.env.json
+++ b/_examples/resterm.env.json
@@ -1,4 +1,18 @@
 {
+  "$shared": {
+    "auth": {
+      "globalToken": "demo-global-token",
+      "clientId": "demo-client",
+      "clientSecret": "demo-secret"
+    },
+    "oauth": {
+      "tokenUrl": "https://auth.example.com/oauth/token",
+      "authUrl": "https://auth.example.com/oauth/authorize",
+      "clientId": "demo-client",
+      "clientSecret": "demo-secret",
+      "scope": "read write analytics"
+    }
+  },
   "dev": {
     "base": {
       "url": "https://httpbin.org"
@@ -15,16 +29,9 @@
       "name": "beta-dashboard"
     },
     "auth": {
-      "token": "dev-token-123",
-      "clientId": "demo-client",
-      "clientSecret": "demo-secret"
+      "token": "dev-token-123"
     },
     "oauth": {
-      "tokenUrl": "https://auth.example.com/oauth/token",
-      "authUrl": "https://auth.example.com/oauth/authorize",
-      "clientId": "demo-client",
-      "clientSecret": "demo-secret",
-      "scope": "read write analytics",
       "audience": "https://api.dev.example.com",
       "cacheKey": "dev:core"
     },
@@ -92,16 +99,9 @@
       "name": "gamma-switch"
     },
     "auth": {
-      "token": "stage-token-456",
-      "clientId": "demo-client",
-      "clientSecret": "demo-secret"
+      "token": "stage-token-456"
     },
     "oauth": {
-      "tokenUrl": "https://auth.example.com/oauth/token",
-      "authUrl": "https://auth.example.com/oauth/authorize",
-      "clientId": "demo-client",
-      "clientSecret": "demo-secret",
-      "scope": "read write analytics",
       "audience": "https://api.stage.example.com",
       "cacheKey": "stage:core"
     },
@@ -167,16 +167,9 @@
       "name": "rollout-feature"
     },
     "auth": {
-      "token": "prod-token-789",
-      "clientId": "demo-client",
-      "clientSecret": "demo-secret"
+      "token": "prod-token-789"
     },
     "oauth": {
-      "tokenUrl": "https://auth.example.com/oauth/token",
-      "authUrl": "https://auth.example.com/oauth/authorize",
-      "clientId": "demo-client",
-      "clientSecret": "demo-secret",
-      "scope": "read write analytics",
       "audience": "https://api.example.com",
       "cacheKey": "prod:core"
     },

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2074,7 +2074,7 @@ Open one in Resterm, switch to the appropriate environment (`resterm.env.json`),
 ## Troubleshooting & Tips
 
 - Use `Ctrl+P` to force a reparse if the navigator seems out of sync with editor changes.
-- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, and expanded bodies. Previews and the request list keep the placeholder intact and list the unresolved names.
+- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, and expanded bodies. Explain previews keep the placeholder intact and list the unresolved names.
 - Combine `@capture request ...` with test scripts to assert on response headers without cluttering file/global scopes.
 - Inline curl import works best with single commands; complex shell pipelines may need manual cleanup.
 - `Ctrl+Shift+V` pins the focused response pane-ideal for diffing the last good response against the current attempt.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2074,7 +2074,7 @@ Open one in Resterm, switch to the appropriate environment (`resterm.env.json`),
 ## Troubleshooting & Tips
 
 - Use `Ctrl+P` to force a reparse if the navigator seems out of sync with editor changes.
-- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, and expanded bodies. Explain previews keep the placeholder intact and list the unresolved names.
+- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, expanded bodies, gRPC targets and messages, and WebSocket steps. Explain previews keep the placeholder intact and list the unresolved names.
 - Combine `@capture request ...` with test scripts to assert on response headers without cluttering file/global scopes.
 - Inline curl import works best with single commands; complex shell pipelines may need manual cleanup.
 - `Ctrl+Shift+V` pins the focused response pane-ideal for diffing the last good response against the current attempt.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2074,7 +2074,7 @@ Open one in Resterm, switch to the appropriate environment (`resterm.env.json`),
 ## Troubleshooting & Tips
 
 - Use `Ctrl+P` to force a reparse if the navigator seems out of sync with editor changes.
-- If a template fails to expand (undefined variable), Resterm leaves the placeholder intact and surfaces an error banner.
+- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, and expanded bodies. Previews and the request list keep the placeholder intact and list the unresolved names.
 - Combine `@capture request ...` with test scripts to assert on response headers without cluttering file/global scopes.
 - Inline curl import works best with single commands; complex shell pipelines may need manual cleanup.
 - `Ctrl+Shift+V` pins the focused response pane-ideal for diffing the last good response against the current attempt.

--- a/internal/engine/request/auth.go
+++ b/internal/engine/request/auth.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -338,7 +339,7 @@ func (e *Engine) BuildCommandAuthConfig(
 	if err != nil {
 		return out, err
 	}
-	if err := expandCommandAuthArgv(out.Argv, res); err != nil {
+	if err := expandCommandAuthArgv(out.Argv, auth, res); err != nil {
 		return out, err
 	}
 	return out.WithBaseTimeout(timeout), nil
@@ -384,7 +385,7 @@ func (e *Engine) BuildOAuthConfig(
 		return cfg, diag.New(diag.ClassAuth, errMissingOAuthSpec)
 	}
 	for _, field := range oauthConfigFields {
-		value, err := expandAuthParam(res, authTypeOAuth2, field.key, auth.Params[field.key])
+		value, err := expandAuthParam(res, auth, authTypeOAuth2, field.key, auth.Params[field.key])
 		if err != nil {
 			return cfg, err
 		}
@@ -431,7 +432,7 @@ func commandAuthParams(auth *restfile.AuthSpec, res *vars.Resolver) (map[string]
 		}
 		if key != authParamArgv {
 			var err error
-			value, err = expandAuthParam(res, authTypeCommand, key, value)
+			value, err = expandAuthParam(res, auth, authTypeCommand, key, value)
 			if err != nil {
 				return nil, err
 			}
@@ -441,21 +442,25 @@ func commandAuthParams(auth *restfile.AuthSpec, res *vars.Resolver) (map[string]
 	return out, nil
 }
 
-func expandCommandAuthArgv(argv []string, res *vars.Resolver) error {
+func expandCommandAuthArgv(argv []string, auth *restfile.AuthSpec, res *vars.Resolver) error {
 	if res == nil {
 		return nil
 	}
 	for i, arg := range argv {
 		value, err := res.ExpandTemplates(arg)
 		if err != nil {
-			return diag.WrapAsf(diag.ClassAuth, err, "expand command auth argv[%d]", i)
+			op := fmt.Sprintf("expand command auth argv[%d]", i)
+			if at := auth.Origin(); at != "" {
+				op += " (" + at + ")"
+			}
+			return diag.WrapAs(diag.ClassAuth, err, op)
 		}
 		argv[i] = value
 	}
 	return nil
 }
 
-func expandAuthParam(res *vars.Resolver, scope, key, raw string) (string, error) {
+func expandAuthParam(res *vars.Resolver, auth *restfile.AuthSpec, scope, key, raw string) (string, error) {
 	if strings.TrimSpace(raw) == "" {
 		return "", nil
 	}
@@ -464,7 +469,11 @@ func expandAuthParam(res *vars.Resolver, scope, key, raw string) (string, error)
 	}
 	value, err := res.ExpandTemplates(raw)
 	if err != nil {
-		return "", diag.WrapAsf(diag.ClassAuth, err, "expand %s param %s", scope, key)
+		op := fmt.Sprintf("expand %s param %s", scope, key)
+		if at := auth.Origin(); at != "" {
+			op += " (" + at + ")"
+		}
+		return "", diag.WrapAs(diag.ClassAuth, err, op)
 	}
 	return strings.TrimSpace(value), nil
 }
@@ -478,7 +487,7 @@ func oauthExtraParams(auth *restfile.AuthSpec, res *vars.Resolver) (map[string]s
 		if isKnownOAuthParam(strings.ToLower(rawKey)) || strings.TrimSpace(rawValue) == "" {
 			continue
 		}
-		value, err := expandAuthParam(res, authTypeOAuth2, rawKey, rawValue)
+		value, err := expandAuthParam(res, auth, authTypeOAuth2, rawKey, rawValue)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/request/auth.go
+++ b/internal/engine/request/auth.go
@@ -385,7 +385,7 @@ func (e *Engine) BuildOAuthConfig(
 		return cfg, diag.New(diag.ClassAuth, errMissingOAuthSpec)
 	}
 	for _, field := range oauthConfigFields {
-		value, err := expandAuthParam(res, auth, authTypeOAuth2, field.key, auth.Params[field.key])
+		value, err := expandAuthParam(res, auth, field.key, auth.Params[field.key])
 		if err != nil {
 			return cfg, err
 		}
@@ -432,7 +432,7 @@ func commandAuthParams(auth *restfile.AuthSpec, res *vars.Resolver) (map[string]
 		}
 		if key != authParamArgv {
 			var err error
-			value, err = expandAuthParam(res, auth, authTypeCommand, key, value)
+			value, err = expandAuthParam(res, auth, key, value)
 			if err != nil {
 				return nil, err
 			}
@@ -460,7 +460,7 @@ func expandCommandAuthArgv(argv []string, auth *restfile.AuthSpec, res *vars.Res
 	return nil
 }
 
-func expandAuthParam(res *vars.Resolver, auth *restfile.AuthSpec, scope, key, raw string) (string, error) {
+func expandAuthParam(res *vars.Resolver, auth *restfile.AuthSpec, key, raw string) (string, error) {
 	if strings.TrimSpace(raw) == "" {
 		return "", nil
 	}
@@ -469,7 +469,7 @@ func expandAuthParam(res *vars.Resolver, auth *restfile.AuthSpec, scope, key, ra
 	}
 	value, err := res.ExpandTemplates(raw)
 	if err != nil {
-		op := fmt.Sprintf("expand %s param %s", scope, key)
+		op := fmt.Sprintf("expand %s auth %s", authKind(auth), key)
 		if at := auth.Origin(); at != "" {
 			op += " (" + at + ")"
 		}
@@ -487,7 +487,7 @@ func oauthExtraParams(auth *restfile.AuthSpec, res *vars.Resolver) (map[string]s
 		if isKnownOAuthParam(strings.ToLower(rawKey)) || strings.TrimSpace(rawValue) == "" {
 			continue
 		}
-		value, err := expandAuthParam(res, auth, authTypeOAuth2, rawKey, rawValue)
+		value, err := expandAuthParam(res, auth, rawKey, rawValue)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/request/auth.go
+++ b/internal/engine/request/auth.go
@@ -2,9 +2,12 @@ package request
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -329,18 +332,27 @@ func (e *Engine) BuildCommandAuthConfig(
 	if auth == nil {
 		return cfg, diag.New(diag.ClassAuth, errMissingCommandAuthSpec)
 	}
-	pm, err := commandAuthParams(auth, res)
-	if err != nil {
-		return cfg, err
+	// Keep going on undefined params so a cycle in argv still fails the
+	// build. If parsing then fails it is probably because the failed params
+	// are missing from the map, so report the undefined variable instead.
+	pm, perr := commandAuthParams(auth, res)
+	if perr != nil && !errors.Is(perr, vars.ErrUndefinedVariable) {
+		return cfg, perr
 	}
 
 	dir := e.cmdDir(doc, auth)
 	out, err := authcmd.Parse(pm, dir)
 	if err != nil {
+		if perr != nil {
+			return cfg, perr
+		}
 		return out, err
 	}
 	if err := expandCommandAuthArgv(out.Argv, auth, res); err != nil {
-		return out, err
+		return out, vars.PreferStructural(perr, err)
+	}
+	if perr != nil {
+		return cfg, perr
 	}
 	return out.WithBaseTimeout(timeout), nil
 }
@@ -384,16 +396,21 @@ func (e *Engine) BuildOAuthConfig(
 	if auth == nil {
 		return cfg, diag.New(diag.ClassAuth, errMissingOAuthSpec)
 	}
+	var firstErr error
 	for _, field := range oauthConfigFields {
 		value, err := expandAuthParam(res, auth, field.key, auth.Params[field.key])
 		if err != nil {
-			return cfg, err
+			firstErr = vars.PreferStructural(firstErr, err)
+			continue
 		}
 		field.set(&cfg, value)
 	}
 	extra, err := oauthExtraParams(auth, res)
 	if err != nil {
-		return cfg, err
+		firstErr = vars.PreferStructural(firstErr, err)
+	}
+	if firstErr != nil {
+		return cfg, firstErr
 	}
 	cfg.Extra = extra
 	return cfg.Normalized(), nil
@@ -420,13 +437,14 @@ func commandAuthParams(auth *restfile.AuthSpec, res *vars.Resolver) (map[string]
 		return nil, nil
 	}
 	out := make(map[string]string, len(auth.Params))
-	for rawKey, rawValue := range auth.Params {
+	var firstErr error
+	for _, rawKey := range slices.Sorted(maps.Keys(auth.Params)) {
 		key := strings.ToLower(strings.TrimSpace(rawKey))
 		if key == "" {
 			continue
 		}
 
-		value := strings.TrimSpace(rawValue)
+		value := strings.TrimSpace(auth.Params[rawKey])
 		if value == "" {
 			continue
 		}
@@ -434,18 +452,20 @@ func commandAuthParams(auth *restfile.AuthSpec, res *vars.Resolver) (map[string]
 			var err error
 			value, err = expandAuthParam(res, auth, key, value)
 			if err != nil {
-				return nil, err
+				firstErr = vars.PreferStructural(firstErr, err)
+				continue
 			}
 		}
 		out[key] = value
 	}
-	return out, nil
+	return out, firstErr
 }
 
 func expandCommandAuthArgv(argv []string, auth *restfile.AuthSpec, res *vars.Resolver) error {
 	if res == nil {
 		return nil
 	}
+	var firstErr error
 	for i, arg := range argv {
 		value, err := res.ExpandTemplates(arg)
 		if err != nil {
@@ -453,11 +473,12 @@ func expandCommandAuthArgv(argv []string, auth *restfile.AuthSpec, res *vars.Res
 			if at := auth.Origin(); at != "" {
 				op += " (" + at + ")"
 			}
-			return diag.WrapAs(diag.ClassAuth, err, op)
+			firstErr = vars.PreferStructural(firstErr, diag.WrapAs(diag.ClassAuth, err, op))
+			continue
 		}
 		argv[i] = value
 	}
-	return nil
+	return firstErr
 }
 
 func expandAuthParam(res *vars.Resolver, auth *restfile.AuthSpec, key, raw string) (string, error) {
@@ -483,18 +504,24 @@ func oauthExtraParams(auth *restfile.AuthSpec, res *vars.Resolver) (map[string]s
 		return nil, nil
 	}
 	out := make(map[string]string)
-	for rawKey, rawValue := range auth.Params {
+	var firstErr error
+	for _, rawKey := range slices.Sorted(maps.Keys(auth.Params)) {
+		rawValue := auth.Params[rawKey]
 		if isKnownOAuthParam(strings.ToLower(rawKey)) || strings.TrimSpace(rawValue) == "" {
 			continue
 		}
 		value, err := expandAuthParam(res, auth, rawKey, rawValue)
 		if err != nil {
-			return nil, err
+			firstErr = vars.PreferStructural(firstErr, err)
+			continue
 		}
 		if value == "" {
 			continue
 		}
 		out[strings.ToLower(strings.ReplaceAll(rawKey, "-", "_"))] = value
+	}
+	if firstErr != nil {
+		return nil, firstErr
 	}
 	if len(out) == 0 {
 		return nil, nil

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -2,8 +2,8 @@ package request
 
 import (
 	"context"
+	"errors"
 	"maps"
-	"strings"
 	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
@@ -349,12 +349,16 @@ func detectPreRequestScripts(req *restfile.Request) (bool, bool) {
 	return hasRTS, hasJS
 }
 
+// base marks every result produced in preview mode as a preview so RunRequest
+// short-circuits. Execution safety must not depend on a failed preview
+// failing again on the send path.
 func (x *execCtx) base() xrunResult {
 	return xrunResult{
 		Executed:       x.req,
 		Environment:    x.env.Label(),
 		Selection:      x.env.Selection(),
 		RuntimeSecrets: append([]string(nil), x.runtimeSecrets...),
+		Preview:        x.preview(),
 	}
 }
 
@@ -724,6 +728,21 @@ func (x *execCtx) prepareAuth() *xrunResult {
 	if x.preview() {
 		out, err := x.eng.prepareExplainAuthPreview(x.doc, x.req, x.res, x.env)
 		if err != nil {
+			// Auth values expand strictly so typed params never parse
+			// placeholder text. Undefined variables degrade to a skipped
+			// stage because the trace already lists the missing names.
+			// Structural errors stay fatal.
+			if errors.Is(err, vars.ErrUndefinedVariable) {
+				x.exp.stage(
+					xplain.StageAuth,
+					xplain.StageSkipped,
+					xplain.SummaryAuthPreviewSkipped,
+					before,
+					x.req,
+					err.Error(),
+				)
+				return nil
+			}
 			x.exp.stage(
 				xplain.StageAuth,
 				xplain.StageError,
@@ -747,8 +766,8 @@ func (x *execCtx) prepareAuth() *xrunResult {
 	}
 
 	var secs []string
-	switch strings.ToLower(strings.TrimSpace(x.req.Metadata.Auth.Type)) {
-	case "command":
+	switch authKind(x.req.Metadata.Auth) {
+	case authTypeCommand:
 		out, err := x.eng.EnsureCommandAuth(x.sendCtx, x.doc, x.req, x.res, x.env, x.timeout)
 		if err != nil {
 			x.exp.stage(
@@ -846,9 +865,6 @@ func (f flow) PrepareRequest() *xexec.RequestResult {
 	return x.prepareProto()
 }
 
-// PreviewResult always returns Preview set so RunRequest short-circuits.
-// Execution safety must not depend on a failed preview failing again on the
-// send path.
 func (f flow) PreviewResult() xexec.RequestResult {
 	if f.ctx == nil || !f.ctx.preview() {
 		return xexec.RequestResult{}
@@ -856,7 +872,6 @@ func (f flow) PreviewResult() xexec.RequestResult {
 	x := f.ctx
 	x.exp.setPrepared(x.req)
 	out := x.base()
-	out.Preview = true
 	out.RequestText = x.reqText()
 	if x.req.GRPC == nil {
 		if err := x.eng.prepareExplainHTTPPreview(

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -802,9 +802,16 @@ func (x *execCtx) prepareAuth() *xrunResult {
 }
 
 func (x *execCtx) prepareProto() *xrunResult {
+	res := x.res
+	if x.preview() {
+		// Preview keeps undefined placeholders literal, matching the lenient
+		// HTTP build. The trace lists the missing names and structural errors
+		// still fail.
+		res = res.Lenient()
+	}
 	if x.req.GRPC != nil {
 		before := CloneRequest(x.req)
-		if err := prepareGRPCRequest(x.req, x.res, x.grpcOpts.BaseDir); err != nil {
+		if err := prepareGRPCRequest(x.req, res, x.grpcOpts.BaseDir); err != nil {
 			x.exp.stage(
 				xplain.StageGRPCPrepare,
 				xplain.StageError,
@@ -825,7 +832,7 @@ func (x *execCtx) prepareProto() *xrunResult {
 	}
 	if x.req.WebSocket != nil {
 		before := CloneRequest(x.req)
-		if err := expandWebSocketSteps(x.req, x.res); err != nil {
+		if err := expandWebSocketSteps(x.req, res); err != nil {
 			x.exp.stage(
 				xplain.StageWebSocketPrepare,
 				xplain.StageError,

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -846,12 +846,18 @@ func (f flow) PrepareRequest() *xexec.RequestResult {
 	return x.prepareProto()
 }
 
+// PreviewResult always returns Preview set so RunRequest short-circuits.
+// Execution safety must not depend on a failed preview failing again on the
+// send path.
 func (f flow) PreviewResult() xexec.RequestResult {
 	if f.ctx == nil || !f.ctx.preview() {
 		return xexec.RequestResult{}
 	}
 	x := f.ctx
 	x.exp.setPrepared(x.req)
+	out := x.base()
+	out.Preview = true
+	out.RequestText = x.reqText()
 	if x.req.GRPC == nil {
 		if err := x.eng.prepareExplainHTTPPreview(
 			x.sendCtx,
@@ -868,16 +874,11 @@ func (f flow) PreviewResult() xexec.RequestResult {
 				nil,
 				err.Error(),
 			)
-			out := x.base()
 			out.Err = err
-			out.RequestText = x.reqText()
 			out.Explain = x.exp.finish(xplain.StatusError, "HTTP preparation failed", err)
 			return out
 		}
 	}
-	out := x.base()
-	out.RequestText = x.reqText()
-	out.Preview = true
 	out.Explain = x.exp.finish(
 		xplain.StatusReady,
 		"Explain preview ready. No request was sent.",

--- a/internal/engine/request/engine_test.go
+++ b/internal/engine/request/engine_test.go
@@ -155,3 +155,105 @@ func TestExecuteWithReportsInsecureSSHWarning(t *testing.T) {
 		})
 	}
 }
+
+func TestPreviewWithUnresolvedVariablesDoesNotExecute(t *testing.T) {
+	transportCalled := false
+	client := httpclient.NewClientWithOptions(
+		httpclient.WithHTTPFactory(func(opts httpclient.Options) (*http.Client, error) {
+			transportCalled = true
+			return &http.Client{}, nil
+		}),
+	)
+	e := New(engcfg.Config{Client: client}, nil)
+	req := &restfile.Request{
+		Method:  http.MethodGet,
+		URL:     "http://example.test",
+		Headers: http.Header{"X-Trace": []string{"{{traceID}}"}},
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type:   "bearer",
+				Params: map[string]string{"token": "{{auth.globalToken}}"},
+			},
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if !res.Preview {
+		t.Fatalf("expected preview result")
+	}
+	if res.Err != nil {
+		t.Fatalf("expected lenient preview to succeed, got %v", res.Err)
+	}
+	if res.Explain == nil {
+		t.Fatalf("expected explain report")
+	}
+	if transportCalled {
+		t.Fatalf("preview must not construct a transport")
+	}
+}
+
+func TestPreviewBuildFailureStillShortCircuits(t *testing.T) {
+	transportCalled := false
+	client := httpclient.NewClientWithOptions(
+		httpclient.WithHTTPFactory(func(opts httpclient.Options) (*http.Client, error) {
+			transportCalled = true
+			return &http.Client{}, nil
+		}),
+	)
+	e := New(engcfg.Config{Client: client}, nil)
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://{{host}}/status",
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if !res.Preview {
+		t.Fatalf("preview error result must keep Preview set")
+	}
+	if res.Err == nil {
+		t.Fatalf("expected request build error")
+	}
+	if transportCalled {
+		t.Fatalf("failed preview must not fall through to execution")
+	}
+}
+
+func TestPreviewCyclicVariablesReportsError(t *testing.T) {
+	transportCalled := false
+	client := httpclient.NewClientWithOptions(
+		httpclient.WithHTTPFactory(func(opts httpclient.Options) (*http.Client, error) {
+			transportCalled = true
+			return &http.Client{}, nil
+		}),
+	)
+	e := New(engcfg.Config{Client: client}, nil)
+	req := &restfile.Request{
+		Method:  http.MethodGet,
+		URL:     "http://example.test",
+		Headers: http.Header{"X-Test": []string{"{{a}}"}},
+		Variables: []restfile.Variable{
+			{Name: "a", Value: "{{b}}"},
+			{Name: "b", Value: "{{a}}"},
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if !res.Preview {
+		t.Fatalf("preview error result must keep Preview set")
+	}
+	if res.Err == nil || !strings.Contains(res.Err.Error(), "variable cycle") {
+		t.Fatalf("expected cycle error, got %v", res.Err)
+	}
+	if transportCalled {
+		t.Fatalf("failed preview must not fall through to execution")
+	}
+}

--- a/internal/engine/request/engine_test.go
+++ b/internal/engine/request/engine_test.go
@@ -451,3 +451,148 @@ func TestSendGRPCUnresolvedVariablesFailsClosed(t *testing.T) {
 		t.Fatalf("failed build must not construct a transport")
 	}
 }
+
+func TestPreviewOAuthStructuralErrorOutranksUndefined(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Variables: []restfile.Variable{
+			{Name: "a", Value: "{{b}}"},
+			{Name: "b", Value: "{{a}}"},
+		},
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type: "oauth2",
+				Params: map[string]string{
+					"token_url": "{{missing}}",
+					"cache_key": "{{a}}",
+				},
+			},
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil || !strings.Contains(res.Err.Error(), "variable cycle") {
+		t.Fatalf("expected fatal cycle error, got %v", res.Err)
+	}
+	if !res.Preview {
+		t.Fatalf("preview-mode failure result must keep Preview set")
+	}
+	if transportCalled() {
+		t.Fatalf("failed preview must not fall through to execution")
+	}
+}
+
+func TestPreviewCommandAuthStructuralErrorOutranksUndefined(t *testing.T) {
+	// Command auth params come out of a map, so an early-return regression
+	// would only mask the cycle on some runs. Repeat to make it reliable.
+	for range 10 {
+		e, transportCalled := newPreviewTestEngine(t)
+		req := &restfile.Request{
+			Method: http.MethodGet,
+			URL:    "http://example.test",
+			Variables: []restfile.Variable{
+				{Name: "a", Value: "{{b}}"},
+				{Name: "b", Value: "{{a}}"},
+			},
+			Metadata: restfile.RequestMetadata{
+				Auth: &restfile.AuthSpec{
+					Type: "command",
+					Params: map[string]string{
+						"argv":      `["demo-auth"]`,
+						"cache_key": "{{a}}",
+						"timeout":   "{{missing}}",
+					},
+				},
+			},
+		}
+
+		res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+		if err != nil {
+			t.Fatalf("ExecuteWith() error = %v", err)
+		}
+		if res.Err == nil || !strings.Contains(res.Err.Error(), "variable cycle") {
+			t.Fatalf("expected fatal cycle error, got %v", res.Err)
+		}
+		if transportCalled() {
+			t.Fatalf("failed preview must not fall through to execution")
+		}
+	}
+}
+
+func TestPreviewCommandAuthArgvCycleOutranksUndefinedParam(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Variables: []restfile.Variable{
+			{Name: "a", Value: "{{b}}"},
+			{Name: "b", Value: "{{a}}"},
+		},
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type: "command",
+				Params: map[string]string{
+					"argv":    `["demo-auth","{{a}}"]`,
+					"timeout": "{{missing}}",
+				},
+			},
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil || !strings.Contains(res.Err.Error(), "variable cycle") {
+		t.Fatalf("expected fatal cycle error, got %v", res.Err)
+	}
+	if transportCalled() {
+		t.Fatalf("failed preview must not fall through to execution")
+	}
+}
+
+func TestPreviewCommandAuthUndefinedParamOutranksDerivedParseError(t *testing.T) {
+	// cache_key fails to expand and is left out of the parsed params, so
+	// Parse claims ttl requires cache_key. The undefined variable is the
+	// real problem and must be the one reported.
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type: "command",
+				Params: map[string]string{
+					"argv":      `["demo-auth"]`,
+					"ttl":       "30s",
+					"cache_key": "{{missing}}",
+				},
+			},
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if !res.Preview || res.Err != nil {
+		t.Fatalf("expected clean preview, got preview=%v err=%v", res.Preview, res.Err)
+	}
+	skipped := false
+	for _, st := range res.Explain.Stages {
+		if st.Name == xplain.StageAuth && st.Status == xplain.StageSkipped {
+			skipped = true
+		}
+	}
+	if !skipped {
+		t.Fatalf("expected skipped auth stage, stages: %+v", res.Explain.Stages)
+	}
+	if transportCalled() {
+		t.Fatalf("preview must not construct a transport")
+	}
+}

--- a/internal/engine/request/engine_test.go
+++ b/internal/engine/request/engine_test.go
@@ -340,3 +340,114 @@ func TestPreviewCommandAuthStructuralErrorStaysFatal(t *testing.T) {
 		t.Fatalf("failed preview must not fall through to execution")
 	}
 }
+
+func TestPreviewGRPCUnresolvedVariablesStillPreviews(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method: "GRPC",
+		URL:    "{{host}}:50051",
+		GRPC: &restfile.GRPCRequest{
+			Target:     "{{host}}:50051",
+			FullMethod: "/pkg.Service/GetUser",
+			Message:    `{"id":"{{missing}}"}`,
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if !res.Preview || res.Err != nil {
+		t.Fatalf("expected clean preview, got preview=%v err=%v", res.Preview, res.Err)
+	}
+	if got := res.Executed.GRPC.Target; got != "{{host}}:50051" {
+		t.Fatalf("expected literal target placeholder, got %q", got)
+	}
+	if got := res.Executed.GRPC.Message; got != `{"id":"{{missing}}"}` {
+		t.Fatalf("expected literal message placeholder, got %q", got)
+	}
+	if transportCalled() {
+		t.Fatalf("preview must not construct a transport")
+	}
+}
+
+func TestPreviewWebSocketUnresolvedStepStillPreviews(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "ws://example.test/ws",
+		WebSocket: &restfile.WebSocketRequest{
+			Steps: []restfile.WebSocketStep{
+				{Type: restfile.WebSocketStepSendJSON, Value: `{"msg":"{{missing}}"}`},
+			},
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if !res.Preview || res.Err != nil {
+		t.Fatalf("expected clean preview, got preview=%v err=%v", res.Preview, res.Err)
+	}
+	if got := res.Executed.WebSocket.Steps[0].Value; got != `{"msg":"{{missing}}"}` {
+		t.Fatalf("expected literal step placeholder, got %q", got)
+	}
+	if transportCalled() {
+		t.Fatalf("preview must not construct a transport")
+	}
+}
+
+func TestPreviewGRPCCyclicVariablesStaysFatal(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method: "GRPC",
+		URL:    "localhost:50051",
+		Variables: []restfile.Variable{
+			{Name: "a", Value: "{{b}}"},
+			{Name: "b", Value: "{{a}}"},
+		},
+		GRPC: &restfile.GRPCRequest{
+			Target:     "localhost:50051",
+			FullMethod: "/pkg.Service/GetUser",
+			Message:    `{"id":"{{a}}"}`,
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil || !strings.Contains(res.Err.Error(), "variable cycle") {
+		t.Fatalf("expected fatal cycle error, got %v", res.Err)
+	}
+	if !res.Preview {
+		t.Fatalf("preview-mode failure result must keep Preview set")
+	}
+	if transportCalled() {
+		t.Fatalf("failed preview must not fall through to execution")
+	}
+}
+
+func TestSendGRPCUnresolvedVariablesFailsClosed(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method: "GRPC",
+		URL:    "{{host}}:50051",
+		GRPC: &restfile.GRPCRequest{
+			Target:     "{{host}}:50051",
+			FullMethod: "/pkg.Service/GetUser",
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil || !strings.Contains(res.Err.Error(), "undefined variable: host") {
+		t.Fatalf("expected undefined variable error, got %v", res.Err)
+	}
+	if transportCalled() {
+		t.Fatalf("failed build must not construct a transport")
+	}
+}

--- a/internal/engine/request/engine_test.go
+++ b/internal/engine/request/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
+	xplain "github.com/unkn0wn-root/resterm/internal/explain"
 	"github.com/unkn0wn-root/resterm/internal/httpclient"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
@@ -156,7 +157,8 @@ func TestExecuteWithReportsInsecureSSHWarning(t *testing.T) {
 	}
 }
 
-func TestPreviewWithUnresolvedVariablesDoesNotExecute(t *testing.T) {
+func newPreviewTestEngine(t *testing.T) (*Engine, func() bool) {
+	t.Helper()
 	transportCalled := false
 	client := httpclient.NewClientWithOptions(
 		httpclient.WithHTTPFactory(func(opts httpclient.Options) (*http.Client, error) {
@@ -164,7 +166,11 @@ func TestPreviewWithUnresolvedVariablesDoesNotExecute(t *testing.T) {
 			return &http.Client{}, nil
 		}),
 	)
-	e := New(engcfg.Config{Client: client}, nil)
+	return New(engcfg.Config{Client: client}, nil), func() bool { return transportCalled }
+}
+
+func TestPreviewWithUnresolvedVariablesDoesNotExecute(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
 	req := &restfile.Request{
 		Method:  http.MethodGet,
 		URL:     "http://example.test",
@@ -181,29 +187,19 @@ func TestPreviewWithUnresolvedVariablesDoesNotExecute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExecuteWith() error = %v", err)
 	}
-	if !res.Preview {
-		t.Fatalf("expected preview result")
-	}
-	if res.Err != nil {
-		t.Fatalf("expected lenient preview to succeed, got %v", res.Err)
+	if !res.Preview || res.Err != nil {
+		t.Fatalf("expected clean preview, got preview=%v err=%v", res.Preview, res.Err)
 	}
 	if res.Explain == nil {
 		t.Fatalf("expected explain report")
 	}
-	if transportCalled {
+	if transportCalled() {
 		t.Fatalf("preview must not construct a transport")
 	}
 }
 
 func TestPreviewBuildFailureStillShortCircuits(t *testing.T) {
-	transportCalled := false
-	client := httpclient.NewClientWithOptions(
-		httpclient.WithHTTPFactory(func(opts httpclient.Options) (*http.Client, error) {
-			transportCalled = true
-			return &http.Client{}, nil
-		}),
-	)
-	e := New(engcfg.Config{Client: client}, nil)
+	e, transportCalled := newPreviewTestEngine(t)
 	req := &restfile.Request{
 		Method: http.MethodGet,
 		URL:    "http://{{host}}/status",
@@ -219,20 +215,13 @@ func TestPreviewBuildFailureStillShortCircuits(t *testing.T) {
 	if res.Err == nil {
 		t.Fatalf("expected request build error")
 	}
-	if transportCalled {
+	if transportCalled() {
 		t.Fatalf("failed preview must not fall through to execution")
 	}
 }
 
 func TestPreviewCyclicVariablesReportsError(t *testing.T) {
-	transportCalled := false
-	client := httpclient.NewClientWithOptions(
-		httpclient.WithHTTPFactory(func(opts httpclient.Options) (*http.Client, error) {
-			transportCalled = true
-			return &http.Client{}, nil
-		}),
-	)
-	e := New(engcfg.Config{Client: client}, nil)
+	e, transportCalled := newPreviewTestEngine(t)
 	req := &restfile.Request{
 		Method:  http.MethodGet,
 		URL:     "http://example.test",
@@ -253,7 +242,101 @@ func TestPreviewCyclicVariablesReportsError(t *testing.T) {
 	if res.Err == nil || !strings.Contains(res.Err.Error(), "variable cycle") {
 		t.Fatalf("expected cycle error, got %v", res.Err)
 	}
-	if transportCalled {
+	if transportCalled() {
+		t.Fatalf("failed preview must not fall through to execution")
+	}
+}
+
+func TestPreviewUnresolvedAuthParamSkipsAuthStage(t *testing.T) {
+	cases := []struct {
+		name string
+		auth *restfile.AuthSpec
+	}{
+		{
+			name: "command argv",
+			auth: &restfile.AuthSpec{
+				Type:   "command",
+				Params: map[string]string{"argv": `["demo-auth","{{missing}}"]`},
+			},
+		},
+		{
+			name: "command typed param",
+			auth: &restfile.AuthSpec{
+				Type:   "command",
+				Params: map[string]string{"argv": `["demo-auth"]`, "timeout": "{{missing}}"},
+			},
+		},
+		{
+			name: "oauth token url",
+			auth: &restfile.AuthSpec{
+				Type:   "oauth2",
+				Params: map[string]string{"token_url": "{{missing}}"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e, transportCalled := newPreviewTestEngine(t)
+			req := &restfile.Request{
+				Method:   http.MethodGet,
+				URL:      "http://example.test",
+				Metadata: restfile.RequestMetadata{Auth: tc.auth},
+			}
+
+			res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+			if err != nil {
+				t.Fatalf("ExecuteWith() error = %v", err)
+			}
+			if !res.Preview || res.Err != nil {
+				t.Fatalf("expected clean preview, got preview=%v err=%v", res.Preview, res.Err)
+			}
+			skipped := false
+			for _, st := range res.Explain.Stages {
+				if st.Name == xplain.StageAuth && st.Status == xplain.StageSkipped {
+					skipped = true
+				}
+			}
+			if !skipped {
+				t.Fatalf("expected skipped auth stage, stages: %+v", res.Explain.Stages)
+			}
+			if transportCalled() {
+				t.Fatalf("preview must not construct a transport")
+			}
+		})
+	}
+}
+
+func TestPreviewCommandAuthStructuralErrorStaysFatal(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Variables: []restfile.Variable{
+			{Name: "a", Value: "{{b}}"},
+			{Name: "b", Value: "{{a}}"},
+		},
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type: "command",
+				Params: map[string]string{
+					"argv":      `["demo-auth"]`,
+					"cache_key": "{{a}}",
+				},
+			},
+		},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil || !strings.Contains(res.Err.Error(), "variable cycle") {
+		t.Fatalf("expected fatal cycle error, got %v", res.Err)
+	}
+	if !res.Preview {
+		t.Fatalf("preview-mode failure result must keep Preview set")
+	}
+	if transportCalled() {
 		t.Fatalf("failed preview must not fall through to execution")
 	}
 }

--- a/internal/engine/request/explain_build.go
+++ b/internal/engine/request/explain_build.go
@@ -1241,7 +1241,7 @@ func (e *Engine) prepareExplainHTTPPreview(
 	if rep == nil || req == nil || e.hc == nil {
 		return nil
 	}
-	httpReq, _, body, err := e.hc.BuildHTTPRequest(ctx, req, res, opts)
+	httpReq, _, body, err := e.hc.BuildHTTPRequest(ctx, req, res.Lenient(), opts)
 	if err != nil {
 		return err
 	}

--- a/internal/explain/defs.go
+++ b/internal/explain/defs.go
@@ -38,6 +38,7 @@ const (
 	SummaryOAuthTokenFetchSkipped      = "oauth token fetch skipped"
 	SummaryCommandAuthExecutionSkipped = "command auth execution skipped"
 	SummaryAuthTypeNotApplied          = "auth type not applied"
+	SummaryAuthPreviewSkipped          = "auth preview skipped"
 	SummaryRTSPreRequestComplete       = "RTS pre-request complete"
 	SummaryRTSPreRequestFailed         = "RTS pre-request failed"
 	SummaryRTSPreRequestOutputBad      = "RTS pre-request output invalid"

--- a/internal/helpdoc/topics/variables.md
+++ b/internal/helpdoc/topics/variables.md
@@ -9,3 +9,5 @@ GET {{apiUrl}}/users/{{userId}}
 ```
 
 Declare values at `@const`, `@request`, `@file`, or `@global` scope. Append `-secret` to mask them in summaries. `@capture` stores response data for later requests. Press `Ctrl+E` to select an environment.
+
+An undefined variable in any part of an outbound request blocks the send. Previews keep the `{{...}}` placeholder and list the missing names.

--- a/internal/httpclient/executor_test.go
+++ b/internal/httpclient/executor_test.go
@@ -209,7 +209,9 @@ func TestApplyAuthenticationBasic(t *testing.T) {
 		Params: map[string]string{"username": "alice", "password": "secret"},
 	}
 	resolver := vars.NewResolver()
-	client.applyAuthentication(httpReq, resolver, auth)
+	if err := client.applyAuthentication(httpReq, resolver, auth); err != nil {
+		t.Fatalf("apply authentication: %v", err)
+	}
 	if got := httpReq.Header.Get("Authorization"); !strings.HasPrefix(got, "Basic ") {
 		t.Fatalf("expected basic auth header, got %s", got)
 	}
@@ -228,7 +230,9 @@ func TestApplyAuthenticationBearer(t *testing.T) {
 		Params: map[string]string{"token": "token-123"},
 	}
 	resolver := vars.NewResolver()
-	client.applyAuthentication(httpReq, resolver, auth)
+	if err := client.applyAuthentication(httpReq, resolver, auth); err != nil {
+		t.Fatalf("apply authentication: %v", err)
+	}
 	if got := httpReq.Header.Get("Authorization"); got != "Bearer token-123" {
 		t.Fatalf("expected bearer auth header, got %q", got)
 	}

--- a/internal/httpclient/request.go
+++ b/internal/httpclient/request.go
@@ -9,6 +9,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/httpver"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/util"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -31,6 +32,7 @@ const (
 	authParamHeader    = "header"
 
 	authPlacementQuery   = "query"
+	authPlacementHeader  = "header"
 	authorizationHeader  = "Authorization"
 	defaultAPIKeyHeader  = "X-API-Key"
 	bearerTokenPrefix    = "Bearer "
@@ -72,8 +74,9 @@ func (c *Client) prepareHTTPRequestWithOpts(
 	return prepared.request, prepared.options, nil
 }
 
-// applyAuthentication fails closed: an unresolved variable in any auth param that
-// would reach the wire aborts the build instead of sending the literal placeholder.
+// applyAuthentication expands every auth param that would reach the wire and
+// propagates expansion errors, so a strict resolver fails the build closed
+// while a lenient one previews with placeholders intact.
 func (c *Client) applyAuthentication(
 	req *http.Request,
 	resolver *vars.Resolver,
@@ -84,20 +87,29 @@ func (c *Client) applyAuthentication(
 	}
 
 	kind := strings.ToLower(auth.Type)
-	expand := func(param string) (string, error) {
+	expandResult := func(param string) (vars.Expansion, error) {
 		value := auth.Params[param]
 		if value == "" || resolver == nil {
-			return value, nil
+			return vars.Expansion{Value: value}, nil
 		}
-		expanded, err := resolver.ExpandTemplates(value)
+		out, err := resolver.ExpandTemplatesResult(value)
 		if err != nil {
 			op := fmt.Sprintf("expand %s auth %s", kind, param)
 			if at := auth.Origin(); at != "" {
 				op += " (" + at + ")"
 			}
-			return "", diag.WrapAs(diag.ClassAuth, err, op)
+			return vars.Expansion{}, diag.WrapAs(
+				diag.ClassAuth,
+				err,
+				op,
+				diag.WithComponent(diag.ComponentHTTP),
+			)
 		}
-		return expanded, nil
+		return out, nil
+	}
+	expand := func(param string) (string, error) {
+		out, err := expandResult(param)
+		return out.Value, err
 	}
 
 	switch kind {
@@ -124,11 +136,16 @@ func (c *Client) applyAuthentication(
 		}
 		req.Header.Set(authorizationHeader, bearerTokenPrefix+token)
 	case string(authTypeAPIKey), legacyAPIKeyAuthType:
+		placement, err := expandResult(authParamPlacement)
+		if err != nil {
+			return err
+		}
 		name, err := expand(authParamName)
 		if err != nil {
 			return err
 		}
-		if strings.ToLower(auth.Params[authParamPlacement]) == authPlacementQuery {
+		switch util.LowerTrim(placement.Value) {
+		case authPlacementQuery:
 			value, err := expand(authParamValue)
 			if err != nil {
 				return err
@@ -136,19 +153,30 @@ func (c *Client) applyAuthentication(
 			q := req.URL.Query()
 			q.Set(name, value)
 			req.URL.RawQuery = q.Encode()
-			return nil
+		case "", authPlacementHeader:
+			if name == "" {
+				name = defaultAPIKeyHeader
+			}
+			if req.Header.Get(name) != "" {
+				return nil
+			}
+			value, err := expand(authParamValue)
+			if err != nil {
+				return err
+			}
+			req.Header.Set(name, value)
+		default:
+			// Only a lenient resolver leaves an undefined placement literal.
+			// The preview must not guess where the key lands, so skip it.
+			if placement.HasUndefinedVariables {
+				return nil
+			}
+			msg := fmt.Sprintf("invalid apikey auth placement %q, expected header or query", placement.Value)
+			if at := auth.Origin(); at != "" {
+				msg += " (" + at + ")"
+			}
+			return diag.New(diag.ClassAuth, msg, diag.WithComponent(diag.ComponentHTTP))
 		}
-		if name == "" {
-			name = defaultAPIKeyHeader
-		}
-		if req.Header.Get(name) != "" {
-			return nil
-		}
-		value, err := expand(authParamValue)
-		if err != nil {
-			return err
-		}
-		req.Header.Set(name, value)
 	case string(authTypeHeader):
 		name, err := expand(authParamHeader)
 		if err != nil {

--- a/internal/httpclient/request.go
+++ b/internal/httpclient/request.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -71,63 +72,98 @@ func (c *Client) prepareHTTPRequestWithOpts(
 	return prepared.request, prepared.options, nil
 }
 
+// applyAuthentication fails closed: an unresolved variable in any auth param that
+// would reach the wire aborts the build instead of sending the literal placeholder.
 func (c *Client) applyAuthentication(
 	req *http.Request,
 	resolver *vars.Resolver,
 	auth *restfile.AuthSpec,
-) {
+) error {
 	if auth == nil || len(auth.Params) == 0 {
-		return
+		return nil
 	}
 
-	expand := func(value string) string {
-		if value == "" {
-			return ""
+	kind := strings.ToLower(auth.Type)
+	expand := func(param string) (string, error) {
+		value := auth.Params[param]
+		if value == "" || resolver == nil {
+			return value, nil
 		}
-		if resolver == nil {
-			return value
+		expanded, err := resolver.ExpandTemplates(value)
+		if err != nil {
+			op := fmt.Sprintf("expand %s auth %s", kind, param)
+			if at := auth.Origin(); at != "" {
+				op += " (" + at + ")"
+			}
+			return "", diag.WrapAs(diag.ClassAuth, err, op)
 		}
-		if expanded, err := resolver.ExpandTemplates(value); err == nil {
-			return expanded
-		}
-		return value
+		return expanded, nil
 	}
 
-	switch strings.ToLower(auth.Type) {
+	switch kind {
 	case string(authTypeBasic):
-		user := expand(auth.Params[authParamUsername])
-		pass := expand(auth.Params[authParamPassword])
-		if req.Header.Get(authorizationHeader) == "" {
-			req.SetBasicAuth(user, pass)
+		if req.Header.Get(authorizationHeader) != "" {
+			return nil
 		}
+		user, err := expand(authParamUsername)
+		if err != nil {
+			return err
+		}
+		pass, err := expand(authParamPassword)
+		if err != nil {
+			return err
+		}
+		req.SetBasicAuth(user, pass)
 	case string(authTypeBearer):
-		token := expand(auth.Params[authParamToken])
-		if req.Header.Get(authorizationHeader) == "" {
-			req.Header.Set(authorizationHeader, bearerTokenPrefix+token)
+		if req.Header.Get(authorizationHeader) != "" {
+			return nil
 		}
+		token, err := expand(authParamToken)
+		if err != nil {
+			return err
+		}
+		req.Header.Set(authorizationHeader, bearerTokenPrefix+token)
 	case string(authTypeAPIKey), legacyAPIKeyAuthType:
-		placement := strings.ToLower(auth.Params[authParamPlacement])
-		name := expand(auth.Params[authParamName])
-		value := expand(auth.Params[authParamValue])
-		if placement == authPlacementQuery {
+		name, err := expand(authParamName)
+		if err != nil {
+			return err
+		}
+		if strings.ToLower(auth.Params[authParamPlacement]) == authPlacementQuery {
+			value, err := expand(authParamValue)
+			if err != nil {
+				return err
+			}
 			q := req.URL.Query()
 			q.Set(name, value)
 			req.URL.RawQuery = q.Encode()
-		} else {
-			if name == "" {
-				name = defaultAPIKeyHeader
-			}
-			if req.Header.Get(name) == "" {
-				req.Header.Set(name, value)
-			}
+			return nil
 		}
+		if name == "" {
+			name = defaultAPIKeyHeader
+		}
+		if req.Header.Get(name) != "" {
+			return nil
+		}
+		value, err := expand(authParamValue)
+		if err != nil {
+			return err
+		}
+		req.Header.Set(name, value)
 	case string(authTypeHeader):
-		name := expand(auth.Params[authParamHeader])
-		value := expand(auth.Params[authParamValue])
-		if name != "" && req.Header.Get(name) == "" {
-			req.Header.Set(name, value)
+		name, err := expand(authParamHeader)
+		if err != nil {
+			return err
 		}
+		if name == "" || req.Header.Get(name) != "" {
+			return nil
+		}
+		value, err := expand(authParamValue)
+		if err != nil {
+			return err
+		}
+		req.Header.Set(name, value)
 	}
+	return nil
 }
 
 type reqMeta struct {

--- a/internal/httpclient/request_build.go
+++ b/internal/httpclient/request_build.go
@@ -172,9 +172,15 @@ func (c *Client) buildHTTPRequest(
 			for _, value := range values {
 				finalValue := value
 				if resolver != nil {
-					if expanded, expandErr := resolver.ExpandTemplates(value); expandErr == nil {
-						finalValue = expanded
+					expanded, expandErr := resolver.ExpandTemplates(value)
+					if expandErr != nil {
+						op := "expand header " + name
+						if at := req.Origin(); at != "" {
+							op += " (" + at + ")"
+						}
+						return nil, opts, diag.WrapAs(diag.ClassProtocol, expandErr, op)
 					}
+					finalValue = expanded
 				}
 				httpReq.Header.Add(name, finalValue)
 			}
@@ -187,6 +193,8 @@ func (c *Client) buildHTTPRequest(
 		}
 	}
 
-	c.applyAuthentication(httpReq, resolver, req.Metadata.Auth)
+	if err := c.applyAuthentication(httpReq, resolver, req.Metadata.Auth); err != nil {
+		return nil, opts, err
+	}
 	return httpReq, opts, nil
 }

--- a/internal/httpclient/request_build.go
+++ b/internal/httpclient/request_build.go
@@ -178,7 +178,12 @@ func (c *Client) buildHTTPRequest(
 						if at := req.Origin(); at != "" {
 							op += " (" + at + ")"
 						}
-						return nil, opts, diag.WrapAs(diag.ClassProtocol, expandErr, op)
+						return nil, opts, diag.WrapAs(
+							diag.ClassProtocol,
+							expandErr,
+							op,
+							diag.WithComponent(diag.ComponentHTTP),
+						)
 					}
 					finalValue = expanded
 				}

--- a/internal/httpclient/request_test.go
+++ b/internal/httpclient/request_test.go
@@ -225,3 +225,166 @@ func TestBuildHTTPRequestLenientResolverKeepsPlaceholders(t *testing.T) {
 		t.Fatalf("unexpected authorization header: %q", got)
 	}
 }
+
+func TestBuildHTTPRequestExpandsAPIKeyPlacement(t *testing.T) {
+	c := NewClient(nil)
+	resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{
+		"apiKeyPlacement": " Query ",
+		"apiKey":          "k-123",
+	}))
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    "https://example.com/path",
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type: "apikey",
+				Params: map[string]string{
+					"placement": "{{apiKeyPlacement}}",
+					"name":      "key",
+					"value":     "{{apiKey}}",
+				},
+			},
+		},
+	}
+
+	httpReq, _, _, err := c.BuildHTTPRequest(context.Background(), req, resolver, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := httpReq.URL.Query().Get("key"); got != "k-123" {
+		t.Fatalf("expected api key in query, got %q", got)
+	}
+	if got := httpReq.Header.Get("key"); got != "" {
+		t.Fatalf("api key must not land in a header, got %q", got)
+	}
+}
+
+func TestBuildHTTPRequestFailsOnUnresolvedAPIKeyPlacement(t *testing.T) {
+	c := NewClient(nil)
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    "https://example.com",
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type: "apikey",
+				Params: map[string]string{
+					"placement": "{{apiKeyPlacement}}",
+					"name":      "key",
+					"value":     "k-123",
+				},
+			},
+		},
+	}
+
+	_, _, _, err := c.BuildHTTPRequest(context.Background(), req, vars.NewResolver(), Options{})
+	if err == nil {
+		t.Fatalf("expected error for unresolved placement")
+	}
+	if !strings.Contains(err.Error(), "expand apikey auth placement") ||
+		!strings.Contains(err.Error(), "undefined variable: apiKeyPlacement") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyAuthenticationInvalidPlacementErrors(t *testing.T) {
+	c := NewClient(nil)
+	httpReq, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	auth := &restfile.AuthSpec{
+		Type: "apikey",
+		Params: map[string]string{
+			"placement": "qurey",
+			"name":      "X-Key",
+			"value":     "k-123",
+		},
+	}
+
+	err = c.applyAuthentication(httpReq, vars.NewResolver(), auth)
+	if err == nil || !strings.Contains(err.Error(), `invalid apikey auth placement "qurey"`) {
+		t.Fatalf("expected invalid placement error, got %v", err)
+	}
+	if got := httpReq.Header.Get("X-Key"); got != "" {
+		t.Fatalf("api key must not be applied on invalid placement, got %q", got)
+	}
+}
+
+func TestApplyAuthenticationEmptyPlacementDefaultsToHeader(t *testing.T) {
+	c := NewClient(nil)
+	httpReq, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	auth := &restfile.AuthSpec{
+		Type:   "apikey",
+		Params: map[string]string{"name": "X-Key", "value": "k-123"},
+	}
+
+	if err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := httpReq.Header.Get("X-Key"); got != "k-123" {
+		t.Fatalf("expected header placement by default, got %q", got)
+	}
+}
+
+func TestApplyAuthenticationLenientAPIKeyPlacement(t *testing.T) {
+	tests := []struct {
+		name      string
+		placement string
+		wantError string
+	}{
+		{
+			name:      "undefined variable skips key",
+			placement: "{{apiKeyPlacement}}",
+		},
+		{
+			name:      "malformed opening marker errors",
+			placement: "foo{{",
+			wantError: `invalid apikey auth placement "foo{{"`,
+		},
+		{
+			name:      "blank placeholder errors",
+			placement: "{{ }}",
+			wantError: `invalid apikey auth placement "{{ }}"`,
+		},
+		{
+			name:      "misspelled placement errors",
+			placement: "qurey",
+			wantError: `invalid apikey auth placement "qurey"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient(nil)
+			httpReq, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			auth := &restfile.AuthSpec{
+				Type: "apikey",
+				Params: map[string]string{
+					"placement": tt.placement,
+					"name":      "X-Key",
+					"value":     "k-123",
+				},
+			}
+
+			err = c.applyAuthentication(httpReq, vars.NewResolver().Lenient(), auth)
+			if tt.wantError == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantError != "" && (err == nil || !strings.Contains(err.Error(), tt.wantError)) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantError, err)
+			}
+			if got := httpReq.Header.Get("X-Key"); got != "" {
+				t.Fatalf("api key with unknown placement must not be applied, got %q", got)
+			}
+			if got := httpReq.URL.RawQuery; got != "" {
+				t.Fatalf("api key with unknown placement must not touch the query, got %q", got)
+			}
+		})
+	}
+}

--- a/internal/httpclient/request_test.go
+++ b/internal/httpclient/request_test.go
@@ -2,11 +2,13 @@ package httpclient
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/unkn0wn-root/resterm/internal/httpver"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 func TestPrepareHTTPRequestRejectsHTTP2OverHTTP(t *testing.T) {
@@ -47,5 +49,148 @@ func TestApplyRequestSettingsIgnoresInvalidHTTPVersion(t *testing.T) {
 
 	if effective.HTTPVersion != httpver.V11 {
 		t.Fatalf("expected HTTP version to remain unchanged, got %v", effective.HTTPVersion)
+	}
+}
+
+func TestBuildHTTPRequestFailsOnUnresolvedHeader(t *testing.T) {
+	c := NewClient(nil)
+	req := &restfile.Request{
+		Method:     "GET",
+		URL:        "https://example.com",
+		Headers:    http.Header{"X-Trace": []string{"{{traceID}}"}},
+		SourcePath: "api.http",
+		LineRange:  restfile.LineRange{Start: 10, End: 12},
+	}
+
+	_, _, _, err := c.BuildHTTPRequest(context.Background(), req, vars.NewResolver(), Options{})
+	if err == nil {
+		t.Fatalf("expected error for unresolved header variable")
+	}
+	if !strings.Contains(err.Error(), "expand header X-Trace (api.http:10)") ||
+		!strings.Contains(err.Error(), "undefined variable: traceID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildHTTPRequestFailsOnUnresolvedBearerToken(t *testing.T) {
+	c := NewClient(nil)
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    "https://example.com",
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type:       "bearer",
+				Params:     map[string]string{"token": "{{auth.globalToken}}"},
+				SourcePath: "auth.http",
+				Line:       3,
+			},
+		},
+	}
+
+	_, _, _, err := c.BuildHTTPRequest(context.Background(), req, vars.NewResolver(), Options{})
+	if err == nil {
+		t.Fatalf("expected error for unresolved bearer token")
+	}
+	if !strings.Contains(err.Error(), "expand bearer auth token (auth.http:3)") ||
+		!strings.Contains(err.Error(), "undefined variable: auth.globalToken") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildHTTPRequestFailsOnUnresolvedBasicAuth(t *testing.T) {
+	c := NewClient(nil)
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    "https://example.com",
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type:   "basic",
+				Params: map[string]string{"username": "svc", "password": "{{secret}}"},
+			},
+		},
+	}
+
+	_, _, _, err := c.BuildHTTPRequest(context.Background(), req, vars.NewResolver(), Options{})
+	if err == nil {
+		t.Fatalf("expected error for unresolved basic auth password")
+	}
+	if !strings.Contains(err.Error(), "expand basic auth password") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildHTTPRequestFailsOnUnresolvedAPIKeyQuery(t *testing.T) {
+	c := NewClient(nil)
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    "https://example.com",
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type: "apikey",
+				Params: map[string]string{
+					"placement": "query",
+					"name":      "key",
+					"value":     "{{apiKey}}",
+				},
+			},
+		},
+	}
+
+	_, _, _, err := c.BuildHTTPRequest(context.Background(), req, vars.NewResolver(), Options{})
+	if err == nil {
+		t.Fatalf("expected error for unresolved apikey value")
+	}
+	if !strings.Contains(err.Error(), "expand apikey auth value") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyAuthenticationSkipsUnusedParams(t *testing.T) {
+	c := NewClient(nil)
+	httpReq, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer explicit")
+	auth := &restfile.AuthSpec{
+		Type:   "bearer",
+		Params: map[string]string{"token": "{{missing}}"},
+	}
+
+	if err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
+		t.Fatalf("unexpected error for unused auth param: %v", err)
+	}
+	if got := httpReq.Header.Get("Authorization"); got != "Bearer explicit" {
+		t.Fatalf("authorization header changed: %q", got)
+	}
+}
+
+func TestBuildHTTPRequestExpandsHeaderAndAuth(t *testing.T) {
+	c := NewClient(nil)
+	resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{
+		"traceID": "abc123",
+		"token":   "tok-1",
+	}))
+	req := &restfile.Request{
+		Method:  "GET",
+		URL:     "https://example.com",
+		Headers: http.Header{"X-Trace": []string{"{{traceID}}"}},
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type:   "bearer",
+				Params: map[string]string{"token": "{{token}}"},
+			},
+		},
+	}
+
+	httpReq, _, _, err := c.BuildHTTPRequest(context.Background(), req, resolver, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := httpReq.Header.Get("X-Trace"); got != "abc123" {
+		t.Fatalf("unexpected trace header: %q", got)
+	}
+	if got := httpReq.Header.Get("Authorization"); got != "Bearer tok-1" {
+		t.Fatalf("unexpected authorization header: %q", got)
 	}
 }

--- a/internal/httpclient/request_test.go
+++ b/internal/httpclient/request_test.go
@@ -194,3 +194,34 @@ func TestBuildHTTPRequestExpandsHeaderAndAuth(t *testing.T) {
 		t.Fatalf("unexpected authorization header: %q", got)
 	}
 }
+
+func TestBuildHTTPRequestLenientResolverKeepsPlaceholders(t *testing.T) {
+	c := NewClient(nil)
+	req := &restfile.Request{
+		Method:  "GET",
+		URL:     "https://example.com",
+		Headers: http.Header{"X-Trace": []string{"{{traceID}}"}},
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type:   "bearer",
+				Params: map[string]string{"token": "{{tok}}"},
+			},
+		},
+	}
+
+	httpReq, _, _, err := c.BuildHTTPRequest(
+		context.Background(),
+		req,
+		vars.NewResolver().Lenient(),
+		Options{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := httpReq.Header.Get("X-Trace"); got != "{{traceID}}" {
+		t.Fatalf("unexpected trace header: %q", got)
+	}
+	if got := httpReq.Header.Get("Authorization"); got != "Bearer {{tok}}" {
+		t.Fatalf("unexpected authorization header: %q", got)
+	}
+}

--- a/internal/parser/comment.go
+++ b/internal/parser/comment.go
@@ -183,6 +183,7 @@ func (b *documentBuilder) handleAuthDirective(
 		}
 		spec := *dir.Spec.Clone()
 		spec.SourcePath = b.doc.Path
+		spec.Line = line
 		b.file.auth = append(b.file.auth, restfile.AuthProfile{
 			Scope:      dir.Scope,
 			Name:       dir.Name,
@@ -200,6 +201,7 @@ func (b *documentBuilder) handleAuthDirective(
 		if dir.Spec != nil {
 			spec := dir.Spec.Clone()
 			spec.SourcePath = b.doc.Path
+			spec.Line = line
 			b.request.metadata.Auth = spec
 			b.request.metadata.AuthDisabled = false
 		}

--- a/internal/parser/document.go
+++ b/internal/parser/document.go
@@ -204,6 +204,7 @@ func (b *documentBuilder) ensureRequest(line int) {
 	b.inRequest = true
 	b.request = &requestBuilder{
 		startLine:         line,
+		sourcePath:        b.doc.Path,
 		metadata:          restfile.RequestMetadata{Tags: []string{}},
 		currentScriptKind: defaultScriptKind,
 		currentScriptLang: defaultScriptLang,
@@ -234,7 +235,6 @@ func (b *documentBuilder) flushRequest(_ int) {
 	b.request.flushPendingScript()
 
 	req := b.request.build()
-	req.SourcePath = b.doc.Path
 	b.lintRequestCaptures(req)
 	if req.Method != "" && req.URL != "" {
 		b.doc.Requests = append(b.doc.Requests, req)

--- a/internal/parser/document.go
+++ b/internal/parser/document.go
@@ -234,6 +234,7 @@ func (b *documentBuilder) flushRequest(_ int) {
 	b.request.flushPendingScript()
 
 	req := b.request.build()
+	req.SourcePath = b.doc.Path
 	b.lintRequestCaptures(req)
 	if req.Method != "" && req.URL != "" {
 		b.doc.Requests = append(b.doc.Requests, req)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -3768,3 +3768,40 @@ GET https://example.com
 		t.Fatalf("expected empty alias, got %q", sp.Alias)
 	}
 }
+
+func TestParseRecordsAuthAndRequestOrigin(t *testing.T) {
+	src := `# @auth file bearer {{fileToken}}
+
+# @auth request bearer {{reqToken}}
+GET https://example.com
+`
+
+	doc := Parse("origin.http", []byte(src))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("expected no parse errors, got %v", doc.Errors)
+	}
+	if len(doc.Auth) != 1 {
+		t.Fatalf("expected 1 auth profile, got %d", len(doc.Auth))
+	}
+	spec := doc.Auth[0].Spec
+	if spec.SourcePath != "origin.http" || spec.Line != 1 {
+		t.Fatalf("unexpected file auth origin: %s:%d", spec.SourcePath, spec.Line)
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if req.SourcePath != "origin.http" {
+		t.Fatalf("unexpected request source path: %q", req.SourcePath)
+	}
+	if req.Metadata.Auth == nil {
+		t.Fatalf("expected request auth metadata")
+	}
+	if req.Metadata.Auth.SourcePath != "origin.http" || req.Metadata.Auth.Line != 3 {
+		t.Fatalf(
+			"unexpected request auth origin: %s:%d",
+			req.Metadata.Auth.SourcePath,
+			req.Metadata.Auth.Line,
+		)
+	}
+}

--- a/internal/parser/request.go
+++ b/internal/parser/request.go
@@ -15,6 +15,7 @@ import (
 
 type requestBuilder struct {
 	startLine         int
+	sourcePath        string
 	metadata          restfile.RequestMetadata
 	variables         []restfile.Variable
 	originalLines     []string
@@ -93,6 +94,7 @@ func (r *requestBuilder) build() *restfile.Request {
 			Start: r.startLine,
 			End:   r.startLine + len(r.originalLines) - 1,
 		},
+		SourcePath:   r.sourcePath,
 		OriginalText: strings.Join(r.originalLines, "\n"),
 	}
 

--- a/internal/restfile/auth.go
+++ b/internal/restfile/auth.go
@@ -1,6 +1,9 @@
 package restfile
 
-import "maps"
+import (
+	"fmt"
+	"maps"
+)
 
 func (a *AuthSpec) Clone() *AuthSpec {
 	if a == nil {
@@ -9,6 +12,26 @@ func (a *AuthSpec) Clone() *AuthSpec {
 	cp := *a
 	cp.Params = cloneAuthParams(a.Params)
 	return &cp
+}
+
+func (a *AuthSpec) Origin() string {
+	if a == nil {
+		return ""
+	}
+	return origin(a.SourcePath, a.Line)
+}
+
+func origin(path string, line int) string {
+	switch {
+	case path != "" && line > 0:
+		return fmt.Sprintf("%s:%d", path, line)
+	case path != "":
+		return path
+	case line > 0:
+		return fmt.Sprintf("line %d", line)
+	default:
+		return ""
+	}
 }
 
 func cloneAuthParams(src map[string]string) map[string]string {

--- a/internal/restfile/auth_test.go
+++ b/internal/restfile/auth_test.go
@@ -1,0 +1,28 @@
+package restfile
+
+import "testing"
+
+func TestOriginFormats(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"auth path and line", (&AuthSpec{SourcePath: "a.http", Line: 3}).Origin(), "a.http:3"},
+		{"auth path only", (&AuthSpec{SourcePath: "a.http"}).Origin(), "a.http"},
+		{"auth line only", (&AuthSpec{Line: 3}).Origin(), "line 3"},
+		{"auth empty", (&AuthSpec{}).Origin(), ""},
+		{"auth nil", (*AuthSpec)(nil).Origin(), ""},
+		{
+			"request path and line",
+			(&Request{SourcePath: "b.http", LineRange: LineRange{Start: 10}}).Origin(),
+			"b.http:10",
+		},
+		{"request empty", (&Request{}).Origin(), ""},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Fatalf("%s: got %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -30,9 +30,11 @@ type Constant struct {
 type AuthSpec struct {
 	Type   string
 	Params map[string]string
-	// SourcePath tracks the file that defined this auth so relative command auth
-	// execution stays anchored to the auth definition, not the consuming request.
+	// SourcePath and Line track where this auth was defined so errors can point
+	// at the definition, and relative command auth execution stays anchored to
+	// the auth definition, not the consuming request.
 	SourcePath string
+	Line       int
 }
 
 type AuthProfile struct {
@@ -353,12 +355,20 @@ type Request struct {
 	Variables    []Variable
 	Settings     map[string]string
 	LineRange    LineRange
+	SourcePath   string
 	OriginalText string
 	GRPC         *GRPCRequest
 	SSE          *SSERequest
 	WebSocket    *WebSocketRequest
 	SSH          *SSHSpec
 	K8s          *K8sSpec
+}
+
+func (req *Request) Origin() string {
+	if req == nil {
+		return ""
+	}
+	return origin(req.SourcePath, req.LineRange.Start)
 }
 
 type SSERequest struct {

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -364,6 +364,17 @@ func (r *Resolver) SetExprPos(pos ExprPos) {
 // as missing. Every other error still fails.
 var ErrUndefinedVariable = errors.New("undefined variable")
 
+// PreferStructural picks which expansion error to report when several occur.
+// The first structural error wins, so an undefined variable seen earlier can
+// never mask a cycle or broken expression seen later. Callers that classify
+// on ErrUndefinedVariable depend on this order.
+func PreferStructural(firstErr, err error) error {
+	if firstErr == nil || (!errors.Is(err, ErrUndefinedVariable) && errors.Is(firstErr, ErrUndefinedVariable)) {
+		return err
+	}
+	return firstErr
+}
+
 // resolveName resolves one placeholder name. A non-nil error means the
 // placeholder cannot be resolved and callers keep it as literal text.
 func (r *Resolver) resolveName(

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -2,6 +2,7 @@ package vars
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -32,9 +33,15 @@ type Resolver struct {
 	expr      ExprEval
 	exprPos   ExprPos
 	trace     *Trace
+	lenient   bool
+	memo      *memoStore
+}
 
-	mu   sync.Mutex
-	memo map[memoKey]memoEntry
+// memoStore lives behind a pointer so derived resolvers share pinned values
+// without copying the lock.
+type memoStore struct {
+	mu      sync.Mutex
+	entries map[memoKey]memoEntry
 }
 
 // memoEntry pins the first expansion of a template-valued variable so every
@@ -69,7 +76,20 @@ type expandState struct {
 }
 
 func NewResolver(providers ...Provider) *Resolver {
-	return &Resolver{providers: providers}
+	return &Resolver{providers: providers, memo: &memoStore{}}
+}
+
+// Lenient returns a resolver whose top level expansion never fails.
+// Unresolved placeholders stay literal and the trace still records the
+// missing names. Preview rendering uses it so display does not depend on
+// every variable resolving.
+func (r *Resolver) Lenient() *Resolver {
+	if r == nil || r.lenient {
+		return r
+	}
+	cp := *r
+	cp.lenient = true
+	return &cp
 }
 
 func (r *Resolver) Resolve(name string) (string, bool) {
@@ -178,9 +198,9 @@ func checkExpandState(name string, key variableKey, st *expandState) error {
 }
 
 func (r *Resolver) memoized(key memoKey) (memoEntry, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	entry, ok := r.memo[key]
+	r.memo.mu.Lock()
+	defer r.memo.mu.Unlock()
+	entry, ok := r.memo.entries[key]
 	return entry, ok
 }
 
@@ -189,15 +209,15 @@ func (r *Resolver) memoized(key memoKey) (memoEntry, bool) {
 // Avoiding a wait on another variable's expansion also keeps concurrent roots
 // of a cyclic graph from deadlocking each other.
 func (r *Resolver) memoize(key memoKey, candidate memoEntry) memoEntry {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.memo == nil {
-		r.memo = make(map[memoKey]memoEntry)
+	r.memo.mu.Lock()
+	defer r.memo.mu.Unlock()
+	if r.memo.entries == nil {
+		r.memo.entries = make(map[memoKey]memoEntry)
 	}
-	if entry, ok := r.memo[key]; ok {
+	if entry, ok := r.memo.entries[key]; ok {
 		return entry
 	}
-	r.memo[key] = candidate
+	r.memo.entries[key] = candidate
 	return candidate
 }
 
@@ -325,6 +345,11 @@ func (r *Resolver) SetExprPos(pos ExprPos) {
 	r.exprPos = pos
 }
 
+// ErrUndefinedVariable marks names no provider could resolve. Lenient
+// rendering suppresses exactly this class since the trace records the name
+// as missing. Every other error still fails.
+var ErrUndefinedVariable = errors.New("undefined variable")
+
 // resolveName resolves one placeholder name. A non-nil error means the
 // placeholder cannot be resolved and callers keep it as literal text.
 func (r *Resolver) resolveName(
@@ -373,7 +398,7 @@ func (r *Resolver) resolveName(
 		return value, nil
 	}
 	r.traceVar(ResolveTrace{Name: name, Missing: true, Uses: 1})
-	return "", fmt.Errorf("undefined variable: %s", name)
+	return "", fmt.Errorf("%w: %s", ErrUndefinedVariable, name)
 }
 
 func resolveDynamic(name string) (string, bool) {

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -27,6 +27,13 @@ type ExprPos struct {
 
 type ExprEval func(expr string, pos ExprPos) (string, error)
 
+// Expansion is the result of rendering one template input. Lenient rendering
+// preserves undefined placeholders in Value and reports their presence here.
+type Expansion struct {
+	Value                 string
+	HasUndefinedVariables bool
+}
+
 type Resolver struct {
 	providers []Provider
 	refs      []RefResolver
@@ -79,10 +86,11 @@ func NewResolver(providers ...Provider) *Resolver {
 	return &Resolver{providers: providers, memo: &memoStore{}}
 }
 
-// Lenient returns a resolver whose top level expansion never fails.
-// Unresolved placeholders stay literal and the trace still records the
-// missing names. Preview rendering uses it so display does not depend on
-// every variable resolving.
+// Lenient returns a resolver that suppresses undefined variable errors at
+// the top level. Placeholders stay literal and the trace still records the
+// missing names, while cycles, nesting depth, and expression failures keep
+// erroring. Derive it only after the resolver is fully configured, since the
+// copy does not see later setter calls.
 func (r *Resolver) Lenient() *Resolver {
 	if r == nil || r.lenient {
 		return r
@@ -319,6 +327,12 @@ func providerLabel(p Provider) string {
 
 func (r *Resolver) ExpandTemplates(input string) (string, error) {
 	return CompileTemplate(input).render(r, r.exprPos, true, true, nil)
+}
+
+// ExpandTemplatesResult expands input and reports whether resolution encountered
+// any undefined variables, including when a lenient resolver suppresses the error.
+func (r *Resolver) ExpandTemplatesResult(input string) (Expansion, error) {
+	return CompileTemplate(input).renderResult(r, r.exprPos, true, true, nil)
 }
 
 func (r *Resolver) ExpandTemplatesAt(input string, pos ExprPos) (string, error) {

--- a/internal/vars/resolver_test.go
+++ b/internal/vars/resolver_test.go
@@ -1,6 +1,7 @@
 package vars
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -397,5 +398,130 @@ func TestExpandTemplatesStaticExpr(t *testing.T) {
 	}
 	if called {
 		t.Fatalf("expected static expansion to skip expression eval")
+	}
+}
+
+func TestLenientResolverPreservesPlaceholders(t *testing.T) {
+	r := NewResolver(NewMapProvider("env", map[string]string{"host": "example.com"}))
+	tr := NewTrace()
+	r.SetTrace(tr)
+	lr := r.Lenient()
+
+	out, err := lr.ExpandTemplates("https://{{host}}/{{missing}}")
+	if err != nil {
+		t.Fatalf("lenient expansion returned error: %v", err)
+	}
+	if out != "https://example.com/{{missing}}" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+
+	if _, err := r.ExpandTemplates("{{missing}}"); err == nil {
+		t.Fatalf("strict resolver should still fail")
+	}
+
+	found := false
+	for _, it := range tr.Items() {
+		if it.Name == "missing" && it.Missing {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("trace did not record missing variable")
+	}
+}
+
+func TestLenientResolverKeepsOuterPlaceholderForNestedFailure(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("file", map[string]string{"a": "{{missing}} x"}))
+	lr := r.Lenient()
+
+	out, err := lr.ExpandTemplates("{{a}}")
+	if err != nil {
+		t.Fatalf("lenient expansion returned error: %v", err)
+	}
+	if out != "{{a}}" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+
+	if _, err := r.ExpandTemplates("{{a}}"); err == nil {
+		t.Fatalf("strict resolver should still fail after lenient render")
+	}
+}
+
+func TestLenientResolverReportsCycles(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("file", map[string]string{
+		"a": "{{b}}",
+		"b": "{{a}}",
+	}))
+
+	out, err := r.Lenient().ExpandTemplates("{{a}}")
+	if err == nil || !strings.Contains(err.Error(), "variable cycle") {
+		t.Fatalf("expected cycle error, got %v", err)
+	}
+	if out != "{{a}}" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestLenientResolverReportsExpressionErrors(t *testing.T) {
+	out, err := NewResolver().Lenient().ExpandTemplates("{{= 1 + 1 }}")
+	if err == nil || !strings.Contains(err.Error(), "expressions not enabled") {
+		t.Fatalf("expected expression error, got %v", err)
+	}
+	if out != "{{= 1 + 1 }}" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestLenientResolverCycleNotMaskedByUndefined(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("file", map[string]string{
+		"a": "{{b}}",
+		"b": "{{a}}",
+	}))
+
+	out, err := r.Lenient().ExpandTemplates("{{missing}} {{a}}")
+	if err == nil || !strings.Contains(err.Error(), "variable cycle") {
+		t.Fatalf("expected cycle error, got %v", err)
+	}
+	if out != "{{missing}} {{a}}" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestUndefinedVariableSentinel(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("file", map[string]string{"a": "{{missing}}"}))
+
+	_, err := r.ExpandTemplates("{{missing}}")
+	if !errors.Is(err, ErrUndefinedVariable) {
+		t.Fatalf("expected sentinel on plain undefined, got %v", err)
+	}
+
+	_, err = r.ExpandTemplates("{{a}}")
+	if !errors.Is(err, ErrUndefinedVariable) {
+		t.Fatalf("expected sentinel through nested wrap, got %v", err)
+	}
+
+	_, err = r.Lenient().ExpandTemplates("{{= 1 }}")
+	if errors.Is(err, ErrUndefinedVariable) {
+		t.Fatalf("expression error must not match the sentinel")
+	}
+}
+
+func TestNestedCycleOutranksUndefined(t *testing.T) {
+	r := NewResolver(NewTemplateProvider("file", map[string]string{
+		"a": "{{missing}} {{b}}",
+		"b": "{{b}}",
+	}))
+
+	out, err := r.Lenient().ExpandTemplates("{{a}}")
+	if err == nil || !strings.Contains(err.Error(), "variable cycle") {
+		t.Fatalf("lenient render must report the nested cycle, got %v", err)
+	}
+	if out != "{{a}}" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+
+	if _, err := r.ExpandTemplates("{{a}}"); err == nil ||
+		!strings.Contains(err.Error(), "variable cycle") {
+		t.Fatalf("strict render must report the cycle over the missing name, got %v", err)
 	}
 }

--- a/internal/vars/resolver_test.go
+++ b/internal/vars/resolver_test.go
@@ -430,6 +430,72 @@ func TestLenientResolverPreservesPlaceholders(t *testing.T) {
 	}
 }
 
+func TestExpandTemplatesResultReportsUndefinedVariables(t *testing.T) {
+	tests := []struct {
+		name          string
+		resolver      *Resolver
+		input         string
+		want          string
+		wantUndefined bool
+	}{
+		{
+			name: "resolved variable",
+			resolver: NewResolver(NewMapProvider("env", map[string]string{
+				"host": "example.com",
+			})).Lenient(),
+			input: "{{host}}",
+			want:  "example.com",
+		},
+		{
+			name:          "undefined variable",
+			resolver:      NewResolver().Lenient(),
+			input:         "{{missing}}",
+			want:          "{{missing}}",
+			wantUndefined: true,
+		},
+		{
+			name: "nested undefined variable",
+			resolver: NewResolver(NewTemplateProvider("file", map[string]string{
+				"outer": "{{missing}}",
+			})).Lenient(),
+			input:         "{{outer}}",
+			want:          "{{outer}}",
+			wantUndefined: true,
+		},
+		{
+			name:     "malformed opening marker",
+			resolver: NewResolver().Lenient(),
+			input:    "foo{{",
+			want:     "foo{{",
+		},
+		{
+			name:     "blank placeholder",
+			resolver: NewResolver().Lenient(),
+			input:    "{{ }}",
+			want:     "{{ }}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.resolver.ExpandTemplatesResult(tt.input)
+			if err != nil {
+				t.Fatalf("ExpandTemplatesResult() error = %v", err)
+			}
+			if result.Value != tt.want {
+				t.Fatalf("ExpandTemplatesResult() value = %q, want %q", result.Value, tt.want)
+			}
+			if result.HasUndefinedVariables != tt.wantUndefined {
+				t.Fatalf(
+					"ExpandTemplatesResult() HasUndefinedVariables = %v, want %v",
+					result.HasUndefinedVariables,
+					tt.wantUndefined,
+				)
+			}
+		})
+	}
+}
+
 func TestLenientResolverKeepsOuterPlaceholderForNestedFailure(t *testing.T) {
 	r := NewResolver(NewTemplateProvider("file", map[string]string{"a": "{{missing}} x"}))
 	lr := r.Lenient()

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -96,9 +96,7 @@ func (t Template) renderResult(
 			if lenientRoot && undefined {
 				return match
 			}
-			if firstErr == nil || (!undefined && errors.Is(firstErr, ErrUndefinedVariable)) {
-				firstErr = err
-			}
+			firstErr = PreferStructural(firstErr, err)
 			return match
 		}
 		return value

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -64,6 +64,16 @@ func (t Template) render(
 	allowDynamic, allowExpr bool,
 	st *expandState,
 ) (string, error) {
+	result, err := t.renderResult(r, pos, allowDynamic, allowExpr, st)
+	return result.Value, err
+}
+
+func (t Template) renderResult(
+	r *Resolver,
+	pos ExprPos,
+	allowDynamic, allowExpr bool,
+	st *expandState,
+) (Expansion, error) {
 	// A lenient root render (st == nil) suppresses only undefined variables,
 	// which the trace records as missing. Cycles, nesting depth, and
 	// expression failures still error, and nested value expansion stays
@@ -72,6 +82,7 @@ func (t Template) render(
 	// declared value can never mask a cycle or broken expression next to it.
 	lenientRoot := st == nil && r.lenient
 	var firstErr error
+	var undef bool
 	out := t.replace(func(match, name string) string {
 		if name == "" {
 			return match
@@ -79,6 +90,9 @@ func (t Template) render(
 		value, err := r.resolveName(name, pos, allowDynamic, allowExpr, st)
 		if err != nil {
 			undefined := errors.Is(err, ErrUndefinedVariable)
+			if undefined {
+				undef = true
+			}
 			if lenientRoot && undefined {
 				return match
 			}
@@ -89,7 +103,7 @@ func (t Template) render(
 		}
 		return value
 	})
-	return out, firstErr
+	return Expansion{Value: out, HasUndefinedVariables: undef}, firstErr
 }
 
 // replace rebuilds the input and passes every placeholder through fn, even a

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -1,6 +1,7 @@
 package vars
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 )
@@ -50,8 +51,9 @@ func CompileTemplate(input string) Template {
 }
 
 // Render expands the template the same way ExpandTemplates does. An
-// unresolvable or blank placeholder stays literal and only the first error
-// is reported.
+// unresolvable or blank placeholder stays literal. One error is reported:
+// the first structural error (cycle, depth, expression) if any occurred,
+// otherwise the first undefined variable.
 func (t Template) Render(r *Resolver) (string, error) {
 	return t.render(r, r.exprPos, true, true, nil)
 }
@@ -62,6 +64,13 @@ func (t Template) render(
 	allowDynamic, allowExpr bool,
 	st *expandState,
 ) (string, error) {
+	// A lenient root render (st == nil) suppresses only undefined variables,
+	// which the trace records as missing. Cycles, nesting depth, and
+	// expression failures still error, and nested value expansion stays
+	// strict so failed values are never memoized. Structural errors outrank
+	// an earlier undefined variable at every level, so a missing name in a
+	// declared value can never mask a cycle or broken expression next to it.
+	lenientRoot := st == nil && r.lenient
 	var firstErr error
 	out := t.replace(func(match, name string) string {
 		if name == "" {
@@ -69,7 +78,11 @@ func (t Template) render(
 		}
 		value, err := r.resolveName(name, pos, allowDynamic, allowExpr, st)
 		if err != nil {
-			if firstErr == nil {
+			undefined := errors.Is(err, ErrUndefinedVariable)
+			if lenientRoot && undefined {
+				return match
+			}
+			if firstErr == nil || (!undefined && errors.Is(firstErr, ErrUndefinedVariable)) {
 				firstErr = err
 			}
 			return match

--- a/internal/vars/template_test.go
+++ b/internal/vars/template_test.go
@@ -23,7 +23,9 @@ func TestReplaceTemplateVarsCallbackContract(t *testing.T) {
 }
 
 // Render must stay byte-for-byte equivalent to ExpandTemplates, including how
-// unresolved placeholders stay literal while only the first error is reported.
+// unresolved placeholders stay literal and which single error is reported:
+// the first structural error if any occurred, otherwise the first undefined
+// variable.
 func TestCompileTemplateRenderMatchesExpandTemplates(t *testing.T) {
 	r := NewResolver(NewMapProvider("test", map[string]string{"name": "resterm", "empty": ""}))
 	inputs := []string{


### PR DESCRIPTION
Prevent unresolved template placeholders from being sent as literal HTTP request data while preserving useful explain previews.

Previously, failed expansion in headers and authentication values could be ignored, allowing values such as `Authorization: Bearer {{auth.globalToken}}` to reach the prepared request. This change makes execution fail closed while keeping unresolved placeholders visible during preview.

## Changes

- Propagate variable expansion errors from request headers and authentication fields.
- Preserve explicit request header precedence without resolving unused auth parameters.
- Include request and auth definition source locations in expansion diagnostics.
- Add a typed `ErrUndefinedVariable` sentinel for reliable error classification.
- Add a lenient resolver mode for explain previews:
  - undefined variables remain as literal placeholders.
  - missing variables continue to appear in the resolution trace.
  - cycles, excessive nesting, and expression errors still fail.
- Share memoized variable values safely between strict and lenient resolver views.
- Ensure preview results are marked as previews before HTTP preparation so failures cannot fall through into execution.