### PR TITLE
RTS-310: rts switch statement

### DIFF
--- a/_examples/rts/loops.rts
+++ b/_examples/rts/loops.rts
@@ -71,6 +71,34 @@ export fn grade(score) {
   }
 }
 
+# a plain break would only leave the switch, so the label is what stops the loop
+export fn firstDenied(codes) {
+  let found = -1
+  outer: for let i, code range codes {
+    switch code {
+    case 401, 403:
+      found = code
+      break outer
+    }
+  }
+  return found
+}
+
+# continue outer abandons the current row as soon as a hole shows up
+export fn fullRows(rows) {
+  let out = ""
+  outer: for let i, row range rows {
+    for let j, value range row {
+      switch value {
+      case null:
+        continue outer
+      }
+    }
+    out = out + str(i)
+  }
+  return out
+}
+
 # break leaves the switch and the loop keeps going, while continue skips to the
 # next iteration of the loop
 export fn switchBreakScope(items) {

--- a/_examples/rts/loops.rts
+++ b/_examples/rts/loops.rts
@@ -47,6 +47,47 @@ export fn countdown(n) {
   return out
 }
 
+export fn statusLabel(code) {
+  let label = ""
+  switch code {
+  case 200, 201:
+    label = "success"
+  case 401, 403:
+    label = "denied"
+  default:
+    label = default(null, "unexpected")
+  }
+  return label
+}
+
+export fn grade(score) {
+  switch {
+  case score >= 90:
+    return "A"
+  case score >= 80:
+    return "B"
+  default:
+    return "C"
+  }
+}
+
+# break leaves the switch and the loop keeps going, while continue skips to the
+# next iteration of the loop
+export fn switchBreakScope(items) {
+  let out = ""
+  for let i, v range items {
+    switch v {
+    case "skip":
+      continue
+    case "mark":
+      out = out + "!"
+      break
+    }
+    out = out + v
+  }
+  return out
+}
+
 export fn constLabel(id) {
   const prefix = "user-"
   return prefix + str(id)

--- a/_examples/rts/rts_all_features.http
+++ b/_examples/rts/rts_all_features.http
@@ -92,15 +92,22 @@ Authorization: {{= helpers.authHeader(vars.get("api.token")) }}
 # @assert response.statusCode == 204
 GET {{base_url}}/status/204
 
-### RTS Loops + Const + Try
+### RTS Loops + Switch + Const + Try
 # @name RTS_Loops
-# @description Exercises for/range/break/continue/const/try in modules.
+# @description Exercises for/range/switch/break/continue/const/try in modules.
 # @assert loops.sampleTag == "rts-examples"
 # @assert loops.sumClassic(6) == 8
 # @assert loops.rangeList() == "0a1b2c"
 # @assert loops.rangeDict() == "ab"
 # @assert loops.rangeString() == "0g1o"
 # @assert loops.countdown(3) == "321"
+# @assert loops.statusLabel(201) == "success"
+# @assert loops.statusLabel(403) == "denied"
+# @assert loops.statusLabel(500) == "unexpected"
+# @assert loops.grade(95) == "A"
+# @assert loops.grade(85) == "B"
+# @assert loops.grade(10) == "C"
+# @assert loops.switchBreakScope(["a", "skip", "mark"]) == "a!mark"
 # @assert loops.constLabel(7) == "user-7"
 # @assert loops.dictAccess() == 3
 # @assert loops.tryFail() == false

--- a/_examples/rts/rts_all_features.http
+++ b/_examples/rts/rts_all_features.http
@@ -92,9 +92,9 @@ Authorization: {{= helpers.authHeader(vars.get("api.token")) }}
 # @assert response.statusCode == 204
 GET {{base_url}}/status/204
 
-### RTS Loops + Switch + Const + Try
+### RTS Loops + Switch + Labels + Const + Try
 # @name RTS_Loops
-# @description Exercises for/range/switch/break/continue/const/try in modules.
+# @description Exercises for/range/switch/labels/break/continue/const/try in modules.
 # @assert loops.sampleTag == "rts-examples"
 # @assert loops.sumClassic(6) == 8
 # @assert loops.rangeList() == "0a1b2c"
@@ -108,6 +108,9 @@ GET {{base_url}}/status/204
 # @assert loops.grade(85) == "B"
 # @assert loops.grade(10) == "C"
 # @assert loops.switchBreakScope(["a", "skip", "mark"]) == "a!mark"
+# @assert loops.firstDenied([200, 403, 401]) == 403
+# @assert loops.firstDenied([200, 201]) == -1
+# @assert loops.fullRows([[1, 2], [3, null], [4, 5]]) == "02"
 # @assert loops.constLabel(7) == "user-7"
 # @assert loops.dictAccess() == 3
 # @assert loops.tryFail() == false

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -249,7 +249,7 @@ Rules:
 - A clause body can be empty, in which case a match does nothing.
 - At most one `default` is allowed. It can sit anywhere among the cases and runs only when no case matched.
 - Every clause is its own scope. `let` and `const` inside a clause do not escape it, while assignment to an outer binding works as usual.
-- `break` leaves the nearest enclosing switch or loop. A `break` inside a switch that sits in a loop ends the switch, and the loop continues.
+- `break` leaves the nearest enclosing switch or loop. A `break` inside a switch that sits in a loop ends the switch, and the loop continues. Use a label when you need to leave the loop instead.
 - `continue` always targets the nearest enclosing loop, including from inside a switch.
 - `return`, runtime errors, and hard aborts propagate out of the switch normally.
 
@@ -275,7 +275,7 @@ default:
 }
 ```
 
-Switch initializers, type switches, switch expressions that produce a value, `fallthrough`, and labels are not part of the language.
+Switch initializers, type switches, switch expressions that produce a value, and `fallthrough` are not part of the language. A switch can carry a label so that a `break` deeper inside can leave it by name, described under [Labels](#labels).
 
 This statement is separate from the `@switch` workflow directive. `@switch` selects a workflow step in an `.http` file and shares the same equality relation, while `switch` is a statement inside RestermScript code.
 
@@ -291,7 +291,7 @@ for let k, v range expr { ... }
 
 The language also supports a three clause loop with init, condition, and post clauses. The clauses are separated by the semicolon token.
 
-Rules for loops are consistent. `continue` is valid only inside loops, and `break` is valid inside loops and switches. `const` is not allowed in loop headers. `for let` introduces loop scoped variables that do not escape the loop block. `for range` without `let` assigns to existing variables.
+Rules for loops are consistent. `continue` is valid only inside loops, and `break` is valid inside loops and switches. Both accept a label to target an enclosing statement by name. `const` is not allowed in loop headers. `for let` introduces loop scoped variables that do not escape the loop block. `for range` without `let` assigns to existing variables.
 
 ### range semantics
 
@@ -308,6 +308,52 @@ for let i, ch range "go" {
   // i is the byte index, ch is "g" and then "o"
 }
 ```
+
+### Labels
+
+A label names a `for` or a `switch` so that a `break` or `continue` deeper inside can target it by name. Without labels there is no way to leave a loop from inside a switch, because a plain `break` stops at the switch.
+
+```
+outer: for let i = 0; i < 10; i = i + 1 {
+  switch i {
+  case 5:
+    break outer
+  }
+}
+```
+
+`continue label` resumes the named loop, skipping the rest of every construct in between:
+
+```
+outer: for let i, row range rows {
+  for let j, value range row {
+    switch value {
+    case null:
+      continue outer
+    }
+  }
+}
+```
+
+Grammar:
+
+```
+LabeledStmt  = identifier ":" ( ForStmt | SwitchStmt ) .
+BreakStmt    = "break" [ identifier ] .
+ContinueStmt = "continue" [ identifier ] .
+```
+
+Rules:
+
+- A label can decorate only a `for` or a `switch`. There are no labeled blocks, no labels on `if` or `fn`, and no `goto`.
+- The unlabeled forms are unchanged. `break` still leaves the nearest switch or loop, and `continue` still resumes the nearest loop.
+- `break label` leaves the named statement. `continue label` resumes the named loop and runs that loop's post clause once, skipping the post clause of every loop it passed through.
+- The target must lexically enclose the `break` or `continue`, and labels do not cross a function boundary.
+- `continue` must name a loop. Naming a switch is an error.
+- Labels live in their own namespace, so a label never collides with a variable or function of the same name.
+- Two active labels cannot share a name, but a name is free again once its statement ends, so sibling statements can reuse it.
+- `_` and `default` are not valid labels.
+- The label of a `break` or `continue` has to stay on the same line as the keyword, because a newline there already ends the statement. A label in front of a `for` or `switch` may sit on its own line.
 
 ## Modules and exports
 

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -81,9 +81,11 @@ Identifiers start with a letter or `_` and can contain letters, digits, and `_` 
 Keywords:
 
 ```
-export module fn let const if elif else try return for break continue range
+export module fn let const if elif else switch case try return for break continue range
 true false null and or not
 ```
+
+`default` is not reserved. It is read as a clause label only at the top level of a `switch` body, so the `default(a, b)` and `rts.default(a, b)` helpers stay available as ordinary identifiers.
 
 ### Literals
 
@@ -202,6 +204,81 @@ if cond {
 
 Conditionals evaluate each branch in order and execute the first branch whose condition is true. The `else` branch runs only when no earlier condition is true.
 
+### switch
+
+`switch` picks one branch out of many. The tagged form compares a value against cases, and the tagless form replaces a long `if`/`elif` chain.
+
+```
+switch response.statusCode {
+case 200, 201:
+  result = "success"
+case 401:
+  result = "unauthorized"
+default:
+  result = "unexpected"
+}
+```
+
+```
+switch {
+case score >= 90:
+  grade = "A"
+case score >= 80:
+  grade = "B"
+default:
+  grade = "C"
+}
+```
+
+Grammar:
+
+```
+SwitchStmt = "switch" [ Expression ] "{" { CaseClause } "}" .
+CaseClause = "case" Expression { "," Expression } ":" StatementList
+           | "default" ":" StatementList .
+```
+
+Rules:
+
+- The tag is evaluated exactly once, before any case.
+- Clauses run top to bottom and the expressions within a clause run left to right. Evaluation stops at the first match, so later case expressions never run.
+- Only the matching clause runs. There is no fallthrough, implicit or explicit.
+- A tagged switch matches with the same equality as `==`. Kinds must match, and only null, bool, number, and string compare by value. Lists and dicts never compare equal, so `switch [1] { case [1]: ... }` falls through to `default`.
+- A tagless switch takes the first case expression that is truthy, using the same truth test as `if`. It does not require a bool.
+- `case` takes one or more expressions separated by commas. A comma can be followed by a newline, but the colon must stay on the last expression's line.
+- A clause body can be empty, in which case a match does nothing.
+- At most one `default` is allowed. It can sit anywhere among the cases and runs only when no case matched.
+- Every clause is its own scope. `let` and `const` inside a clause do not escape it, while assignment to an outer binding works as usual.
+- `break` leaves the nearest enclosing switch or loop. A `break` inside a switch that sits in a loop ends the switch, and the loop continues.
+- `continue` always targets the nearest enclosing loop, including from inside a switch.
+- `return`, runtime errors, and hard aborts propagate out of the switch normally.
+
+A `{` right after `switch` always starts the tagless form, so a dict literal tag needs parentheses:
+
+```
+switch ({a: 1}).a {
+case 1:
+  matched = true
+}
+```
+
+Case expressions are arbitrary runtime expressions, so duplicate cases are not reported at parse time. The first one written wins.
+
+Because `default` stays an ordinary identifier, the stdlib helper of the same name still works, including inside a switch body:
+
+```
+let value = default(null, "fallback")
+
+switch value {
+default:
+  value = rts.default(value, "other")
+}
+```
+
+Switch initializers, type switches, switch expressions that produce a value, `fallthrough`, and labels are not part of the language.
+
+This statement is separate from the `@switch` workflow directive. `@switch` selects a workflow step in an `.http` file and shares the same equality relation, while `switch` is a statement inside RestermScript code.
+
 ### for loops
 
 RTS supports several loop forms.
@@ -214,7 +291,7 @@ for let k, v range expr { ... }
 
 The language also supports a three clause loop with init, condition, and post clauses. The clauses are separated by the semicolon token.
 
-Rules for loops are consistent. `break` and `continue` are valid only inside loops. `const` is not allowed in loop headers. `for let` introduces loop scoped variables that do not escape the loop block. `for range` without `let` assigns to existing variables.
+Rules for loops are consistent. `continue` is valid only inside loops, and `break` is valid inside loops and switches. `const` is not allowed in loop headers. `for let` introduces loop scoped variables that do not escape the loop block. `for range` without `let` assigns to existing variables.
 
 ### range semantics
 
@@ -510,6 +587,8 @@ These directives are used in workflows to branch steps.
 # @case 401 run=StepRefresh
 # @default fail="unexpected status"
 ```
+
+These directives route workflow steps and are not the `switch` statement. They share the same equality relation, but each `@case` names a step to run instead of holding a statement list.
 
 ### @for-each
 

--- a/internal/rts/ast.go
+++ b/internal/rts/ast.go
@@ -94,23 +94,28 @@ type CaseClause struct {
 }
 
 // SwitchStmt keeps its clauses in source order because evaluation stops at the
-// first match. Tag is nil for the tagless form, which tests clauses for truth
+// first match. Tag is nil for the tagless form, which tests clauses for truth.
+// Label is the optional name a break can target and is empty when unlabeled
 type SwitchStmt struct {
-	P       Pos
-	Tag     Expr
-	Clauses []CaseClause
+	P        Pos
+	Label    string
+	LabelPos Pos
+	Tag      Expr
+	Clauses  []CaseClause
 }
 
 func (*SwitchStmt) stmtNode()  {}
 func (s *SwitchStmt) Pos() Pos { return s.P }
 
 type ForStmt struct {
-	P     Pos
-	Init  Stmt
-	Cond  Expr
-	Post  Stmt
-	Range *ForRange
-	Body  *Block
+	P        Pos
+	Label    string
+	LabelPos Pos
+	Init     Stmt
+	Cond     Expr
+	Post     Stmt
+	Range    *ForRange
+	Body     *Block
 }
 
 func (*ForStmt) stmtNode()  {}
@@ -123,15 +128,21 @@ type ForRange struct {
 	Declare bool
 }
 
+// Label names the enclosing for or switch to leave. It is empty for the plain
+// form, which targets the nearest one
 type BreakStmt struct {
-	P Pos
+	P     Pos
+	Label string
 }
 
 func (*BreakStmt) stmtNode()  {}
 func (s *BreakStmt) Pos() Pos { return s.P }
 
+// Label names the enclosing loop to resume. It is empty for the plain form,
+// which targets the nearest one
 type ContinueStmt struct {
-	P Pos
+	P     Pos
+	Label string
 }
 
 func (*ContinueStmt) stmtNode()  {}

--- a/internal/rts/ast.go
+++ b/internal/rts/ast.go
@@ -85,6 +85,25 @@ type IfStmt struct {
 func (*IfStmt) stmtNode()  {}
 func (s *IfStmt) Pos() Pos { return s.P }
 
+// CaseClause is one clause of a switch. Exprs is nil for the default clause
+// and holds at least one expression otherwise
+type CaseClause struct {
+	P     Pos
+	Exprs []Expr
+	Body  *Block
+}
+
+// SwitchStmt keeps its clauses in source order because evaluation stops at the
+// first match. Tag is nil for the tagless form, which tests clauses for truth
+type SwitchStmt struct {
+	P       Pos
+	Tag     Expr
+	Clauses []CaseClause
+}
+
+func (*SwitchStmt) stmtNode()  {}
+func (s *SwitchStmt) Pos() Pos { return s.P }
+
 type ForStmt struct {
 	P     Pos
 	Init  Stmt

--- a/internal/rts/lexer_test.go
+++ b/internal/rts/lexer_test.go
@@ -25,6 +25,42 @@ func TestLexerAutoSemi(t *testing.T) {
 	}
 }
 
+func TestLexerSwitchKeywords(t *testing.T) {
+	got := lexKinds("switch case default")
+	want := []Kind{KW_SWITCH, KW_CASE, IDENT, AUTO_SEMI, EOF}
+	if !slices.Equal(got, want) {
+		t.Fatalf("kinds: got %v, want %v", got, want)
+	}
+}
+
+func TestKeywordClassSwitchCase(t *testing.T) {
+	cases := []struct {
+		name string
+		want KeywordClass
+	}{
+		{"switch", KeywordControl},
+		{"case", KeywordControl},
+		{"default", KeywordNone},
+	}
+	for _, tc := range cases {
+		if got := KeywordClassOf(tc.name); got != tc.want {
+			t.Fatalf("%s: got class %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestLexerNoSemiInCaseList(t *testing.T) {
+	k := lexKinds("switch x {\ncase 1,\n2:\n}\n")
+	for i := 0; i < len(k)-1; i++ {
+		if k[i] == COMMA && k[i+1] == AUTO_SEMI {
+			t.Fatalf("unexpected auto semi after case comma")
+		}
+		if k[i] == COLON && k[i+1] == AUTO_SEMI {
+			t.Fatalf("unexpected auto semi after case colon")
+		}
+	}
+}
+
 func TestLexerNoSemiInParens(t *testing.T) {
 	src := "let a = (1\n+2)\n"
 	k := lexKinds(src)

--- a/internal/rts/parser.go
+++ b/internal/rts/parser.go
@@ -5,15 +5,36 @@ import (
 	"strconv"
 )
 
-// loopDepth gates continue, breakDepth gates break. Loops raise both, switches
-// raise only breakDepth so continue inside a switch still targets the loop
+type controlKind uint8
+
+const (
+	controlSwitch controlKind = iota
+	controlLoop
+)
+
+// controlTarget is one lexically enclosing for or switch. label is empty for
+// unlabeled statements and pos points at the label that opened the target
+type controlTarget struct {
+	kind  controlKind
+	label string
+	pos   Pos
+}
+
+// stmtLabel is the optional name in front of a for or switch. The zero value
+// means the statement carries no label
+type stmtLabel struct {
+	name string
+	pos  Pos
+}
+
+// controls holds every for and switch enclosing the statement being parsed, so
+// break and continue can be checked against real targets instead of a depth
 type Parser struct {
-	lx         *Lexer
-	cur        Tok
-	peek       Tok
-	ahead      []Tok
-	loopDepth  int
-	breakDepth int
+	lx       *Lexer
+	cur      Tok
+	peek     Tok
+	ahead    []Tok
+	controls []controlTarget
 }
 
 func NewParserAt(path string, src []byte, pos Pos) *Parser {
@@ -118,11 +139,11 @@ func (p *Parser) parseStmt() Stmt {
 	case KW_IF:
 		return p.parseIf()
 	case KW_SWITCH:
-		return p.parseSwitch()
+		return p.parseSwitch(stmtLabel{})
 	case KW_CASE:
 		p.fail(p.cur.P, "case outside switch body")
 	case KW_FOR:
-		return p.parseFor()
+		return p.parseFor(stmtLabel{})
 	case KW_BREAK:
 		return p.parseBreak()
 	case KW_CONTINUE:
@@ -133,8 +154,8 @@ func (p *Parser) parseStmt() Stmt {
 		if p.peek.K == ASSIGN {
 			return p.parseAssign()
 		}
-		if p.isDefaultClause() {
-			p.fail(p.cur.P, "default outside switch body")
+		if p.peek.K == COLON {
+			return p.parseLabeled()
 		}
 	}
 	return p.parseExprStmt()
@@ -199,10 +220,10 @@ func (p *Parser) parseFn(exp bool) Stmt {
 	p.expect(LPAREN)
 	params := p.parseParams()
 	p.expect(RPAREN)
-	savedLoop, savedBreak := p.loopDepth, p.breakDepth
-	p.loopDepth, p.breakDepth = 0, 0
+	saved := p.controls
+	p.controls = nil
 	body := p.parseBlock()
-	p.loopDepth, p.breakDepth = savedLoop, savedBreak
+	p.controls = saved
 	return &FnDef{P: pos, Exported: exp, Name: name, Params: params, Body: body}
 }
 
@@ -256,20 +277,92 @@ func (p *Parser) parseIf() Stmt {
 	return &IfStmt{P: pos, Cond: cond, Then: then, Elifs: elifs, Else: els}
 }
 
+// parseLabeled reads "name:" in front of a for or switch. Labels live in their
+// own namespace and decorate nothing else, so there is no general labeled
+// statement and no goto
+func (p *Parser) parseLabeled() Stmt {
+	tok := p.cur
+	switch tok.Lit {
+	case defaultClause:
+		// a switch body consumes its own default: before reaching a statement
+		p.fail(tok.P, "default outside switch body")
+	case "_":
+		p.fail(tok.P, fmt.Sprintf("invalid label %q", tok.Lit))
+	}
+	if t := p.findControl(tok.Lit); t != nil {
+		p.fail(
+			tok.P,
+			fmt.Sprintf("duplicate label %q, active since %d:%d", tok.Lit, t.pos.Line, t.pos.Col),
+		)
+	}
+	p.next()
+	p.next()
+
+	lb := stmtLabel{name: tok.Lit, pos: tok.P}
+	switch p.cur.K {
+	case KW_FOR:
+		return p.parseFor(lb)
+	case KW_SWITCH:
+		return p.parseSwitch(lb)
+	default:
+		p.failCur(fmt.Sprintf("label must be followed by for or switch, got %s", p.cur.K))
+		return nil
+	}
+}
+
+func (p *Parser) pushControl(kind controlKind, lb stmtLabel) {
+	p.controls = append(p.controls, controlTarget{kind: kind, label: lb.name, pos: lb.pos})
+}
+
+func (p *Parser) popControl() {
+	p.controls = p.controls[:len(p.controls)-1]
+}
+
+// findControl looks up an active label. It is never called with an empty name,
+// which would match the unlabeled targets
+func (p *Parser) findControl(label string) *controlTarget {
+	for i := len(p.controls) - 1; i >= 0; i-- {
+		if p.controls[i].label == label {
+			return &p.controls[i]
+		}
+	}
+	return nil
+}
+
+func (p *Parser) inLoop() bool {
+	for _, c := range p.controls {
+		if c.kind == controlLoop {
+			return true
+		}
+	}
+	return false
+}
+
+// labelRef reads the optional target of a break or continue. The lexer inserts
+// a semicolon after both keywords, so a label only parses on the same line
+func (p *Parser) labelRef() (Tok, bool) {
+	if p.cur.K != IDENT {
+		return Tok{}, false
+	}
+	tok := p.cur
+	p.next()
+	return tok, true
+}
+
 // parseSwitch reads both switch forms. A brace right after the keyword means
 // the tagless form, mirroring Go: a dict literal tag has to be parenthesized
-func (p *Parser) parseSwitch() Stmt {
+func (p *Parser) parseSwitch(lb stmtLabel) Stmt {
 	pos := p.expect(KW_SWITCH).P
 	var tag Expr
 	if p.cur.K != LBRACE {
 		tag = p.parseExpr()
 	}
 	p.expect(LBRACE)
-	p.breakDepth++
+	p.pushControl(controlSwitch, lb)
 	clauses := p.parseCaseClauses()
-	p.breakDepth--
+	p.popControl()
 	p.expect(RBRACE)
-	return &SwitchStmt{P: pos, Tag: tag, Clauses: clauses}
+	return &SwitchStmt{P: pos, Label: lb.name, LabelPos: lb.pos, Tag: tag, Clauses: clauses}
 }
 
 func (p *Parser) parseCaseClauses() []CaseClause {
@@ -338,20 +431,21 @@ func (p *Parser) parseClauseBody(pos Pos) *Block {
 	}
 }
 
-// isDefaultClause matches the contextual default label. Nothing else in the
-// language starts a statement with an identifier followed by a colon, so
-// default(a, b) and dict keys stay untouched
+// isDefaultClause matches the contextual default label. It shares the
+// "identifier followed by a colon" shape with a statement label, so the switch
+// body checks this first and parseLabeled rejects default outright. Neither
+// reaches default(a, b) or a dict key, which are parsed as expressions
 func (p *Parser) isDefaultClause() bool {
 	return p.cur.K == IDENT && p.cur.Lit == defaultClause && p.peek.K == COLON
 }
 
-func (p *Parser) parseFor() Stmt {
+func (p *Parser) parseFor(lb stmtLabel) Stmt {
 	pos := p.expect(KW_FOR).P
 	if p.cur.K == LBRACE {
-		return p.parseForBody(pos, nil, nil, nil, nil)
+		return p.parseForBody(pos, lb, nil, nil, nil, nil)
 	}
 	if p.isForRangeStart() {
-		return p.parseForRange(pos)
+		return p.parseForRange(pos, lb)
 	}
 
 	if p.isSemi(p.cur.K) {
@@ -359,7 +453,7 @@ func (p *Parser) parseFor() Stmt {
 		cond := p.parseForCond()
 		p.expectSemi()
 		post := p.parseForPost()
-		return p.parseForBody(pos, nil, cond, post, nil)
+		return p.parseForBody(pos, lb, nil, cond, post, nil)
 	}
 
 	init := p.parseForInit()
@@ -368,14 +462,14 @@ func (p *Parser) parseFor() Stmt {
 		cond := p.parseForCond()
 		p.expectSemi()
 		post := p.parseForPost()
-		return p.parseForBody(pos, init, cond, post, nil)
+		return p.parseForBody(pos, lb, init, cond, post, nil)
 	}
 
 	exprStmt, ok := init.(*ExprStmt)
 	if !ok {
 		p.fail(init.Pos(), "for condition must be expression")
 	}
-	return p.parseForBody(pos, nil, exprStmt.Exp, nil, nil)
+	return p.parseForBody(pos, lb, nil, exprStmt.Exp, nil, nil)
 }
 
 func (p *Parser) isForRangeStart() bool {
@@ -401,7 +495,7 @@ func (p *Parser) isForRangeStart() bool {
 	return next.K == KW_RANGE
 }
 
-func (p *Parser) parseForRange(pos Pos) Stmt {
+func (p *Parser) parseForRange(pos Pos, lb stmtLabel) Stmt {
 	decl := false
 	if p.cur.K == KW_LET {
 		decl = true
@@ -424,7 +518,7 @@ func (p *Parser) parseForRange(pos Pos) Stmt {
 	p.expect(KW_RANGE)
 	src := p.parseExpr()
 	rng := &ForRange{Key: key, Val: val, Expr: src, Declare: decl}
-	return p.parseForBody(pos, nil, nil, nil, rng)
+	return p.parseForBody(pos, lb, nil, nil, nil, rng)
 }
 
 func (p *Parser) parseForCond() Expr {
@@ -464,29 +558,62 @@ func (p *Parser) parseForClause(allowLet bool, label string) Stmt {
 	return p.parseExprStmt()
 }
 
-func (p *Parser) parseForBody(pos Pos, init Stmt, cond Expr, post Stmt, rng *ForRange) Stmt {
-	p.loopDepth++
-	p.breakDepth++
+func (p *Parser) parseForBody(
+	pos Pos,
+	lb stmtLabel,
+	init Stmt,
+	cond Expr,
+	post Stmt,
+	rng *ForRange,
+) Stmt {
+	p.pushControl(controlLoop, lb)
 	body := p.parseBlock()
-	p.loopDepth--
-	p.breakDepth--
-	return &ForStmt{P: pos, Init: init, Cond: cond, Post: post, Range: rng, Body: body}
+	p.popControl()
+	return &ForStmt{
+		P:        pos,
+		Label:    lb.name,
+		LabelPos: lb.pos,
+		Init:     init,
+		Cond:     cond,
+		Post:     post,
+		Range:    rng,
+		Body:     body,
+	}
 }
 
 func (p *Parser) parseBreak() Stmt {
 	pos := p.expect(KW_BREAK).P
-	if p.breakDepth == 0 {
-		p.fail(pos, "break outside loop or switch")
+	tok, ok := p.labelRef()
+	if !ok {
+		if len(p.controls) == 0 {
+			p.fail(pos, "break outside loop or switch")
+		}
+		return &BreakStmt{P: pos}
 	}
-	return &BreakStmt{P: pos}
+	if p.findControl(tok.Lit) == nil {
+		p.fail(tok.P, fmt.Sprintf("undefined label %q", tok.Lit))
+	}
+	return &BreakStmt{P: pos, Label: tok.Lit}
 }
 
 func (p *Parser) parseContinue() Stmt {
 	pos := p.expect(KW_CONTINUE).P
-	if p.loopDepth == 0 {
-		p.fail(pos, "continue outside loop")
+	tok, ok := p.labelRef()
+	if !ok {
+		if !p.inLoop() {
+			p.fail(pos, "continue outside loop")
+		}
+		return &ContinueStmt{P: pos}
 	}
-	return &ContinueStmt{P: pos}
+
+	t := p.findControl(tok.Lit)
+	if t == nil {
+		p.fail(tok.P, fmt.Sprintf("undefined label %q", tok.Lit))
+	}
+	if t.kind != controlLoop {
+		p.fail(tok.P, fmt.Sprintf("continue label %q is not a loop", tok.Lit))
+	}
+	return &ContinueStmt{P: pos, Label: tok.Lit}
 }
 
 func (p *Parser) parseBlock() *Block {

--- a/internal/rts/parser.go
+++ b/internal/rts/parser.go
@@ -5,12 +5,15 @@ import (
 	"strconv"
 )
 
+// loopDepth gates continue, breakDepth gates break. Loops raise both, switches
+// raise only breakDepth so continue inside a switch still targets the loop
 type Parser struct {
-	lx        *Lexer
-	cur       Tok
-	peek      Tok
-	ahead     []Tok
-	loopDepth int
+	lx         *Lexer
+	cur        Tok
+	peek       Tok
+	ahead      []Tok
+	loopDepth  int
+	breakDepth int
 }
 
 func NewParserAt(path string, src []byte, pos Pos) *Parser {
@@ -114,6 +117,10 @@ func (p *Parser) parseStmt() Stmt {
 		return p.parseFn(false)
 	case KW_IF:
 		return p.parseIf()
+	case KW_SWITCH:
+		return p.parseSwitch()
+	case KW_CASE:
+		p.fail(p.cur.P, "case outside switch body")
 	case KW_FOR:
 		return p.parseFor()
 	case KW_BREAK:
@@ -125,6 +132,9 @@ func (p *Parser) parseStmt() Stmt {
 	case IDENT:
 		if p.peek.K == ASSIGN {
 			return p.parseAssign()
+		}
+		if p.isDefaultClause() {
+			p.fail(p.cur.P, "default outside switch body")
 		}
 	}
 	return p.parseExprStmt()
@@ -189,10 +199,10 @@ func (p *Parser) parseFn(exp bool) Stmt {
 	p.expect(LPAREN)
 	params := p.parseParams()
 	p.expect(RPAREN)
-	savedDepth := p.loopDepth
-	p.loopDepth = 0
+	savedLoop, savedBreak := p.loopDepth, p.breakDepth
+	p.loopDepth, p.breakDepth = 0, 0
 	body := p.parseBlock()
-	p.loopDepth = savedDepth
+	p.loopDepth, p.breakDepth = savedLoop, savedBreak
 	return &FnDef{P: pos, Exported: exp, Name: name, Params: params, Body: body}
 }
 
@@ -244,6 +254,95 @@ func (p *Parser) parseIf() Stmt {
 		els = p.parseBlock()
 	}
 	return &IfStmt{P: pos, Cond: cond, Then: then, Elifs: elifs, Else: els}
+}
+
+// parseSwitch reads both switch forms. A brace right after the keyword means
+// the tagless form, mirroring Go: a dict literal tag has to be parenthesized
+func (p *Parser) parseSwitch() Stmt {
+	pos := p.expect(KW_SWITCH).P
+	var tag Expr
+	if p.cur.K != LBRACE {
+		tag = p.parseExpr()
+	}
+	p.expect(LBRACE)
+	p.breakDepth++
+	clauses := p.parseCaseClauses()
+	p.breakDepth--
+	p.expect(RBRACE)
+	return &SwitchStmt{P: pos, Tag: tag, Clauses: clauses}
+}
+
+func (p *Parser) parseCaseClauses() []CaseClause {
+	var out []CaseClause
+	seenDefault := false
+	for {
+		p.skipSemi()
+		switch {
+		case p.cur.K == RBRACE:
+			return out
+		case p.cur.K == EOF:
+			p.fail(p.cur.P, "unterminated switch")
+		case p.cur.K == KW_CASE:
+			out = append(out, p.parseCase())
+		case p.isDefaultClause():
+			if seenDefault {
+				p.fail(p.cur.P, "duplicate default in switch")
+			}
+			seenDefault = true
+			out = append(out, p.parseDefault())
+		default:
+			p.failCur(fmt.Sprintf("expected case or default, got %s", p.cur.K))
+		}
+	}
+}
+
+func (p *Parser) parseCase() CaseClause {
+	pos := p.expect(KW_CASE).P
+	exprs := p.parseCaseExprs()
+	colon := p.expect(COLON).P
+	return CaseClause{P: pos, Exprs: exprs, Body: p.parseClauseBody(colon)}
+}
+
+func (p *Parser) parseCaseExprs() []Expr {
+	var out []Expr
+	for {
+		if p.cur.K == COLON {
+			p.fail(p.cur.P, "case requires an expression")
+		}
+		out = append(out, p.parseExpr())
+		if p.cur.K != COMMA {
+			return out
+		}
+		p.next()
+	}
+}
+
+func (p *Parser) parseDefault() CaseClause {
+	pos := p.cur.P
+	p.next()
+	colon := p.expect(COLON).P
+	return CaseClause{P: pos, Body: p.parseClauseBody(colon)}
+}
+
+func (p *Parser) parseClauseBody(pos Pos) *Block {
+	var out []Stmt
+	for {
+		p.skipSemi()
+		if p.cur.K == RBRACE || p.cur.K == KW_CASE || p.isDefaultClause() {
+			return &Block{P: pos, Stmts: out}
+		}
+		if p.cur.K == EOF {
+			p.fail(p.cur.P, "unterminated switch")
+		}
+		out = append(out, p.parseStmt())
+	}
+}
+
+// isDefaultClause matches the contextual default label. Nothing else in the
+// language starts a statement with an identifier followed by a colon, so
+// default(a, b) and dict keys stay untouched
+func (p *Parser) isDefaultClause() bool {
+	return p.cur.K == IDENT && p.cur.Lit == defaultClause && p.peek.K == COLON
 }
 
 func (p *Parser) parseFor() Stmt {
@@ -355,7 +454,7 @@ func (p *Parser) parseForClause(allowLet bool, label string) Stmt {
 		return p.parseLet(false, false)
 	case KW_CONST:
 		p.fail(p.cur.P, fmt.Sprintf("for %s clause cannot use const", label))
-	case KW_EXPORT, KW_FN, KW_IF, KW_FOR, KW_RETURN, KW_BREAK, KW_CONTINUE, KW_RANGE:
+	case KW_EXPORT, KW_FN, KW_IF, KW_SWITCH, KW_FOR, KW_RETURN, KW_BREAK, KW_CONTINUE, KW_RANGE:
 		p.fail(p.cur.P, fmt.Sprintf("invalid for %s clause", label))
 	case IDENT:
 		if p.peek.K == ASSIGN {
@@ -367,15 +466,17 @@ func (p *Parser) parseForClause(allowLet bool, label string) Stmt {
 
 func (p *Parser) parseForBody(pos Pos, init Stmt, cond Expr, post Stmt, rng *ForRange) Stmt {
 	p.loopDepth++
+	p.breakDepth++
 	body := p.parseBlock()
 	p.loopDepth--
+	p.breakDepth--
 	return &ForStmt{P: pos, Init: init, Cond: cond, Post: post, Range: rng, Body: body}
 }
 
 func (p *Parser) parseBreak() Stmt {
 	pos := p.expect(KW_BREAK).P
-	if p.loopDepth == 0 {
-		p.fail(pos, "break outside loop")
+	if p.breakDepth == 0 {
+		p.fail(pos, "break outside loop or switch")
 	}
 	return &BreakStmt{P: pos}
 }

--- a/internal/rts/parser_test.go
+++ b/internal/rts/parser_test.go
@@ -445,6 +445,159 @@ func TestParseSwitchBreakAndContinue(t *testing.T) {
 	}
 }
 
+func parseOneStmt(t *testing.T, src string) Stmt {
+	t.Helper()
+	m, err := ParseModule("test", []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Stmts) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(m.Stmts))
+	}
+	return m.Stmts[0]
+}
+
+func TestParseLabeledFor(t *testing.T) {
+	st := parseOneStmt(t, "outer: for let i = 0; i < 3; i = i + 1 {\n  break outer\n}\n")
+	loop, ok := st.(*ForStmt)
+	if !ok {
+		t.Fatalf("expected for stmt, got %T", st)
+	}
+	if loop.Label != "outer" {
+		t.Fatalf("label: got %q, want %q", loop.Label, "outer")
+	}
+	if loop.LabelPos.Line != 1 || loop.LabelPos.Col != 1 {
+		t.Fatalf("label pos: got %d:%d, want 1:1", loop.LabelPos.Line, loop.LabelPos.Col)
+	}
+	if loop.Pos().Col != 8 {
+		t.Fatalf("for pos: got col %d, want 8", loop.Pos().Col)
+	}
+	brk, ok := loop.Body.Stmts[0].(*BreakStmt)
+	if !ok {
+		t.Fatalf("expected break stmt, got %T", loop.Body.Stmts[0])
+	}
+	if brk.Label != "outer" {
+		t.Fatalf("break label: got %q, want %q", brk.Label, "outer")
+	}
+}
+
+func TestParseLabeledSwitchAndRange(t *testing.T) {
+	st := parseOneStmt(t, "sw: switch x {\ncase 1:\n  break sw\ndefault:\n  y = 2\n}\n")
+	sw, ok := st.(*SwitchStmt)
+	if !ok {
+		t.Fatalf("expected switch stmt, got %T", st)
+	}
+	if sw.Label != "sw" {
+		t.Fatalf("label: got %q, want %q", sw.Label, "sw")
+	}
+	if len(sw.Clauses) != 2 || sw.Clauses[1].Exprs != nil {
+		t.Fatalf("expected default to stay a clause, got %+v", sw.Clauses)
+	}
+
+	st = parseOneStmt(t, "rows: for let i, row range items {\n  continue rows\n}\n")
+	loop, ok := st.(*ForStmt)
+	if !ok {
+		t.Fatalf("expected for stmt, got %T", st)
+	}
+	if loop.Label != "rows" || loop.Range == nil {
+		t.Fatalf("expected labeled range loop, got %+v", loop)
+	}
+	cont, ok := loop.Body.Stmts[0].(*ContinueStmt)
+	if !ok {
+		t.Fatalf("expected continue stmt, got %T", loop.Body.Stmts[0])
+	}
+	if cont.Label != "rows" {
+		t.Fatalf("continue label: got %q, want %q", cont.Label, "rows")
+	}
+}
+
+func TestParseLabelOnOwnLine(t *testing.T) {
+	st := parseOneStmt(t, "outer:\nfor {\n  break outer\n}\n")
+	loop, ok := st.(*ForStmt)
+	if !ok {
+		t.Fatalf("expected for stmt, got %T", st)
+	}
+	if loop.Label != "outer" {
+		t.Fatalf("label: got %q, want %q", loop.Label, "outer")
+	}
+}
+
+// the lexer closes the statement after break and continue, so a label on the
+// next line is a separate expression statement rather than a target
+func TestParseBreakLabelMustShareLine(t *testing.T) {
+	st := parseOneStmt(t, "outer: for {\n  break\n  outer\n}\n")
+	loop := st.(*ForStmt)
+	if len(loop.Body.Stmts) != 2 {
+		t.Fatalf("expected 2 stmts, got %d", len(loop.Body.Stmts))
+	}
+	brk, ok := loop.Body.Stmts[0].(*BreakStmt)
+	if !ok || brk.Label != "" {
+		t.Fatalf("expected unlabeled break, got %T %+v", loop.Body.Stmts[0], loop.Body.Stmts[0])
+	}
+	if _, ok := loop.Body.Stmts[1].(*ExprStmt); !ok {
+		t.Fatalf("expected expr stmt, got %T", loop.Body.Stmts[1])
+	}
+}
+
+func TestParseLabelReuseAfterStatementEnds(t *testing.T) {
+	src := "outer: for { break outer }\nouter: switch x {\ncase 1:\n  break outer\n}\n"
+	m, err := ParseModule("test", []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Stmts) != 2 {
+		t.Fatalf("expected 2 stmts, got %d", len(m.Stmts))
+	}
+}
+
+func TestParseLabelErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		msg  string
+	}{
+		{"label on let", "outer: let x = 1\n", "label must be followed by for or switch, got let"},
+		{"label on if", "outer: if x {\n}\n", "label must be followed by for or switch, got if"},
+		{"label on block", "outer: {\n}\n", "label must be followed by for or switch, got {"},
+		{"blank label", "_: for {\n}\n", `invalid label "_"`},
+		{"default label", "default: for {\n}\n", "default outside switch body"},
+		{"undefined break label", "for {\n  break missing\n}\n", `undefined label "missing"`},
+		{"undefined continue label", "for {\n  continue missing\n}\n", `undefined label "missing"`},
+		{
+			"continue targets switch",
+			"sw: switch x {\ncase 1:\n  for {\n    continue sw\n  }\n}\n",
+			`continue label "sw" is not a loop`,
+		},
+		{
+			"duplicate active label",
+			"outer: for {\n  outer: for {\n  }\n}\n",
+			`duplicate label "outer", active since 1:1`,
+		},
+		{
+			"label across function boundary",
+			"outer: for {\n  fn f() {\n    break outer\n  }\n}\n",
+			`undefined label "outer"`,
+		},
+		{
+			"label out of scope",
+			"a: for {\n}\nb: for {\n  break a\n}\n",
+			`undefined label "a"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseModule("test", []byte(tc.src))
+			pe, ok := err.(*ParseError)
+			if !ok {
+				t.Fatalf("expected *ParseError, got %T (%v)", err, err)
+			}
+			if pe.Msg != tc.msg {
+				t.Fatalf("msg: got %q, want %q", pe.Msg, tc.msg)
+			}
+		})
+	}
+}
+
 func TestParseDefaultStaysIdentifier(t *testing.T) {
 	src := "let a = default(null, \"x\")\nlet b = rts.default(a, \"y\")\nlet c = {default: 1}.default\n"
 	m, err := ParseModule("test", []byte(src))

--- a/internal/rts/parser_test.go
+++ b/internal/rts/parser_test.go
@@ -219,6 +219,243 @@ func TestParseBreakContinueOutsideLoop(t *testing.T) {
 	}
 }
 
