### PR TITLE
RST-305: grpc metadata encoding and status bar folding

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -1506,11 +1506,13 @@ Supplying any gRPC TLS setting (roots, client cert/key, insecure) automatically 
 
 Reserved transport metadata keys (`grpc-*`, `content-type`, `user-agent`, `te`, etc.) are rejected in `@grpc-metadata` (and gRPC headers).
 
+Metadata keys ending in `-bin` carry binary values. Write the raw bytes in `@grpc-metadata`; gRPC base64-encodes them on the wire, so the request metadata pane shows the encoded form rather than the literal you typed.
+
 `@auth` works on gRPC requests. `basic`, `bearer`, `apikey` and `header` auth are sent as metadata, as are `command` and `oauth2`. `apikey` with `placement query` is rejected, because gRPC has no query string.
 
 Descriptor sets and message files resolve relative to the request file, then against the fallback roots used for HTTP body files.
 
-The request body contains protobuf JSON. Use `< payload.json` to load from disk, and add `# @body expand` if the file includes templates. Responses display message JSON, headers, and trailers; a failing call also shows any `google.rpc.*` status details the server attached. History stores method, status, and timing alongside HTTP calls.
+The request body contains protobuf JSON. Use `< payload.json` to load from disk, and add `# @body expand` if the file includes templates. Responses display message JSON, headers, and trailers, with `-bin` metadata base64-encoded as it travels on the wire; a failing call also shows any `google.rpc.*` status details the server attached. History stores method, status, and timing alongside HTTP calls.
 
 Streaming (server/client/bidi) is supported. Unary/server streaming requests use a single JSON object, while client/bidi streaming requests send a JSON array of message objects. Streaming responses return a JSON array, and the Stream tab shows a per-message transcript with a summary.
 
@@ -1583,7 +1585,7 @@ Objects:
   - `status`, `statusCode`, `url`, `duration`
   - `body()` (raw string)
   - `json()` (parsed JSON or `null`)
-  - `headers.get(name)`, `headers.has(name)`, `headers.all` (lowercase map)
+  - `headers.get(name)`, `headers.has(name)`, `headers.all` (lowercase map). For gRPC the map merges response metadata with the trailers, each trailer prefixed with `Grpc-Trailer-`, and `-bin` values arrive base64-encoded.
 - `stream`
   - `enabled()` - returns `true` when the current response is an SSE or WebSocket transcript.
   - `kind()` - returns `"sse"` or `"websocket"`.

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -392,6 +392,8 @@ For named environments, `env.name` is unchanged and `env.groups` is empty.
 
 `last` provides a summary of the most recent response. It exposes `status`, `statusCode`, `statusText`, `url`, `headers`, `header(name)`, `text()`, and `json(path)`. `headers` contains the first value per header, while `header(name)` is case-insensitive. `json(path)` accepts a simple dot and `[index]` path (optional leading `$`) and returns null when a value is missing.
 
+For gRPC responses, `headers` merges the response metadata with the trailers, each trailer prefixed with `Grpc-Trailer-`. Values under keys ending in `-bin` are binary and read back base64-encoded without padding, the way they travel on the wire, so a trailer sent as `x-trace-bin` reads as `last.header("grpc-trailer-x-trace-bin")`.
+
 ### response
 
 `response` provides a summary of the current response when evaluating `@assert`. It has the same shape as `last`.

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -145,17 +145,12 @@ func rtsGRPC(resp *grpcx.Response) *rts.Resp {
 	if resp == nil {
 		return nil
 	}
-	h := make(map[string][]string, len(resp.Headers)+len(resp.Trailers))
-	for k, vs := range resp.Headers {
-		h[k] = append([]string(nil), vs...)
-	}
-	for k, vs := range resp.Trailers {
-		h[k] = append([]string(nil), vs...)
-	}
+	// Same map scripts read, so an assertion and a script name a trailer the
+	// same way: prefixed with Grpc-Trailer- and binary metadata base64-encoded.
 	return &rts.Resp{
 		Status: resp.StatusMessage,
 		Code:   int(resp.StatusCode),
-		H:      h,
+		H:      resp.HeaderMap(),
 		Body:   resp.Body,
 	}
 }

--- a/internal/engine/request/rts_test.go
+++ b/internal/engine/request/rts_test.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -9,7 +10,9 @@ import (
 	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/mock"
 	"github.com/unkn0wn-root/resterm/internal/parser"
+	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/rts"
+	"google.golang.org/grpc/codes"
 )
 
 type testMockInspector struct{}
