### PR TITLE
fix(grpc): carry status details into json and headless reports

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,7 +151,7 @@ Output rules worth knowing:
 | `--fail-fast` | `-ff` | Stop after the first failed top-level result and mark the remaining selected requests as skipped. |
 | `--exit-code-mode <mode>` | `-m <mode>` | `detailed` returns classified CI exit codes; `summary` preserves the legacy `0`/`1`/`2` contract. |
 
-JSON output includes a top-level `schemaVersion`, `summary.exitCode`, `summary.failureCodes`, and per-result `failure` metadata when a result fails. Workflow, compare, and profile failures include the same structured failure object at the step or profile-iteration level.
+JSON output includes a top-level `schemaVersion`, `summary.exitCode`, `summary.failureCodes`, and per-result `failure` metadata when a result fails. Workflow, compare, and profile failures include the same structured failure object at the step or profile-iteration level. gRPC results include `grpc.statusDetails` with each status detail message encoded as JSON when the server returns any.
 
 ### Artifacts And Persisted State
 

--- a/headless/adapt.go
+++ b/headless/adapt.go
@@ -123,6 +123,7 @@ func grpcFromFmt(grpc *runfmt.GRPC) *GRPC {
 		Code:          grpc.Code,
 		StatusCode:    grpc.StatusCode,
 		StatusMessage: grpc.StatusMessage,
+		StatusDetails: grpc.StatusDetails,
 	}
 }
 

--- a/headless/report.go
+++ b/headless/report.go
@@ -243,9 +243,10 @@ type HTTP struct {
 
 // GRPC contains gRPC response summary fields.
 type GRPC struct {
-	Code          string `json:"code,omitempty"`
-	StatusCode    int    `json:"statusCode,omitempty"`
-	StatusMessage string `json:"statusMessage,omitempty"`
+	Code          string   `json:"code,omitempty"`
+	StatusCode    int      `json:"statusCode,omitempty"`
+	StatusMessage string   `json:"statusMessage,omitempty"`
+	StatusDetails []string `json:"statusDetails,omitempty"`
 }
 
 // Test contains one assertion result.
@@ -481,6 +482,7 @@ func toFormatGRPC(grpc *GRPC) *runfmt.GRPC {
 		Code:          grpc.Code,
 		StatusCode:    grpc.StatusCode,
 		StatusMessage: grpc.StatusMessage,
+		StatusDetails: grpc.StatusDetails,
 	}
 }
 

--- a/headless/types_test.go
+++ b/headless/types_test.go
@@ -88,6 +88,7 @@ func TestJSONTags(t *testing.T) {
 		{typ: reflect.TypeFor[Step](), name: "Failure", tag: ""},
 		{typ: reflect.TypeFor[HTTP](), name: "StatusCode", tag: "statusCode,omitempty"},
 		{typ: reflect.TypeFor[GRPC](), name: "StatusMessage", tag: "statusMessage,omitempty"},
+		{typ: reflect.TypeFor[GRPC](), name: "StatusDetails", tag: "statusDetails,omitempty"},
 		{typ: reflect.TypeFor[Test](), name: "Elapsed", tag: "elapsed,omitempty"},
 		{typ: reflect.TypeFor[Profile](), name: "TotalRuns", tag: "totalRuns,omitempty"},
 		{typ: reflect.TypeFor[ProfileFailure](), name: "StatusCode", tag: "statusCode,omitempty"},

--- a/headless/write_test.go
+++ b/headless/write_test.go
@@ -480,6 +480,56 @@ func TestReportMarshalJSONMatchesWriteJSON(t *testing.T) {
 	}
 }
 