+func parseSwitchStmt(t *testing.T, src string) *SwitchStmt {
+	t.Helper()
+	m, err := ParseModule("test", []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Stmts) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(m.Stmts))
+	}
+	sw, ok := m.Stmts[0].(*SwitchStmt)
+	if !ok {
+		t.Fatalf("expected switch stmt, got %T", m.Stmts[0])
+	}
+	return sw
+}
+
+func TestParseSwitchTagged(t *testing.T) {
+	src := "switch code {\ncase 200, 201:\n  out = \"ok\"\ncase 401:\n  out = \"no\"\ndefault:\n  out = \"?\"\n}\n"
+	sw := parseSwitchStmt(t, src)
+	if sw.Tag == nil {
+		t.Fatalf("expected tag expression")
+	}
+	if len(sw.Clauses) != 3 {
+		t.Fatalf("expected 3 clauses, got %d", len(sw.Clauses))
+	}
+	if len(sw.Clauses[0].Exprs) != 2 {
+		t.Fatalf("expected 2 case expressions, got %d", len(sw.Clauses[0].Exprs))
+	}
+	if sw.Clauses[2].Exprs != nil {
+		t.Fatalf("expected default clause to carry no expressions")
+	}
+	for i, cl := range sw.Clauses {
+		if cl.Body == nil || len(cl.Body.Stmts) != 1 {
+			t.Fatalf("clause %d: expected one body statement", i)
+		}
+	}
+}
+
+func TestParseSwitchTagless(t *testing.T) {
+	src := "switch {\ncase score >= 90:\n  grade = \"A\"\ndefault:\n  grade = \"C\"\n}\n"
+	sw := parseSwitchStmt(t, src)
+	if sw.Tag != nil {
+		t.Fatalf("expected tagless switch, got tag %T", sw.Tag)
+	}
+	if len(sw.Clauses) != 2 {
+		t.Fatalf("expected 2 clauses, got %d", len(sw.Clauses))
+	}
+	if _, ok := sw.Clauses[0].Exprs[0].(*Binary); !ok {
+		t.Fatalf("expected binary case expression, got %T", sw.Clauses[0].Exprs[0])
+	}
+}
+
+func TestParseSwitchBraceIsAlwaysTagless(t *testing.T) {
+	if _, err := ParseModule("test", []byte("switch {a: 1} {\ncase 1:\n}\n")); err == nil {
+		t.Fatalf("expected a bare dict tag to be read as the tagless form")
+	}
+	sw := parseSwitchStmt(t, "switch ({a: 1}) {\ncase 1:\n}\n")
+	if _, ok := sw.Tag.(*DictLit); !ok {
+		t.Fatalf("expected parenthesized dict tag, got %T", sw.Tag)
+	}
+}
+
+func TestParseSwitchEmptyForms(t *testing.T) {
+	sw := parseSwitchStmt(t, "switch x {\n}\n")
+	if len(sw.Clauses) != 0 {
+		t.Fatalf("expected no clauses, got %d", len(sw.Clauses))
+	}
+
+	sw = parseSwitchStmt(t, "switch x {\ncase 1:\ncase 2:\ndefault:\n}\n")
+	if len(sw.Clauses) != 3 {
+		t.Fatalf("expected 3 clauses, got %d", len(sw.Clauses))
+	}
+	for i, cl := range sw.Clauses {
+		if cl.Body == nil {
+			t.Fatalf("clause %d: expected body block", i)
+		}
+		if len(cl.Body.Stmts) != 0 {
+			t.Fatalf("clause %d: expected empty body, got %d stmts", i, len(cl.Body.Stmts))
+		}
+	}
+}
+
+func TestParseSwitchDefaultFirst(t *testing.T) {
+	sw := parseSwitchStmt(t, "switch x {\ndefault:\n  y = 0\ncase 1:\n  y = 1\n}\n")
+	if sw.Clauses[0].Exprs != nil {
+		t.Fatalf("expected leading default clause")
+	}
+	if len(sw.Clauses[1].Exprs) != 1 {
+		t.Fatalf("expected trailing case clause")
+	}
+}
+
+func TestParseSwitchMultilineCaseList(t *testing.T) {
+	sw := parseSwitchStmt(t, "switch x {\ncase 1,\n  2,\n  3:\n  y = 1\n}\n")
+	if len(sw.Clauses[0].Exprs) != 3 {
+		t.Fatalf("expected 3 case expressions, got %d", len(sw.Clauses[0].Exprs))
+	}
+}
+
+func TestParseSwitchNested(t *testing.T) {
+	src := "switch a {\ncase 1:\n  switch b {\n  case 2:\n    y = 1\n  }\n}\n"
+	sw := parseSwitchStmt(t, src)
+	inner, ok := sw.Clauses[0].Body.Stmts[0].(*SwitchStmt)
+	if !ok {
+		t.Fatalf("expected nested switch, got %T", sw.Clauses[0].Body.Stmts[0])
+	}
+	if len(inner.Clauses) != 1 {
+		t.Fatalf("expected 1 inner clause, got %d", len(inner.Clauses))
+	}
+}
+
+// a clause body that ends in a block leaves the lexer on an auto semi, which
+// must not leak into the next clause
+func TestParseSwitchClauseEndingInBlock(t *testing.T) {
+	src := "switch x {\ncase 1:\n  if y {\n    z = 1\n  }\ncase 2:\n  for {\n    break\n  }\ndefault:\n  z = 3\n}\n"
+	sw := parseSwitchStmt(t, src)
+	if len(sw.Clauses) != 3 {
+		t.Fatalf("expected 3 clauses, got %d", len(sw.Clauses))
+	}
+	for i, cl := range sw.Clauses {
+		if len(cl.Body.Stmts) != 1 {
+			t.Fatalf("clause %d: expected 1 stmt, got %d", i, len(cl.Body.Stmts))
+		}
+	}
+}
+
+func TestParseSwitchPositions(t *testing.T) {
+	src := "let x = 1\nswitch x {\ncase 1:\n  x = 2\ndefault:\n  x = 3\n}\n"
+	m, err := ParseModule("test", []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	sw, ok := m.Stmts[1].(*SwitchStmt)
+	if !ok {
+		t.Fatalf("expected switch stmt, got %T", m.Stmts[1])
+	}
+	if sw.Pos().Line != 2 || sw.Pos().Col != 1 {
+		t.Fatalf("switch pos: got %d:%d, want 2:1", sw.Pos().Line, sw.Pos().Col)
+	}
+	if sw.Tag.Pos().Line != 2 || sw.Tag.Pos().Col != 8 {
+		t.Fatalf("tag pos: got %d:%d, want 2:8", sw.Tag.Pos().Line, sw.Tag.Pos().Col)
+	}
+	if sw.Clauses[0].P.Line != 3 || sw.Clauses[0].P.Col != 1 {
+		t.Fatalf("case pos: got %d:%d, want 3:1", sw.Clauses[0].P.Line, sw.Clauses[0].P.Col)
+	}
+	if sw.Clauses[0].Body.P.Line != 3 || sw.Clauses[0].Body.P.Col != 7 {
+		t.Fatalf(
+			"case body pos: got %d:%d, want 3:7",
+			sw.Clauses[0].Body.P.Line,
+			sw.Clauses[0].Body.P.Col,
+		)
+	}
+	if sw.Clauses[1].P.Line != 5 || sw.Clauses[1].P.Col != 1 {
+		t.Fatalf("default pos: got %d:%d, want 5:1", sw.Clauses[1].P.Line, sw.Clauses[1].P.Col)
+	}
+}
+
+func TestParseSwitchMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		msg  string
+	}{
+		{"empty case list", "switch x {\ncase:\n}\n", "case requires an expression"},
+		{"trailing comma", "switch x {\ncase 1, :\n}\n", "case requires an expression"},
+		{"colon on next line", "switch x {\ncase 1\n:\n}\n", "expected :, got <auto-semi>"},
+		{"brace on next line", "switch x\n{\n}\n", "expected {, got <auto-semi>"},
+		{
+			"statement before clause",
+			"switch x {\nlet y = 1\ncase 1:\n}\n",
+			"expected case or default, got let",
+		},
+		{"duplicate default", "switch x {\ndefault:\ndefault:\n}\n", "duplicate default in switch"},
+		{"unterminated", "switch x {\ncase 1:\n  y = 1\n", "unterminated switch"},
+		{"case outside switch", "case 1:\n", "case outside switch body"},
+		{"default outside switch", "default:\n", "default outside switch body"},
+		{"default in nested block", "switch x {\ncase 1:\n  if y {\n  default:\n  }\n}\n",
+			"default outside switch body"},
+		{"switch in for init", "for switch x { }; y; z { }\n", "invalid for init clause"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseModule("test", []byte(tc.src))
+			pe, ok := err.(*ParseError)
+			if !ok {
+				t.Fatalf("expected *ParseError, got %T (%v)", err, err)
+			}
+			if pe.Msg != tc.msg {
+				t.Fatalf("msg: got %q, want %q", pe.Msg, tc.msg)
+			}
+		})
+	}
+}
+
+func TestParseSwitchBreakAndContinue(t *testing.T) {
+	ok := []string{
+		"switch 1 {\ncase 1:\n  break\n}\n",
+		"for {\n  switch 1 {\n  case 1:\n    continue\n  }\n}\n",
+		"for {\n  switch 1 {\n  case 1:\n    break\n  }\n  break\n}\n",
+	}
+	for _, src := range ok {
+		if _, err := ParseModule("test", []byte(src)); err != nil {
+			t.Fatalf("parse %q: %v", src, err)
+		}
+	}
+
+	bad := []struct {
+		src string
+		msg string
+	}{
+		{"switch 1 {\ncase 1:\n  continue\n}\n", "continue outside loop"},
+		{"switch 1 {\ncase 1:\n  fn g() {\n    break\n  }\n}\n", "break outside loop or switch"},
+		{"break\n", "break outside loop or switch"},
+	}
+	for _, tc := range bad {
+		_, err := ParseModule("test", []byte(tc.src))
+		pe, ok := err.(*ParseError)
+		if !ok {
+			t.Fatalf("expected *ParseError for %q, got %T", tc.src, err)
+		}
+		if pe.Msg != tc.msg {
+			t.Fatalf("msg: got %q, want %q", pe.Msg, tc.msg)
+		}
+	}
+}
+
+func TestParseDefaultStaysIdentifier(t *testing.T) {
+	src := "let a = default(null, \"x\")\nlet b = rts.default(a, \"y\")\nlet c = {default: 1}.default\n"
+	m, err := ParseModule("test", []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Stmts) != 3 {
+		t.Fatalf("expected 3 stmts, got %d", len(m.Stmts))
+	}
+}
+
 func TestParseModuleDecl(t *testing.T) {
 	src := "module mod\nexport let x = 1\n"
 	m, err := ParseModule("test", []byte(src))

--- a/internal/rts/stdlib/stdlib_test.go
+++ b/internal/rts/stdlib/stdlib_test.go
@@ -51,6 +51,34 @@ func TestStdlibCore(t *testing.T) {
 	}
 }
 
