### PR TITLE
RST-306: preserve stream and response ownership across split panes

### DIFF
--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -92,6 +92,7 @@ type RequestResult struct {
 	Response       *httpx.Response
 	GRPC           *grpcx.Response
 	Stream         *scripts.StreamInfo
+	StreamID       string
 	Transcript     []byte
 	Err            error
 	Tests          []scripts.TestResult

--- a/internal/stream/session.go
+++ b/internal/stream/session.go
@@ -90,6 +90,13 @@ type Snapshot struct {
 
 var sessionCounter uint64
 
+// closedEvents is handed to subscribers that arrive after a session ended.
+var closedEvents = func() chan *Event {
+	ch := make(chan *Event)
+	close(ch)
+	return ch
+}()
+
 func NewSession(parent context.Context, kind Kind, cfg Config) *Session {
 	cfg = defaultConfig(cfg)
 	ctx, cancel := context.WithCancel(parent)
@@ -157,9 +164,21 @@ func (s *Session) EventsSnapshot() []*Event {
 	return s.events.snapshot()
 }
 
+// Subscribe returns the events still to come plus a snapshot of the ones
+// already published. A session that has ended hands back a closed channel, so
+// a late subscriber reads the transcript and stops instead of waiting on a
+// listener that nothing will ever write to.
 func (s *Session) Subscribe() Listener {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	snapshot := Snapshot{
+		Events: s.events.snapshot(),
+		State:  s.state,
+		Err:    s.err,
+	}
+	if s.ended() {
+		return Listener{C: closedEvents, Cancel: func() {}, Snapshot: snapshot}
+	}
 
 	id := s.nextLID
 	s.nextLID++
@@ -169,12 +188,6 @@ func (s *Session) Subscribe() Listener {
 	}
 	s.listeners[id] = l
 
-	snapshot := Snapshot{
-		Events: s.events.snapshot(),
-		State:  s.state,
-		Err:    s.err,
-	}
-
 	return Listener{
 		C: l.ch,
 		Cancel: func() {
@@ -182,6 +195,12 @@ func (s *Session) Subscribe() Listener {
 		},
 		Snapshot: snapshot,
 	}
+}
+
+// ended reports whether Close already ran. Callers must hold s.mu: EndedAt is
+// stamped under the lock, while s.done closes just after it is released.
+func (s *Session) ended() bool {
+	return !s.stats.EndedAt.IsZero()
 }
 
 func (s *Session) removeListener(id int) {
@@ -296,7 +315,7 @@ func (s *Session) MarkClosing() {
 func (s *Session) Close(err error) {
 	s.cancel()
 	s.mu.Lock()
-	if s.stats.EndedAt.IsZero() {
+	if !s.ended() {
 		if err != nil {
 			s.state = StateFailed
 			s.err = err

--- a/internal/stream/session_test.go
+++ b/internal/stream/session_test.go
@@ -69,3 +69,29 @@ func TestSessionDropNewestPolicy(t *testing.T) {
 	s.Close(nil)
 	listener.Cancel()
 }
+
+func TestSessionSubscribeAfterClose(t *testing.T) {
+	s := NewSession(context.Background(), KindGRPC, Config{})
+	s.Publish(&Event{Kind: KindGRPC, Direction: DirReceive, Payload: []byte("last")})
+	s.Close(context.DeadlineExceeded)
+
+	listener := s.Subscribe()
+	if got := len(listener.Snapshot.Events); got != 1 {
+		t.Fatalf("expected one snapshot event, got %d", got)
+	}
+	if listener.Snapshot.State != StateFailed {
+		t.Fatalf("expected failed snapshot, got %v", listener.Snapshot.State)
+	}
+	if listener.Snapshot.Err != context.DeadlineExceeded {
+		t.Fatalf("expected deadline error, got %v", listener.Snapshot.Err)
+	}
+	select {
+	case _, ok := <-listener.C:
+		if ok {
+			t.Fatal("expected closed listener channel")
+		}
+	default:
+		t.Fatal("expected listener channel to be closed immediately")
+	}
+	listener.Cancel()
+}

--- a/internal/ui/explain_test.go
+++ b/internal/ui/explain_test.go
@@ -308,24 +308,21 @@ func TestConsumeHTTPResponseActiveExplainRendersBeforeResponseFormatting(t *test
 	}
 	pane.activeTab = responseTabExplain
 
-	cmd := model.consumeHTTPResponse(
-		&httpx.Response{
+	cmd := model.consumeHTTPResponse(responseMsg{
+		response: &httpx.Response{
 			Status:       "200 OK",
 			StatusCode:   200,
 			ReqMethod:    "GET",
 			EffectiveURL: "https://example.com",
 			Body:         []byte("ok"),
 		},
-		nil,
-		nil,
-		"",
-		&xplain.Report{
+		explain: &xplain.Report{
 			Status:   xplain.StatusReady,
 			Method:   "GET",
 			URL:      "https://example.com",
 			Decision: "HTTP request sent",
 		},
-	)
+	})
 	if cmd == nil {
 		t.Fatal("expected async response render command")
 	}

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -38,6 +38,7 @@ type responseMsg struct {
 	response       *httpx.Response
 	grpc           *grpcx.Response
 	stream         *scripts.StreamInfo
+	streamID       string
 	transcript     []byte
 	err            error
 	tests          []scripts.TestResult
@@ -53,6 +54,32 @@ type responseMsg struct {
 	explain        *xplain.Report
 	historyDone    bool
 	latGen         int
+	target         runTarget
+}
+
+// runTarget remembers which response pane a run was launched from so a late
+// response lands there instead of wherever focus has drifted to. The zero
+// value means the run never captured one.
+type runTarget struct {
+	pane responsePaneID
+	set  bool
+}
+
+func paneRunTarget(id responsePaneID) runTarget {
+	return runTarget{pane: id, set: true}
+}
+
+// resolve reports the pane the run was launched from and whether it is still a
+// destination worth honouring. The pane is always usable: an unset target, or a
+// secondary pane after the split closed, resolves to the primary pane.
+func (t runTarget) resolve(split bool) (responsePaneID, bool) {
+	if !t.set {
+		return responsePanePrimary, false
+	}
+	if t.pane == responsePaneSecondary && !split {
+		return responsePanePrimary, false
+	}
+	return t.pane, true
 }
 
 type statusMsg struct {
@@ -83,8 +110,17 @@ type streamCompleteMsg struct {
 	sessionID string
 }
 
-type streamReadyMsg struct {
-	sessionID string
+// streamAttachMsg hands a session opened on the engine goroutine to the update
+// loop, which owns every map and pane it has to be recorded in. gen is the
+// stream generation the run started under, so an attachment that arrives after
+// a workspace change can be dropped instead of writing into the new workspace.
+type streamAttachMsg struct {
+	session *stream.Session
+	req     *restfile.Request
+	sender  *httpx.WebSocketSender
+	baseDir string
+	pane    responsePaneID
+	gen     uint64
 }
 
 type wsConsoleResultMsg struct {
@@ -109,6 +145,7 @@ type runReqMsg struct {
 	res    engine.RequestResult
 	err    error
 	latGen int
+	target runTarget
 }
 
 type runEvtMsg struct {

--- a/internal/ui/model_compare_run.go
+++ b/internal/ui/model_compare_run.go
@@ -307,43 +307,32 @@ func (m *Model) consumeCompareRow(
 	var cmds []tea.Cmd
 	if !canceled && msg.skipped {
 		m.lastError = nil
-		if cmd := m.consumeSkippedRequest(msg.skipReason, msg.explain); cmd != nil {
+		if cmd := m.consumeSkippedRequest(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	} else if !canceled && msg.err != nil {
 		result.Err = msg.err
 		m.lastError = msg.err
-		if cmd := m.consumeRequestError(msg.err, msg.explain); cmd != nil {
+		if cmd := m.consumeRequestError(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	} else if !canceled && msg.grpc != nil {
 		result.GRPC = msg.grpc
 		m.lastError = nil
-		if cmd := m.consumeGRPCResponse(
-			msg.grpc,
-			msg.tests,
-			msg.scriptErr,
-			msg.executed,
-			msg.environment,
-			msg.explain,
-		); cmd != nil {
+		if cmd := m.consumeGRPCResponse(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	} else if !canceled && msg.response != nil {
 		result.Response = msg.response
 		m.lastError = nil
-		if cmd := m.consumeHTTPResponse(
-			msg.response,
-			msg.tests,
-			msg.scriptErr,
-			msg.environment,
-			msg.explain,
-		); cmd != nil {
+		if cmd := m.consumeHTTPResponse(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	} else if !canceled && (msg.stream != nil || len(msg.transcript) > 0) {
 		m.lastError = nil
-		m.applyRunSnapshot(newStreamSnapshot(msg.stream, msg.transcript, msg.environment), nil, nil)
+		if cmd := m.consumeStreamTranscript(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	} else {
 		m.lastError = nil
 	}
@@ -373,8 +362,7 @@ func (m *Model) finalizeCompareRun(state *compareState) tea.Cmd {
 
 	if secondary := m.pane(responsePaneSecondary); secondary != nil {
 		secondary.followLatest = true
-		secondary.snapshot = m.responseLatest
-		secondary.invalidateCaches()
+		m.setPaneSnapshot(responsePaneSecondary, m.responseLatest)
 	}
 
 	if bundle := buildCompareBundle(state.results, state.baseline); bundle != nil {
@@ -444,9 +432,8 @@ func (m *Model) pinCompareReferencePane(state *compareState) {
 	if snapshot == nil {
 		return
 	}
-	secondary.snapshot = snapshot
+	m.setPaneSnapshot(responsePaneSecondary, snapshot)
 	secondary.followLatest = false
-	secondary.invalidateCaches()
 }
 
 func (m *Model) storeCompareSnapshot(env string) {

--- a/internal/ui/model_compare_ui.go
+++ b/internal/ui/model_compare_ui.go
@@ -104,19 +104,13 @@ func (m *Model) selectCompareFocus() tea.Cmd {
 	if cmd := m.ensureCompareSplit(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
+	m.setPaneSnapshot(responsePanePrimary, targetSnap)
 	primary := m.pane(responsePanePrimary)
-	secondary := m.pane(responsePaneSecondary)
-	if primary != nil {
-		primary.snapshot = targetSnap
-		primary.followLatest = false
-		primary.invalidateCaches()
-		primary.setActiveTab(responseTabDiff)
-	}
-	if secondary != nil {
-		secondary.snapshot = baselineSnap
-		secondary.followLatest = false
-		secondary.invalidateCaches()
-	}
+	primary.followLatest = false
+	primary.setActiveTab(responseTabDiff)
+
+	m.setPaneSnapshot(responsePaneSecondary, baselineSnap)
+	m.pane(responsePaneSecondary).followLatest = false
 	m.compareSelectedEnv = targetEnv
 	m.compareFocusedEnv = targetEnv
 	m.compareRowIndex = compareRowIndexForEnv(bundle, targetEnv)

--- a/internal/ui/model_console.go
+++ b/internal/ui/model_console.go
@@ -396,14 +396,14 @@ func (m *Model) ensureWebSocketConsole(
 
 func (m *Model) handleWebSocketConsoleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	key := msg.String()
-	sessionID := m.sessionIDForRequest(m.currentRequest)
+	sessionID := m.activeStreamID()
 
 	console := m.wsConsole
 	if console == nil || console.sessionID != sessionID {
 		return nil, false
 	}
 
-	pane := m.pane(responsePanePrimary)
+	pane := m.pane(m.responsePaneFocus)
 	if pane == nil || pane.activeTab != responseTabStream {
 		return nil, false
 	}
@@ -465,11 +465,11 @@ func (m *Model) websocketConsoleCapturesInput() bool {
 	if console == nil || !console.active {
 		return false
 	}
-	pane := m.pane(responsePanePrimary)
+	pane := m.pane(m.responsePaneFocus)
 	if pane == nil || pane.activeTab != responseTabStream {
 		return false
 	}
-	sessionID := m.sessionIDForRequest(m.currentRequest)
+	sessionID := m.activeStreamID()
 	if sessionID == "" {
 		return false
 	}
@@ -477,7 +477,7 @@ func (m *Model) websocketConsoleCapturesInput() bool {
 }
 
 func (m *Model) armWebSocketCommandMode() tea.Cmd {
-	sessionID := m.sessionIDForRequest(m.currentRequest)
+	sessionID := m.activeStreamID()
 	if sessionID == "" {
 		m.wsCommandChord = false
 		m.setStatusMessage(statusMsg{text: "No active websocket stream", level: statusWarn})
@@ -526,7 +526,7 @@ func (m *Model) handleWebSocketCommandChord(msg tea.KeyMsg) (tea.Cmd, bool) {
 
 func (m *Model) toggleWebSocketConsole() tea.Cmd {
 	var cmds []tea.Cmd
-	sessionID := m.sessionIDForRequest(m.currentRequest)
+	sessionID := m.activeStreamID()
 	if sessionID == "" {
 		m.setStatusMessage(statusMsg{text: "No active websocket stream", level: statusWarn})
 		return nil
@@ -568,10 +568,14 @@ func (m *Model) toggleWebSocketConsole() tea.Cmd {
 }
 
 func (m *Model) focusStreamPane() tea.Cmd {
-	if pane := m.pane(responsePanePrimary); pane != nil {
-		pane.setActiveTab(responseTabStream)
+	id := responsePanePrimary
+	if m.wsConsole != nil {
+		if ids := m.panesForStream(m.wsConsole.sessionID); len(ids) > 0 {
+			id = ids[0]
+		}
 	}
-	m.responsePaneFocus = responsePanePrimary
+	m.pane(id).setActiveTab(responseTabStream)
+	m.responsePaneFocus = id
 	if m.focus != focusResponse {
 		return m.setFocus(focusResponse)
 	}
@@ -640,16 +644,13 @@ func (m *Model) sendConsoleClose() tea.Cmd {
 }
 
 func (m *Model) clearStreamBufferCmd() tea.Cmd {
-	sessionID := m.sessionIDForRequest(m.currentRequest)
+	sessionID := m.activeStreamID()
 	if sessionID != "" {
-		if ls := m.liveSession(sessionID); ls != nil {
-			ls.events = nil
-			ls.filter = ""
-			ls.paused = false
-			ls.pausedIndex = -1
-			ls.bookmarks = nil
-			ls.bookmarkIdx = -1
+		ls := m.streamForPane(m.responsePaneFocus)
+		if ls == nil {
+			ls = m.liveSession(sessionID)
 		}
+		ls.reset()
 		if m.wsConsole != nil && m.wsConsole.sessionID == sessionID {
 			m.wsConsole.history = nil
 			m.wsConsole.historyIdx = -1

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -233,8 +233,6 @@ type Model struct {
 
 	responseLatest           *responseSnapshot
 	responsePrevious         *responseSnapshot
-	responsePending          *responseSnapshot
-	responseTokens           map[string]*responseSnapshot
 	responseLastFocused      responsePaneID
 	focus                    paneFocus
 	compareSnapshots         map[string]*responseSnapshot
@@ -312,10 +310,9 @@ type Model struct {
 	updateLastErr   string
 	updateLastCheck time.Time
 
-	responseRenderToken  string
+	render               pendingRender
 	responseLoading      bool
 	responseLoadingFrame int
-	responseRenderCancel context.CancelFunc
 	respTasks            *respTasks
 
 	activeThemeKey      string
@@ -401,6 +398,7 @@ type Model struct {
 	streamMsgChan      chan tea.Msg
 	streamBatchWindow  time.Duration
 	streamMaxEvents    int
+	streamGen          uint64
 	liveSessions       map[string]*liveSession
 	wsSenders          map[string]*httpx.WebSocketSender
 	sessionHandles     map[string]*stream.Session
@@ -657,7 +655,6 @@ func New(cfg Config) Model {
 		reqCompact:               &reqCompact,
 		wfCompact:                &wfCompact,
 		respTasks:                newRespTasks(),
-		responseTokens:           make(map[string]*responseSnapshot),
 		responseLastFocused:      responsePanePrimary,
 		focus:                    focusFile,
 		sidebarWidth:             sidebarWidthDefault,

--- a/internal/ui/model_engine.go
+++ b/internal/ui/model_engine.go
@@ -11,6 +11,7 @@ import (
 	rqeng "github.com/unkn0wn-root/resterm/internal/engine/request"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/stream"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -78,8 +79,11 @@ type requestRunner interface {
 // workflow run shares one wrapper so repeated warnings are only shown once.
 type uiRequestEngine struct {
 	*rqeng.Engine
-	model *Model
-	seen  map[string]struct{}
+	model   *Model
+	seen    map[string]struct{}
+	pane    responsePaneID
+	gen     uint64
+	baseDir string
 }
 
 func (e *uiRequestEngine) ExecuteWith(
@@ -95,10 +99,65 @@ func (e *uiRequestEngine) ExecuteWith(
 		}
 		e.queueWarning(string(warning))
 	}
-	opt.AttachSSE = e.model.attachSSEHandle
-	opt.AttachWS = e.model.attachWebSocketHandle
-	opt.AttachGRPC = e.model.attachGRPCSession
-	return e.Engine.ExecuteWith(doc, req, env, opt)
+	// Every protocol reports its session the same way, so each hook only has to
+	// unwrap its own handle. The hooks run on this goroutine, which is what
+	// makes the captured id safe to read once the run returns.
+	var streamID string
+	nextSSE := opt.AttachSSE
+	opt.AttachSSE = func(handle *httpx.StreamHandle, req *restfile.Request) {
+		if nextSSE != nil {
+			nextSSE(handle, req)
+		}
+		if handle == nil {
+			return
+		}
+		streamID = e.attach(handle.Session, req, nil, handle.Meta.BaseDir)
+	}
+	nextWS := opt.AttachWS
+	opt.AttachWS = func(handle *httpx.WebSocketHandle, req *restfile.Request) {
+		if nextWS != nil {
+			nextWS(handle, req)
+		}
+		if handle == nil {
+			return
+		}
+		streamID = e.attach(handle.Session, req, handle.Sender, handle.Meta.BaseDir)
+	}
+	nextGRPC := opt.AttachGRPC
+	opt.AttachGRPC = func(session *stream.Session, req *restfile.Request) {
+		if nextGRPC != nil {
+			nextGRPC(session, req)
+		}
+		streamID = e.attach(session, req, nil, "")
+	}
+	res, err := e.Engine.ExecuteWith(doc, req, env, opt)
+	res.StreamID = streamID
+	return res, err
+}
+
+// attach hands a session to the update loop and reports its id. The engine
+// goroutine must not touch the model, so ownership is transferred by message.
+func (e *uiRequestEngine) attach(
+	session *stream.Session,
+	req *restfile.Request,
+	sender *httpx.WebSocketSender,
+	baseDir string,
+) string {
+	if session == nil {
+		return ""
+	}
+	if baseDir == "" {
+		baseDir = e.baseDir
+	}
+	e.model.emitStreamMsg(streamAttachMsg{
+		session: session,
+		req:     req,
+		sender:  sender,
+		baseDir: baseDir,
+		pane:    e.pane,
+		gen:     e.gen,
+	})
+	return session.ID()
 }
 
 // Engine warnings only. Parse warnings have their own status bar segment, and
@@ -118,12 +177,24 @@ func (e *uiRequestEngine) queueWarning(text string) {
 	emitQueuedMsg(e.model.runMsgChan, runWarningMsg{text: text})
 }
 
+// newUIRequestEngine pins the run to the pane and stream generation it started
+// under. Both are read here, on the update loop, and never again afterwards.
+func (m *Model) newUIRequestEngine(rq *rqeng.Engine, baseDir string) *uiRequestEngine {
+	return &uiRequestEngine{
+		Engine:  rq,
+		model:   m,
+		pane:    m.responseTargetPane(),
+		gen:     m.streamGen,
+		baseDir: baseDir,
+	}
+}
+
 func (m *Model) runRequestSvc(opts httpx.Options) *uiRequestEngine {
 	rq := m.requestSvc(opts)
 	if rq == nil {
 		return nil
 	}
-	return &uiRequestEngine{Engine: rq, model: m}
+	return m.newUIRequestEngine(rq, opts.BaseDir)
 }
 
 func (m *Model) runMsg(fn func(context.Context) tea.Msg) tea.Cmd {
@@ -180,8 +251,9 @@ func (m *Model) startRun(sp runSpec) (tea.Cmd, bool) {
 	}
 	var rq requestRunner = svc
 	if sp.mode == rqeng.ExecModeSend {
-		rq = &uiRequestEngine{Engine: svc, model: m}
+		rq = m.newUIRequestEngine(svc, sp.opts.BaseDir)
 	}
+	target := paneRunTarget(m.responseTargetPane())
 	gen := m.latencySeries.generation()
 	return m.runMsg(func(ctx context.Context) tea.Msg {
 		res, err := rq.ExecuteWith(sp.doc, sp.req, env, rqeng.ExecOptions{
@@ -190,17 +262,19 @@ func (m *Model) startRun(sp runSpec) (tea.Cmd, bool) {
 			Mode:   sp.mode,
 		})
 		if sp.record {
-			return runReqMsg{res: res, err: err, latGen: gen}
+			return runReqMsg{res: res, err: err, latGen: gen, target: target}
 		}
 		if err != nil {
 			return responseMsg{
 				err:         err,
 				executed:    sp.req.Clone(),
 				environment: env.Label(),
+				target:      target,
 			}
 		}
 		msg := m.responseMsgFromRunState(res, false)
 		msg.latGen = gen
+		msg.target = target
 		return msg
 	}), true
 }

--- a/internal/ui/model_engine_consume.go
+++ b/internal/ui/model_engine_consume.go
@@ -24,6 +24,7 @@ func (m *Model) handleRunReqMsg(msg runReqMsg) tea.Cmd {
 	}
 	rm := m.responseMsgFromRun(msg.res)
 	rm.latGen = msg.latGen
+	rm.target = msg.target
 	return m.handleResponseMessage(rm)
 }
 
@@ -43,6 +44,7 @@ func (m *Model) responseMsgFromRunState(res engine.RequestResult, done bool) res
 		response:       res.Response,
 		grpc:           res.GRPC,
 		stream:         res.Stream,
+		streamID:       res.StreamID,
 		transcript:     append([]byte(nil), res.Transcript...),
 		err:            res.Err,
 		tests:          append([]scripts.TestResult(nil), res.Tests...),
@@ -74,6 +76,17 @@ func (m *Model) applyRunSnapshot(
 	m.setResponseSnapshotContent(sn)
 	m.lastResponse = hr
 	m.lastGRPC = gr
+}
+
+// consumeStreamTranscript shows a finished stream run: the transcript the run
+// captured, still pointing at the session so the Stream tab keeps its events.
+// Like every other consumer it returns the pane sync, because the pane that did
+// not receive the transcript still has to redraw anything derived from it.
+func (m *Model) consumeStreamTranscript(msg responseMsg) tea.Cmd {
+	snap := newStreamSnapshot(msg.stream, msg.transcript, msg.environment)
+	m.bindSnapshotStream(snap, msg.streamID)
+	m.applyRunSnapshot(snap, nil, nil)
+	return m.syncResponsePanes()
 }
 
 func (m *Model) syncRecordedHistory() {

--- a/internal/ui/model_engine_consume_test.go
+++ b/internal/ui/model_engine_consume_test.go
@@ -27,6 +27,7 @@ func TestResponseMsgFromRunStateUsesEngineExplainAndCarriesRuntimeSecrets(t *tes
 		},
 		Environment: "dev",
 		Explain:     exp,
+		StreamID:    "grpc-1",
 	}
 
 	msg := model.responseMsgFromRunState(res, false)
@@ -35,6 +36,9 @@ func TestResponseMsgFromRunStateUsesEngineExplainAndCarriesRuntimeSecrets(t *tes
 	}
 	if len(msg.runtimeSecrets) != 2 {
 		t.Fatalf("expected runtime secrets to be preserved, got %d", len(msg.runtimeSecrets))
+	}
+	if msg.streamID != "grpc-1" {
+		t.Fatalf("expected stream ID to be preserved, got %q", msg.streamID)
 	}
 }
 

--- a/internal/ui/model_exec_test.go
+++ b/internal/ui/model_exec_test.go
@@ -265,7 +265,7 @@ func TestConsumeGRPCResponseUsesBinaryBody(t *testing.T) {
 		WireContentType: "application/grpc+proto",
 	}
 
-	cmd := model.consumeGRPCResponse(resp, nil, nil, req, "", nil)
+	cmd := model.consumeGRPCResponse(responseMsg{grpc: resp, executed: req})
 	if cmd != nil {
 		collectMsgs(cmd)
 	}
@@ -1505,6 +1505,7 @@ func TestExecuteRequestInteractiveWebSocketStaysAlive(t *testing.T) {
 	if got := resp.response.Headers.Get(httpx.StreamHeaderType); got != "websocket" {
 		t.Fatalf("expected websocket placeholder header, got %q", got)
 	}
+	applyQueuedStreamAttach(t, &model)
 
 	sessionID := model.sessionIDForRequest(req)
 	if sessionID == "" {
@@ -1562,6 +1563,10 @@ func TestRunRequestServiceAttachesInteractiveWebSocket(t *testing.T) {
 	if got := res.Response.Headers.Get(httpx.StreamHeaderType); got != "websocket" {
 		t.Fatalf("expected websocket placeholder header, got %q", got)
 	}
+	if res.StreamID == "" {
+		t.Fatal("expected websocket result to carry its stream ID")
+	}
+	applyQueuedStreamAttach(t, &model)
 
 	sessionID := model.sessionIDForRequest(req)
 	session := model.sessionHandles[sessionID]
@@ -1578,6 +1583,20 @@ func TestRunRequestServiceAttachesInteractiveWebSocket(t *testing.T) {
 	case <-session.Done():
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for websocket session shutdown")
+	}
+}
+
+func applyQueuedStreamAttach(t *testing.T, model *Model) {
+	t.Helper()
+	select {
+	case msg := <-model.streamMsgChan:
+		attach, ok := msg.(streamAttachMsg)
+		if !ok {
+			t.Fatalf("expected queued stream attachment, got %T", msg)
+		}
+		model.handleStreamAttach(attach)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream attachment")
 	}
 }
 

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -49,7 +49,7 @@ func (m *Model) handleResponseMessage(msg responseMsg) tea.Cmd {
 		m.lastError = nil
 		m.testResults = nil
 		m.scriptError = nil
-		cmd := m.consumeSkippedRequest(msg.skipReason, msg.explain)
+		cmd := m.consumeSkippedRequest(msg)
 		if msg.historyDone {
 			m.syncRecordedHistory()
 		} else {
@@ -71,14 +71,7 @@ func (m *Model) handleResponseMessage(msg responseMsg) tea.Cmd {
 		} else {
 			m.lastError = nil
 		}
-		cmd := m.consumeGRPCResponse(
-			msg.grpc,
-			msg.tests,
-			msg.scriptErr,
-			msg.executed,
-			msg.environment,
-			msg.explain,
-		)
+		cmd := m.consumeGRPCResponse(msg)
 		if msg.historyDone {
 			m.syncRecordedHistory()
 		} else {
@@ -104,18 +97,12 @@ func (m *Model) handleResponseMessage(msg responseMsg) tea.Cmd {
 		m.lastResponse = nil
 		m.lastGRPC = nil
 
-		cmd := m.consumeRequestError(msg.err, msg.explain)
+		cmd := m.consumeRequestError(msg)
 		m.setStatusMessage(requestErrorStatus(canceled))
 		return cmd
 	}
 
-	cmd := m.consumeHTTPResponse(
-		msg.response,
-		msg.tests,
-		msg.scriptErr,
-		msg.environment,
-		msg.explain,
-	)
+	cmd := m.consumeHTTPResponse(msg)
 	if msg.historyDone {
 		m.syncRecordedHistory()
 	} else {
@@ -173,7 +160,8 @@ func (m *Model) recordResponseLatency(msg responseMsg) {
 	}
 }
 
-func (m *Model) consumeRequestError(err error, rep *xplain.Report) tea.Cmd {
+func (m *Model) consumeRequestError(msg responseMsg) tea.Cmd {
+	err := msg.err
 	if err == nil {
 		return nil
 	}
@@ -184,15 +172,7 @@ func (m *Model) consumeRequestError(err error, rep *xplain.Report) tea.Cmd {
 		m.responsePrevious = m.responseLatest
 	}
 
-	m.responseLoading = false
-	m.responseLoadingFrame = 0
-	m.responsePending = nil
-	m.responseRenderToken = ""
-	if m.responseTokens != nil {
-		for key := range m.responseTokens {
-			delete(m.responseTokens, key)
-		}
-	}
+	m.resetPendingResponse()
 
 	class := diag.ClassOf(err)
 	view := m.errView(err)
@@ -220,47 +200,29 @@ func (m *Model) consumeRequestError(err error, rep *xplain.Report) tea.Cmd {
 		headers:        view.head,
 		requestHeaders: view.head,
 		explain: explainState{
-			report: rep,
+			report: msg.explain,
 		},
 		ready: true,
 	}
 	m.responseLatest = snapshot
-	m.responsePending = nil
+	m.bindSnapshotStream(snapshot, msg.streamID)
 
-	target := m.responseTargetPane()
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		pane.snapshot = snapshot
-		pane.invalidateCaches()
-		pane.viewport.SetContent(view.pretty)
-		pane.viewport.GotoTop()
-		pane.setCurrPosition()
-	}
-	m.setLivePane(target)
+	pane := m.showSnapshot(m.responseTargetForMsg(msg), snapshot)
+	pane.viewport.SetContent(view.pretty)
+	pane.resetScroll()
 
 	return m.syncResponsePanes()
 }
 
-func (m *Model) consumeSkippedRequest(reason string, rep *xplain.Report) tea.Cmd {
+func (m *Model) consumeSkippedRequest(msg responseMsg) tea.Cmd {
 	if m.responseLatest != nil && m.responseLatest.ready {
 		m.responsePrevious = m.responseLatest
 	}
 
-	m.responseLoading = false
-	m.responseLoadingFrame = 0
-	m.responsePending = nil
-	m.responseRenderToken = ""
-	if m.responseTokens != nil {
-		for key := range m.responseTokens {
-			delete(m.responseTokens, key)
-		}
-	}
+	m.resetPendingResponse()
 
 	title := "Request Skipped"
-	detail := strings.TrimSpace(reason)
+	detail := strings.TrimSpace(msg.skipReason)
 	if detail == "" {
 		detail = "Condition evaluated to false."
 	}
@@ -274,26 +236,15 @@ func (m *Model) consumeSkippedRequest(reason string, rep *xplain.Report) tea.Cmd
 		raw:     raw,
 		headers: headers,
 		explain: explainState{
-			report: rep,
+			report: msg.explain,
 		},
 		ready: true,
 	}
 	m.responseLatest = snapshot
-	m.responsePending = nil
 
-	target := m.responseTargetPane()
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		pane.snapshot = snapshot
-		pane.invalidateCaches()
-		pane.viewport.SetContent(pretty)
-		pane.viewport.GotoTop()
-		pane.setCurrPosition()
-	}
-	m.setLivePane(target)
+	pane := m.showSnapshot(m.responseTargetForMsg(msg), snapshot)
+	pane.viewport.SetContent(pretty)
+	pane.resetScroll()
 
 	m.setStatusMessage(statusMsg{text: detail, level: statusWarn})
 	return m.syncResponsePanes()
@@ -307,15 +258,7 @@ func (m *Model) consumeExplainPreview(env string, rep *xplain.Report) tea.Cmd {
 		m.responsePrevious = m.responseLatest
 	}
 
-	m.responseLoading = false
-	m.responseLoadingFrame = 0
-	m.responsePending = nil
-	m.responseRenderToken = ""
-	if m.responseTokens != nil {
-		for key := range m.responseTokens {
-			delete(m.responseTokens, key)
-		}
-	}
+	m.resetPendingResponse()
 
 	detail := "Explain preview ready. No request was sent."
 	if txt := strings.TrimSpace(rep.Decision); txt != "" {
@@ -342,23 +285,11 @@ func (m *Model) consumeExplainPreview(env string, rep *xplain.Report) tea.Cmd {
 		environment: env,
 	}
 	m.responseLatest = snapshot
-	m.responsePending = nil
 
-	target := m.responseTargetPane()
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		if id == target {
-			pane.snapshot = snapshot
-			pane.invalidateCaches()
-			pane.setActiveTab(responseTabExplain)
-			pane.viewport.GotoTop()
-			pane.setCurrPosition()
-		}
-	}
-	m.setLivePane(target)
+	pane := m.showSnapshot(m.responseTargetPane(), snapshot)
+	pane.setActiveTab(responseTabExplain)
+	pane.resetScroll()
+
 	m.setStatusMessage(statusMsg{text: detail, level: statusInfo})
 	return m.syncResponsePanes()
 }
@@ -411,13 +342,10 @@ func requestErrorNote(class diag.Class) string {
 	}
 }
 
-func (m *Model) consumeHTTPResponse(
-	resp *httpx.Response,
-	tests []scripts.TestResult,
-	scriptErr error,
-	environment string,
-	rep *xplain.Report,
-) tea.Cmd {
+func (m *Model) consumeHTTPResponse(msg responseMsg) tea.Cmd {
+	resp := msg.response
+	tests := msg.tests
+	scriptErr := msg.scriptErr
 	m.lastGRPC = nil
 	m.lastResponse = resp
 
@@ -425,33 +353,15 @@ func (m *Model) consumeHTTPResponse(
 		m.responsePrevious = m.responseLatest
 	}
 
+	m.resetPendingResponse()
+
 	if resp == nil {
-		m.abortResponseFormatting()
 		m.responseLatest = nil
-		m.responsePending = nil
-		target := m.responseTargetPane()
-		for _, id := range m.visiblePaneIDs() {
-			pane := m.pane(id)
-			if pane == nil {
-				continue
-			}
-			if id == target {
-				pane.snapshot = nil
-				pane.invalidateCaches()
-				width := pane.viewport.Width
-				if width <= 0 {
-					width = defaultResponseViewportWidth
-				}
-				pane.viewport.SetContent(logoPlaceholder(width, pane.viewport.Height))
-				pane.viewport.GotoTop()
-				pane.setCurrPosition()
-			}
-		}
-		m.setLivePane(target)
+		pane := m.showSnapshot(m.responseTargetForMsg(msg), nil)
+		pane.viewport.SetContent(logoPlaceholder(paneWidth(pane), pane.viewport.Height))
+		pane.resetScroll()
 		return nil
 	}
-
-	m.abortResponseFormatting()
 
 	var traceSpec *restfile.TraceSpec
 	if cloned := traceSpecFromRequest(resp.Request).Clone(); cloned != nil &&
@@ -499,15 +409,14 @@ func (m *Model) consumeHTTPResponse(
 	token := nextResponseRenderToken()
 	snapshot := &responseSnapshot{
 		id:          token,
-		environment: environment,
+		environment: msg.environment,
 		explain: explainState{
-			report: rep,
+			report: msg.explain,
 		},
 		source: newHTTPResponseRenderSource(resp, tests, scriptErr),
 	}
-	m.responseRenderToken = token
-	m.responsePending = snapshot
 	m.responseLatest = snapshot
+	m.bindSnapshotStream(snapshot, msg.streamID)
 	if traceSpec != nil {
 		snapshot.traceSpec = traceSpec
 	}
@@ -516,36 +425,18 @@ func (m *Model) consumeHTTPResponse(
 		snapshot.traceReport = timeline
 		snapshot.traceData = resp.TraceReport.Clone()
 	}
-	if m.responseTokens == nil {
-		m.responseTokens = make(map[string]*responseSnapshot)
-	}
-	m.responseTokens[token] = snapshot
 	m.responseLoading = true
 	m.responseLoadingFrame = 0
 
-	target := m.responseTargetPane()
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		if id == target {
-			pane.snapshot = snapshot
-			pane.invalidateCaches()
-			pane.viewport.SetContent(m.responseLoadingMessage())
-			pane.viewport.GotoTop()
-			pane.setCurrPosition()
-		}
-	}
-	m.setLivePane(target)
+	target := m.responseTargetForMsg(msg)
+	pane := m.showSnapshot(target, snapshot)
+	pane.viewport.SetContent(m.responseLoadingMessage())
+	pane.resetScroll()
 
-	primaryWidth := m.pane(responsePanePrimary).viewport.Width
-	if primaryWidth <= 0 {
-		primaryWidth = defaultResponseViewportWidth
-	}
+	primaryWidth := paneWidth(m.pane(responsePanePrimary))
 
 	formatCtx, cancel := context.WithCancel(context.Background())
-	m.responseRenderCancel = cancel
+	m.render = pendingRender{token: token, snapshot: snapshot, cancel: cancel}
 
 	renderCmd := m.respCmd(m.respFmtCmd(formatCtx, token, resp, tests, scriptErr, primaryWidth))
 	if pane := m.pane(target); pane != nil &&
@@ -574,25 +465,25 @@ func (m *Model) responseReflowMessage() string {
 	return responseReflowingMessage + " " + spin
 }
 
-func (m *Model) abortResponseFormatting() {
-	if m.responseRenderCancel != nil {
-		m.responseRenderCancel()
-		m.responseRenderCancel = nil
+// resetPendingResponse retires the render that was in flight. Any path that
+// replaces the response synchronously has to call this: a render left running
+// would otherwise finish and overwrite the view that replaced it. Retiring it
+// as one value is what makes that safe, since there is no half-cleared state a
+// late result could still match.
+func (m *Model) resetPendingResponse() {
+	if m.render.cancel != nil {
+		m.render.cancel()
 	}
-	if m.responseRenderToken != "" && m.responseTokens != nil {
-		delete(m.responseTokens, m.responseRenderToken)
-	}
-	m.responseRenderToken = ""
+	m.render = pendingRender{}
 	m.responseLoading = false
 	m.responseLoadingFrame = 0
 	m.respSpinStop()
 }
 
 func (m *Model) cancelResponseFormatting(reason string) tea.Cmd {
-	pending := m.responsePending
+	pending := m.render.snapshot
 	previous := m.responsePrevious
-	m.abortResponseFormatting()
-	m.responsePending = nil
+	m.resetPendingResponse()
 
 	if pending != nil && !pending.ready {
 		switch {
@@ -633,18 +524,15 @@ func (m *Model) scheduleResponseLoadingTick() tea.Cmd {
 	})
 }
 
+// handleResponseRendered fills in the snapshot its render was started for, and
+// only that one. A result whose render has been retired is dropped: the
+// snapshot it was building is no longer on screen, so writing it anywhere else
+// would replace a response the user is actually looking at.
 func (m *Model) handleResponseRendered(msg responseRenderedMsg) tea.Cmd {
-	if msg.token == "" || msg.token != m.responseRenderToken {
+	if !m.render.owns(msg.token) {
 		return nil
 	}
-
-	snapshot, ok := m.responseTokens[msg.token]
-	if !ok {
-		snapshot = m.responseLatest
-	}
-	if snapshot == nil {
-		return nil
-	}
+	snapshot := m.render.snapshot
 
 	snapshot.pretty = msg.pretty
 	snapshot.raw = msg.raw
@@ -667,14 +555,9 @@ func (m *Model) handleResponseRendered(msg responseRenderedMsg) tea.Cmd {
 	applyRawViewMode(snapshot, snapshot.rawMode)
 	snapshot.ready = true
 
-	delete(m.responseTokens, msg.token)
-	if m.responsePending == snapshot {
-		m.responsePending = nil
-	}
-	m.responseRenderToken = ""
+	m.render = pendingRender{}
 	m.responseLoading = false
 	m.responseLoadingFrame = 0
-	m.responseRenderCancel = nil
 	m.responseLatest = snapshot
 	m.respSpinStop()
 
@@ -774,39 +657,22 @@ func (m *Model) handleResponseLoadingTick() tea.Cmd {
 	return m.scheduleResponseLoadingTick()
 }
 
-func (m *Model) consumeGRPCResponse(
-	resp *grpcx.Response,
-	tests []scripts.TestResult,
-	scriptErr error,
-	req *restfile.Request,
-	environment string,
-	rep *xplain.Report,
-) tea.Cmd {
+func (m *Model) consumeGRPCResponse(msg responseMsg) tea.Cmd {
+	resp := msg.grpc
+	tests := msg.tests
+	scriptErr := msg.scriptErr
+	req := msg.executed
 	m.lastResponse = nil
 	m.lastGRPC = resp
-	m.responseLoading = false
-	m.responseRenderToken = ""
-	m.responsePending = nil
 	if m.responseLatest != nil && m.responseLatest.ready {
 		m.responsePrevious = m.responseLatest
 	}
+	m.resetPendingResponse()
 
 	if resp == nil {
-		target := m.responseTargetPane()
-		for _, id := range m.visiblePaneIDs() {
-			pane := m.pane(id)
-			if pane == nil {
-				continue
-			}
-			if id == target {
-				pane.snapshot = nil
-				pane.invalidateCaches()
-				pane.viewport.SetContent("No gRPC response")
-				pane.viewport.GotoTop()
-				pane.setCurrPosition()
-			}
-		}
-		m.setLivePane(target)
+		pane := m.showSnapshot(m.responseTargetForMsg(msg), nil)
+		pane.viewport.SetContent("No gRPC response")
+		pane.resetScroll()
 		return nil
 	}
 
@@ -819,15 +685,16 @@ func (m *Model) consumeGRPCResponse(
 	statusLine := renderer.grpcStatusLine(resp, fullMethod)
 
 	snapshot := &responseSnapshot{
+		id:         nextResponseRenderToken(),
 		pretty:     views.pretty,
 		raw:        views.raw,
 		rawSummary: views.rawSummary,
 		headers:    views.headers,
 		explain: explainState{
-			report: rep,
+			report: msg.explain,
 		},
 		ready:           true,
-		environment:     environment,
+		environment:     msg.environment,
 		body:            append([]byte(nil), resp.Wire...),
 		bodyMeta:        views.meta,
 		contentType:     views.contentType,
@@ -844,13 +711,7 @@ func (m *Model) consumeGRPCResponse(
 	}
 	applyRawViewMode(snapshot, snapshot.rawMode)
 	m.responseLatest = snapshot
-	m.responsePending = nil
-
-	if m.responseTokens != nil {
-		for key := range m.responseTokens {
-			delete(m.responseTokens, key)
-		}
-	}
+	m.bindSnapshotStream(snapshot, msg.streamID)
 
 	status := statusMsg{text: statusLine, level: statusSuccess}
 	if !resp.OK() {
@@ -859,20 +720,7 @@ func (m *Model) consumeGRPCResponse(
 	status.testSummary, status.testLevel = responseTestStatusSummary(tests, scriptErr)
 	m.setStatusMessage(status)
 
-	target := m.responseTargetPane()
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		if id == target {
-			pane.snapshot = snapshot
-		}
-		pane.invalidateCaches()
-		pane.viewport.GotoTop()
-		pane.setCurrPosition()
-	}
-	m.setLivePane(target)
+	m.showSnapshot(m.responseTargetForMsg(msg), snapshot).resetScroll()
 
 	return m.syncResponsePanes()
 }
@@ -1806,68 +1654,47 @@ func (m *Model) previewRequest(req *restfile.Request) tea.Cmd {
 
 func (m *Model) applyPreview(preview string, statusText string) tea.Cmd {
 	snapshot := &responseSnapshot{
+		id:             nextResponseRenderToken(),
 		pretty:         preview,
 		raw:            preview,
 		headers:        preview,
 		requestHeaders: preview,
 		ready:          true,
 	}
-	m.responseRenderToken = ""
-	m.responsePending = nil
-	m.responseLoading = false
+	m.resetPendingResponse()
 	m.responseLatest = snapshot
 
-	targetPaneID := m.responseTargetPane()
+	pane := m.showSnapshot(m.responseTargetPane(), snapshot)
+	pane.setActiveTab(responseTabPretty)
+	pane.resetScroll()
 
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		if id == targetPaneID {
-			pane.snapshot = snapshot
-		}
-		pane.invalidateCaches()
-		if id == targetPaneID {
-			pane.setActiveTab(responseTabPretty)
-		}
-		pane.viewport.GotoTop()
-		pane.setCurrPosition()
-	}
-	m.setLivePane(targetPaneID)
-
-	if pane := m.pane(targetPaneID); pane != nil {
-		displayWidth := pane.viewport.Width
-		if displayWidth <= 0 {
-			displayWidth = defaultResponseViewportWidth
-		}
-		content := displayContent(preview)
-		prettyCache := wrapCache(
-			responseTabPretty,
-			content,
-			responseWrapWidth(responseTabPretty, displayWidth),
-		)
-		pane.setCacheForTab(responseTabPretty, rawViewText, pane.headersView, prettyCache)
-		pane.setCacheForTab(
-			responseTabRaw,
-			snapshot.rawMode,
-			pane.headersView,
-			wrapCache(responseTabRaw, content, responseWrapWidth(responseTabRaw, displayWidth)),
-		)
-		pane.setCacheForTab(
+	displayWidth := paneWidth(pane)
+	content := displayContent(preview)
+	prettyCache := wrapCache(
+		responseTabPretty,
+		content,
+		responseWrapWidth(responseTabPretty, displayWidth),
+	)
+	pane.setCacheForTab(responseTabPretty, rawViewText, pane.headersView, prettyCache)
+	pane.setCacheForTab(
+		responseTabRaw,
+		snapshot.rawMode,
+		pane.headersView,
+		wrapCache(responseTabRaw, content, responseWrapWidth(responseTabRaw, displayWidth)),
+	)
+	pane.setCacheForTab(
+		responseTabHeaders,
+		rawViewText,
+		pane.headersView,
+		wrapCache(
 			responseTabHeaders,
-			rawViewText,
-			pane.headersView,
-			wrapCache(
-				responseTabHeaders,
-				content,
-				responseWrapWidth(responseTabHeaders, displayWidth),
-			),
-		)
-		pane.wrapCache[responseTabDiff] = cachedWrap{}
-		pane.wrapCache[responseTabStats] = cachedWrap{}
-		pane.viewport.SetContent(prettyCache.content)
-	}
+			content,
+			responseWrapWidth(responseTabHeaders, displayWidth),
+		),
+	)
+	pane.wrapCache[responseTabDiff] = cachedWrap{}
+	pane.wrapCache[responseTabStats] = cachedWrap{}
+	pane.viewport.SetContent(prettyCache.content)
 
 	m.testResults = nil
 	m.scriptError = nil
@@ -2279,27 +2106,21 @@ func (m *Model) applyHistorySnapshot(snap *responseSnapshot) {
 		return
 	}
 
-	m.responsePending = nil
+	// A history entry replaces the response, so a render still formatting the
+	// previous one has to be retired before it can finish into this snapshot.
+	m.resetPendingResponse()
 	m.responseLatest = snap
-	if m.responseTokens != nil {
-		for key := range m.responseTokens {
-			delete(m.responseTokens, key)
-		}
-	}
 
+	// Browsing history replaces both panes: the entry is the whole view now,
+	// not one side of a comparison.
 	for _, id := range m.visiblePaneIDs() {
+		m.setPaneSnapshot(id, snap)
 		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		pane.snapshot = snap
-		pane.invalidateCaches()
 		if pane.activeTab == responseTabHistory {
 			continue
 		}
 		pane.viewport.SetContent(displayContent(snap.pretty))
-		pane.viewport.GotoTop()
-		pane.setCurrPosition()
+		pane.resetScroll()
 	}
 }
 

--- a/internal/ui/model_history_test.go
+++ b/internal/ui/model_history_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"google.golang.org/grpc/codes"
 
+	xplain "github.com/unkn0wn-root/resterm/internal/explain"
 	"github.com/unkn0wn-root/resterm/internal/history"
 	histdb "github.com/unkn0wn-root/resterm/internal/history/sqlite"
 	"github.com/unkn0wn-root/resterm/internal/nettrace"
@@ -321,6 +323,130 @@ func TestBundleFromHistoryResolvesBaselineEnvironment(t *testing.T) {
 	}
 }
 
+// Replacing a response while its formatter is still running has to retire that
+// render. Its token stops matching, so handleResponseRendered drops the result
+// without ever collecting the snapshot it was building.
+func TestSynchronousResponsesRetireTheInFlightRender(t *testing.T) {
+	cases := []struct {
+		name  string
+		apply func(m *Model)
+	}{
+		{
+			name: "error",
+			apply: func(m *Model) {
+				m.consumeRequestError(responseMsg{err: errors.New("boom")})
+			},
+		},
+		{
+			name:  "preview",
+			apply: func(m *Model) { m.applyPreview("GET https://example.com", "Previewing") },
+		},
+		{
+			name: "stream transcript",
+			apply: func(m *Model) {
+				m.consumeStreamTranscript(responseMsg{transcript: []byte("data: hi\n")})
+			},
+		},
+		{
+			name: "history",
+			apply: func(m *Model) {
+				m.applyHistorySnapshot(newTextSnapshot("history entry body", "dev"))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := New(Config{})
+			model.ready = true
+			model.width = 120
+			model.height = 40
+			if cmd := model.applyLayout(); cmd != nil {
+				collectMsgs(cmd)
+			}
+
+			render := model.consumeHTTPResponse(responseMsg{response: &httpx.Response{
+				Status:       "200 OK",
+				StatusCode:   200,
+				Body:         []byte("<html><body><p>Hello</p></body></html>"),
+				EffectiveURL: "https://example.com",
+			}})
+			if render == nil {
+				t.Fatal("expected an async render to be scheduled")
+			}
+			if model.render.snapshot == nil || model.render.cancel == nil ||
+				model.render.token == "" {
+				t.Fatalf("expected a render in flight, got %+v", model.render)
+			}
+
+			tc.apply(&model)
+
+			if model.render.token != "" || model.render.snapshot != nil ||
+				model.render.cancel != nil {
+				t.Fatalf("render outlived the response it was building: %+v", model.render)
+			}
+			if model.responseLoading {
+				t.Fatal("expected the loading indicator to stop")
+			}
+			// A canceled formatter yields nothing, so running it now is a no-op
+			// rather than a render that lands on top of the new response.
+			for _, msg := range collectMsgs(render) {
+				if rendered, ok := msg.(responseRenderedMsg); ok {
+					t.Fatalf("canceled formatter still produced a render: %+v", rendered.token)
+				}
+			}
+		})
+	}
+}
+
+// Canceling the formatter does not unqueue a result it already produced, so the
+// late message still has to be refused. Otherwise it lands on the history entry
+// that replaced it and silently rewrites the entry with another response's body.
+func TestLateRenderCannotOverwriteHistorySnapshot(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.width = 120
+	model.height = 40
+	if cmd := model.applyLayout(); cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	if cmd := model.consumeHTTPResponse(responseMsg{response: &httpx.Response{
+		Status:       "200 OK",
+		StatusCode:   200,
+		Body:         []byte("live response body"),
+		EffectiveURL: "https://example.com",
+	}}); cmd == nil {
+		t.Fatal("expected an async render to be scheduled")
+	}
+	// The formatter finished before the user moved: its result is already in
+	// the queue and will be delivered no matter what happens next.
+	inFlight := responseRenderedMsg{
+		token:  model.render.token,
+		pretty: "live response body",
+		raw:    "live response body",
+	}
+
+	entry := newTextSnapshot("history entry body", "dev")
+	model.applyHistorySnapshot(entry)
+
+	if cmd := model.handleResponseRendered(inFlight); cmd != nil {
+		t.Fatal("expected the retired render to be refused")
+	}
+	if entry.pretty != "history entry body" {
+		t.Fatalf("history entry was rewritten by the retired render: %q", entry.pretty)
+	}
+	if model.responseLatest != entry {
+		t.Fatal("the retired render stole the latest response")
+	}
+	if got := ansi.Strip(model.pane(responsePanePrimary).viewport.View()); !strings.Contains(
+		got,
+		"history entry body",
+	) {
+		t.Fatalf("pane stopped showing the history entry: %q", got)
+	}
+}
+
 func TestConsumeHTTPResponseSchedulesAsyncRender(t *testing.T) {
 	model := New(Config{})
 	model.ready = true
@@ -339,15 +465,15 @@ func TestConsumeHTTPResponseSchedulesAsyncRender(t *testing.T) {
 		EffectiveURL: "https://example.com",
 	}
 
-	cmd := model.consumeHTTPResponse(resp, nil, nil, "", nil)
+	cmd := model.consumeHTTPResponse(responseMsg{response: resp})
 	if cmd == nil {
 		t.Fatalf("expected consumeHTTPResponse to return render command")
 	}
 	if !model.responseLoading {
 		t.Fatalf("expected responseLoading to be true after scheduling render")
 	}
-	if model.responseRenderToken == "" {
-		t.Fatalf("expected responseRenderToken to be assigned")
+	if model.render.token == "" {
+		t.Fatalf("expected a render token to be assigned")
 	}
 	if content := model.pane(
 		responsePanePrimary,
@@ -401,7 +527,7 @@ func TestConsumeHTTPResponseStatusLevelFollowsHTTPStatusCode(t *testing.T) {
 				Body:       []byte("body"),
 			}
 
-			if cmd := model.consumeHTTPResponse(resp, nil, nil, "", nil); cmd == nil {
+			if cmd := model.consumeHTTPResponse(responseMsg{response: resp}); cmd == nil {
 				t.Fatalf("expected consumeHTTPResponse to return render command")
 			}
 			if model.statusMessage.level != tt.want {
@@ -430,7 +556,7 @@ func TestConsumeHTTPResponseUsesSeparateStatusBarTestSummary(t *testing.T) {
 	}
 	tests := []scripts.TestResult{{Name: "status", Passed: false}}
 
-	if cmd := model.consumeHTTPResponse(resp, tests, nil, "", nil); cmd == nil {
+	if cmd := model.consumeHTTPResponse(responseMsg{response: resp, tests: tests}); cmd == nil {
 		t.Fatalf("expected consumeHTTPResponse to return render command")
 	}
 	if strings.Contains(model.statusMessage.text, " - ") {
@@ -480,7 +606,7 @@ func TestConsumeGRPCResponseKeepsStatusDetailsInResponsePane(t *testing.T) {
 		},
 	}
 
-	if cmd := model.consumeGRPCResponse(resp, nil, nil, req, "", nil); cmd != nil {
+	if cmd := model.consumeGRPCResponse(responseMsg{grpc: resp, executed: req}); cmd != nil {
 		collectMsgs(cmd)
 	}
 
@@ -507,6 +633,150 @@ func TestConsumeGRPCResponseKeepsStatusDetailsInResponsePane(t *testing.T) {
 	}
 }
 
+// A response lands in one pane only. The pinned neighbour used to be scrolled
+// back to the top by every gRPC response, losing the reader's place.
+func TestConsumeGRPCResponseLeavesPinnedPaneScrollAlone(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.width = 160
+	model.height = 40
+	model.responseSplit = true
+	model.responseLastFocused = responsePanePrimary
+	if cmd := model.applyLayout(); cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	pinned := model.pane(responsePaneSecondary)
+	pinned.followLatest = false
+	pinned.snapshot = &responseSnapshot{ready: true, pretty: strings.Repeat("line\n", 50)}
+	pinned.viewport.Height = 5
+	pinned.viewport.SetContent(pinned.snapshot.pretty)
+	pinned.viewport.SetYOffset(12)
+	pinned.setCurrPosition()
+	pinned.wrapCache[responseTabDiff] = cachedWrap{content: "stale diff", valid: true}
+
+	cmd := model.consumeGRPCResponse(responseMsg{
+		grpc:     &grpcx.Response{StatusCode: codes.OK},
+		executed: &restfile.Request{Method: "GRPC", GRPC: &restfile.GRPCRequest{FullMethod: "/s/M"}},
+	})
+	if cmd != nil {
+		collectMsgs(cmd)
+	}
+
+	if pinned.snapshot == model.responseLatest {
+		t.Fatal("response leaked into the pinned pane")
+	}
+	if pinned.viewport.YOffset != 12 {
+		t.Fatalf("pinned pane was scrolled, offset=%d want 12", pinned.viewport.YOffset)
+	}
+	if pinned.wrapCache[responseTabDiff].valid {
+		t.Fatal("expected the pinned pane's diff cache to be dropped")
+	}
+}
+
+// A Diff is rendered from both panes, so replacing one side makes the cached
+// rendering on the other side describe a response that is no longer on screen.
+// Dropping that cache is what makes the neighbour recompute against the new
+// response: the Diff tab keeps working, it just stops showing the old answer.
+func TestResponsesRecomputeNeighbourDiff(t *testing.T) {
+	const stale = "STALE DIFF CONTENT"
+
+	cases := []struct {
+		name string
+		// marker is text unique to the incoming response. The neighbour's
+		// recomputed Diff has to contain it, because that response is now one
+		// side of the comparison.
+		marker string
+		apply  func(m *Model)
+	}{
+		{
+			name:   "error",
+			marker: "boom",
+			apply: func(m *Model) {
+				m.consumeRequestError(responseMsg{err: errors.New("boom")})
+			},
+		},
+		{
+			name:   "skipped",
+			marker: "Request Skipped",
+			apply: func(m *Model) {
+				m.consumeSkippedRequest(responseMsg{skipped: true, skipReason: "condition false"})
+			},
+		},
+		{
+			name:   "explain preview",
+			marker: "Explain Preview",
+			apply: func(m *Model) {
+				m.consumeExplainPreview("dev", &xplain.Report{Decision: "would send"})
+			},
+		},
+		{
+			name:   "stream transcript",
+			marker: "transcript-marker",
+			apply: func(m *Model) {
+				m.consumeStreamTranscript(responseMsg{
+					transcript: []byte("event: one\ndata: transcript-marker\n"),
+					streamID:   "sse-1",
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := New(Config{})
+			model.ready = true
+			model.width = 160
+			model.height = 40
+			model.responseSplit = true
+			model.responseLastFocused = responsePanePrimary
+			if cmd := model.applyLayout(); cmd != nil {
+				collectMsgs(cmd)
+			}
+
+			model.pane(responsePanePrimary).snapshot = &responseSnapshot{
+				ready:  true,
+				pretty: "replaced body",
+			}
+			neighbour := model.pane(responsePaneSecondary)
+			neighbour.snapshot = &responseSnapshot{ready: true, pretty: "kept body"}
+			neighbour.followLatest = false
+			neighbour.setActiveTab(responseTabDiff)
+			neighbour.wrapCache[responseTabDiff] = cachedWrap{
+				width:   neighbour.viewport.Width,
+				content: stale,
+				valid:   true,
+			}
+
+			tc.apply(&model)
+
+			if got := neighbour.wrapCache[responseTabDiff]; got.valid &&
+				strings.Contains(got.content, stale) {
+				t.Fatal("neighbour kept a diff cached against the replaced response")
+			}
+
+			view := ansi.Strip(neighbour.viewport.View())
+			if strings.Contains(view, stale) {
+				t.Fatal("neighbour still shows the stale diff")
+			}
+			// The Diff tab is still a Diff tab: the neighbour keeps its own
+			// response and now compares it against the one that just landed.
+			if neighbour.activeTab != responseTabDiff {
+				t.Fatalf("neighbour left the Diff tab, now on %v", neighbour.activeTab)
+			}
+			if neighbour.snapshot.pretty != "kept body" {
+				t.Fatalf("neighbour lost its own response: %q", neighbour.snapshot.pretty)
+			}
+			if !strings.Contains(view, "kept body") {
+				t.Fatalf("recomputed diff dropped the neighbour's side: %q", view)
+			}
+			if !strings.Contains(view, tc.marker) {
+				t.Fatalf("recomputed diff missing the new response %q: %q", tc.marker, view)
+			}
+		})
+	}
+}
+
 // Multi-line status details in the status bar grew the view past the terminal,
 // which scrolled the whole TUI up instead of staying inside the frame.
 func TestConsumeGRPCResponseKeepsViewWithinTerminalHeight(t *testing.T) {
@@ -526,7 +796,7 @@ func TestConsumeGRPCResponseKeepsViewWithinTerminalHeight(t *testing.T) {
 		Method: "GRPC",
 		GRPC:   &restfile.GRPCRequest{FullMethod: "/pkg.Service/FailWithDetails"},
 	}
-	if cmd := model.consumeGRPCResponse(resp, nil, nil, req, "", nil); cmd != nil {
+	if cmd := model.consumeGRPCResponse(responseMsg{grpc: resp, executed: req}); cmd != nil {
 		collectMsgs(cmd)
 	}
 
@@ -576,8 +846,8 @@ func drainResponseCommands(t *testing.T, model *Model, initial tea.Cmd) {
 		queue = queue[1:]
 		switch typed := msg.(type) {
 		case responseRenderedMsg:
-			if typed.token != model.responseRenderToken {
-				t.Fatalf("render token mismatch: %s vs %s", typed.token, model.responseRenderToken)
+			if typed.token != model.render.token {
+				t.Fatalf("render token mismatch: %s vs %s", typed.token, model.render.token)
 			}
 			if follow := model.handleResponseRendered(typed); follow != nil {
 				queue = append(queue, collectMsgs(follow)...)
@@ -617,7 +887,7 @@ func TestToggleResponseSplitConfiguresSecondaryPane(t *testing.T) {
 		EffectiveURL: "https://example.com",
 	}
 
-	drainResponseCommands(t, &model, model.consumeHTTPResponse(resp, nil, nil, "", nil))
+	drainResponseCommands(t, &model, model.consumeHTTPResponse(responseMsg{response: resp}))
 	if model.responseLatest == nil || !model.responseLatest.ready {
 		t.Fatalf("expected latest snapshot to be ready")
 	}
@@ -722,7 +992,7 @@ func TestDiffTabAvailableAfterDualResponses(t *testing.T) {
 		Body:         []byte("first"),
 		EffectiveURL: "https://example.com/one",
 	}
-	drainResponseCommands(t, &model, model.consumeHTTPResponse(first, nil, nil, "", nil))
+	drainResponseCommands(t, &model, model.consumeHTTPResponse(responseMsg{response: first}))
 	if model.diffAvailable() {
 		t.Fatalf("diff should be unavailable before split")
 	}
@@ -741,7 +1011,7 @@ func TestDiffTabAvailableAfterDualResponses(t *testing.T) {
 		Body:         []byte("second"),
 		EffectiveURL: "https://example.com/two",
 	}
-	drainResponseCommands(t, &model, model.consumeHTTPResponse(second, nil, nil, "", nil))
+	drainResponseCommands(t, &model, model.consumeHTTPResponse(responseMsg{response: second}))
 	if !model.diffAvailable() {
 		t.Fatalf("expected diff to be available after second response")
 	}
@@ -779,7 +1049,7 @@ func TestResponsesFollowLastFocusedPane(t *testing.T) {
 		Body:         []byte("first"),
 		EffectiveURL: "https://example.com/one",
 	}
-	drainResponseCommands(t, &model, model.consumeHTTPResponse(resp1, nil, nil, "", nil))
+	drainResponseCommands(t, &model, model.consumeHTTPResponse(responseMsg{response: resp1}))
 
 	primary := model.pane(responsePanePrimary)
 	if primary == nil || primary.snapshot == nil ||
@@ -801,7 +1071,7 @@ func TestResponsesFollowLastFocusedPane(t *testing.T) {
 		Body:         []byte("second"),
 		EffectiveURL: "https://example.com/two",
 	}
-	drainResponseCommands(t, &model, model.consumeHTTPResponse(resp2, nil, nil, "", nil))
+	drainResponseCommands(t, &model, model.consumeHTTPResponse(responseMsg{response: resp2}))
 
 	secondary := model.pane(responsePaneSecondary)
 	if secondary == nil || secondary.snapshot == nil ||
@@ -832,7 +1102,7 @@ func TestTogglePaneFollowLatestPinsSnapshot(t *testing.T) {
 		Body:         []byte("first"),
 		EffectiveURL: "https://example.com/a",
 	}
-	drainResponseCommands(t, &model, model.consumeHTTPResponse(resp1, nil, nil, "", nil))
+	drainResponseCommands(t, &model, model.consumeHTTPResponse(responseMsg{response: resp1}))
 	primary := model.pane(responsePanePrimary)
 	firstSnapshot := primary.snapshot
 	if firstSnapshot == nil {
@@ -861,7 +1131,7 @@ func TestTogglePaneFollowLatestPinsSnapshot(t *testing.T) {
 		Body:         []byte("second"),
 		EffectiveURL: "https://example.com/b",
 	}
-	drainResponseCommands(t, &model, model.consumeHTTPResponse(resp2, nil, nil, "", nil))
+	drainResponseCommands(t, &model, model.consumeHTTPResponse(responseMsg{response: resp2}))
 	if primary.snapshot != firstSnapshot {
 		t.Fatalf("expected pinned pane to retain original snapshot")
 	}

--- a/internal/ui/model_mouse.go
+++ b/internal/ui/model_mouse.go
@@ -506,7 +506,7 @@ func (m *Model) responseTabAt(id responsePaneID, x int) (responseTab, bool) {
 	row := m.renderPaneTabs(id, true, width)
 	line := firstLine(ansi.Strip(row))
 	off := 0
-	for _, tab := range m.availableResponseTabs() {
+	for _, tab := range m.availableResponseTabsFor(id) {
 		label := responseTabLabelForSnapshot(tab, pane.snapshot)
 		r := findVisibleTabRange(line, label, off)
 		if !r.ok {

--- a/internal/ui/model_profile.go
+++ b/internal/ui/model_profile.go
@@ -390,17 +390,11 @@ func (m *Model) finalizeProfileRun(msg responseMsg, state *profileState) tea.Cmd
 	var cmds []tea.Cmd
 	canceled := state != nil && state.canceled
 	if msg.err != nil && (!canceled || !isCanceled(msg.err)) {
-		if cmd := m.consumeRequestError(msg.err, msg.explain); cmd != nil {
+		if cmd := m.consumeRequestError(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	} else if msg.response != nil {
-		if cmd := m.consumeHTTPResponse(
-			msg.response,
-			msg.tests,
-			msg.scriptErr,
-			msg.environment,
-			msg.explain,
-		); cmd != nil {
+		if cmd := m.consumeHTTPResponse(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	} else {

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1323,7 +1323,7 @@ func (m Model) renderPaneTabs(id responsePaneID, focused bool, width int) string
 		return ""
 	}
 
-	tabs := m.availableResponseTabs()
+	tabs := m.availableResponseTabsFor(id)
 	lineWidth := max(width, 1)
 	rowStyle := m.theme.Tabs.Width(lineWidth).Align(lipgloss.Center)
 	contentLimit := max(lineWidth, 1)
@@ -1352,6 +1352,25 @@ func (m Model) renderResponseDivider(left, right string) string {
 	return m.theme.PaneDivider.Render(line)
 }
 
+// paneModeLabel names what the pane is following. The Stream tab reports the
+// tail, every other tab reports whether new responses land here, because those
+// are two independent things the same pane can be doing.
+func paneModeLabel(pane *responsePaneState) string {
+	switch {
+	case pane == nil:
+		return "Pinned"
+	case pane.activeTab == responseTabStream:
+		if pane.tail {
+			return "Tail"
+		}
+		return "Scroll"
+	case pane.followLatest:
+		return "Live"
+	default:
+		return "Pinned"
+	}
+}
+
 func (m Model) buildTabRowContent(
 	tabs []responseTab,
 	pane *responsePaneState,
@@ -1362,21 +1381,16 @@ func (m Model) buildTabRowContent(
 		limit = 1
 	}
 	active := responseTabPretty
-	followLatest := false
 	var snapshot *responseSnapshot
 	if pane != nil {
 		active = pane.activeTab
-		followLatest = pane.followLatest
 		snapshot = pane.snapshot
 	}
 	labels := make([]string, len(tabs))
 	for i, tab := range tabs {
 		labels[i] = responseTabLabelForSnapshot(tab, snapshot)
 	}
-	mode := "Pinned"
-	if followLatest {
-		mode = "Live"
-	}
+	mode := paneModeLabel(pane)
 	badge := m.tabBadgeText(mode)
 	shortBadge := m.tabBadgeShort(mode)
 	actTab := m.theme.TabActive

--- a/internal/ui/model_response_scroll.go
+++ b/internal/ui/model_response_scroll.go
@@ -41,6 +41,7 @@ func (m *Model) scrollResponseToEdge(top bool) tea.Cmd {
 	} else {
 		pane.viewport.GotoBottom()
 	}
+	pane.syncStreamTail(!top)
 	pane.setCurrPosition()
 	if m.syncRespCursorToEdge(pane, top) {
 		return m.syncResponsePane(m.responsePaneFocus)
@@ -86,7 +87,8 @@ func isScrollableResponsePane(pane *responsePaneState) bool {
 		return false
 	}
 	switch pane.activeTab {
-	case responseTabPretty, responseTabRaw, responseTabHeaders, responseTabExplain:
+	case responseTabPretty, responseTabRaw, responseTabHeaders, responseTabExplain,
+		responseTabStream:
 		return true
 	default:
 		return false
@@ -99,6 +101,7 @@ func (m *Model) scrollResponseViewport(pane *responsePaneState, scrollFn func())
 	}
 	prevOffset := pane.viewport.YOffset
 	scrollFn()
+	pane.syncStreamTail(pane.viewport.AtBottom())
 	pane.setCurrPosition()
 	if m.followRespCursorOnScroll(pane, prevOffset, pane.viewport.YOffset) {
 		return m.syncResponsePane(m.responsePaneFocus)

--- a/internal/ui/model_response_scroll_test.go
+++ b/internal/ui/model_response_scroll_test.go
@@ -30,6 +30,34 @@ func TestScrollResponseToTopAndBottom(t *testing.T) {
 	}
 }
 
+func TestScrollStreamControlsTailFollow(t *testing.T) {
+	model := newModelWithResponseTab(
+		responseTabStream,
+		&responseSnapshot{ready: true, streamID: "grpc-1"},
+	)
+	pane := model.pane(responsePanePrimary)
+	pane.viewport.Height = 5
+	pane.viewport.SetContent(strings.Repeat("event\n", 30))
+	pane.tail = true
+
+	model.scrollResponseToEdge(true)
+	if pane.viewport.YOffset != 0 || pane.tail {
+		t.Fatalf("expected gg to stop stream tail at top, offset=%d tail=%v", pane.viewport.YOffset, pane.tail)
+	}
+
+	model.scrollResponseToEdge(false)
+	if pane.viewport.YOffset == 0 || !pane.tail {
+		t.Fatalf("expected G to resume stream tail, offset=%d tail=%v", pane.viewport.YOffset, pane.tail)
+	}
+
+	model.scrollResponseViewport(pane, func() {
+		pane.viewport.ScrollUp(1)
+	})
+	if pane.tail {
+		t.Fatal("manual stream scrolling should stop tail follow")
+	}
+}
+
 func TestScrollResponseIgnoredInEditorFocus(t *testing.T) {
 	model := newModelWithResponseTab(responseTabPretty, &responseSnapshot{ready: true})
 	pane := model.pane(responsePanePrimary)

--- a/internal/ui/model_response_snapshot.go
+++ b/internal/ui/model_response_snapshot.go
@@ -1,36 +1,57 @@
 package ui
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// setPaneSnapshot hands a pane its response. The snapshot takes over stream
+// ownership from the pane, so a pane pinned to an older response keeps showing
+// that response's transcript instead of the one still running.
+func (m *Model) setPaneSnapshot(id responsePaneID, snap *responseSnapshot) {
+	pane := m.pane(id)
+	if pane == nil {
+		return
+	}
+	if snap != nil && snap.id == "" {
+		snap.id = nextResponseRenderToken()
+	}
+	pane.snapshot = snap
+	pane.streamID = ""
+	pane.tail = snap != nil && snap.streamID != ""
+	if snap != nil && snap.stream.failed() {
+		pane.stopStreamTail()
+	}
+	pane.invalidateCaches()
+	// One side of the comparison moved, so the neighbour's cached Diff has to
+	// be recomputed. It keeps its own response and its Diff tab either way.
+	m.invalidatePaneDiffs(id)
+	m.ensurePaneActiveTabValid(id, pane)
+}
+
+// showSnapshot moves the run's target pane onto snap and makes it the live
+// pane. Only that pane changes: a split neighbour keeps what it was showing,
+// beyond having to recompute a Diff against the new response.
+func (m *Model) showSnapshot(id responsePaneID, snap *responseSnapshot) *responsePaneState {
+	m.setPaneSnapshot(id, snap)
+	m.setLivePane(id)
+	return m.pane(id)
+}
 
 func (m *Model) setResponseSnapshotContent(snapshot *responseSnapshot) {
 	if snapshot == nil {
 		return
 	}
-	m.responsePending = nil
-	m.responseRenderToken = ""
-	m.responseLoading = false
-	m.responseLoadingFrame = 0
+	if snapshot.id == "" {
+		snapshot.id = nextResponseRenderToken()
+	}
+	m.resetPendingResponse()
 	m.lastResponse = nil
 	m.lastGRPC = nil
 	m.responseLatest = snapshot
 
-	target := m.responseTargetPane()
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		pane.snapshot = snapshot
-		pane.invalidateCaches()
-		width := pane.viewport.Width
-		if width <= 0 {
-			width = defaultResponseViewportWidth
-		}
-		pane.viewport.SetContent(wrapToWidth(snapshot.pretty, width))
-		pane.viewport.GotoTop()
-		pane.setCurrPosition()
-	}
-	m.setLivePane(target)
+	pane := m.showSnapshot(m.responseTargetForStream(snapshot.streamID), snapshot)
+	pane.viewport.SetContent(wrapToWidth(snapshot.pretty, paneWidth(pane)))
+	pane.resetScroll()
 }
 
 func (m *Model) activateProfileStatsTab(snapshot *responseSnapshot) tea.Cmd {

--- a/internal/ui/model_stream.go
+++ b/internal/ui/model_stream.go
@@ -28,9 +28,17 @@ const (
 	streamJSONIndent         = "  "
 )
 
-func (m *Model) attachStreamSession(session *stream.Session) {
+// attachStreamSession starts tracking a session, returning the existing entry
+// if it is already tracked. Subscribing seeds the buffer with whatever the
+// stream published before the attachment reached the update loop, so nothing
+// that arrived in that window is lost.
+func (m *Model) attachStreamSession(session *stream.Session) *liveSession {
 	if session == nil {
-		return
+		return nil
+	}
+	id := session.ID()
+	if ls := m.liveSession(id); ls != nil {
+		return ls
 	}
 	if m.streamMgr != nil {
 		m.streamMgr.Register(session)
@@ -41,33 +49,58 @@ func (m *Model) attachStreamSession(session *stream.Session) {
 	if m.sessionHandles == nil {
 		m.sessionHandles = make(map[string]*stream.Session)
 	}
-	id := session.ID()
 	ls := newLiveSession(id, m.streamMaxEvents)
 	ls.kind = session.Kind()
+	listener := session.Subscribe()
+	ls.append(listener.Snapshot.Events)
+	ls.setState(listener.Snapshot.State, listener.Snapshot.Err)
 	m.liveSessions[id] = ls
 	m.sessionHandles[id] = session
-	go m.runStreamSession(session)
-	m.emitStreamMsg(streamReadyMsg{sessionID: id})
+	go m.runStreamSession(session, listener)
+	return ls
 }
 
-func (m *Model) attachGRPCSession(session *stream.Session, req *restfile.Request) {
-	if session == nil {
+// handleStreamAttach takes ownership of a session the engine just opened. Every
+// map and pane it touches belongs to the update loop, which is why the engine
+// hands the session over as a message instead of registering it itself.
+func (m *Model) handleStreamAttach(msg streamAttachMsg) {
+	if msg.session == nil {
 		return
 	}
-	m.recordSessionMapping(req, session)
-	m.attachStreamSession(session)
+	if msg.gen != m.streamGen {
+		msg.session.Cancel()
+		return
+	}
+	m.recordSessionMapping(msg.req, msg.session)
+	ls := m.attachStreamSession(msg.session)
+	if ls == nil {
+		return
+	}
+
+	// The pane owns the session until the response carrying it arrives, which
+	// is what puts a stream on screen before its request has finished.
+	id := msg.session.ID()
+	target, _ := paneRunTarget(msg.pane).resolve(m.responseSplit)
+	m.pane(target).streamID = id
+	m.linkStreamSnapshots(ls)
+
+	if ls.kind == stream.KindWebSocket {
+		if m.wsSenders == nil {
+			m.wsSenders = make(map[string]*httpx.WebSocketSender)
+		}
+		if msg.sender != nil {
+			m.wsSenders[id] = msg.sender
+		}
+		m.ensureWebSocketConsole(id, msg.session, msg.sender, msg.req, msg.baseDir)
+	}
+	m.showStreamTab(id)
 }
 
-func (m *Model) runStreamSession(session *stream.Session) {
-	if session == nil {
+func (m *Model) runStreamSession(session *stream.Session, listener stream.Listener) {
+	if session == nil || listener.C == nil {
 		return
 	}
-	listener := session.Subscribe()
 	defer listener.Cancel()
-
-	if snapshot := listener.Snapshot.Events; len(snapshot) > 0 {
-		m.emitStreamMsg(streamEventMsg{sessionID: session.ID(), events: cloneEventSlice(snapshot)})
-	}
 
 	batchWindow := m.streamBatchWindow
 	if batchWindow <= 0 {
@@ -143,39 +176,6 @@ func (m *Model) nextStreamMsgCmd() tea.Cmd {
 	}
 }
 
-func (m *Model) attachSSEHandle(handle *httpx.StreamHandle, req *restfile.Request) {
-	if handle == nil {
-		return
-	}
-	m.recordSessionMapping(req, handle.Session)
-	m.attachStreamSession(handle.Session)
-}
-
-func (m *Model) attachWebSocketHandle(handle *httpx.WebSocketHandle, req *restfile.Request) {
-	if handle == nil {
-		return
-	}
-	m.recordSessionMapping(req, handle.Session)
-	m.attachStreamSession(handle.Session)
-	if m.wsSenders == nil {
-		m.wsSenders = make(map[string]*httpx.WebSocketSender)
-	}
-	sessionID := ""
-	if handle.Session != nil {
-		sessionID = handle.Session.ID()
-	}
-	if sessionID != "" && handle.Sender != nil {
-		m.wsSenders[sessionID] = handle.Sender
-	}
-	baseDir := ""
-	if handle.Meta.BaseDir != "" {
-		baseDir = handle.Meta.BaseDir
-	} else {
-		baseDir = m.sessionBaseDir(req)
-	}
-	m.ensureWebSocketConsole(sessionID, handle.Session, handle.Sender, req, baseDir)
-}
-
 // liveSession returns the tracked session for id. Entries are created only in
 // attachStreamSession, so an unknown id is a stale stream from a workspace
 // that has been left.
@@ -184,6 +184,131 @@ func (m *Model) liveSession(id string) *liveSession {
 		return nil
 	}
 	return m.liveSessions[id]
+}
+
+// paneStream resolves the session a pane is showing. A pane owns its session
+// directly from the moment it attaches until the response carrying it arrives;
+// from then on the snapshot is the owner, which is what lets a pinned pane keep
+// a finished transcript while a new run streams into the other pane.
+func (m *Model) paneStream(id responsePaneID) (string, *liveSession) {
+	pane := m.pane(id)
+	if pane == nil {
+		return "", nil
+	}
+	if pane.streamID != "" {
+		return pane.streamID, m.liveSession(pane.streamID)
+	}
+	if pane.snapshot == nil {
+		return "", nil
+	}
+	sid := pane.snapshot.streamID
+	if ls := pane.snapshot.stream; ls != nil {
+		return sid, ls
+	}
+	return sid, m.liveSession(sid)
+}
+
+func (m *Model) streamIDForPane(id responsePaneID) string {
+	sid, _ := m.paneStream(id)
+	return sid
+}
+
+func (m *Model) streamForPane(id responsePaneID) *liveSession {
+	_, ls := m.paneStream(id)
+	return ls
+}
+
+// activeStreamID is the session the console shortcuts act on. Focus in the
+// response pane picks the pane's stream, otherwise it is the one the request
+// under the cursor opened.
+func (m *Model) activeStreamID() string {
+	if m.focus == focusResponse {
+		if id := m.streamIDForPane(m.responsePaneFocus); id != "" {
+			return id
+		}
+	}
+	return m.sessionIDForRequest(m.currentRequest)
+}
+
+// bindSnapshotStream gives a snapshot the session its run opened. The session
+// may not have attached yet, so the id is recorded either way and
+// linkStreamSnapshots fills in the rest once the attachment lands.
+func (m *Model) bindSnapshotStream(snap *responseSnapshot, id string) {
+	if snap == nil {
+		return
+	}
+	snap.streamID = id
+	if ls := m.liveSession(id); ls != nil {
+		m.linkSnapshot(snap, ls)
+		m.releaseLiveStream(ls)
+	}
+}
+
+// linkStreamSnapshots runs the same binding the other way: a session that has
+// just attached reaches every snapshot already waiting for it.
+func (m *Model) linkStreamSnapshots(ls *liveSession) {
+	if ls == nil {
+		return
+	}
+	m.linkSnapshot(m.responseLatest, ls)
+	m.linkSnapshot(m.responsePrevious, ls)
+	m.linkSnapshot(m.render.snapshot, ls)
+	for i := range m.responsePanes {
+		m.linkSnapshot(m.responsePanes[i].snapshot, ls)
+	}
+	m.releaseLiveStream(ls)
+}
+
+func (m *Model) linkSnapshot(snap *responseSnapshot, ls *liveSession) {
+	if snap == nil || snap.streamID != ls.id {
+		return
+	}
+	snap.stream = ls
+	ls.bound = true
+}
+
+// releaseLiveStream drops a finished session from the registry once a snapshot
+// holds it. Both conditions are needed, in either order: see liveSession.
+func (m *Model) releaseLiveStream(ls *liveSession) {
+	if ls == nil || !ls.bound || !ls.done {
+		return
+	}
+	delete(m.liveSessions, ls.id)
+}
+
+func (m *Model) panesForStream(id string) []responsePaneID {
+	if id == "" {
+		return nil
+	}
+	var ids []responsePaneID
+	for _, paneID := range m.visiblePaneIDs() {
+		if m.streamIDForPane(paneID) == id {
+			ids = append(ids, paneID)
+		}
+	}
+	return ids
+}
+
+// responseTargetForStream keeps a stream's later responses in the pane that
+// already owns it, so a transcript and its response never split up.
+func (m *Model) responseTargetForStream(id string) responsePaneID {
+	if ids := m.panesForStream(id); len(ids) > 0 {
+		return ids[0]
+	}
+	return m.responseTargetPane()
+}
+
+// responseTargetForMsg picks where a response lands: the pane holding its
+// stream, else the pane the run was launched from, else the live pane. Focus
+// moving mid-run must not drag the response along with it.
+func (m *Model) responseTargetForMsg(msg responseMsg) responsePaneID {
+	if ids := m.panesForStream(msg.streamID); len(ids) > 0 {
+		return ids[0]
+	}
+	if id, ok := msg.target.resolve(m.responseSplit); ok {
+		return id
+	}
+	return m.responseTargetPane()
 }
 
 func (m *Model) handleStreamEvents(msg streamEventMsg) {
@@ -213,8 +338,11 @@ func (m *Model) handleStreamState(msg streamStateMsg) {
 	}
 	ls.setState(msg.state, msg.err)
 	level := statusInfo
-	if msg.err != nil || msg.state == stream.StateFailed {
+	if ls.failed() {
 		level = statusWarn
+		for _, id := range m.panesForStream(msg.sessionID) {
+			m.pane(id).stopStreamTail()
+		}
 	}
 	m.setStatusMessage(
 		statusMsg{
@@ -237,6 +365,8 @@ func (m *Model) handleStreamComplete(msg streamCompleteMsg) {
 	if ls.state != stream.StateFailed {
 		ls.state = stream.StateClosed
 	}
+	ls.done = true
+	filterID := m.streamIDForPane(m.responsePaneFocus)
 	if ls.kind == stream.KindWebSocket {
 		if m.wsConsole != nil && m.wsConsole.sessionID == msg.sessionID {
 			m.wsConsole = nil
@@ -259,29 +389,36 @@ func (m *Model) handleStreamComplete(msg streamCompleteMsg) {
 		}
 		delete(m.sessionRequests, msg.sessionID)
 	}
-	if sessionID := m.sessionIDForRequest(m.currentRequest); sessionID == msg.sessionID {
+	if filterID == msg.sessionID {
 		m.streamFilterActive = false
 		m.streamFilterInput.SetValue("")
 		m.streamFilterInput.Blur()
 	}
-	m.setStatusMessage(
-		statusMsg{text: fmt.Sprintf("Stream %s completed", msg.sessionID), level: statusSuccess},
-	)
+	status := statusMsg{text: fmt.Sprintf("Stream %s completed", msg.sessionID), level: statusSuccess}
+	if ls.failed() {
+		detail := streamStateString(ls.state, ls.err)
+		if ls.err != nil {
+			detail = ls.err.Error()
+		}
+		status.text = fmt.Sprintf("Stream %s failed: %s", msg.sessionID, detail)
+		status.level = statusWarn
+	}
+	m.setStatusMessage(status)
+	m.releaseLiveStream(ls)
 	m.refreshStreamPanes()
 }
 
-func (m *Model) handleStreamReady(msg streamReadyMsg) {
-	sessionID := msg.sessionID
+// showStreamTab brings every pane that owns the session onto its transcript.
+func (m *Model) showStreamTab(sessionID string) {
 	if m.liveSession(sessionID) == nil {
 		return
 	}
-	currentID := m.sessionIDForRequest(m.currentRequest)
-	if currentID == sessionID {
-		if pane := m.pane(responsePanePrimary); pane != nil {
-			pane.setActiveTab(responseTabStream)
-		}
-		if m.focus == focusResponse {
-			m.setLivePane(m.responsePaneFocus)
+	for _, id := range m.panesForStream(sessionID) {
+		pane := m.pane(id)
+		pane.setActiveTab(responseTabStream)
+		pane.tail = true
+		if m.focus == focusResponse && id == m.responsePaneFocus {
+			m.setLivePane(id)
 		}
 	}
 	m.refreshStreamPanes()
@@ -310,8 +447,8 @@ func (m *Model) handleStreamKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 		return nil, false
 	}
-	sessionID := m.sessionIDForRequest(m.currentRequest)
-	ls := m.liveSession(sessionID)
+	sessionID := m.streamIDForPane(m.responsePaneFocus)
+	ls := m.streamForPane(m.responsePaneFocus)
 	if sessionID == "" && !m.streamFilterActive {
 		return nil, false
 	}
@@ -349,22 +486,20 @@ func (m *Model) handleStreamKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	}
 
 	switch msg.String() {
-	case "ctrl+space":
+	// Terminals that send NUL for ctrl+space surface it as ctrl+@.
+	case "ctrl+space", "ctrl+@":
 		if ls == nil {
 			return nil, false
 		}
 		ls.setPaused(!ls.paused)
+		// Pausing holds the transcript still. It says nothing about which pane
+		// the next response belongs in, so followLatest stays untouched.
+		pane.tail = !ls.paused
+		text := "Stream resumed"
 		if ls.paused {
-			m.setStatusMessage(statusMsg{text: "Stream paused", level: statusInfo})
-			if pane != nil {
-				pane.followLatest = false
-			}
-		} else {
-			m.setStatusMessage(statusMsg{text: "Stream resumed", level: statusInfo})
-			if pane != nil {
-				pane.followLatest = true
-			}
+			text = "Stream paused"
 		}
+		m.setStatusMessage(statusMsg{text: text, level: statusInfo})
 		m.refreshStreamPanes()
 		return nil, true
 	case "ctrl+f":
@@ -392,46 +527,36 @@ func (m *Model) handleStreamKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		m.refreshStreamPanes()
 		return nil, true
 	case "ctrl+up":
-		if ls == nil || len(ls.bookmarks) == 0 {
-			m.setStatusMessage(statusMsg{text: "No bookmarks", level: statusInfo})
-			return nil, true
-		}
-		if bm := ls.nextBookmark(false); bm != nil {
-			ls.setPaused(true)
-			if bm.Index >= 0 && bm.Index <= len(ls.events) {
-				ls.pausedIndex = bm.Index
-			}
-			m.setStatusMessage(
-				statusMsg{text: fmt.Sprintf("Bookmark: %s", bookmarkLabel(*bm)), level: statusInfo},
-			)
-			if pane != nil {
-				pane.followLatest = false
-			}
-			m.refreshStreamPanes()
-		}
+		m.jumpToStreamBookmark(pane, ls, false)
 		return nil, true
 	case "ctrl+down":
-		if ls == nil || len(ls.bookmarks) == 0 {
-			m.setStatusMessage(statusMsg{text: "No bookmarks", level: statusInfo})
-			return nil, true
-		}
-		if bm := ls.nextBookmark(true); bm != nil {
-			ls.setPaused(true)
-			if bm.Index >= 0 && bm.Index <= len(ls.events) {
-				ls.pausedIndex = bm.Index
-			}
-			m.setStatusMessage(
-				statusMsg{text: fmt.Sprintf("Bookmark: %s", bookmarkLabel(*bm)), level: statusInfo},
-			)
-			if pane != nil {
-				pane.followLatest = false
-			}
-			m.refreshStreamPanes()
-		}
+		m.jumpToStreamBookmark(pane, ls, true)
 		return nil, true
 	}
 
 	return nil, false
+}
+
+// jumpToStreamBookmark pauses on the next bookmark in either direction. The
+// pause is what freezes the transcript at that point, so tailing has to stop.
+func (m *Model) jumpToStreamBookmark(pane *responsePaneState, ls *liveSession, forward bool) {
+	if ls == nil || len(ls.bookmarks) == 0 {
+		m.setStatusMessage(statusMsg{text: "No bookmarks", level: statusInfo})
+		return
+	}
+	bm := ls.nextBookmark(forward)
+	if bm == nil {
+		return
+	}
+	ls.setPaused(true)
+	if bm.Index >= 0 && bm.Index <= len(ls.events) {
+		ls.pausedIndex = bm.Index
+	}
+	m.setStatusMessage(
+		statusMsg{text: fmt.Sprintf("Bookmark: %s", bookmarkLabel(*bm)), level: statusInfo},
+	)
+	pane.tail = false
+	m.refreshStreamPanes()
 }
 
 func streamStateString(state stream.State, err error) string {
@@ -492,64 +617,21 @@ func (m *Model) sessionIDForRequest(req *restfile.Request) string {
 	return ""
 }
 
-func (m *Model) hasActiveStream() bool {
-	if m.wsConsole != nil {
-		return true
-	}
-	if len(m.liveSessions) == 0 {
-		return false
-	}
-	for _, ls := range m.liveSessions {
-		if ls == nil {
-			continue
-		}
-		if ls.state != stream.StateClosed || len(ls.events) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *Model) streamContentForPane(id responsePaneID) string {
-	req := m.requestForPane(id)
-	if req == nil {
-		if id == responsePanePrimary {
-			return "No active request\n"
-		}
+	if m.streamIDForPane(id) == "" {
 		return "No stream available\n"
 	}
-	sessionID := m.sessionIDForRequest(req)
-	if sessionID == "" {
-		return "Waiting for stream session\n"
-	}
-	ls := m.liveSession(sessionID)
+	ls := m.streamForPane(id)
 	if ls == nil {
 		return "Waiting for stream session\n"
 	}
 	return m.formatStreamContent(ls)
 }
 
-func (m *Model) requestForPane(id responsePaneID) *restfile.Request {
-	switch id {
-	case responsePanePrimary:
-		return m.currentRequest
-	default:
-		return nil
-	}
-}
-
 func (m *Model) consoleForPane(id responsePaneID) *websocketConsole {
-	req := m.requestForPane(id)
-	if req == nil {
-		return nil
-	}
-	sessionID := m.sessionIDForRequest(req)
+	sessionID := m.streamIDForPane(id)
 	if sessionID == "" {
-		if m.wsConsole == nil || m.wsConsole.sessionID == "" {
-			return nil
-		}
-		// Allow console display while mapping is pending as long as we're on the active request.
-		sessionID = m.wsConsole.sessionID
+		return nil
 	}
 	if m.wsConsole == nil {
 		return nil
@@ -799,7 +881,12 @@ func (m *Model) renderGRPCEvent(evt *stream.Event) string {
 	if evt.Direction == stream.DirNA {
 		summary := grpcSummaryLine(evt.Metadata)
 		if summary != "" {
-			parts = append(parts, th.StreamSummary.Render(summary))
+			style := th.StreamSummary
+			status := grpcMetaVal(evt.Metadata, grpcx.MetaStatus)
+			if status != "" && !strings.EqualFold(status, "OK") {
+				style = th.StreamError
+			}
+			parts = append(parts, style.Render(summary))
 		}
 		return strings.Join(filterEmpty(parts), " ")
 	}
@@ -1007,58 +1094,57 @@ func opcodeToType(op int) string {
 
 func (m *Model) refreshStreamPanes() {
 	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil {
-			continue
-		}
-		if pane.wrapCache == nil {
-			pane.wrapCache = make(map[responseTab]cachedWrap)
-		}
-		if pane.activeTab != responseTabStream {
-			pane.wrapCache[responseTabStream] = cachedWrap{}
-			continue
-		}
-		req := m.requestForPane(id)
-		sessionID := m.sessionIDForRequest(req)
-		streamContent := m.streamContentForPane(id)
-		if streamContent == "" {
-			streamContent = "<stream idle>\n"
-		}
-		width := pane.viewport.Width
-		if m.streamFilterActive && sessionID != "" &&
-			sessionID == m.sessionIDForRequest(m.currentRequest) {
-			if !strings.HasSuffix(streamContent, "\n") {
-				streamContent += "\n"
-			}
-			filterInput := m.streamFilterInput
-			streamContent += filterInput.View()
-			streamContent += "\n"
-			m.streamFilterInput = filterInput
-		}
-		wrappedStream := wrapStructuredContent(streamContent, width)
-		pane.wrapCache[responseTabStream] = cachedWrap{
-			width:   width,
-			content: wrappedStream,
-			valid:   true,
-		}
-		decorated := m.applyResponseContentStyles(responseTabStream, wrappedStream)
-		console := m.consoleForPane(id)
-		if console != nil {
-			if !strings.HasSuffix(decorated, "\n") {
-				decorated += "\n"
-			}
-			if !strings.HasSuffix(decorated, "\n\n") {
-				decorated += "\n"
-			}
-			consoleView := console.view(width, m.theme)
-			decorated += consoleView
-		}
-		pane.viewport.SetContent(decorated)
-		if pane.followLatest {
-			pane.viewport.GotoBottom()
-		} else {
-			pane.restoreScrollForActiveTab()
-		}
-		pane.setCurrPosition()
+		m.refreshStreamPane(id)
 	}
+}
+
+func (m *Model) refreshStreamPane(id responsePaneID) {
+	pane := m.pane(id)
+	if pane == nil {
+		return
+	}
+	if pane.wrapCache == nil {
+		pane.wrapCache = make(map[responseTab]cachedWrap)
+	}
+	if pane.activeTab != responseTabStream {
+		pane.wrapCache[responseTabStream] = cachedWrap{}
+		return
+	}
+	sessionID := m.streamIDForPane(id)
+	content := m.streamContentForPane(id)
+	if content == "" {
+		content = "<stream idle>\n"
+	}
+	width := pane.viewport.Width
+	// The filter prompt belongs to the pane being typed in, not to every pane
+	// showing the same session.
+	if m.streamFilterActive && sessionID != "" && id == m.responsePaneFocus {
+		if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += m.streamFilterInput.View() + "\n"
+	}
+	wrapped := wrapStructuredContent(content, width)
+	pane.wrapCache[responseTabStream] = cachedWrap{
+		width:   width,
+		content: wrapped,
+		valid:   true,
+	}
+	decorated := m.applyResponseContentStyles(responseTabStream, wrapped)
+	if console := m.consoleForPane(id); console != nil {
+		if !strings.HasSuffix(decorated, "\n") {
+			decorated += "\n"
+		}
+		if !strings.HasSuffix(decorated, "\n\n") {
+			decorated += "\n"
+		}
+		decorated += console.view(width, m.theme)
+	}
+	pane.viewport.SetContent(decorated)
+	if pane.tail {
+		pane.viewport.GotoBottom()
+	} else {
+		pane.restoreScrollForActiveTab()
+	}
+	pane.setCurrPosition()
 }

--- a/internal/ui/model_stream_test.go
+++ b/internal/ui/model_stream_test.go
@@ -1,10 +1,14 @@
 package ui
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/stream"
@@ -110,6 +114,185 @@ func TestStreamFilterPromptClearsWhenFocusLeavesResponse(t *testing.T) {
 	}
 }
 
+// Two panes can show the same session. The filter is typed into one of them,
+// so only the focused pane grows the prompt line.
+func TestStreamFilterPromptRendersOnlyInFocusedPane(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.focus = focusResponse
+	model.width = 160
+	model.height = 40
+	model.responseSplit = true
+	_ = model.applyLayout()
+
+	ls := newLiveSession("sse-1", 100)
+	ls.kind = stream.KindSSE
+	model.liveSessions[ls.id] = ls
+	for _, id := range model.visiblePaneIDs() {
+		pane := model.pane(id)
+		pane.streamID = ls.id
+		pane.setActiveTab(responseTabStream)
+	}
+
+	model.responsePaneFocus = responsePaneSecondary
+	model.streamFilterActive = true
+	model.streamFilterInput.SetValue("needle")
+	model.refreshStreamPanes()
+
+	primary := ansi.Strip(model.pane(responsePanePrimary).viewport.View())
+	secondary := ansi.Strip(model.pane(responsePaneSecondary).viewport.View())
+	if !strings.Contains(secondary, "needle") {
+		t.Fatalf("focused pane lost the filter prompt: %q", secondary)
+	}
+	if strings.Contains(primary, "needle") {
+		t.Fatalf("filter prompt leaked into the unfocused pane: %q", primary)
+	}
+}
+
+func TestStreamPauseDoesNotPinResponsePane(t *testing.T) {
+	model := newStreamFilterPromptModel(t)
+	pane := model.pane(responsePanePrimary)
+	if !pane.followLatest {
+		t.Fatal("expected primary response pane to start live")
+	}
+
+	if _, ok := model.handleStreamKey(tea.KeyMsg{Type: tea.KeyCtrlAt}); !ok {
+		t.Fatal("expected pause shortcut to be handled")
+	}
+	if !pane.followLatest {
+		t.Fatal("pausing a stream pinned the response pane")
+	}
+	if pane.tail {
+		t.Fatal("expected pausing to stop tail follow")
+	}
+
+	if _, ok := model.handleStreamKey(tea.KeyMsg{Type: tea.KeyCtrlAt}); !ok {
+		t.Fatal("expected resume shortcut to be handled")
+	}
+	if !pane.followLatest || !pane.tail {
+		t.Fatal("expected resume to follow the stream without changing response mode")
+	}
+}
+
+func TestFailedStreamSurvivesMainSplitReflow(t *testing.T) {
+	model := New(Config{})
+	model.ready = true
+	model.focus = focusResponse
+	model.width = 140
+	model.height = 42
+	_ = model.applyLayout()
+
+	pane := model.pane(responsePanePrimary)
+	pane.activeTab = responseTabStream
+	pane.streamID = "grpc-1"
+	pane.viewport.Height = 6
+	ls := newLiveSession("grpc-1", 100)
+	ls.kind = stream.KindGRPC
+	for range 20 {
+		ls.append([]*stream.Event{{
+			Kind:      stream.KindGRPC,
+			Direction: stream.DirReceive,
+			Payload:   []byte(`{"item":"value"}`),
+		}})
+	}
+	model.liveSessions[ls.id] = ls
+	snap := newTextSnapshot("request failed", "test")
+	model.bindSnapshotStream(snap, ls.id)
+	model.setPaneSnapshot(responsePanePrimary, snap)
+	pane.setActiveTab(responseTabStream)
+	pane.tail = true
+	model.refreshStreamPanes()
+	if pane.viewport.YOffset == 0 {
+		t.Fatal("expected live stream to follow the tail before failure")
+	}
+
+	err := errors.New("stream deadline exceeded")
+	model.handleStreamState(streamStateMsg{sessionID: ls.id, state: stream.StateFailed, err: err})
+	if pane.tail {
+		t.Fatal("expected failure to stop tail follow")
+	}
+	if pane.viewport.YOffset != 0 {
+		t.Fatalf("expected failure to reveal the error header, offset=%d", pane.viewport.YOffset)
+	}
+	model.handleStreamComplete(streamCompleteMsg{sessionID: ls.id})
+	if model.liveSession(ls.id) != nil {
+		t.Fatal("expected completed bound session to leave the live registry")
+	}
+
+	model.mainSplitOrientation = mainSplitHorizontal
+	_ = model.setMainSplitOrientation(mainSplitVertical)
+	plain := ansi.Strip(pane.viewport.View())
+	if !strings.Contains(plain, err.Error()) {
+		t.Fatalf("expected failed transcript after reflow, got %q", plain)
+	}
+	if strings.Contains(plain, "Waiting for stream session") {
+		t.Fatalf("completed stream lost its response ownership after reflow: %q", plain)
+	}
+	if model.statusMessage.level != statusWarn {
+		t.Fatalf("expected failed completion warning, got level %v", model.statusMessage.level)
+	}
+	if !strings.Contains(model.statusMessage.text, err.Error()) {
+		t.Fatalf("expected failure status to include the cause, got %q", model.statusMessage.text)
+	}
+}
+
+func TestStaleStreamAttachmentIsCanceled(t *testing.T) {
+	model := New(Config{})
+	model.streamGen = 2
+	sess := stream.NewSession(context.Background(), stream.KindSSE, stream.Config{})
+
+	model.handleStreamAttach(streamAttachMsg{session: sess, gen: 1})
+	if model.liveSession(sess.ID()) != nil {
+		t.Fatal("stale attachment entered the live registry")
+	}
+	select {
+	case <-sess.Context().Done():
+	default:
+		t.Fatal("stale session was not canceled")
+	}
+}
+
+func TestFailedStreamResponseDoesNotResumeTail(t *testing.T) {
+	model := New(Config{})
+	ls := newLiveSession("grpc-1", 10)
+	ls.setState(stream.StateFailed, errors.New("deadline exceeded"))
+	model.liveSessions[ls.id] = ls
+	snap := newTextSnapshot("failed", "")
+	model.bindSnapshotStream(snap, ls.id)
+
+	model.setPaneSnapshot(responsePanePrimary, snap)
+	pane := model.pane(responsePanePrimary)
+	if pane.tail {
+		t.Fatal("late response ownership resumed tail follow for a failed stream")
+	}
+}
+
+func TestStreamResponseKeepsRunTargetBeforeAttachment(t *testing.T) {
+	model := New(Config{})
+	model.responseSplit = true
+	model.responseLastFocused = responsePanePrimary
+
+	target := model.responseTargetForMsg(responseMsg{
+		streamID: "grpc-1",
+		target:   paneRunTarget(responsePaneSecondary),
+	})
+	if target != responsePaneSecondary {
+		t.Fatalf("expected captured secondary target, got %v", target)
+	}
+}
+
+func TestRunTargetIgnoresSecondaryPaneWithoutSplit(t *testing.T) {
+	model := New(Config{})
+	model.responseLastFocused = responsePanePrimary
+
+	target := model.responseTargetForMsg(responseMsg{
+		target: paneRunTarget(responsePaneSecondary),
+	})
+	if target != responsePanePrimary {
+		t.Fatalf("expected the closed split to fall back to primary, got %v", target)
+	}
+}
+
 func newStreamFilterPromptModel(t *testing.T) Model {
 	t.Helper()
 	model := New(Config{})
@@ -121,6 +304,7 @@ func newStreamFilterPromptModel(t *testing.T) Model {
 		t.Fatalf("expected primary response pane")
 	}
 	pane.activeTab = responseTabStream
+	pane.streamID = "stream-1"
 
 	req := &restfile.Request{Method: "GET", URL: "https://example.com/events"}
 	model.currentRequest = req

--- a/internal/ui/model_tabs.go
+++ b/internal/ui/model_tabs.go
@@ -11,7 +11,7 @@ func (m *Model) activatePrevTabFor(id responsePaneID) tea.Cmd {
 	if pane == nil {
 		return nil
 	}
-	tabs := m.availableResponseTabs()
+	tabs := m.availableResponseTabsFor(id)
 	idx := indexOfResponseTab(tabs, pane.activeTab)
 	if idx == -1 {
 		pane.setActiveTab(tabs[0])
@@ -31,7 +31,7 @@ func (m *Model) activateNextTabFor(id responsePaneID) tea.Cmd {
 	if pane == nil {
 		return nil
 	}
-	tabs := m.availableResponseTabs()
+	tabs := m.availableResponseTabsFor(id)
 	idx := indexOfResponseTab(tabs, pane.activeTab)
 	if idx == -1 {
 		pane.setActiveTab(tabs[0])
@@ -65,17 +65,28 @@ func indexOfResponseTab(tabs []responseTab, target responseTab) int {
 }
 
 func (m *Model) availableResponseTabs() []responseTab {
+	return m.availableResponseTabsFor(m.responsePaneFocus)
+}
+
+// availableResponseTabsFor answers per pane, not per model: Explain, Stream and
+// the report tabs belong to whatever that pane is showing, so a split never
+// offers a tab that would render the other pane's response.
+func (m *Model) availableResponseTabsFor(id responsePaneID) []responseTab {
+	var snap *responseSnapshot
+	if pane := m.pane(id); pane != nil {
+		snap = pane.snapshot
+	}
 	tabs := []responseTab{responseTabPretty, responseTabRaw, responseTabHeaders}
-	if m.snapshotHasExplain() {
+	if snap != nil && snap.explain.report != nil {
 		tabs = append(tabs, responseTabExplain)
 	}
-	if m.hasActiveStream() {
+	if m.streamIDForPane(id) != "" {
 		tabs = append(tabs, responseTabStream)
 	}
-	if m.snapshotHasStats() {
+	if snap != nil && strings.TrimSpace(snap.stats) != "" {
 		tabs = append(tabs, responseTabStats)
 	}
-	if m.snapshotHasTimeline() {
+	if snapshotHasTrace(snap) {
 		tabs = append(tabs, responseTabTimeline)
 	}
 	if m.compareTabAvailable() {
@@ -86,6 +97,13 @@ func (m *Model) availableResponseTabs() []responseTab {
 	}
 	tabs = append(tabs, responseTabHistory)
 	return tabs
+}
+
+func snapshotHasTrace(snap *responseSnapshot) bool {
+	if snap == nil {
+		return false
+	}
+	return snap.timeline != nil || snap.traceSpec != nil && snap.traceSpec.Enabled
 }
 
 func responseTabLabelForSnapshot(tab responseTab, snapshot *responseSnapshot) string {
@@ -147,59 +165,17 @@ func (m *Model) diffAvailable() bool {
 	return true
 }
 
-func (m *Model) snapshotHasStats() bool {
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil || pane.snapshot == nil {
-			continue
-		}
-		if strings.TrimSpace(pane.snapshot.stats) != "" {
-			return true
-		}
-	}
-	if m.responseLatest != nil && strings.TrimSpace(m.responseLatest.stats) != "" {
-		return true
-	}
-	return false
-}
-
-func (m *Model) snapshotHasExplain() bool {
-	for _, id := range m.visiblePaneIDs() {
-		pane := m.pane(id)
-		if pane == nil || pane.snapshot == nil {
-			continue
-		}
-		if pane.snapshot.explain.report != nil {
-			return true
-		}
-	}
-	return m.responseLatest != nil && m.responseLatest.explain.report != nil
-}
-
 func (m *Model) snapshotHasTimeline() bool {
-	hasTrace := func(snapshot *responseSnapshot) bool {
-		if snapshot == nil {
-			return false
-		}
-		if snapshot.timeline != nil {
-			return true
-		}
-		if snapshot.traceSpec != nil && snapshot.traceSpec.Enabled {
-			return true
-		}
-		return false
-	}
-
 	for _, id := range m.visiblePaneIDs() {
 		pane := m.pane(id)
 		if pane == nil {
 			continue
 		}
-		if hasTrace(pane.snapshot) {
+		if snapshotHasTrace(pane.snapshot) {
 			return true
 		}
 	}
-	return hasTrace(m.responseLatest)
+	return snapshotHasTrace(m.responseLatest)
 }
 
 func (m *Model) compareTabAvailable() bool {

--- a/internal/ui/model_tabs_test.go
+++ b/internal/ui/model_tabs_test.go
@@ -80,3 +80,37 @@ func TestResponseTabLabelFallsBackToStats(t *testing.T) {
 		t.Fatalf("expected generic stats label, got %q", label)
 	}
 }
+
+func TestStreamTabBelongsToOwningPaneAndResponse(t *testing.T) {
+	model := New(Config{})
+	model.responseSplit = true
+	streamSnap := &responseSnapshot{ready: true, streamID: "grpc-1"}
+	plainSnap := &responseSnapshot{ready: true}
+	model.responsePanes[responsePanePrimary].snapshot = streamSnap
+	model.responsePanes[responsePanePrimary].activeTab = responseTabStream
+	model.responsePanes[responsePaneSecondary].snapshot = plainSnap
+
+	if !containsResponseTab(
+		model.availableResponseTabsFor(responsePanePrimary),
+		responseTabStream,
+	) {
+		t.Fatal("expected Stream on its owning pane")
+	}
+	if containsResponseTab(
+		model.availableResponseTabsFor(responsePaneSecondary),
+		responseTabStream,
+	) {
+		t.Fatal("Stream leaked into the other response pane")
+	}
+
+	model.setPaneSnapshot(responsePanePrimary, plainSnap)
+	if containsResponseTab(
+		model.availableResponseTabsFor(responsePanePrimary),
+		responseTabStream,
+	) {
+		t.Fatal("Stream remained after a non-stream response")
+	}
+	if got := model.responsePanes[responsePanePrimary].activeTab; got != responseTabPretty {
+		t.Fatalf("expected invalid Stream tab to fall back to Pretty, got %v", got)
+	}
+}

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -188,8 +188,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamCompleteMsg:
 		m.handleStreamComplete(typed)
 		cmds = append(cmds, m.nextStreamMsgCmd())
-	case streamReadyMsg:
-		m.handleStreamReady(typed)
+	case streamAttachMsg:
+		m.handleStreamAttach(typed)
 		cmds = append(cmds, m.nextStreamMsgCmd())
 	case fileChangedMsg:
 		if cmd := m.handleFileChangeEvent(typed); cmd != nil {

--- a/internal/ui/model_workflow_run.go
+++ b/internal/ui/model_workflow_run.go
@@ -519,36 +519,25 @@ func (m *Model) wfConsume(st *workflowState, msg responseMsg) []tea.Cmd {
 	switch {
 	case msg.skipped:
 		m.lastError = nil
-		if cmd := m.consumeSkippedRequest(msg.skipReason, msg.explain); cmd != nil {
+		if cmd := m.consumeSkippedRequest(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	case msg.err != nil:
-		if cmd := m.consumeRequestError(msg.err, msg.explain); cmd != nil {
+		if cmd := m.consumeRequestError(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	case msg.response != nil:
-		if cmd := m.consumeHTTPResponse(
-			msg.response,
-			msg.tests,
-			msg.scriptErr,
-			msg.environment,
-			msg.explain,
-		); cmd != nil {
+		if cmd := m.consumeHTTPResponse(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	case msg.grpc != nil:
-		if cmd := m.consumeGRPCResponse(
-			msg.grpc,
-			msg.tests,
-			msg.scriptErr,
-			msg.executed,
-			msg.environment,
-			msg.explain,
-		); cmd != nil {
+		if cmd := m.consumeGRPCResponse(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	case msg.stream != nil || len(msg.transcript) > 0:
-		m.applyRunSnapshot(newStreamSnapshot(msg.stream, msg.transcript, msg.environment), nil, nil)
+		if cmd := m.consumeStreamTranscript(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	}
 
 	if st != nil && st.origin == workflowOriginForEach {
@@ -640,7 +629,6 @@ func (m *Model) finalizeWorkflowRun(state *workflowState) tea.Cmd {
 			workflowStats:  statsView,
 			ready:          true,
 		}
-		m.responsePending = nil
 	}
 
 	var cmd tea.Cmd

--- a/internal/ui/model_workspace_change_test.go
+++ b/internal/ui/model_workspace_change_test.go
@@ -436,7 +436,7 @@ func TestCommitMoveClearsResponseAndStreamState(t *testing.T) {
 	m.sessionHandles[sess.ID()] = sess
 	m.liveSessions[sess.ID()] = newLiveSession(sess.ID(), 10)
 	m.responsePanes[0].snapshot = &responseSnapshot{}
-	m.responseTokens["t"] = &responseSnapshot{}
+	m.render = pendingRender{token: "t", snapshot: &responseSnapshot{}, cancel: func() {}}
 	m.testResults = []scripts.TestResult{{Name: "x", Passed: true}}
 	m.scriptError = errors.New("old")
 	m.lastError = errors.New("old")
@@ -453,8 +453,8 @@ func TestCommitMoveClearsResponseAndStreamState(t *testing.T) {
 	if m.responsePanes[0].snapshot != nil {
 		t.Fatal("pane snapshot survived the move")
 	}
-	if m.responseTokens == nil || len(m.responseTokens) != 0 {
-		t.Fatal("response tokens must be cleared but stay usable")
+	if m.render.token != "" || m.render.snapshot != nil || m.render.cancel != nil {
+		t.Fatal("the in-flight render survived the move")
 	}
 	if m.testResults != nil || m.scriptError != nil || m.lastError != nil {
 		t.Fatal("test and error state survived the move")
@@ -534,7 +534,7 @@ func TestStaleStreamMessagesAreDropped(t *testing.T) {
 	m.handleStreamEvents(streamEventMsg{sessionID: id, events: []*stream.Event{{}}})
 	m.handleStreamState(streamStateMsg{sessionID: id, state: stream.StateClosed})
 	m.handleStreamComplete(streamCompleteMsg{sessionID: id})
-	m.handleStreamReady(streamReadyMsg{sessionID: id})
+	m.showStreamTab(id)
 
 	if len(m.liveSessions) != 0 {
 		t.Fatal("a stale stream message resurrected its session")

--- a/internal/ui/response_async.go
+++ b/internal/ui/response_async.go
@@ -15,6 +15,23 @@ const (
 	respRflMax = 2
 )
 
+// pendingRender is the response format currently in flight: the token that
+// identifies it, the snapshot it will fill in, and the cancel that stops it.
+// Those are one fact, so they are stored as one value. Held apart they drift:
+// a path that forgets the snapshot but leaves the token behind lets a finished
+// render land on whatever response replaced it.
+type pendingRender struct {
+	token    string
+	snapshot *responseSnapshot
+	cancel   context.CancelFunc
+}
+
+// owns reports whether a finished render still belongs here. Anything else was
+// retired while it ran, and its result has nowhere left to go.
+func (p pendingRender) owns(token string) bool {
+	return token != "" && token == p.token && p.snapshot != nil
+}
+
 type respTasks struct {
 	fmtLim chan struct{}
 	rflLim chan struct{}

--- a/internal/ui/response_split.go
+++ b/internal/ui/response_split.go
@@ -41,6 +41,8 @@ type explainState struct {
 
 type responseSnapshot struct {
 	id              string
+	streamID        string
+	stream          *liveSession
 	pretty          string
 	raw             string
 	rawSummary      string
@@ -86,6 +88,8 @@ type responsePaneState struct {
 	activeTab        responseTab
 	lastContentTab   responseTab
 	followLatest     bool
+	streamID         string
+	tail             bool
 	snapshot         *responseSnapshot
 	wrapCache        map[responseTab]cachedWrap
 	rawWrapCache     map[rawViewMode]cachedWrap
@@ -117,6 +121,7 @@ func newResponsePaneState(vp viewport.Model, followLatest bool) responsePaneStat
 		activeTab:        responseTabPretty,
 		lastContentTab:   responseTabPretty,
 		followLatest:     followLatest,
+		tail:             true,
 		wrapCache:        make(map[responseTab]cachedWrap),
 		rawWrapCache:     make(map[rawViewMode]cachedWrap),
 		headersWrapCache: make(map[headersViewMode]cachedWrap),
@@ -346,6 +351,30 @@ func (pane *responsePaneState) setCurrPosition() {
 	pane.tabScroll[pane.activeTab] = offset
 }
 
+// resetScroll puts a pane back at the top after its content was replaced.
+func (pane *responsePaneState) resetScroll() {
+	pane.viewport.GotoTop()
+	pane.setCurrPosition()
+}
+
+// stopStreamTail pins the stream view to the top. A stream that failed prints
+// the reason in its header, and following the tail would scroll it off screen.
+func (pane *responsePaneState) stopStreamTail() {
+	pane.tail = false
+	if pane.tabScroll == nil {
+		pane.tabScroll = make(map[responseTab]int)
+	}
+	pane.tabScroll[responseTabStream] = 0
+}
+
+// syncStreamTail resumes or stops tailing after the user scrolled the stream.
+func (pane *responsePaneState) syncStreamTail(tail bool) {
+	if pane.activeTab != responseTabStream {
+		return
+	}
+	pane.tail = tail
+}
+
 func (pane *responsePaneState) restoreScrollForActiveTab() {
 	if pane == nil {
 		return
@@ -418,6 +447,19 @@ func (m *Model) setLivePane(id responsePaneID) {
 	}
 }
 
+// invalidatePaneDiffs drops the cached Diff rendering everywhere but the pane
+// that just changed. A diff is rendered from both panes, so the neighbour's
+// copy still describes the response that was replaced. Only the cache goes: the
+// next sync recomputes the diff against whatever each pane now holds.
+func (m *Model) invalidatePaneDiffs(except responsePaneID) {
+	for _, id := range m.visiblePaneIDs() {
+		if id == except {
+			continue
+		}
+		m.pane(id).wrapCache[responseTabDiff] = cachedWrap{}
+	}
+}
+
 func (m *Model) syncResponsePanes() tea.Cmd {
 	var cmds []tea.Cmd
 	for _, id := range m.visiblePaneIDs() {
@@ -460,13 +502,17 @@ func paneDims(p *responsePaneState, tab responseTab) (int, int, int) {
 	if p == nil {
 		return 0, 0, 0
 	}
-	w := p.viewport.Width
-	if w <= 0 {
-		w = defaultResponseViewportWidth
+	w := paneWidth(p)
+	return w, responseWrapWidth(tab, w), p.viewport.Height
+}
+
+// paneWidth is the pane's render width, falling back to the default before the
+// first layout pass has sized the viewport.
+func paneWidth(p *responsePaneState) int {
+	if p == nil || p.viewport.Width <= 0 {
+		return defaultResponseViewportWidth
 	}
-	ww := responseWrapWidth(tab, w)
-	h := p.viewport.Height
-	return w, ww, h
+	return p.viewport.Width
 }
 
 func paneSnap(p *responsePaneState) (bool, string) {
@@ -613,10 +659,14 @@ func (m *Model) syncResponsePane(id responsePaneID) tea.Cmd {
 		return nil
 	}
 
-	m.ensurePaneActiveTabValid(pane)
+	m.ensurePaneActiveTabValid(id, pane)
 
 	tab := pane.activeTab
 	if tab == responseTabHistory {
+		return nil
+	}
+	if tab == responseTabStream {
+		m.refreshStreamPane(id)
 		return nil
 	}
 
@@ -1237,8 +1287,8 @@ func splitDiffMarker(line string) (marker string, markerWidth int, remainder str
 	}
 }
 
-func (m *Model) ensurePaneActiveTabValid(pane *responsePaneState) {
-	tabs := m.availableResponseTabs()
+func (m *Model) ensurePaneActiveTabValid(id responsePaneID, pane *responsePaneState) {
+	tabs := m.availableResponseTabsFor(id)
 	if len(tabs) == 0 {
 		pane.setActiveTab(responseTabPretty)
 		return
@@ -1260,13 +1310,9 @@ func (m *Model) disableResponseSplit() tea.Cmd {
 	m.responseSplitOrientation = responseSplitVertical
 	m.responsePaneFocus = responsePanePrimary
 	m.setLivePane(responsePanePrimary)
-	if secondary := m.pane(responsePaneSecondary); secondary != nil {
-		secondary.snapshot = nil
-		secondary.invalidateCaches()
-	}
-	if primary := m.pane(responsePanePrimary); primary != nil {
-		primary.wrapCache[responseTabDiff] = cachedWrap{}
-	}
+	// The split is already closed, so this drops the secondary pane's content
+	// and, through it, the primary's now meaningless Diff.
+	m.setPaneSnapshot(responsePaneSecondary, nil)
 	cmd := m.applyLayout()
 	status := func() tea.Msg {
 		return statusMsg{text: "Response split disabled", level: statusInfo}
@@ -1284,11 +1330,8 @@ func (m *Model) enableResponseSplit(orientation responseSplitOrientation) tea.Cm
 	m.responseSplitOrientation = orientation
 	m.ensurePaneFocusValid()
 	if !wasSplit {
-		if secondary := m.pane(responsePaneSecondary); secondary != nil {
-			secondary.snapshot = m.responseLatest
-			secondary.invalidateCaches()
-			secondary.setActiveTab(responseTabPretty)
-		}
+		m.setPaneSnapshot(responsePaneSecondary, m.responseLatest)
+		m.pane(responsePaneSecondary).setActiveTab(responseTabPretty)
 	}
 	if wasSplit {
 		m.setLivePane(m.responseTargetPane())
@@ -1343,7 +1386,7 @@ func (m *Model) togglePaneFollowLatest(id responsePaneID) tea.Cmd {
 	pane.followLatest = !pane.followLatest
 	var note string
 	if pane.followLatest {
-		pane.snapshot = m.responseLatest
+		m.setPaneSnapshot(id, m.responseLatest)
 		note = "Pane now following latest responses"
 		m.setLivePane(id)
 	} else {
@@ -1361,23 +1404,16 @@ func (m *Model) togglePaneFollowLatest(id responsePaneID) tea.Cmd {
 		}
 	}
 	pane.invalidateCaches()
-	for _, otherID := range m.visiblePaneIDs() {
-		if other := m.pane(otherID); other != nil {
-			other.wrapCache[responseTabDiff] = cachedWrap{}
-		}
-	}
+	// Pinning changes no snapshot, so the neighbour's Diff has to be dropped
+	// here rather than on the way through setPaneSnapshot.
+	m.invalidatePaneDiffs(id)
 
 	if pane.snapshot == nil {
-		width := pane.viewport.Width
-		if width <= 0 {
-			width = defaultResponseViewportWidth
-		}
-		pane.viewport.SetContent(logoPlaceholder(width, pane.viewport.Height))
+		pane.viewport.SetContent(logoPlaceholder(paneWidth(pane), pane.viewport.Height))
 	} else if !pane.snapshot.ready {
 		pane.viewport.SetContent(m.responseLoadingMessage())
 	}
-	pane.viewport.GotoTop()
-	pane.setCurrPosition()
+	pane.resetScroll()
 
 	syncCmd := m.syncResponsePane(id)
 	status := func() tea.Msg {

--- a/internal/ui/stream_state.go
+++ b/internal/ui/stream_state.go
@@ -7,6 +7,14 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/stream"
 )
 
+// liveSession is the UI's copy of one stream: the events it has seen plus the
+// view state (filter, pause, bookmarks) the user applied to them.
+//
+// bound and done drive its lifetime in Model.liveSessions. The registry is what
+// a stream that has no response yet is looked up through, so an entry can only
+// be dropped once a snapshot holds the session (bound) and no more events are
+// coming (done). Either order works: a stream that ends before its response
+// arrives stays in the registry until that response adopts it.
 type liveSession struct {
 	id          string
 	events      []*stream.Event
@@ -19,6 +27,12 @@ type liveSession struct {
 	pausedIndex int
 	bookmarks   []streamBookmark
 	bookmarkIdx int
+	bound       bool
+	done        bool
+}
+
+func (ls *liveSession) failed() bool {
+	return ls != nil && (ls.err != nil || ls.state == stream.StateFailed)
 }
 
 func newLiveSession(id string, max int) *liveSession {
@@ -69,6 +83,20 @@ func (ls *liveSession) append(events []*stream.Event) {
 	if ls.paused && ls.pausedIndex == -1 {
 		ls.pausedIndex = len(ls.events)
 	}
+}
+
+// reset empties the buffer and every view applied to it. The session itself
+// keeps running, so new events land in a clean transcript.
+func (ls *liveSession) reset() {
+	if ls == nil {
+		return
+	}
+	ls.events = nil
+	ls.filter = ""
+	ls.paused = false
+	ls.pausedIndex = -1
+	ls.bookmarks = nil
+	ls.bookmarkIdx = -1
 }
 
 func (ls *liveSession) setState(state stream.State, err error) {

--- a/internal/ui/theme_runtime_response.go
+++ b/internal/ui/theme_runtime_response.go
@@ -69,10 +69,7 @@ func (m *Model) collectResponseSnapshots() []*responseSnapshot {
 
 	add(m.responseLatest)
 	add(m.responsePrevious)
-	add(m.responsePending)
-	for _, snapshot := range m.responseTokens {
-		add(snapshot)
-	}
+	add(m.render.snapshot)
 	for _, snapshot := range m.compareSnapshots {
 		add(snapshot)
 	}
@@ -160,23 +157,17 @@ func (m *Model) rerenderGRPCResponseSnapshot(
 }
 
 func (m *Model) restartPendingResponseRender() tea.Cmd {
-	pending := m.responsePending
+	pending := m.render.snapshot
 	if pending == nil || pending.ready || !pending.source.hasHTTP() {
 		return nil
 	}
 
-	m.abortResponseFormatting()
+	m.resetPendingResponse()
 
 	// Always issue a fresh render token when restarting canceled work.
 	// The snapshot identity can stay stable; the async task identity must not.
 	token := nextResponseRenderToken()
-	m.responsePending = pending
 	m.responseLatest = pending
-	if m.responseTokens == nil {
-		m.responseTokens = make(map[string]*responseSnapshot)
-	}
-	m.responseTokens[token] = pending
-	m.responseRenderToken = token
 	m.responseLoading = true
 	m.responseLoadingFrame = 0
 
@@ -186,7 +177,7 @@ func (m *Model) restartPendingResponseRender() tea.Cmd {
 	}
 
 	formatCtx, cancel := context.WithCancel(context.Background())
-	m.responseRenderCancel = cancel
+	m.render = pendingRender{token: token, snapshot: pending, cancel: cancel}
 	return m.respFmtCmd(
 		formatCtx,
 		token,

--- a/internal/ui/theme_runtime_test.go
+++ b/internal/ui/theme_runtime_test.go
@@ -289,16 +289,16 @@ func TestSyncThemedResponseStateRestartsPendingRenderWithFreshToken(t *testing.T
 		EffectiveURL: "https://api.example.com/items",
 	}
 
-	initialCmd := model.consumeHTTPResponse(resp, nil, nil, "", nil)
+	initialCmd := model.consumeHTTPResponse(responseMsg{response: resp})
 	if initialCmd == nil {
 		t.Fatalf("expected pending response render command")
 	}
-	if model.responsePending == nil {
+	if model.render.snapshot == nil {
 		t.Fatalf("expected pending snapshot")
 	}
 
-	oldRenderToken := model.responseRenderToken
-	oldSnapshotID := model.responsePending.id
+	oldRenderToken := model.render.token
+	oldSnapshotID := model.render.snapshot.id
 	if oldRenderToken == "" || oldSnapshotID == "" {
 		t.Fatalf("expected initial render token and snapshot id")
 	}
@@ -327,13 +327,13 @@ func TestSyncThemedResponseStateRestartsPendingRenderWithFreshToken(t *testing.T
 	if restartCmd == nil {
 		t.Fatalf("expected themed response sync command")
 	}
-	if model.responseRenderToken == "" {
+	if model.render.token == "" {
 		t.Fatalf("expected restarted render token")
 	}
-	if model.responseRenderToken == oldRenderToken {
+	if model.render.token == oldRenderToken {
 		t.Fatalf("expected pending restart to use a fresh render token")
 	}
-	if model.responsePending == nil || model.responsePending.id != oldSnapshotID {
+	if model.render.snapshot == nil || model.render.snapshot.id != oldSnapshotID {
 		t.Fatalf("expected pending snapshot identity to stay stable")
 	}
 
@@ -341,7 +341,7 @@ func TestSyncThemedResponseStateRestartsPendingRenderWithFreshToken(t *testing.T
 	if cmd := model.handleResponseRendered(stale); cmd != nil {
 		t.Fatalf("expected stale render to be ignored")
 	}
-	if model.responseRenderToken == "" || model.responseRenderToken == oldRenderToken {
+	if model.render.token == "" || model.render.token == oldRenderToken {
 		t.Fatalf("expected stale render to leave restarted token active")
 	}
 
@@ -372,7 +372,7 @@ func TestApplyThemeDefinitionKeepsGRPCRawContentType(t *testing.T) {
 		GRPC: &restfile.GRPCRequest{FullMethod: "/demo.Service/Call"},
 	}
 
-	if cmd := model.consumeGRPCResponse(resp, nil, nil, req, "", nil); cmd != nil {
+	if cmd := model.consumeGRPCResponse(responseMsg{grpc: resp, executed: req}); cmd != nil {
 		_ = collectMsgs(cmd)
 	}
 	if model.responseLatest == nil {

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -237,6 +237,7 @@ func (m *Model) commitMove(mv wsMove) (statusMsg, tea.Cmd) {
 // stopLiveStreams cancels every live session and drops their consoles, so a
 // stream opened in one workspace cannot keep writing into the next.
 func (m *Model) stopLiveStreams() {
+	m.streamGen++
 	for _, s := range m.sessionHandles {
 		s.Cancel()
 	}
@@ -253,13 +254,8 @@ func (m *Model) stopLiveStreams() {
 // produced. The engine seeds scripts with the last response, so leaving any of
 // it in place lets one workspace read another's traffic.
 func (m *Model) clearResponseState() {
-	if m.responseRenderCancel != nil {
-		m.responseRenderCancel()
-		m.responseRenderCancel = nil
-	}
+	m.resetPendingResponse()
 	m.cancelResponseReflow()
-	m.responseLoading = false
-	m.responseRenderToken = ""
 	m.respTasks = newRespTasks()
 
 	m.lastResponse = nil
@@ -269,8 +265,6 @@ func (m *Model) clearResponseState() {
 	m.scriptError = nil
 	m.responseLatest = nil
 	m.responsePrevious = nil
-	m.responsePending = nil
-	m.responseTokens = make(map[string]*responseSnapshot)
 	m.compareBundle = nil
 	m.resetCompareState()
 	m.latencySeries.reset()


### PR DESCRIPTION
Fix stream and response ownership across TUI response panes, particularly when using response splits or when focus changes while a request is running.

This also prevents stale async response formatting from overwriting newer content such as history entries, previews, errors, gRPC responses, or completed stream transcripts.

## Changes

- Route stream attachment through the Bubble Tea update loop instead of mutating UI state from engine goroutines.
- Bind SSE, WebSocket, and gRPC sessions to the response pane and snapshot that own them.
- Keep late responses in the pane where their run started, even when focus changes during execution.
- Preserve completed stream transcripts across pane pinning, stream completion, and layout reflow.
- Cancel stale stream attachments after workspace changes.
- Return an immediately closed event channel when subscribing to an already-completed stream.
- Prevent superseded HTTP formatting results from overwriting newer response content.
- Preserve pinned-pane content and scroll position when another pane receives a response.
- Recompute Diff content when either response pane changes.
- Determine Stream, Explain, Stats, and Timeline tab availability per pane.
- Make WebSocket console actions target the focused stream-owning pane.
- Separate stream tail-follow state from response-pane Live/Pinned state:
  - scrolling upward stops tailing.
  - scrolling to the bottom resumes tailing.
  - `Ctrl+Space` pauses/resumes the transcript without pinning the response pane.
- `Ctrl+@` is supported as a terminal-compatible alias.
- Keep failed stream errors visible and report failed completion as a warning.
- Render non-OK gRPC stream summaries using error styling.

## TUI impact

- Responses remain in the pane where their run originated.
- Stream-related tabs and controls belong to the pane showing that stream.
- Pinned panes are no longer overwritten or scrolled by responses arriving in another pane.
- The Stream tab displays `Tail` or `Scroll` instead of reusing the response pane's `Live` or `Pinned` state.
- Pausing a stream no longer changes whether the pane receives future responses