+func TestReportRoundTripKeepsGRPCStatusDetails(t *testing.T) {
+	detail := `{"@type":"type.googleapis.com/google.rpc.RetryInfo"}`
+	rep := reportFromRunner(&runner.Report{
+		FilePath: "api.http",
+		Total:    1,
+		Failed:   1,
+		Results: []runner.Result{{
+			Kind:   runner.ResultKindRequest,
+			Name:   "invalid request",
+			Method: "GRPC",
+			Target: "/demo.Service/List",
+			GRPC: &grpcx.Response{
+				StatusCode:    codes.InvalidArgument,
+				StatusMessage: "invalid page size",
+				StatusDetails: []string{detail},
+			},
+		}},
+	})
+	if rep == nil {
+		t.Fatal("expected report")
+	}
+
+	grpc := rep.Results[0].GRPC
+	if grpc == nil || len(grpc.StatusDetails) != 1 || grpc.StatusDetails[0] != detail {
+		t.Fatalf("expected status details on the public report, got %+v", grpc)
+	}
+
+	var out strings.Builder
+	if err := rep.WriteJSON(&out); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	var got struct {
+		Results []struct {
+			GRPC struct {
+				StatusDetails []string `json:"statusDetails"`
+			} `json:"grpc"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("expected one result, got %+v", got.Results)
+	}
+	if details := got.Results[0].GRPC.StatusDetails; len(details) != 1 || details[0] != detail {
+		t.Fatalf("statusDetails = %v, want [%s]", details, detail)
+	}
+}
+
 func sampleRunnerReport() *runner.Report {
 	return &runner.Report{
 		Version:   "v1",

--- a/internal/protocol/grpcx/codec.go
+++ b/internal/protocol/grpcx/codec.go
@@ -6,6 +6,10 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/dynamicpb"
+
+	// Registers the google.rpc.* detail types in the global registry so status
+	// details resolve when the request carries no descriptor for them.
+	_ "google.golang.org/genproto/googleapis/rpc/errdetails"
 )
 
 // codec resolves Any payloads from request descriptors first, then falls back

--- a/internal/runx/report/json.go
+++ b/internal/runx/report/json.go
@@ -64,9 +64,10 @@ type jsonHTTP struct {
 }
 
 type jsonGRPC struct {
-	Code          string `json:"code,omitempty"`
-	StatusCode    int    `json:"statusCode,omitempty"`
-	StatusMessage string `json:"statusMessage,omitempty"`
+	Code          string   `json:"code,omitempty"`
+	StatusCode    int      `json:"statusCode,omitempty"`
+	StatusMessage string   `json:"statusMessage,omitempty"`
+	StatusDetails []string `json:"statusDetails,omitempty"`
 }
 
 type jsonFailure struct {
@@ -355,6 +356,7 @@ func (grpc *GRPC) json() *jsonGRPC {
 		Code:          grpc.Code,
 		StatusCode:    grpc.StatusCode,
 		StatusMessage: grpc.StatusMessage,
+		StatusDetails: grpc.StatusDetails,
 	}
 }
 

--- a/internal/runx/report/json_test.go
+++ b/internal/runx/report/json_test.go
@@ -1,0 +1,69 @@
+package runfmt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWriteJSONIncludesGRPCStatusDetails(t *testing.T) {
+	detail := `{"@type":"type.googleapis.com/google.rpc.RetryInfo"}`
+	rep := grpcStatusReport([]string{detail})
+
+	var out strings.Builder
+	if err := WriteJSON(&out, rep); err != nil {
+		t.Fatalf("WriteJSON(...): %v", err)
+	}
+
+	var got struct {
+		Results []struct {
+			GRPC struct {
+				StatusMessage string   `json:"statusMessage"`
+				StatusDetails []string `json:"statusDetails"`
+			} `json:"grpc"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("expected one result, got %+v", got.Results)
+	}
+	grpc := got.Results[0].GRPC
+	if grpc.StatusMessage != "invalid page size" {
+		t.Fatalf("statusMessage = %q, want invalid page size", grpc.StatusMessage)
+	}
+	if len(grpc.StatusDetails) != 1 || grpc.StatusDetails[0] != detail {
+		t.Fatalf("statusDetails = %v, want [%s]", grpc.StatusDetails, detail)
+	}
+}
+
+func TestWriteJSONOmitsEmptyGRPCStatusDetails(t *testing.T) {
+	var out strings.Builder
+	if err := WriteJSON(&out, grpcStatusReport(nil)); err != nil {
+		t.Fatalf("WriteJSON(...): %v", err)
+	}
+	if strings.Contains(out.String(), "statusDetails") {
+		t.Fatalf("json should omit empty status details, got %s", out.String())
+	}
+}
+
+func grpcStatusReport(details []string) *Report {
+	return &Report{
+		FilePath: "api.http",
+		Results: []Result{{
+			Kind:   "request",
+			Name:   "invalid request",
+			Method: "GRPC",
+			Status: StatusFail,
+			GRPC: &GRPC{
+				Code:          "InvalidArgument",
+				StatusCode:    3,
+				StatusMessage: "invalid page size",
+				StatusDetails: details,
+			},
+		}},
+		Total:  1,
+		Failed: 1,
+	}
+}

--- a/internal/runx/report/model.go
+++ b/internal/runx/report/model.go
@@ -97,7 +97,7 @@ type GRPC struct {
 	Code          string
 	StatusCode    int
 	StatusMessage string
-	StatusDetails []string `json:",omitempty"`
+	StatusDetails []string
 }
 
 type Test struct {


### PR DESCRIPTION
Status details were captured on the response but dropped on the way out. The json report had no field for them and the headless GRPC type dropped them in both conversion directions.