+// default is a contextual switch label, so the stdlib helper of the same name
+// has to stay callable in both spellings, including inside a switch body
+func TestStdlibDefaultSurvivesSwitch(t *testing.T) {
+	ctx := rts.NewCtx(context.Background(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
+	mod := `
+fn label(code) {
+  let out = default(null, "fallback")
+  switch code {
+  case 200:
+    out = default("ok", "unused")
+  default:
+    out = rts.default(null, "other")
+  }
+  return out
+}
+`
+	if v := evalExprMod(t, ctx, mod, `label(200)`); v.K != rts.VStr || v.S != "ok" {
+		t.Fatalf("expected ok, got %+v", v)
+	}
+	if v := evalExprMod(t, ctx, mod, `label(500)`); v.K != rts.VStr || v.S != "other" {
+		t.Fatalf("expected other, got %+v", v)
+	}
+	v := evalExprCtx(t, ctx, `default(null, "fallback")`)
+	if v.K != rts.VStr || v.S != "fallback" {
+		t.Fatalf("expected fallback, got %+v", v)
+	}
+}
+
 func TestStdlibCrypto(t *testing.T) {
 	ctx := rts.NewCtx(context.Background(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
 	v := evalExprCtx(t, ctx, "crypto.sha256(\"abc\")")

--- a/internal/rts/token.go
+++ b/internal/rts/token.go
@@ -18,6 +18,8 @@ const (
 	KW_IF
 	KW_ELIF
 	KW_ELSE
+	KW_SWITCH
+	KW_CASE
 	KW_RETURN
 	KW_FOR
 	KW_BREAK
@@ -104,6 +106,10 @@ func (k Kind) String() string {
 		return "elif"
 	case KW_ELSE:
 		return "else"
+	case KW_SWITCH:
+		return "switch"
+	case KW_CASE:
+		return "case"
 	case KW_RETURN:
 		return "return"
 	case KW_FOR:
@@ -183,6 +189,11 @@ func (k Kind) String() string {
 	}
 }
 
+// defaultClause labels the fallback clause of a switch. It is matched
+// contextually instead of being reserved so the default(a, b) stdlib helper
+// keeps working as an ordinary identifier
+const defaultClause = "default"
+
 var kw = map[string]Kind{
 	"export":   KW_EXPORT,
 	"module":   KW_MODULE,
@@ -192,6 +203,8 @@ var kw = map[string]Kind{
 	"if":       KW_IF,
 	"elif":     KW_ELIF,
 	"else":     KW_ELSE,
+	"switch":   KW_SWITCH,
+	"case":     KW_CASE,
 	"return":   KW_RETURN,
 	"for":      KW_FOR,
 	"break":    KW_BREAK,
@@ -219,7 +232,17 @@ func keywordClassForKind(k Kind) KeywordClass {
 	switch k {
 	case KW_EXPORT, KW_MODULE, KW_FN, KW_LET, KW_CONST:
 		return KeywordDecl
-	case KW_IF, KW_ELIF, KW_ELSE, KW_RETURN, KW_FOR, KW_BREAK, KW_CONTINUE, KW_RANGE, KW_TRY:
+	case KW_IF,
+		KW_ELIF,
+		KW_ELSE,
+		KW_SWITCH,
+		KW_CASE,
+		KW_RETURN,
+		KW_FOR,
+		KW_BREAK,
+		KW_CONTINUE,
+		KW_RANGE,
+		KW_TRY:
 		return KeywordControl
 	case KW_TRUE, KW_FALSE, KW_NULL:
 		return KeywordLiteral

--- a/internal/rts/value.go
+++ b/internal/rts/value.go
@@ -88,6 +88,9 @@ func (v Value) IsTruthy() bool {
 	}
 }
 
+// ValueEqual is the one equality relation in the language. It backs ==, !=,
+// switch case matching, workflow @switch, and the collection helpers: kinds
+// must match, primitives compare by value, and collections are never equal
 func ValueEqual(a, b Value) bool {
 	if a.K != b.K {
 		return false

--- a/internal/rts/vm.go
+++ b/internal/rts/vm.go
@@ -32,16 +32,24 @@ type ret struct {
 func (r ret) Error() string { return "return" }
 
 type breakSig struct {
-	pos Pos
+	pos   Pos
+	label string
 }
 
 func (b breakSig) Error() string { return "break" }
 
 type continueSig struct {
-	pos Pos
+	pos   Pos
+	label string
 }
 
 func (c continueSig) Error() string { return "continue" }
+
+// targets reports whether a break or continue naming label should be consumed
+// by a for or switch named target. An unlabeled signal stops at the first one
+func targets(label, target string) bool {
+	return label == "" || label == target
+}
 
 func Exec(ctx *Ctx, mod *Mod, pre map[string]Value) (*Comp, error) {
 	if mod == nil {
@@ -169,9 +177,9 @@ func (vm *VM) execStmt(env *Env, exp map[string]Value, st Stmt) error {
 	case *ForStmt:
 		return vm.execFor(env, exp, s)
 	case *BreakStmt:
-		return breakSig{pos: s.Pos()}
+		return breakSig{pos: s.Pos(), label: s.Label}
 	case *ContinueStmt:
-		return continueSig{pos: s.Pos()}
+		return continueSig{pos: s.Pos(), label: s.Label}
 	default:
 		return Errf(vm.ctx, st.Pos(), "unknown stmt")
 	}
@@ -218,10 +226,10 @@ func (vm *VM) execSwitch(up *Env, exp map[string]Value, s *SwitchStmt) error {
 			return err
 		}
 		if match {
-			return vm.execClause(up, exp, cl.Body)
+			return vm.execClause(up, exp, s.Label, cl.Body)
 		}
 	}
-	return vm.execClause(up, exp, def)
+	return vm.execClause(up, exp, s.Label, def)
 }
 
 func (vm *VM) matchCase(env *Env, tagged bool, tag Value, exprs []Expr) (bool, error) {
@@ -243,11 +251,12 @@ func (vm *VM) matchCase(env *Env, tagged bool, tag Value, exprs []Expr) (bool, e
 	return false, nil
 }
 
-// execClause runs a clause body and stops break at the switch. Everything else
-// (return, continue, aborts, runtime errors) keeps propagating
-func (vm *VM) execClause(up *Env, exp map[string]Value, body *Block) error {
+// execClause runs a clause body and stops break at the switch. A break naming
+// some outer target keeps going, and so does everything else: continue, return,
+// aborts, and runtime errors
+func (vm *VM) execClause(up *Env, exp map[string]Value, label string, body *Block) error {
 	err := vm.execBlock(up, exp, body)
-	if _, ok := err.(breakSig); ok {
+	if b, ok := err.(breakSig); ok && targets(b.label, label) {
 		return nil
 	}
 	return err
@@ -276,7 +285,7 @@ func (vm *VM) execFor(up *Env, exp map[string]Value, s *ForStmt) error {
 				break
 			}
 		}
-		action, err := vm.execLoopBlock(env, exp, s.Body)
+		action, err := vm.execLoopBlock(env, exp, s.Label, s.Body)
 		if err != nil {
 			return err
 		}
@@ -300,18 +309,31 @@ func (vm *VM) execFor(up *Env, exp map[string]Value, s *ForStmt) error {
 	return nil
 }
 
-func (vm *VM) execLoopBlock(env *Env, exp map[string]Value, body *Block) (loopAction, error) {
+// execLoopBlock runs one iteration. A signal aimed at an outer label is handed
+// back as an error so it keeps travelling up through the enclosing statements
+func (vm *VM) execLoopBlock(
+	env *Env,
+	exp map[string]Value,
+	label string,
+	body *Block,
+) (loopAction, error) {
 	err := vm.execBlock(env, exp, body)
 	if err == nil {
 		return loopNext, nil
 	}
-	switch err.(type) {
+	switch sig := err.(type) {
 	case ret:
 		return loopNext, err
 	case breakSig:
-		return loopBreak, nil
+		if targets(sig.label, label) {
+			return loopBreak, nil
+		}
+		return loopNext, err
 	case continueSig:
-		return loopContinue, nil
+		if targets(sig.label, label) {
+			return loopContinue, nil
+		}
+		return loopNext, err
 	default:
 		return loopNext, err
 	}
@@ -406,7 +428,7 @@ func (vm *VM) execRangeStep(
 	if err := vm.assignRangeVar(env, rng.Val, itemVal, rng.Declare, pos); err != nil {
 		return loopNext, err
 	}
-	return vm.execLoopBlock(env, exp, s.Body)
+	return vm.execLoopBlock(env, exp, s.Label, s.Body)
 }
 
 func (vm *VM) defRangeVar(env *Env, name string) {

--- a/internal/rts/vm.go
+++ b/internal/rts/vm.go
@@ -62,7 +62,7 @@ func Exec(ctx *Ctx, mod *Mod, pre map[string]Value) (*Comp, error) {
 				return nil, Errf(ctx, st.Pos(), "return outside fn")
 			}
 			if b, ok := err.(breakSig); ok {
-				return nil, Errf(ctx, b.pos, "break outside loop")
+				return nil, Errf(ctx, b.pos, "break outside loop or switch")
 			}
 			if c, ok := err.(continueSig); ok {
 				return nil, Errf(ctx, c.pos, "continue outside loop")
@@ -164,6 +164,8 @@ func (vm *VM) execStmt(env *Env, exp map[string]Value, st Stmt) error {
 			return vm.execBlock(env, exp, s.Else)
 		}
 		return nil
+	case *SwitchStmt:
+		return vm.execSwitch(env, exp, s)
 	case *ForStmt:
 		return vm.execFor(env, exp, s)
 	case *BreakStmt:
@@ -189,6 +191,66 @@ func (vm *VM) execBlock(up *Env, exp map[string]Value, b *Block) error {
 		}
 	}
 	return nil
+}
+
+// execSwitch evaluates the tag once, then walks clauses in source order and
+// runs the first match. The default clause is remembered rather than run in
+// place so it can sit anywhere between the cases
+func (vm *VM) execSwitch(up *Env, exp map[string]Value, s *SwitchStmt) error {
+	var tag Value
+	if s.Tag != nil {
+		v, err := vm.eval(up, s.Tag)
+		if err != nil {
+			return err
+		}
+		tag = v
+	}
+
+	var def *Block
+	for i := range s.Clauses {
+		cl := &s.Clauses[i]
+		if cl.Exprs == nil {
+			def = cl.Body
+			continue
+		}
+		match, err := vm.matchCase(up, s.Tag != nil, tag, cl.Exprs)
+		if err != nil {
+			return err
+		}
+		if match {
+			return vm.execClause(up, exp, cl.Body)
+		}
+	}
+	return vm.execClause(up, exp, def)
+}
+
+func (vm *VM) matchCase(env *Env, tagged bool, tag Value, exprs []Expr) (bool, error) {
+	for _, ex := range exprs {
+		v, err := vm.eval(env, ex)
+		if err != nil {
+			return false, err
+		}
+		if tagged {
+			if ValueEqual(tag, v) {
+				return true, nil
+			}
+			continue
+		}
+		if v.IsTruthy() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// execClause runs a clause body and stops break at the switch. Everything else
+// (return, continue, aborts, runtime errors) keeps propagating
+func (vm *VM) execClause(up *Env, exp map[string]Value, body *Block) error {
+	err := vm.execBlock(up, exp, body)
+	if _, ok := err.(breakSig); ok {
+		return nil
+	}
+	return err
 }
 
 func (vm *VM) execFor(up *Env, exp map[string]Value, s *ForStmt) error {
@@ -597,7 +659,7 @@ func (vm *VM) callVal(pos Pos, cal Value, args []Value) (Value, error) {
 				return r.v, nil
 			}
 			if b, ok := err.(breakSig); ok {
-				return Null(), Errf(vm.ctx, b.pos, "break outside loop")
+				return Null(), Errf(vm.ctx, b.pos, "break outside loop or switch")
 			}
 			if c, ok := err.(continueSig); ok {
 				return Null(), Errf(vm.ctx, c.pos, "continue outside loop")
@@ -713,9 +775,9 @@ func (vm *VM) evalBin(env *Env, e *Binary) (Value, error) {
 			return Num(math.Mod(ln, rn)), nil
 		}
 	case OpEq:
-		return Bool(eq(l, r)), nil
+		return Bool(ValueEqual(l, r)), nil
 	case OpNe:
-		return Bool(!eq(l, r)), nil
+		return Bool(!ValueEqual(l, r)), nil
 	case OpLt, OpLe, OpGt, OpGe:
 		return cmp(vm.ctx, e.Pos(), e.Op, l, r)
 	}
@@ -758,24 +820,6 @@ func (vm *VM) checkStr(pos Pos, s string) error {
 		return Errf(vm.ctx, pos, "string too long")
 	}
 	return nil
-}
-
-func eq(a, b Value) bool {
-	if a.K != b.K {
-		return false
-	}
-	switch a.K {
-	case VNull:
-		return true
-	case VBool:
-		return a.B == b.B
-	case VNum:
-		return a.N == b.N
-	case VStr:
-		return a.S == b.S
-	default:
-		return false
-	}
 }
 
 func cmp(ctx *Ctx, pos Pos, op BinOp, a, b Value) (Value, error) {

--- a/internal/rts/vm_test.go
+++ b/internal/rts/vm_test.go
@@ -575,6 +575,152 @@ for let i = 0; i < 4; i = i + 1 {
 	wantStr(t, comp, "out", "0two3")
 }
 
+func TestLabeledBreakEscapesLoopFromSwitch(t *testing.T) {
+	src := `
+let out = ""
+outer: for let i = 0; i < 5; i = i + 1 {
+  switch i {
+  case 3:
+    break outer
+  }
+  out = out + str(i)
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "012")
+}
+
+func TestLabeledBreakPropagatesThroughNesting(t *testing.T) {
+	src := `
+let out = ""
+outer: for let i = 0; i < 3; i = i + 1 {
+  for let j = 0; j < 3; j = j + 1 {
+    switch j {
+    case 1:
+      switch i {
+      case 1:
+        break outer
+      }
+    }
+    out = out + str(i) + str(j)
+  }
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "00010210")
+}
+
+// a labeled continue runs the target loop's post once and skips the post of
+// every loop it travels through
+func TestLabeledContinueRunsTargetPostOnce(t *testing.T) {
+	src := `
+let posts = 0
+let inner = 0
+fn bumpOuter(i) {
+  posts = posts + 1
+  return i + 1
+}
+fn bumpInner(j) {
+  inner = inner + 1
+  return j + 1
+}
+let out = ""
+outer: for let i = 0; i < 3; i = bumpOuter(i) {
+  for let j = 0; j < 3; j = bumpInner(j) {
+    continue outer
+  }
+  out = out + "unreachable"
+}
+`
+	comp := execModule(t, src)
+	wantNum(t, comp, "posts", 3)
+	wantNum(t, comp, "inner", 0)
+	wantStr(t, comp, "out", "")
+}
+
+func TestLabeledRangeBreakAndContinue(t *testing.T) {
+	src := `
+let out = ""
+outer: for let i, row range [[1, 2], [3, 9], [5, 6]] {
+  for let j, v range row {
+    switch v {
+    case 9:
+      continue outer
+    case 5:
+      break outer
+    }
+    out = out + str(v)
+  }
+  out = out + "|"
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "12|3")
+}
+
+func TestLabeledBreakLeavesOuterSwitch(t *testing.T) {
+	src := `
+let out = ""
+outer: switch 1 {
+case 1:
+  out = out + "a"
+  switch 2 {
+  case 2:
+    out = out + "b"
+    break outer
+  }
+  out = out + "c"
+}
+out = out + "d"
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "abd")
+}
+
+// a labeled break travels past the loop it is written in when the label names
+// an enclosing switch
+func TestLabeledBreakSkipsLoopToReachSwitch(t *testing.T) {
+	src := `
+let out = ""
+sw: switch 1 {
+case 1:
+  for let i = 0; i < 3; i = i + 1 {
+    switch i {
+    case 1:
+      break sw
+    }
+    out = out + str(i)
+  }
+  out = out + "tail"
+}
+out = out + "end"
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "0end")
+}
+
+func TestLabeledSignalsInsideFunction(t *testing.T) {
+	src := `
+fn firstMissing(rows) {
+  outer: for let i, row range rows {
+    for let j, v range row {
+      switch v {
+      case null:
+        continue outer
+      }
+    }
+    return i
+  }
+  return -1
+}
+let a = firstMissing([[1, null], [2, 3]])
+let b = firstMissing([[null], [null]])
+`
+	comp := execModule(t, src)
+	wantNum(t, comp, "a", 1)
+	wantNum(t, comp, "b", -1)
+}
+
 func TestSwitchReturnPropagates(t *testing.T) {
 	src := `
 fn grade(score) {

--- a/internal/rts/vm_test.go
+++ b/internal/rts/vm_test.go
@@ -40,6 +40,35 @@ func execModule(t *testing.T, src string) *Comp {
 	return comp
 }
 
+func execModuleErr(t *testing.T, src string, lim Limits) error {
+	t.Helper()
+	m, err := ParseModule("test", []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Exec(NewCtx(context.Background(), lim), m, testStdlib()); err != nil {
+		return err
+	}
+	t.Fatalf("expected exec error")
+	return nil
+}
+
+func wantStr(t *testing.T, comp *Comp, name, want string) {
+	t.Helper()
+	v, ok := comp.Env.Get(name)
+	if !ok || v.K != VStr || v.S != want {
+		t.Fatalf("expected %s=%q, got %+v (ok=%v)", name, want, v, ok)
+	}
+}
+
+func wantNum(t *testing.T, comp *Comp, name string, want float64) {
+	t.Helper()
+	v, ok := comp.Env.Get(name)
+	if !ok || v.K != VNum || v.N != want {
+		t.Fatalf("expected %s=%v, got %+v (ok=%v)", name, want, v, ok)
+	}
+}
+
 func TestEvalBasic(t *testing.T) {
 	v := evalExpr(t, "1 + 2 * 3")
 	if v.K != VNum || v.N != 7 {
@@ -293,6 +322,368 @@ for let i, ch range "ab" {
 	out, ok := comp.Env.Get("out")
 	if !ok || out.K != VStr || out.S != "ab" {
 		t.Fatalf("expected out=ab, got %+v (ok=%v)", out, ok)
+	}
+}
+
+func TestSwitchEvaluatesTagOnce(t *testing.T) {
+	src := `
+let calls = 0
+fn tag() {
+  calls = calls + 1
+  return 3
+}
+let out = ""
+switch tag() {
+case 1:
+  out = "one"
+case 2:
+  out = "two"
+case 3:
+  out = "three"
+}
+`
+	comp := execModule(t, src)
+	wantNum(t, comp, "calls", 1)
+	wantStr(t, comp, "out", "three")
+}
+
+func TestSwitchCaseEvaluationOrderStops(t *testing.T) {
+	src := `
+let log = ""
+fn probe(name, v) {
+  log = log + name
+  return v
+}
+let out = ""
+switch 2 {
+case probe("a", 1), probe("b", 2), probe("c", 2):
+  out = "hit"
+case probe("d", 2):
+  out = "miss"
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "log", "ab")
+	wantStr(t, comp, "out", "hit")
+}
+
+func TestSwitchFirstMatchOnlyNoFallthrough(t *testing.T) {
+	src := `
+let out = ""
+switch 1 {
+case 1:
+  out = out + "a"
+case 1:
+  out = out + "b"
+default:
+  out = out + "d"
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "a")
+}
+
+func TestSwitchDefault(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			"runs when nothing matches",
+			"switch 9 {\ncase 1:\n  out = \"a\"\ndefault:\n  out = \"d\"\n}",
+			"d",
+		},
+		{
+			"skipped when a case matches",
+			"switch 1 {\ncase 1:\n  out = \"a\"\ndefault:\n  out = \"d\"\n}",
+			"a",
+		},
+		{
+			"reachable from any position",
+			"switch 9 {\ndefault:\n  out = \"d\"\ncase 1:\n  out = \"a\"\n}",
+			"d",
+		},
+		{
+			"absent leaves state untouched",
+			"switch 9 {\ncase 1:\n  out = \"a\"\n}",
+			"none",
+		},
+		{
+			"empty body runs nothing",
+			"switch 9 {\ncase 1:\n  out = \"a\"\ndefault:\n}",
+			"none",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			comp := execModule(t, "let out = \"none\"\n"+tc.src+"\n")
+			wantStr(t, comp, "out", tc.want)
+		})
+	}
+}
+
+func TestSwitchEqualityIsTypeSensitive(t *testing.T) {
+	cases := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{"number matches number", "1", "num"},
+		{"string is not number", "\"1\"", "str"},
+		{"bool is not number", "true", "bool"},
+		{"zero is not false", "0", "d"},
+		{"null matches null", "null", "null"},
+		{"lists never match", "[1]", "d"},
+		{"dicts never match", "({a: 1})", "d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "let out = \"\"\nswitch " + tc.tag + " {\n" +
+				"case 1:\n  out = \"num\"\n" +
+				"case \"1\":\n  out = \"str\"\n" +
+				"case null:\n  out = \"null\"\n" +
+				"case true:\n  out = \"bool\"\n" +
+				"case [1]:\n  out = \"list\"\n" +
+				"case {a: 1}:\n  out = \"dict\"\n" +
+				"default:\n  out = \"d\"\n}\n"
+			comp := execModule(t, src)
+			wantStr(t, comp, "out", tc.want)
+		})
+	}
+}
+
+func TestSwitchTaglessUsesTruthiness(t *testing.T) {
+	src := `
+let out = ""
+switch {
+case "":
+  out = "empty string"
+case 0:
+  out = "zero"
+case []:
+  out = "empty list"
+case "x":
+  out = "truthy"
+default:
+  out = "d"
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "truthy")
+}
+
+func TestSwitchTaglessFallsToDefault(t *testing.T) {
+	src := `
+let out = ""
+switch {
+case null:
+  out = "null"
+case 0:
+  out = "zero"
+default:
+  out = "d"
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "d")
+}
+
+func TestSwitchClauseScope(t *testing.T) {
+	src := `
+let out = "outer"
+let shadow = 1
+switch 1 {
+case 1:
+  let inner = "clause"
+  let shadow = 2
+  out = inner
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "clause")
+	wantNum(t, comp, "shadow", 1)
+	if _, ok := comp.Env.Get("inner"); ok {
+		t.Fatalf("expected clause declaration to stay in the clause")
+	}
+}
+
+func TestSwitchBreakStopsAtSwitch(t *testing.T) {
+	src := `
+let out = ""
+switch 1 {
+case 1:
+  out = out + "a"
+  break
+  out = out + "b"
+default:
+  out = out + "d"
+}
+out = out + "after"
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "aafter")
+}
+
+func TestSwitchNestedBreakLeavesOuterRunning(t *testing.T) {
+	src := `
+let out = ""
+switch 1 {
+case 1:
+  switch 2 {
+  case 2:
+    out = out + "inner"
+    break
+  }
+  out = out + "outer"
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "innerouter")
+}
+
+func TestSwitchBreakInLoopTargetsSwitch(t *testing.T) {
+	src := `
+let out = ""
+for let i = 0; i < 4; i = i + 1 {
+  switch i {
+  case 2:
+    break
+  }
+  out = out + str(i)
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "0123")
+}
+
+func TestSwitchContinueTargetsLoop(t *testing.T) {
+	src := `
+let out = ""
+for let i = 0; i < 4; i = i + 1 {
+  switch i {
+  case 1:
+    continue
+  case 2:
+    out = out + "two"
+    continue
+  }
+  out = out + str(i)
+}
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "out", "0two3")
+}
+
+func TestSwitchReturnPropagates(t *testing.T) {
+	src := `
+fn grade(score) {
+  switch {
+  case score >= 90:
+    return "A"
+  case score >= 80:
+    return "B"
+  default:
+    return "C"
+  }
+  return "unreachable"
+}
+let a = grade(95)
+let b = grade(85)
+let c = grade(10)
+`
+	comp := execModule(t, src)
+	wantStr(t, comp, "a", "A")
+	wantStr(t, comp, "b", "B")
+	wantStr(t, comp, "c", "C")
+}
+
+func TestSwitchErrorsKeepPosition(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		msg  string
+		line int
+		col  int
+	}{
+		{"tag", "switch missing {\ncase 1:\n}\n", "undefined name \"missing\"", 1, 8},
+		{"case expression", "switch 1 {\ncase missing:\n}\n", "undefined name \"missing\"", 2, 6},
+		{"clause body", "switch 1 {\ncase 1:\n  let x = missing\n}\n",
+			"undefined name \"missing\"", 3, 11},
+		{"default body", "switch 9 {\ndefault:\n  let x = missing\n}\n",
+			"undefined name \"missing\"", 3, 11},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := execModuleErr(t, tc.src, Limits{})
+			se, ok := err.(*StackError)
+			if !ok {
+				t.Fatalf("expected *StackError, got %T", err)
+			}
+			re, ok := se.Err.(*RuntimeError)
+			if !ok {
+				t.Fatalf("expected *RuntimeError, got %T", se.Err)
+			}
+			if re.Msg != tc.msg {
+				t.Fatalf("msg: got %q, want %q", re.Msg, tc.msg)
+			}
+			if re.Pos.Line != tc.line || re.Pos.Col != tc.col {
+				t.Fatalf("pos: got %d:%d, want %d:%d", re.Pos.Line, re.Pos.Col, tc.line, tc.col)
+			}
+		})
+	}
+}
+
+func TestSwitchCaseErrorKeepsCallStack(t *testing.T) {
+	src := `
+fn boom() {
+  return missing
+}
+switch 1 {
+case boom():
+  let x = 1
+}
+`
+	err := execModuleErr(t, src, Limits{})
+	se, ok := err.(*StackError)
+	if !ok {
+		t.Fatalf("expected *StackError, got %T", err)
+	}
+	if len(se.Frames) != 1 || se.Frames[0].Name != "boom" {
+		t.Fatalf("expected boom frame, got %+v", se.Frames)
+	}
+}
+
+func TestSwitchStepLimitPropagates(t *testing.T) {
+	src := `
+let out = 0
+switch 1 {
+case 1:
+  out = 1
+}
+`
+	err := execModuleErr(t, src, Limits{MaxSteps: 6})
+	if !isAbort(err) {
+		t.Fatalf("expected abort, got %T (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), "step limit exceeded") {
+		t.Fatalf("expected step limit error, got %v", err)
+	}
+}
+
+func TestSwitchHardAbortNotSwallowed(t *testing.T) {
+	src := `
+let out = 0
+switch 1 {
+case 1:
+  for {
+    out = out + 1
+  }
+}
+`
+	err := execModuleErr(t, src, Limits{MaxSteps: 200})
+	if !isAbort(err) {
+		t.Fatalf("expected abort, got %T (%v)", err, err)
 	}
 }
 

--- a/internal/ui/editor_rts_highlighter.go
+++ b/internal/ui/editor_rts_highlighter.go
@@ -163,6 +163,10 @@ func (s *rtsRuneStyler) computeStyles(line []rune) []lipgloss.Style {
 				i++
 			}
 			token := string(line[start:i])
+			// switch and case are reserved so they classify on their own, but a
+			// switch default label is deliberately left alone: it is an ordinary
+			// identifier, and one line cannot tell "default:" in a clause from
+			// "default:" as a key in a multiline dict
 			class := rts.KeywordClassOf(token)
 			if class != rts.KeywordNone {
 				if style, ok := s.keywordStyleForClass(class); ok {

--- a/internal/ui/editor_rts_highlighter_test.go
+++ b/internal/ui/editor_rts_highlighter_test.go
@@ -4,6 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/unkn0wn-root/resterm/internal/rts"
 	"github.com/unkn0wn-root/resterm/internal/theme"
 )
 
@@ -62,6 +65,64 @@ func TestRTSRuneStylerHighlightsFnCall(t *testing.T) {
 	want := style.Render("s")
 	if got != want {
 		t.Fatalf("fn call style mismatch:\nwant %q\n got %q", want, got)
+	}
+}
+
+// default is not a keyword and the line styler cannot tell a switch clause
+// label from a multiline dict key, so it stays unstyled as control everywhere
+func TestRTSRuneStylerLeavesDefaultUnstyledAsControl(t *testing.T) {
+	p := theme.DefaultTheme().EditorMetadata
+	p.RTSKeywordControl = lipgloss.Color("#112233")
+	st := newRTSRuneStyler(p)
+	rs, ok := st.(*rtsRuneStyler)
+	if !ok {
+		t.Fatalf("expected rts rune styler")
+	}
+
+	control, ok := rs.keywordStyleForClass(rts.KeywordControl)
+	if !ok {
+		t.Fatalf("expected control keyword style")
+	}
+
+	lines := []string{
+		"  default:",
+		"  default: 1",
+		"x = default(a, b)",
+		"x = rts.default(a, b)",
+	}
+	for i, src := range lines {
+		styles := rs.StylesForLine([]rune(src), i)
+		idx := strings.Index(src, "default")
+		var fg lipgloss.TerminalColor = lipgloss.NoColor{}
+		if idx < len(styles) {
+			fg = styles[idx].GetForeground()
+		}
+		if fg == control.GetForeground() {
+			t.Fatalf("%q: default should not use the control keyword color", src)
+		}
+	}
+}
+
+func TestRTSRuneStylerHighlightsSwitchKeywords(t *testing.T) {
+	p := theme.DefaultTheme().EditorMetadata
+	p.RTSKeywordControl = lipgloss.Color("#112233")
+	st := newRTSRuneStyler(p)
+	rs, ok := st.(*rtsRuneStyler)
+	if !ok {
+		t.Fatalf("expected rts rune styler")
+	}
+
+	control, ok := rs.keywordStyleForClass(rts.KeywordControl)
+	if !ok {
+		t.Fatalf("expected control keyword style")
+	}
+
+	for i, src := range []string{"switch code {", "case 200, 201:"} {
+		styles := rs.StylesForLine([]rune(src), i)
+		got := styles[0].GetForeground()
+		if want := control.GetForeground(); got != want {
+			t.Fatalf("%q color: got %v, want %v", src, got, want)
+		}
 	}
 }
 

--- a/internal/workspace/rts_refs.go
+++ b/internal/workspace/rts_refs.go
@@ -69,6 +69,14 @@ func walkStmt(st rts.Stmt, add func(string)) {
 			walkBlock(el.Body, add)
 		}
 		walkBlock(s.Else, add)
+	case *rts.SwitchStmt:
+		walkExpr(s.Tag, add)
+		for _, cl := range s.Clauses {
+			for _, ex := range cl.Exprs {
+				walkExpr(ex, add)
+			}
+			walkBlock(cl.Body, add)
+		}
 	case *rts.ForStmt:
 		walkStmt(s.Init, add)
 		walkExpr(s.Cond, add)

--- a/internal/workspace/rts_refs_test.go
+++ b/internal/workspace/rts_refs_test.go
@@ -1,0 +1,49 @@
+package workspace
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestRTSRefsWalksTaggedSwitch(t *testing.T) {
+	src := `
+fn pick() {
+  switch json.file("./tag.json").kind {
+  case json.file("./a.json").id, json.file("./b.json").id:
+    return json.file("./matched.json")
+  case "other":
+    return json.file("./unmatched.json")
+  default:
+    return json.file("./default.json")
+  }
+}
+`
+	got := jsonFileModuleRefs("mod.rts", src)
+	want := []string{
+		"./tag.json",
+		"./a.json",
+		"./b.json",
+		"./matched.json",
+		"./unmatched.json",
+		"./default.json",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("refs: got %v, want %v", got, want)
+	}
+}
+
+func TestRTSRefsWalksTaglessSwitch(t *testing.T) {
+	src := `
+switch {
+case rts.json.file("./flag.json").on:
+  let a = json.file("./on.json")
+default:
+  let b = json.file("./off.json")
+}
+`
+	got := jsonFileModuleRefs("mod.rts", src)
+	want := []string{"./flag.json", "./on.json", "./off.json"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("refs: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Adds a Go-style switch to RestermScript, plus labels on for and switch so break/continue can target an enclosing statement by name.

### Switch

Tagged and tagless forms:

```
switch response.statusCode {
case 200, 201:
  result = "success"
case 401:
  result = "unauthorized"
default:
  result = "unexpected"
}

switch {
case score >= 90:
  grade = "A"
default:
  grade = "C"
}
```

Tag evaluated once, clauses top to bottom, first match wins, no fallthrough, one default anywhere, per-clause scope. Tagged matching uses the same equality as `==`. Tagless uses the same truth test as `if`.

`default` is not reserved. It's matched contextually inside a switch body only, so `default(a, b)` and `rts.default(a, b)` keep working - including inside a switch. Only switch and case become keywords.

### Labels

```
outer: for let i, row range rows {
  for let j, value range row {
    switch value {
    case null:
      continue outer
    }
  }
}
```

Labels decorate only for and switch - no labeled blocks, no goto. Unlabeled `break/continue` are unchanged. `continue` must name a loop. Labels can't cross a function boundary. `_` and `default` are rejected. A labeled continue runs the target loop's post clause once and skips the ones it passes through.