@@ -134,5 +137,30 @@ GET https://example.com
 		if !strings.Contains(out, want) {
 			t.Fatalf("expected rendered for-each error to contain %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestRTSGRPCExposesEncodedTrailers(t *testing.T) {
+	raw := string([]byte{0x00, 0x01, 0xff})
+	resp := &grpcx.Response{
+		StatusCode:    codes.InvalidArgument,
+		StatusMessage: "invalid page size",
+		Headers:       map[string][]string{"x-shared": {"header"}},
+		Trailers: map[string][]string{
+			"x-shared":  {"trailer"},
+			"trace-bin": {raw},
+		},
+	}
+
+	h := rtsGRPC(resp).H
+	if got := h["x-shared"]; len(got) != 1 || got[0] != "header" {
+		t.Fatalf("x-shared = %q, want the header value to survive the trailer", got)
+	}
+	if got := h["Grpc-Trailer-x-shared"]; len(got) != 1 || got[0] != "trailer" {
+		t.Fatalf("Grpc-Trailer-x-shared = %q, want the trailer under its prefix", got)
+	}
+	want := base64.RawStdEncoding.EncodeToString([]byte(raw))
+	if got := h["Grpc-Trailer-trace-bin"]; len(got) != 1 || got[0] != want {
+		t.Fatalf("Grpc-Trailer-trace-bin = %q, want %q", got, want)
 	}
 }

--- a/internal/protocol/grpcx/response.go
+++ b/internal/protocol/grpcx/response.go
@@ -1,6 +1,7 @@
 package grpcx
 
 import (
+	"encoding/base64"
 	"net/http"
 	"slices"
 	"strings"
@@ -18,6 +19,7 @@ const (
 	wireContentType    = "application/grpc+proto"
 
 	trailerHeaderPrefix = "Grpc-Trailer-"
+	binaryMetaSuffix    = "-bin"
 )
 
 type Response struct {
@@ -85,7 +87,7 @@ func statusDetails(st *status.Status, cd codec) []string {
 	return out
 }
 
-func cloneMetaMap[M ~map[string][]string](src M) map[string][]string {
+func cloneMetaMap(src map[string][]string) map[string][]string {
 	if len(src) == 0 {
 		return nil
 	}
@@ -95,6 +97,32 @@ func cloneMetaMap[M ~map[string][]string](src M) map[string][]string {
 		out[key] = slices.Clone(vals)
 	}
 	return out
+}
+
+// EncodeMetadataHeader converts decoded gRPC metadata to its printable HTTP/2
+// representation. grpc-go exposes -bin values as raw bytes in strings; the
+// transport represents those bytes as unpadded base64. Encode on the way out
+// only: feeding the result back through doubles the encoding.
+func EncodeMetadataHeader(src map[string][]string) http.Header {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make(http.Header, len(src))
+	encodeMetaInto(out, "", src)
+	return out
+}
+
+func encodeMetaInto(dst http.Header, prefix string, src map[string][]string) {
+	for key, vals := range src {
+		encoded := slices.Clone(vals)
+		if strings.HasSuffix(strings.ToLower(key), binaryMetaSuffix) {
+			for i := range encoded {
+				encoded[i] = base64.RawStdEncoding.EncodeToString([]byte(encoded[i]))
+			}
+		}
+		dst[prefix+key] = encoded
+	}
 }
 
 func (r *Response) Clone() *Response {
@@ -112,8 +140,9 @@ func (r *Response) Clone() *Response {
 }
 
 // HeaderMap combines headers and trailers without changing their key casing.
-// Trailer keys are prefixed with "Grpc-Trailer-". Content-Type is added when
-// gRPC omits it from the returned metadata.
+// Binary metadata is base64-encoded as it is on the wire. Trailer keys are
+// prefixed with "Grpc-Trailer-". Content-Type is added when gRPC omits it from
+// the returned metadata.
 func (r *Response) HeaderMap() http.Header {
 	if r == nil {
 		return nil
@@ -125,12 +154,8 @@ func (r *Response) HeaderMap() http.Header {
 	}
 
 	out := make(http.Header, len(r.Headers)+len(r.Trailers)+1)
-	for key, vals := range r.Headers {
-		out[key] = slices.Clone(vals)
-	}
-	for key, vals := range r.Trailers {
-		out[trailerHeaderPrefix+key] = slices.Clone(vals)
-	}
+	encodeMetaInto(out, "", r.Headers)
+	encodeMetaInto(out, trailerHeaderPrefix, r.Trailers)
 	if ct != "" && !hasContentType(out) {
 		out.Set("Content-Type", ct)
 	}
@@ -144,6 +169,11 @@ func hasContentType(h http.Header) bool {
 		}
 	}
 	return false
+}
+
+// OK reports whether the call finished with codes.OK.
+func (r *Response) OK() bool {
+	return r != nil && r.StatusCode == codes.OK
 }
 
 // StatusText formats the gRPC status code and message for display.

--- a/internal/protocol/grpcx/response_test.go
+++ b/internal/protocol/grpcx/response_test.go
@@ -1,6 +1,7 @@
 package grpcx
 
 import (
+	"encoding/base64"
 	"net/http"
 	"reflect"
 	"testing"
@@ -91,6 +92,41 @@ func TestResponseHeaderMapFoldsTrailers(t *testing.T) {
 	resp.Headers[hdrKey][0] = "mutated"
 	if got[hdrKey][0] != "a" {
 		t.Fatalf("HeaderMap shares the header slice: %v", got)
+	}
+}
+
+func TestEncodeMetadataHeaderEncodesBinaryValues(t *testing.T) {
+	const binaryKey = "Trace-Bin"
+	raw := string([]byte{0x00, 0x01, 0x7f, 0x80, 0xff})
+	src := map[string][]string{
+		binaryKey: {raw},
+		"X-Text":  {"plain"},
+	}
+
+	got := EncodeMetadataHeader(src)
+	wantBinary := base64.RawStdEncoding.EncodeToString([]byte(raw))
+	if values := got[binaryKey]; !reflect.DeepEqual(values, []string{wantBinary}) {
+		t.Fatalf("binary metadata = %q, want %q", values, wantBinary)
+	}
+	if values := got["X-Text"]; !reflect.DeepEqual(values, []string{"plain"}) {
+		t.Fatalf("text metadata = %q, want plain", values)
+	}
+	if src[binaryKey][0] != raw {
+		t.Fatalf("EncodeMetadataHeader mutated source value: %q", src[binaryKey][0])
+	}
+}
+
+func TestResponseHeaderMapEncodesBinaryTrailers(t *testing.T) {
+	raw := string([]byte{0x08, 0x03, 0x12, 0x00})
+	resp := &Response{
+		Trailers: map[string][]string{"grpc-status-details-bin": {raw}},
+	}
+
+	key := trailerHeaderPrefix + "grpc-status-details-bin"
+	want := base64.RawStdEncoding.EncodeToString([]byte(raw))
+	values := resp.HeaderMap()[key]
+	if len(values) != 1 || values[0] != want {
+		t.Fatalf("HeaderMap()[%q] = %q, want [%q]", key, values, want)
 	}
 }
 

--- a/internal/ui/model_compare_state.go
+++ b/internal/ui/model_compare_state.go
@@ -13,7 +13,6 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/scripts"
 	"github.com/unkn0wn-root/resterm/internal/vars"
-	"google.golang.org/grpc/codes"
 )
 
 type compareResult struct {
@@ -265,7 +264,7 @@ func compareResultSuccess(result *compareResult) bool {
 	case result.Response != nil:
 		return result.Response.StatusCode < 400
 	case result.GRPC != nil:
-		return result.GRPC.StatusCode == codes.OK
+		return result.GRPC.OK()
 	default:
 		return false
 	}

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -23,7 +23,6 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/scripts"
 	"github.com/unkn0wn-root/resterm/internal/vars"
-	"google.golang.org/grpc/codes"
 )
 
 const responseLoadingTickInterval = 200 * time.Millisecond
@@ -817,7 +816,7 @@ func (m *Model) consumeGRPCResponse(
 		fullMethod = req.GRPC.FullMethod
 	}
 	views := renderer.buildGRPCResponseViews(resp, fullMethod)
-	statusLine := grpcStatusLine(resp, fullMethod)
+	statusLine := renderer.grpcStatusLine(resp, fullMethod)
 
 	snapshot := &responseSnapshot{
 		pretty:     views.pretty,
@@ -854,7 +853,7 @@ func (m *Model) consumeGRPCResponse(
 	}
 
 	status := statusMsg{text: statusLine, level: statusSuccess}
-	if resp.StatusCode != codes.OK {
+	if !resp.OK() {
 		status.level = statusWarn
 	}
 	status.testSummary, status.testLevel = responseTestStatusSummary(tests, scriptErr)

--- a/internal/ui/model_history_test.go
+++ b/internal/ui/model_history_test.go
@@ -495,11 +495,11 @@ func TestConsumeGRPCResponseKeepsStatusDetailsInResponsePane(t *testing.T) {
 		t.Fatal("expected response snapshot")
 	}
 	for _, detail := range details {
-		if !strings.Contains(model.responseLatest.pretty, detail) {
-			t.Fatalf("response pane omitted status detail %q", detail)
+		if !strings.Contains(model.responseLatest.raw, detail) {
+			t.Fatalf("raw response pane omitted status detail %q", detail)
 		}
 	}
-	viewport := model.pane(responsePanePrimary).viewport.View()
+	viewport := ansi.Strip(model.pane(responsePanePrimary).viewport.View())
 	for _, detailType := range []string{"BadRequest", "RetryInfo"} {
 		if !strings.Contains(viewport, detailType) {
 			t.Fatalf("response viewport omitted status detail type %q", detailType)

--- a/internal/ui/model_render_test.go
+++ b/internal/ui/model_render_test.go
@@ -595,12 +595,14 @@ func TestStatusBarMessageLevelsRenderStyled(t *testing.T) {
 // A multi-line message must not grow the bar past its single row; the error
 // modal still gets the untouched text.
 func TestStatusBarFoldsMultiLineMessage(t *testing.T) {
+	const fullText = "auth command failed:\n  first  line\r\n  second line"
+
 	model := New(Config{})
 	model.width = 96
 	model.statusUser = ""
 	model.statusHost = ""
 	model.statusMessage = statusMsg{
-		text:  "auth command failed:\n  first line\n  second line",
+		text:  fullText,
 		level: statusError,
 	}
 
@@ -608,14 +610,106 @@ func TestStatusBarFoldsMultiLineMessage(t *testing.T) {
 	if got := lipgloss.Height(bar); got != 1 {
 		t.Fatalf("status bar height = %d, want 1", got)
 	}
-	if plain := ansi.Strip(bar); !strings.Contains(plain, "auth command failed: first line second line") {
+	if plain := ansi.Strip(bar); !strings.Contains(
+		plain,
+		"auth command failed: first  line second line",
+	) {
 		t.Fatalf("expected folded message in bar, got %q", plain)
 	}
-	if got, _ := model.statusBarMessage(); strings.Contains(got, "\n") {
-		t.Fatalf("statusBarMessage kept a newline: %q", got)
+	if got, _ := model.statusBarMessage(); got != fullText {
+		t.Fatalf("statusBarMessage() = %q, want untouched text %q", got, fullText)
 	}
-	if model.statusMessage.text != "auth command failed:\n  first line\n  second line" {
+	if model.statusMessage.text != fullText {
 		t.Fatalf("stored status text was rewritten: %q", model.statusMessage.text)
+	}
+}
+
+func TestStatusBarFoldsLineBreaksInEverySection(t *testing.T) {
+	model := New(Config{})
+	model.width = 96
+	model.statusMessage = statusMsg{text: "Ready", level: statusInfo}
+	model.statusUser = "user"
+	model.statusHost = "host\r\n  name"
+
+	bar := model.renderStatusBar()
+	if got := lipgloss.Height(bar); got != 1 {
+		t.Fatalf("status bar height = %d, want 1", got)
+	}
+	if plain := ansi.Strip(bar); !strings.Contains(plain, "host name") {
+		t.Fatalf("expected folded host section in bar, got %q", plain)
+	}
+}
+
+func TestStatusBarDropsTabsFromRenderedBar(t *testing.T) {
+	model := New(Config{})
+	model.width = 96
+	model.statusUser = ""
+	model.statusHost = ""
+	model.statusMessage = statusMsg{text: "auth command failed:\tretry", level: statusError}
+
+	plain := ansi.Strip(model.renderStatusBar())
+	if strings.Contains(plain, "\t") {
+		t.Fatalf("status bar kept a tab the width math cannot measure: %q", plain)
+	}
+	if !strings.Contains(plain, "auth command failed: retry") {
+		t.Fatalf("expected folded message in bar, got %q", plain)
+	}
+}
+
+func TestStatusBarFoldsLineBreaksInStyledRuns(t *testing.T) {
+	sections := compactStatusBarSections([]statusBarSection{{
+		text: "stale width text",
+		runs: []styledRun{
+			{text: "first\r\n", style: lipgloss.NewStyle()},
+			{text: "  second", style: lipgloss.NewStyle()},
+		},
+		valueStyle: lipgloss.NewStyle(),
+	}})
+	if len(sections) != 1 {
+		t.Fatalf("compactStatusBarSections() returned %d sections, want 1", len(sections))
+	}
+	if got := sections[0].text; got != "first second" {
+		t.Fatalf("folded section text = %q, want %q", got, "first second")
+	}
+	if got := styledRunsText(sections[0].runs); got != sections[0].text {
+		t.Fatalf("rendered run text = %q, want layout text %q", got, sections[0].text)
+	}
+}
+
+func TestStatusBarOneLineFoldsBreaksAndTabs(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{name: "LF", text: "first\n  second", want: "first second"},
+		{name: "CRLF", text: "first\r\n\tsecond", want: "first second"},
+		{name: "CR", text: "first\r  second", want: "first second"},
+		{
+			name: "blank lines",
+			text: "first\n \r\nsecond",
+			want: "first second",
+		},
+		{
+			name: "intra-line spacing kept",
+			text: "first  value\nsecond   value",
+			want: "first  value second   value",
+		},
+		{
+			// A tab measures as zero width but expands in the terminal.
+			name: "tab without a line break",
+			text: "first\tvalue",
+			want: "first value",
+		},
+		{name: "single line untouched", text: " first  value ", want: " first  value "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusBarOneLine(tt.text); got != tt.want {
+				t.Fatalf("statusBarOneLine(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/ui/response_render.go
+++ b/internal/ui/response_render.go
@@ -339,15 +339,15 @@ func (r responseRenderer) renderGRPCRespHdrs(
 		return noResponseMessage
 	}
 	return r.renderHdrDoc(
-		grpcStatusLine(resp, fullMethod),
+		r.renderGRPCStatusLine(resp, fullMethod),
 		[]hdrPanel{
 			{
-				fields: bodyfmt.HeaderFields(http.Header(resp.Headers)),
+				fields: bodyfmt.HeaderFields(grpcx.EncodeMetadataHeader(resp.Headers)),
 				empty:  "No response headers captured",
 			},
 			{
 				title:  "Trailers",
-				fields: bodyfmt.HeaderFields(http.Header(resp.Trailers)),
+				fields: bodyfmt.HeaderFields(grpcx.EncodeMetadataHeader(resp.Trailers)),
 				empty:  "No trailers captured",
 			},
 		},
@@ -523,7 +523,8 @@ func (r responseRenderer) buildGRPCResponseViews(
 		}
 	}
 
-	block := grpcStatusBlock(resp, fullMethod)
+	statusBlock := r.grpcStatusBlock(resp, fullMethod)
+	prettyStatusBlock := r.renderGRPCStatusBlock(resp, fullMethod)
 
 	viewBody, viewContentType := resp.ViewBody()
 	rawBody, rawContentType := resp.RawBody()
@@ -545,9 +546,9 @@ func (r responseRenderer) buildGRPCResponseViews(
 	)
 
 	return responseViews{
-		pretty:     joinSections(block, bv.pretty),
-		raw:        joinSections(block, bv.raw),
-		rawSummary: block,
+		pretty:     joinSections(prettyStatusBlock, bv.pretty),
+		raw:        joinSections(statusBlock, bv.raw),
+		rawSummary: statusBlock,
 		headers:    r.renderGRPCRespHdrs(resp, fullMethod, defaultResponseViewportWidth),
 		meta:       meta,
 		// Snapshot contentType must continue to describe the stored raw body.
@@ -561,16 +562,51 @@ func (r responseRenderer) buildGRPCResponseViews(
 	}
 }
 
-func grpcStatusLine(resp *grpcx.Response, fullMethod string) string {
-	return fmt.Sprintf(
-		"gRPC %s - %s",
-		strings.TrimPrefix(strings.TrimSpace(fullMethod), "/"),
-		resp.StatusText(),
+func (r responseRenderer) renderGRPCStatusLine(
+	resp *grpcx.Response,
+	fullMethod string,
+) string {
+	statusStyle := r.stats.Warn
+	if resp.OK() {
+		statusStyle = r.stats.Success
+	}
+	method := strings.TrimPrefix(strings.TrimSpace(fullMethod), "/")
+	return r.stats.Label.Render("gRPC") + " " +
+		r.stats.Value.Render(method) +
+		r.stats.SubLabel.Render(" - ") +
+		statusStyle.Render(resp.StatusText())
+}
+
+// The plain views share the styled line so the two never drift apart. Only the
+// details differ: the raw block keeps them on the wire, one JSON blob per line.
+func (r responseRenderer) grpcStatusLine(resp *grpcx.Response, fullMethod string) string {
+	return stripANSIEscape(r.renderGRPCStatusLine(resp, fullMethod))
+}
+
+func (r responseRenderer) grpcStatusBlock(resp *grpcx.Response, fullMethod string) string {
+	return joinSections(
+		append([]string{r.grpcStatusLine(resp, fullMethod)}, resp.StatusDetails...)...,
 	)
 }
 
-func grpcStatusBlock(resp *grpcx.Response, fullMethod string) string {
-	return joinSections(append([]string{grpcStatusLine(resp, fullMethod)}, resp.StatusDetails...)...)
+func (r responseRenderer) renderGRPCStatusBlock(
+	resp *grpcx.Response,
+	fullMethod string,
+) string {
+	sections := make([]string, 0, len(resp.StatusDetails)+1)
+	sections = append(sections, r.renderGRPCStatusLine(resp, fullMethod))
+	for _, detail := range resp.StatusDetails {
+		sections = append(sections, bodyfmt.Prettify(
+			context.Background(),
+			[]byte(detail),
+			"application/json",
+			bodyfmt.PrettyOptions{
+				Color: termcolor.TrueColor(),
+				Style: r.syntaxStyle,
+			},
+		))
+	}
+	return joinSections(sections...)
 }
 
 func buildRequestHeaderMap(resp *httpx.Response) http.Header {
@@ -621,7 +657,7 @@ func grpcRequestHeaderMap(req *restfile.Request) http.Header {
 	if len(h) == 0 {
 		return nil
 	}
-	return h
+	return grpcx.EncodeMetadataHeader(h)
 }
 
 func formatRawBody(body []byte, contentType string) string {

--- a/internal/ui/response_render_test.go
+++ b/internal/ui/response_render_test.go
@@ -3,18 +3,26 @@ package ui
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/unkn0wn-root/resterm/internal/binaryview"
 	"github.com/unkn0wn-root/resterm/internal/bodyfmt"
+	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/termcolor"
 	"github.com/unkn0wn-root/resterm/internal/theme"
 )
 
@@ -193,6 +201,112 @@ func TestBuildHTTPResponseViewsWithLightPaletteUsesReadableSummaryStyles(t *test
 	}
 }
 
+func TestBuildGRPCResponseViewsColorsPrettyStatusAndDetailsOnly(t *testing.T) {
+	prevProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prevProfile)
+
+	const (
+		method = "/pkg.Service/Fail"
+		detail = `{"@type":"type.googleapis.com/google.rpc.BadRequest","field":"page_size"}`
+	)
+	resp := &grpcx.Response{
+		ContentType:   "application/json",
+		StatusCode:    codes.InvalidArgument,
+		StatusMessage: "invalid page size",
+		StatusDetails: []string{detail},
+	}
+	renderer := defaultResponseRenderer()
+	views := renderer.buildGRPCResponseViews(resp, method)
+
+	if !strings.Contains(
+		views.pretty,
+		renderer.stats.Warn.Render(resp.StatusText()),
+	) {
+		t.Fatalf("expected colored gRPC status in pretty view, got %q", views.pretty)
+	}
+	prettyDetail := bodyfmt.Prettify(
+		context.Background(),
+		[]byte(detail),
+		"application/json",
+		bodyfmt.PrettyOptions{Color: termcolor.TrueColor(), Style: renderer.syntaxStyle},
+	)
+	if !strings.Contains(views.pretty, strings.TrimRight(prettyDetail, "\r\n")) {
+		t.Fatalf("expected syntax-colored gRPC detail in pretty view, got %q", views.pretty)
+	}
+	if strings.Contains(views.raw, "\x1b[") {
+		t.Fatalf("expected raw gRPC view without ANSI codes, got %q", views.raw)
+	}
+	if !strings.Contains(views.raw, detail) {
+		t.Fatalf("expected raw gRPC view to preserve detail JSON, got %q", views.raw)
+	}
+	if !strings.Contains(views.headers, renderer.renderGRPCStatusLine(resp, method)) {
+		t.Fatalf("expected colored gRPC status in headers view, got %q", views.headers)
+	}
+	if views.rawSummary != renderer.grpcStatusBlock(resp, method) {
+		t.Fatalf(
+			"raw summary = %q, want plain status block %q",
+			views.rawSummary,
+			renderer.grpcStatusBlock(resp, method),
+		)
+	}
+	// The plain line is stripped from the styled one, so pin the wording here.
+	wantLine := "gRPC pkg.Service/Fail - " + resp.StatusText()
+	if got := renderer.grpcStatusLine(resp, method); got != wantLine {
+		t.Fatalf("grpcStatusLine() = %q, want %q", got, wantLine)
+	}
+}
+
+func TestRenderGRPCResponseHeadersEncodesBinaryMetadata(t *testing.T) {
+	st, err := status.New(codes.InvalidArgument, "invalid page size").WithDetails(
+		&errdetails.BadRequest{
+			FieldViolations: []*errdetails.BadRequest_FieldViolation{{
+				Field:       "page_size",
+				Description: "must be between 1 and 1000",
+			}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("build gRPC status: %v", err)
+	}
+	wire, err := proto.Marshal(st.Proto())
+	if err != nil {
+		t.Fatalf("marshal gRPC status: %v", err)
+	}
+
+	resp := &grpcx.Response{
+		StatusCode:    codes.InvalidArgument,
+		StatusMessage: "invalid page size",
+		Trailers: map[string][]string{
+			"content-type":            {"application/grpc"},
+			"grpc-status-details-bin": {string(wire)},
+		},
+	}
+	const width = 64
+	view := stripANSIEscape(defaultResponseRenderer().renderGRPCRespHdrs(
+		resp,
+		"/pkg.Service/Fail",
+		width,
+	))
+	if !strings.Contains(view, "grpc-status-details-bin:") {
+		t.Fatalf("expected binary trailer name, got %q", view)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(wire)
+	if !strings.Contains(view, encoded[:16]) {
+		t.Fatalf("expected base64 binary trailer prefix %q, got %q", encoded[:16], view)
+	}
+	for _, r := range view {
+		if unicode.IsControl(r) && r != '\n' {
+			t.Fatalf("rendered binary metadata contains control character %U in %q", r, view)
+		}
+	}
+	for line := range strings.SplitSeq(view, "\n") {
+		if got := lipgloss.Width(line); got > width {
+			t.Fatalf("rendered header width = %d, want <= %d in %q", got, width, line)
+		}
+	}
+}
+
 func TestBuildHTTPRequestHeadersViewUsesExecutedRequest(t *testing.T) {
 	resp := &httpx.Response{
 		ReqMethod:    "GET",
@@ -217,6 +331,23 @@ func TestBuildHTTPRequestHeadersViewUsesExecutedRequest(t *testing.T) {
 	}
 	if !strings.Contains(plain, "1 HEADER") {
 		t.Fatalf("expected request header count, got %q", plain)
+	}
+}
+
+func TestGRPCRequestHeaderMapEncodesBinaryMetadata(t *testing.T) {
+	raw := string([]byte{0x00, 0x01, 0xff})
+	req := &restfile.Request{
+		GRPC: &restfile.GRPCRequest{
+			Metadata: []restfile.MetadataPair{{Key: "trace-bin", Value: raw}},
+		},
+	}
+
+	want := base64.RawStdEncoding.EncodeToString([]byte(raw))
+	if got := grpcRequestHeaderMap(req).Get("trace-bin"); got != want {
+		t.Fatalf("trace-bin = %q, want %q", got, want)
+	}
+	if req.GRPC.Metadata[0].Value != raw {
+		t.Fatalf("grpcRequestHeaderMap mutated request metadata: %q", req.GRPC.Metadata[0].Value)
 	}
 }
 

--- a/internal/ui/status_bar.go
+++ b/internal/ui/status_bar.go
@@ -175,19 +175,35 @@ func statusBarSegmentStyle(
 	return style
 }
 
-// The bar is one row, and its width math measures widest-line only, so a
-// multi-line message silently grows it and pushes the view past the terminal
-// height. Callers keep their full text for the error modal; only the bar folds.
+// The bar is one row, and its width math measures the widest line only, so a
+// line break silently grows it and pushes the view past the terminal height. A
+// tab measures as zero width here but expands in the terminal, so it overflows
+// the row the same way. Fold both without touching the spacing inside a line.
 func statusBarOneLine(text string) string {
-	if !strings.ContainsAny(text, "\r\n") {
+	if !strings.ContainsAny(text, "\r\n\t") {
 		return text
 	}
-	return strings.Join(strings.Fields(text), " ")
+
+	var folded strings.Builder
+	folded.Grow(len(text))
+	for _, part := range strings.FieldsFunc(text, func(r rune) bool {
+		return r == '\r' || r == '\n'
+	}) {
+		part = strings.TrimSpace(strings.ReplaceAll(part, "\t", " "))
+		if part == "" {
+			continue
+		}
+		if folded.Len() > 0 {
+			folded.WriteByte(' ')
+		}
+		folded.WriteString(part)
+	}
+	return folded.String()
 }
 
 func (m Model) statusBarMessage() (string, statusLevel) {
 	if m.statusMessage.text != "" {
-		return statusBarOneLine(m.statusMessage.text), m.statusMessage.level
+		return m.statusMessage.text, m.statusMessage.level
 	}
 	switch {
 	case m.dirty:
@@ -664,10 +680,20 @@ func compactStatusBarSections(
 ) []statusBarSection {
 	out := make([]statusBarSection, 0, len(segs))
 	for _, seg := range segs {
-		seg.text = strings.TrimSpace(seg.text)
-		if seg.text == "" {
+		if len(seg.runs) > 0 {
+			// Runs are what render; keep the layout mirror derived from them.
+			seg.text = styledRunsText(seg.runs)
+		}
+		text := strings.TrimSpace(statusBarOneLine(seg.text))
+		if text == "" {
 			continue
 		}
+		if text != seg.text && len(seg.runs) > 0 {
+			// Folding can cross styled-run boundaries. Collapse only rewritten
+			// text so rendered text and width accounting stay equal.
+			seg.runs = []styledRun{{text: text, style: seg.valueStyle}}
+		}
+		seg.text = text
 		out = append(out, seg)
 	}
 	return out

--- a/internal/ui/workflow_stats_view.go
+++ b/internal/ui/workflow_stats_view.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/unkn0wn-root/resterm/internal/bodyfmt"
 	"github.com/unkn0wn-root/resterm/internal/engine/core"
+	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 )
 
 const (
@@ -761,31 +763,24 @@ func buildWorkflowGRPCDetail(result workflowStepResult) string {
 		return ""
 	}
 	method := strings.TrimSpace(result.Step.Using)
-	statusLine := fmt.Sprintf(
-		"gRPC %s - %s",
-		strings.TrimPrefix(method, "/"),
-		resp.StatusCode.String(),
-	)
-	if resp.StatusMessage != "" {
-		statusLine += " (" + resp.StatusMessage + ")"
-	}
+	renderer := defaultResponseRenderer()
 
 	builder := strings.Builder{}
-	builder.WriteString(statusLine)
+	builder.WriteString(renderer.renderGRPCStatusLine(resp, method))
 	builder.WriteString("\n")
 
-	if len(resp.Headers) > 0 {
-		builder.WriteString("Headers:\n")
-		for name, values := range resp.Headers {
-			fmt.Fprintf(&builder, "%s: %s\n", name, strings.Join(values, ", "))
+	writeMeta := func(title string, meta map[string][]string) {
+		hdrs := grpcx.EncodeMetadataHeader(meta)
+		if len(hdrs) == 0 {
+			return
 		}
+		builder.WriteString(title)
+		builder.WriteString(":\n")
+		builder.WriteString(bodyfmt.FormatHeaders(hdrs))
+		builder.WriteString("\n")
 	}
-	if len(resp.Trailers) > 0 {
-		builder.WriteString("Trailers:\n")
-		for name, values := range resp.Trailers {
-			fmt.Fprintf(&builder, "%s: %s\n", name, strings.Join(values, ", "))
-		}
-	}
+	writeMeta("Headers", resp.Headers)
+	writeMeta("Trailers", resp.Trailers)
 
 	contentType := "application/json"
 	bodyRaw := prettifyBody([]byte(resp.Message), contentType)

--- a/internal/ui/workflow_stats_view_test.go
+++ b/internal/ui/workflow_stats_view_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"encoding/base64"
 	"net/http"
 	"strings"
 	"testing"
@@ -8,9 +9,11 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/theme"
+	"google.golang.org/grpc/codes"
 )
 
 func TestNewWorkflowStatsViewSelectsFirstFailure(t *testing.T) {
@@ -425,5 +428,33 @@ func workflowStatsTestView() *workflowStatsView {
 			},
 		},
 		selected: 0,
+	}
+}
+
+func TestBuildWorkflowGRPCDetailEncodesBinaryMetadata(t *testing.T) {
+	raw := string([]byte{0x00, 0x01, 0xff})
+	resp := &grpcx.Response{
+		StatusCode:    codes.OK,
+		StatusMessage: "OK",
+		Trailers:      map[string][]string{"trace-bin": {raw}},
+		Message:       "{}",
+	}
+
+	detail := stripANSIEscape(buildWorkflowGRPCDetail(workflowStepResult{
+		GRPC: resp,
+		Step: restfile.WorkflowStep{Using: "/pkg.Service/Call"},
+	}))
+	if strings.Contains(detail, raw) {
+		t.Fatalf("workflow detail kept raw binary metadata: %q", detail)
+	}
+	want := base64.RawStdEncoding.EncodeToString([]byte(raw))
+	if !strings.Contains(detail, "trace-bin: "+want) {
+		t.Fatalf("workflow detail = %q, want encoded trailer %q", detail, want)
+	}
+	if !strings.Contains(detail, "gRPC pkg.Service/Call - OK") {
+		t.Fatalf("workflow detail omitted status line: %q", detail)
+	}
+	if strings.Contains(detail, "OK (OK)") {
+		t.Fatalf("workflow detail repeated the status code as its message: %q", detail)
 	}
 }


### PR DESCRIPTION
* fix(grpc): base64-encode binary metadata for display, scripts, and assertions
* fix(ui): colour gRPC status line and details in the pretty view only
* fix(ui): share one gRPC status line formatter across response, history, and workflow views
* fix(ui): fold line breaks and tabs in every status bar section
* docs: describe -bin metadata on the request, script, and assertion surfaces