### PR TITLE
feat(rts)!: reserve default and remove default() (RST-312)

### DIFF
--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -81,11 +81,16 @@ Identifiers start with a letter or `_` and can contain letters, digits, and `_` 
 Keywords:
 
 ```
-export module fn let const if elif else switch case try return for break continue range
+export module fn let const if elif else switch case default try return for break continue range
 true false null and or not
 ```
 
-`default` is not reserved. It is read as a clause label only at the top level of a `switch` body, so the deprecated `default(a, b)` and `rts.default(a, b)` helpers stay available as ordinary identifiers. Prefer `a ?? b`.
+A reserved word cannot be a bare name anywhere, which includes dict keys and field access. Data that carries a key spelled like a keyword uses the quoted forms instead:
+
+```
+let cfg = {"default": 1}
+let v = cfg["default"]
+```
 
 ### Literals
 
@@ -102,15 +107,20 @@ String escapes include `\n`, `\r`, `\t`, `\\`, `\"`, and `\'`. Dict keys in lite
 
 ### Operators by precedence
 
+Listed from tightest to loosest. Each level binds more tightly than the one below it.
+
 - Postfix operators include function calls, indexing, and member access.
 - Unary operators include `not`, `try`, and unary `-`.
 - Multiplicative operators include `*`, `/`, and `%`.
 - Additive operators include `+` and `-`.
 - Comparison operators include `<`, `<=`, `>`, and `>=`.
 - Equality operators include `==` and `!=`.
-- Logical operators include `and` and `or`.
+- `and`.
+- `or`.
 - The coalesce operator `??` returns the right side when the left side is null.
 - The ternary operator `cond ? a : b` selects between two values.
+
+`??` sits near the bottom, so it binds looser than arithmetic, comparison, and both logical operators. `a ?? b + c` means `a ?? (b + c)`, and `a ?? b or c` means `a ?? (b or c)`. Parenthesise when you want the other grouping.
 
 `+` adds numbers or concatenates strings. Non numeric values are converted to string using `str()`. Comparisons only work for numbers or strings, and equality only works for primitive types.
 
@@ -143,6 +153,36 @@ let value = candidate ? candidate : "something"
 ```
 
 `??` does not rescue an undefined name. `missingName ?? "fallback"` is still an error, which keeps typos visible. Optional lookups return null explicitly instead, so `vars.get("missing") ?? "fallback"` works.
+
+#### Migrating from default()
+
+`default(a, b)`, `rts.default(a, b)`, and `stdlib.default(a, b)` were removed, and `default` became a reserved word. Replace every call with `(a ?? b)`:
+
+```
+default(vars.get("token"), "anon")     # removed
+(vars.get("token") ?? "anon")          # replacement
+```
+
+Keep the parentheses. A call is a single tight unit, but `??` binds looser than every operator except the ternary, so dropping them regroups the expression whenever the call was part of a larger one:
+
+```
+default(a, b) + c   # old, means (a ?? b) + c
+a ?? b + c          # wrong, parses as a ?? (b + c)
+(a ?? b) + c        # right
+```
+
+The parentheses are only redundant when the call was the entire expression, as in the `vars.get` example above.
+
+The replacement is not only shorter. `default(a, b)` was an ordinary call, so `b` was evaluated before the call ran, whether or not `a` was null. `??` evaluates `b` only when `a` is null. If a fallback did real work, that work now happens only when it is actually needed:
+
+```
+default(a, fail("missing"))   # always failed
+a ?? fail("missing")          # fails only when a is null
+```
+
+Check fallbacks that call `uuid()`, mutate `vars`, or fail. Migrating them changes when they run, not just how they are spelled.
+
+Because `default` is reserved, these spellings are now parse errors: `let default = 1`, `fn default() {}`, `{default: 1}`, and `value.default`. Dict data that genuinely has a `default` key uses `{"default": 1}` and `value["default"]`.
 
 ### Error handling with try
 
@@ -294,19 +334,13 @@ case 1:
 
 Case expressions are arbitrary runtime expressions, so duplicate cases are not reported at parse time. The first one written wins.
 
-Because `default` stays an ordinary identifier, the deprecated helper of the same name still parses inside a switch body, so existing files keep working:
+`default` is a reserved word, so it is always the clause label and never a name. Use `??` for a fallback value:
 
 ```
 switch value {
 default:
-  value = rts.default(value, "other")   # deprecated, prefer value ?? "other"
+  value = candidate ?? "fallback"
 }
-```
-
-New code should use `??`:
-
-```
-let value = candidate ?? "fallback"
 ```
 
 Switch initializers, type switches, switch expressions that produce a value, and `fallthrough` are not part of the language. A switch can carry a label so that a `break` deeper inside can leave it by name, described under [Labels](#labels).
@@ -386,7 +420,7 @@ Rules:
 - `continue` must name a loop. Naming a switch is an error.
 - Labels live in their own namespace, so a label never collides with a variable or function of the same name.
 - Two active labels cannot share a name, but a name is free again once its statement ends, so sibling statements can reuse it.
-- `_` and `default` are not valid labels.
+- `_` is not a valid label, and neither is any reserved word.
 - The label of a `break` or `continue` has to stay on the same line as the keyword, because a newline there already ends the statement. A label in front of a `for` or `switch` may sit on its own line.
 
 ## Modules and exports
@@ -427,7 +461,6 @@ RTS provides a small standard library that covers common request needs without e
 - `rts.contains(haystack, needle)` checks whether a value is contained in a string, list, or dict.
 - `rts.match(pattern, text)` applies a regular expression to text and returns true when it matches.
 - `rts.str(x)` converts a value to a string, using JSON for lists and dicts.
-- `rts.default(a, b)` returns `a` unless it is null, otherwise it returns `b`. Deprecated, use `a ?? b`. It still works, but as a function call it evaluates both arguments, so `default("ok", fail("boom"))` fails where `"ok" ?? fail("boom")` returns `"ok"`.
 - `rts.num(x[, def])` converts a value to a number, or returns `def` when conversion fails.
 - `rts.int(x[, def])` converts a value to an integer, or returns `def` when conversion fails.
 - `rts.bool(x[, def])` converts a value to a bool, or returns `def` when conversion fails.

--- a/internal/parser/directive.go
+++ b/internal/parser/directive.go
@@ -15,10 +15,18 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
+// bindingKind names the directive slot a binding came from
+type bindingKind string
+
+const (
+	useAlias    bindingKind = "@use alias"
+	forEachName bindingKind = "@for-each name"
+)
+
 // checkRTSBinding validates a directive token that becomes an RTS binding. A
 // reserved word looks like an identifier but lexes as a keyword, so the binding
 // would be created and then be impossible to reference
-func checkRTSBinding(kind, name string) error {
+func checkRTSBinding(kind bindingKind, name string) error {
 	if !directive.IsIdent(name) {
 		return fmt.Errorf("%s %q is invalid", kind, name)
 	}
@@ -162,7 +170,7 @@ func parseUseSpec(rest string, line int) (restfile.UseSpec, error) {
 		if p == "" || a == "" {
 			return restfile.UseSpec{}, fmt.Errorf("@use requires a non-empty path and alias")
 		}
-		if err := checkRTSBinding("@use alias", a); err != nil {
+		if err := checkRTSBinding(useAlias, a); err != nil {
 			return restfile.UseSpec{}, err
 		}
 		return restfile.UseSpec{
@@ -199,7 +207,7 @@ func parseForEachSpec(rest string, line int) (*restfile.ForEachSpec, error) {
 		if expr == "" || name == "" {
 			return nil, fmt.Errorf("@for-each requires '<expr> as <name>'")
 		}
-		if err := checkRTSBinding("@for-each name", name); err != nil {
+		if err := checkRTSBinding(forEachName, name); err != nil {
 			return nil, err
 		}
 		return &restfile.ForEachSpec{Expression: expr, Var: name, Line: line, Col: 1}, nil
@@ -210,7 +218,7 @@ func parseForEachSpec(rest string, line int) (*restfile.ForEachSpec, error) {
 		if expr == "" || name == "" {
 			return nil, fmt.Errorf("@for-each requires '<name> in <expr>'")
 		}
-		if err := checkRTSBinding("@for-each name", name); err != nil {
+		if err := checkRTSBinding(forEachName, name); err != nil {
 			return nil, err
 		}
 		return &restfile.ForEachSpec{Expression: expr, Var: name, Line: line, Col: 1}, nil

--- a/internal/parser/directive.go
+++ b/internal/parser/directive.go
@@ -10,9 +10,23 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/duration"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
 	"github.com/unkn0wn-root/resterm/internal/tracebudget"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
+
+// checkRTSBinding validates a directive token that becomes an RTS binding. A
+// reserved word looks like an identifier but lexes as a keyword, so the binding
+// would be created and then be impossible to reference
+func checkRTSBinding(kind, name string) error {
+	if !directive.IsIdent(name) {
+		return fmt.Errorf("%s %q is invalid", kind, name)
+	}
+	if rts.IsKeyword(name) {
+		return fmt.Errorf("%s %q is a reserved word", kind, name)
+	}
+	return nil
+}
 
 func parseApplySpec(rest string, line int) (restfile.ApplySpec, error) {
 	raw := strings.TrimSpace(rest)
@@ -148,8 +162,8 @@ func parseUseSpec(rest string, line int) (restfile.UseSpec, error) {
 		if p == "" || a == "" {
 			return restfile.UseSpec{}, fmt.Errorf("@use requires a non-empty path and alias")
 		}
-		if !directive.IsIdent(a) {
-			return restfile.UseSpec{}, fmt.Errorf("@use alias %q is invalid", a)
+		if err := checkRTSBinding("@use alias", a); err != nil {
+			return restfile.UseSpec{}, err
 		}
 		return restfile.UseSpec{
 			Path:  p,
@@ -185,8 +199,8 @@ func parseForEachSpec(rest string, line int) (*restfile.ForEachSpec, error) {
 		if expr == "" || name == "" {
 			return nil, fmt.Errorf("@for-each requires '<expr> as <name>'")
 		}
-		if !directive.IsIdent(name) {
-			return nil, fmt.Errorf("@for-each name %q is invalid", name)
+		if err := checkRTSBinding("@for-each name", name); err != nil {
+			return nil, err
 		}
 		return &restfile.ForEachSpec{Expression: expr, Var: name, Line: line, Col: 1}, nil
 	}
@@ -196,8 +210,8 @@ func parseForEachSpec(rest string, line int) (*restfile.ForEachSpec, error) {
 		if expr == "" || name == "" {
 			return nil, fmt.Errorf("@for-each requires '<name> in <expr>'")
 		}
-		if !directive.IsIdent(name) {
-			return nil, fmt.Errorf("@for-each name %q is invalid", name)
+		if err := checkRTSBinding("@for-each name", name); err != nil {
+			return nil, err
 		}
 		return &restfile.ForEachSpec{Expression: expr, Var: name, Line: line, Col: 1}, nil
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -3766,6 +3766,44 @@ GET https://example.com
 	}
 }
 
+// a reserved word passes the identifier test but lexes as an RTS keyword, so the
+// binding would exist and be impossible to reference. Reject it at parse time
+func TestParseRejectsReservedRTSBindingNames(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		msg  string
+	}{
+		{"use alias", "# @use ./rts/helpers.rts as default\n", `@use alias "default" is a reserved word`},
+		{"use alias other keyword", "# @use ./rts/helpers.rts as range\n", `@use alias "range" is a reserved word`},
+		{"for-each as", "# @for-each [1] as default\n", `@for-each name "default" is a reserved word`},
+		{"for-each in", "# @for-each default in [1]\n", `@for-each name "default" is a reserved word`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := Parse("reserved.http", []byte(tc.src+"GET https://example.com\n"))
+			if !hasParseMessage(d.Errors, tc.msg) && !hasParseMessage(d.Warnings, tc.msg) {
+				t.Fatalf("expected %q, got errors=%v warnings=%v", tc.msg, d.Errors, d.Warnings)
+			}
+		})
+	}
+}
+
+// the reserved-word check must not reject names that merely resemble keywords
+func TestParseAllowsKeywordLikeRTSBindingNames(t *testing.T) {
+	src := `# @use ./rts/helpers.rts as Default
+# @for-each [1] as defaults
+GET https://example.com
+`
+	d := Parse("ok.http", []byte(src))
+	if len(d.Errors) != 0 {
+		t.Fatalf("expected no parse errors, got %v", d.Errors)
+	}
+	if len(d.Uses) != 1 || d.Uses[0].Alias != "Default" {
+		t.Fatalf("expected alias Default, got %+v", d.Uses)
+	}
+}
+
 func TestParseRecordsAuthAndRequestOrigin(t *testing.T) {
 	src := `# @auth file bearer {{fileToken}}
 

--- a/internal/rts/engine.go
+++ b/internal/rts/engine.go
@@ -190,6 +190,9 @@ func (e *Eng) buildPre(cx *Ctx, rt RT, pos Pos) (map[string]Value, error) {
 		if k == "" {
 			continue
 		}
+		if IsKeyword(k) {
+			return nil, Errf(cx, pos, "name is a reserved word: %s", k)
+		}
 		if _, ok := pre[k]; ok {
 			return nil, Errf(cx, pos, "name already defined: %s", k)
 		}

--- a/internal/rts/lexer_test.go
+++ b/internal/rts/lexer_test.go
@@ -27,9 +27,19 @@ func TestLexerAutoSemi(t *testing.T) {
 
 func TestLexerSwitchKeywords(t *testing.T) {
 	got := lexKinds("switch case default")
-	want := []Kind{KW_SWITCH, KW_CASE, IDENT, AUTO_SEMI, EOF}
+	want := []Kind{KW_SWITCH, KW_CASE, KW_DEFAULT, EOF}
 	if !slices.Equal(got, want) {
 		t.Fatalf("kinds: got %v, want %v", got, want)
+	}
+}
+
+// default carries a colon like case does, so it must not close a statement
+func TestLexerNoSemiAfterDefault(t *testing.T) {
+	k := lexKinds("switch x {\ndefault:\n  y = 1\n}\n")
+	for i := 0; i < len(k)-1; i++ {
+		if k[i] == KW_DEFAULT && k[i+1] == AUTO_SEMI {
+			t.Fatalf("unexpected auto semi after default")
+		}
 	}
 }
 
@@ -40,7 +50,7 @@ func TestKeywordClassSwitchCase(t *testing.T) {
 	}{
 		{"switch", KeywordControl},
 		{"case", KeywordControl},
-		{"default", KeywordNone},
+		{"default", KeywordControl},
 	}
 	for _, tc := range cases {
 		if got := KeywordClassOf(tc.name); got != tc.want {

--- a/internal/rts/module_test.go
+++ b/internal/rts/module_test.go
@@ -114,3 +114,44 @@ func TestUseAliasCollisionBeforeParse(t *testing.T) {
 		t.Fatalf("expected alias collision error, got %v", err)
 	}
 }
+
+// hosts other than the directive parser can build an RT directly, so the engine
+// refuses a reserved binding rather than creating one nothing can reference
+func TestEngineRejectsReservedBindings(t *testing.T) {
+	dir := t.TempDir()
+	fs := &memFS{files: map[string]*memFile{}}
+	p := filepath.Join(dir, "a.rts")
+	fs.files[p] = &memFile{data: []byte("module mod\nexport let x = 1\n"), mod: time.Unix(10, 0)}
+
+	cases := []struct {
+		name string
+		rt   RT
+		msg  string
+	}{
+		{
+			"use alias",
+			RT{BaseDir: dir, Uses: []Use{{Path: "a.rts", Alias: "default"}}},
+			"alias is a reserved word: default",
+		},
+		{
+			"extra binding",
+			RT{BaseDir: dir, Extra: map[string]Value{"default": Num(1)}},
+			"name is a reserved word: default",
+		},
+		{
+			"extra binding other keyword",
+			RT{BaseDir: dir, Extra: map[string]Value{"range": Num(1)}},
+			"name is a reserved word: range",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewEng(testStdlib)
+			e.C = NewCache(fs, e.modulePre)
+			_, err := e.Eval(context.Background(), tc.rt, "1", Pos{Path: "test", Line: 1, Col: 1})
+			if err == nil || !strings.Contains(err.Error(), tc.msg) {
+				t.Fatalf("expected %q, got %v", tc.msg, err)
+			}
+		})
+	}
+}

--- a/internal/rts/parser.go
+++ b/internal/rts/parser.go
@@ -107,6 +107,10 @@ func (p *Parser) parseMod() *Mod {
 
 func (p *Parser) parseModDecl() (string, Pos) {
 	pos := p.expect(KW_MODULE).P
+	// the module name becomes the binding when @use omits an alias
+	if p.cur.K.isKeyword() {
+		p.fail(p.cur.P, fmt.Sprintf("module name cannot be the reserved word %s", p.cur.K))
+	}
 	if p.cur.K != IDENT {
 		p.fail(p.cur.P, "module requires a name")
 	}
@@ -142,6 +146,8 @@ func (p *Parser) parseStmt() Stmt {
 		return p.parseSwitch(stmtLabel{})
 	case KW_CASE:
 		p.fail(p.cur.P, "case outside switch body")
+	case KW_DEFAULT:
+		p.fail(p.cur.P, "default outside switch body")
 	case KW_FOR:
 		return p.parseFor(stmtLabel{})
 	case KW_BREAK:
@@ -282,11 +288,7 @@ func (p *Parser) parseIf() Stmt {
 // statement and no goto
 func (p *Parser) parseLabeled() Stmt {
 	tok := p.cur
-	switch tok.Lit {
-	case defaultClause:
-		// a switch body consumes its own default: before reaching a statement
-		p.fail(tok.P, "default outside switch body")
-	case "_":
+	if tok.Lit == "_" {
 		p.fail(tok.P, fmt.Sprintf("invalid label %q", tok.Lit))
 	}
 	if t := p.findControl(tok.Lit); t != nil {
@@ -370,14 +372,14 @@ func (p *Parser) parseCaseClauses() []CaseClause {
 	seenDefault := false
 	for {
 		p.skipSemi()
-		switch {
-		case p.cur.K == RBRACE:
+		switch p.cur.K {
+		case RBRACE:
 			return out
-		case p.cur.K == EOF:
+		case EOF:
 			p.fail(p.cur.P, "unterminated switch")
-		case p.cur.K == KW_CASE:
+		case KW_CASE:
 			out = append(out, p.parseCase())
-		case p.isDefaultClause():
+		case KW_DEFAULT:
 			if seenDefault {
 				p.fail(p.cur.P, "duplicate default in switch")
 			}
@@ -411,8 +413,7 @@ func (p *Parser) parseCaseExprs() []Expr {
 }
 
 func (p *Parser) parseDefault() CaseClause {
-	pos := p.cur.P
-	p.next()
+	pos := p.expect(KW_DEFAULT).P
 	colon := p.expect(COLON).P
 	return CaseClause{P: pos, Body: p.parseClauseBody(colon)}
 }
@@ -421,7 +422,7 @@ func (p *Parser) parseClauseBody(pos Pos) *Block {
 	var out []Stmt
 	for {
 		p.skipSemi()
-		if p.cur.K == RBRACE || p.cur.K == KW_CASE || p.isDefaultClause() {
+		if p.cur.K == RBRACE || p.cur.K == KW_CASE || p.cur.K == KW_DEFAULT {
 			return &Block{P: pos, Stmts: out}
 		}
 		if p.cur.K == EOF {
@@ -429,14 +430,6 @@ func (p *Parser) parseClauseBody(pos Pos) *Block {
 		}
 		out = append(out, p.parseStmt())
 	}
-}
-
-// isDefaultClause matches the contextual default label. It shares the
-// "identifier followed by a colon" shape with a statement label, so the switch
-// body checks this first and parseLabeled rejects default outright. Neither
-// reaches default(a, b) or a dict key, which are parsed as expressions
-func (p *Parser) isDefaultClause() bool {
-	return p.cur.K == IDENT && p.cur.Lit == defaultClause && p.peek.K == COLON
 }
 
 func (p *Parser) parseFor(lb stmtLabel) Stmt {
@@ -813,6 +806,12 @@ func (p *Parser) parsePostfix() Expr {
 		case DOT:
 			pos := p.cur.P
 			p.next()
+			// member access has no quoted spelling, so the fix here is an index
+			if p.cur.K.isKeyword() {
+				p.fail(p.cur.P, fmt.Sprintf(
+					"field name cannot be the reserved word %s, use [%q] instead", p.cur.K, p.cur.K,
+				))
+			}
 			name := p.expect(IDENT).Lit
 			left = &Member{P: pos, X: left, Name: name}
 		default:
@@ -937,6 +936,11 @@ func (p *Parser) parseDict() Expr {
 			key = p.cur.Lit
 			p.next()
 		default:
+			if p.cur.K.isKeyword() {
+				p.fail(p.cur.P, fmt.Sprintf(
+					"dict key cannot be the reserved word %s, quote it as %q", p.cur.K, p.cur.K,
+				))
+			}
 			p.fail(p.cur.P, "dict key must be string or ident")
 		}
 		p.expect(COLON)

--- a/internal/rts/parser_test.go
+++ b/internal/rts/parser_test.go
@@ -598,14 +598,52 @@ func TestParseLabelErrors(t *testing.T) {
 	}
 }
 
-func TestParseDefaultStaysIdentifier(t *testing.T) {
-	src := "let a = default(null, \"x\")\nlet b = rts.default(a, \"y\")\nlet c = {default: 1}.default\n"
+func TestParseDefaultIsReserved(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		msg  string
+	}{
+		{"let binding", "let default = 1\n", "expected IDENT, got default"},
+		{"assignment", "default = 1\n", "default outside switch body"},
+		{"fn name", "fn default() {\n}\n", "expected IDENT, got default"},
+		{"fn param", "fn f(default) {\n}\n", "expected parameter name"},
+		{"call", "let a = default(null, \"x\")\n", "unexpected default"},
+		{"namespaced call", "let a = rts.default(null, \"x\")\n",
+			`field name cannot be the reserved word default, use ["default"] instead`},
+		{"dict key", "let a = {default: 1}\n",
+			`dict key cannot be the reserved word default, quote it as "default"`},
+		{"member access", "let a = x.default\n",
+			`field name cannot be the reserved word default, use ["default"] instead`},
+		{"member access of other keyword", "let a = x.range\n",
+			`field name cannot be the reserved word range, use ["range"] instead`},
+		{"range variable", "for default range [1] {\n}\n", "unexpected default"},
+		{"module name", "module default\n", "module name cannot be the reserved word default"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseModule("test", []byte(tc.src))
+			pe, ok := err.(*ParseError)
+			if !ok {
+				t.Fatalf("expected *ParseError, got %T (%v)", err, err)
+			}
+			if pe.Msg != tc.msg {
+				t.Fatalf("msg: got %q, want %q", pe.Msg, tc.msg)
+			}
+		})
+	}
+}
+
+// reserving default only closes the bare-name spellings, so data keeps its
+// "default" key through the quoted forms
+func TestParseDefaultAsQuotedKey(t *testing.T) {
+	src := "let a = {\"default\": 1}\nlet b = a[\"default\"]\n"
 	m, err := ParseModule("test", []byte(src))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if len(m.Stmts) != 3 {
-		t.Fatalf("expected 3 stmts, got %d", len(m.Stmts))
+	if len(m.Stmts) != 2 {
+		t.Fatalf("expected 2 stmts, got %d", len(m.Stmts))
 	}
 }
 

--- a/internal/rts/resolve.go
+++ b/internal/rts/resolve.go
@@ -1,6 +1,9 @@
 package rts
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 func (e *Eng) resolveUses(cx *Ctx, rt RT, pre map[string]Value, pos Pos) ([]Use, error) {
 	if len(rt.Uses) == 0 {
@@ -31,6 +34,9 @@ func (e *Eng) resolveUses(cx *Ctx, rt RT, pre map[string]Value, pos Pos) ([]Use,
 			}
 			al = nm
 			u.Alias = nm
+		}
+		if IsKeyword(al) {
+			return nil, Errf(cx, pos, "alias is a reserved word: %s", al)
 		}
 		if _, ok := seen[al]; ok {
 			return nil, Errf(cx, pos, "alias already defined: %s", al)
@@ -97,6 +103,12 @@ func modHead(path string, src []byte) (string, Pos, error) {
 			nt := lx.Next()
 			if nt.K == ILLEGAL {
 				return "", nt.P, &ParseError{Pos: nt.P, Msg: nt.Lit}
+			}
+			if nt.K.isKeyword() {
+				return "", nt.P, &ParseError{
+					Pos: nt.P,
+					Msg: fmt.Sprintf("module name cannot be the reserved word %s", nt.K),
+				}
 			}
 			if nt.K != IDENT {
 				return "", nt.P, &ParseError{Pos: nt.P, Msg: "module requires a name"}

--- a/internal/rts/stdlib/core.go
+++ b/internal/rts/stdlib/core.go
@@ -15,7 +15,6 @@ const (
 	sigContains = "contains(a, b)"
 	sigMatch    = "match(pattern, text)"
 	sigStr      = "str(x)"
-	sigDefault  = "default(a, b)"
 	sigUUID     = "uuid()"
 )
 
@@ -25,7 +24,6 @@ var coreSpec = map[string]rts.NativeFunc{
 	"contains": coreContains,
 	"match":    coreMatch,
 	"str":      coreStr,
-	"default":  coreDefault,
 	"num":      coreNum,
 	"int":      coreInt,
 	"bool":     coreBool,
@@ -135,20 +133,6 @@ func coreStr(ctx *rts.Ctx, pos rts.Pos, args []rts.Value) (rts.Value, error) {
 		return rts.Null(), err
 	}
 	return rts.Str(s), nil
-}
-
-// Deprecated: the ?? operator covers this and is lazy. Both arguments here are
-// already evaluated by the time the call runs, so a failing fallback fails even
-// when it is not needed. Kept callable because existing request files use it
-func coreDefault(ctx *rts.Ctx, pos rts.Pos, args []rts.Value) (rts.Value, error) {
-	na := rts.NewArgs(ctx, pos, args, sigDefault)
-	if err := na.Count(2); err != nil {
-		return rts.Null(), err
-	}
-	if na.Arg(0).K != rts.VNull {
-		return na.Arg(0), nil
-	}
-	return na.Arg(1), nil
 }
 
 func coreUUID(ctx *rts.Ctx, pos rts.Pos, args []rts.Value) (rts.Value, error) {

--- a/internal/rts/stdlib/stdlib_test.go
+++ b/internal/rts/stdlib/stdlib_test.go
@@ -51,51 +51,28 @@ func TestStdlibCore(t *testing.T) {
 	}
 }
 
-// default(a, b) is deprecated in favour of ?? because a call evaluates both
-// arguments. This pins the difference that motivates the deprecation
-func TestStdlibDefaultIsEagerUnlikeCoalesce(t *testing.T) {
-	ctx := rts.NewCtx(context.Background(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
-
-	mod, err := rts.ParseModule("test", []byte(`export let __v = default("ok", fail("boom"))`))
-	if err != nil {
-		t.Fatalf("parse: %v", err)
+// the default(a, b) helper was removed in favour of ??. Dropping it from
+// coreSpec has to clear all three spellings at once, because the prelude and
+// both namespace objects are built from that one map
+func TestStdlibDoesNotExposeDefault(t *testing.T) {
+	env := New()
+	if _, ok := env["default"]; ok {
+		t.Fatalf("default is still in the top level prelude")
 	}
-	if _, err := rts.Exec(ctx, mod, New()); err == nil {
-		t.Fatalf("expected default to evaluate its unused fallback")
-	} else if !strings.Contains(err.Error(), "boom") {
-		t.Fatalf("expected boom from the fallback, got %v", err)
-	}
-
-	if v := evalExprCtx(t, ctx, `"ok" ?? fail("boom")`); v.K != rts.VStr || v.S != "ok" {
-		t.Fatalf("expected ?? to skip the fallback, got %+v", v)
-	}
-}
-
-// default is a contextual switch label, so the stdlib helper of the same name
-// has to stay callable in both spellings, including inside a switch body
-func TestStdlibDefaultSurvivesSwitch(t *testing.T) {
-	ctx := rts.NewCtx(context.Background(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
-	mod := `
-fn label(code) {
-  let out = default(null, "fallback")
-  switch code {
-  case 200:
-    out = default("ok", "unused")
-  default:
-    out = rts.default(null, "other")
-  }
-  return out
-}
-`
-	if v := evalExprMod(t, ctx, mod, `label(200)`); v.K != rts.VStr || v.S != "ok" {
-		t.Fatalf("expected ok, got %+v", v)
-	}
-	if v := evalExprMod(t, ctx, mod, `label(500)`); v.K != rts.VStr || v.S != "other" {
-		t.Fatalf("expected other, got %+v", v)
-	}
-	v := evalExprCtx(t, ctx, `default(null, "fallback")`)
-	if v.K != rts.VStr || v.S != "fallback" {
-		t.Fatalf("expected fallback, got %+v", v)
+	for _, ns := range []string{"rts", "stdlib"} {
+		v, ok := env[ns]
+		if !ok {
+			t.Fatalf("missing %s namespace", ns)
+		}
+		if v.K != rts.VObj {
+			t.Fatalf("%s: expected an object, got kind %v", ns, v.K)
+		}
+		if _, ok := v.O.GetMember("default"); ok {
+			t.Fatalf("%s.default is still exposed", ns)
+		}
+		if _, ok := v.O.GetMember("str"); !ok {
+			t.Fatalf("%s.str went missing, the namespace lookup is not proving anything", ns)
+		}
 	}
 }
 

--- a/internal/rts/token.go
+++ b/internal/rts/token.go
@@ -20,6 +20,7 @@ const (
 	KW_ELSE
 	KW_SWITCH
 	KW_CASE
+	KW_DEFAULT
 	KW_RETURN
 	KW_FOR
 	KW_BREAK
@@ -110,6 +111,8 @@ func (k Kind) String() string {
 		return "switch"
 	case KW_CASE:
 		return "case"
+	case KW_DEFAULT:
+		return "default"
 	case KW_RETURN:
 		return "return"
 	case KW_FOR:
@@ -189,10 +192,20 @@ func (k Kind) String() string {
 	}
 }
 
-// defaultClause labels the fallback clause of a switch. It is matched
-// contextually instead of being reserved so the default(a, b) stdlib helper
-// keeps working as an ordinary identifier
-const defaultClause = "default"
+// isKeyword reports whether k is a reserved word. The keyword kinds are
+// contiguous in the enum, so a new one has to be declared between KW_EXPORT and
+// KW_NOT to be recognised here
+func (k Kind) isKeyword() bool {
+	return k >= KW_EXPORT && k <= KW_NOT
+}
+
+// IsKeyword reports whether name is reserved. Hosts that turn user input into an
+// RTS binding check this first, because a reserved name passes an ordinary
+// identifier test but lexes as a keyword, leaving the binding unreferenceable
+func IsKeyword(name string) bool {
+	_, ok := kw[name]
+	return ok
+}
 
 var kw = map[string]Kind{
 	"export":   KW_EXPORT,
@@ -205,6 +218,7 @@ var kw = map[string]Kind{
 	"else":     KW_ELSE,
 	"switch":   KW_SWITCH,
 	"case":     KW_CASE,
+	"default":  KW_DEFAULT,
 	"return":   KW_RETURN,
 	"for":      KW_FOR,
 	"break":    KW_BREAK,
@@ -237,6 +251,7 @@ func keywordClassForKind(k Kind) KeywordClass {
 		KW_ELSE,
 		KW_SWITCH,
 		KW_CASE,
+		KW_DEFAULT,
 		KW_RETURN,
 		KW_FOR,
 		KW_BREAK,

--- a/internal/rts/vm_test.go
+++ b/internal/rts/vm_test.go
@@ -106,8 +106,8 @@ func TestEvalLogic(t *testing.T) {
 	}
 }
 
-// ?? must not evaluate its right side unless the left side is null, which is
-// what separates it from a default(a, b) call
+// ?? must not evaluate its right side unless the left side is null, so a
+// fallback with side effects or its own failure stays untouched when it is unused
 func TestCoalesceIsLazy(t *testing.T) {
 	src := `
 let calls = 0
@@ -124,6 +124,39 @@ let unresolved = "ok" ?? missingName
 	wantStr(t, comp, "taken", "fallback")
 	wantStr(t, comp, "unresolved", "ok")
 	wantNum(t, comp, "calls", 1)
+}
+
+// the migration guide tells people to keep the parentheses when replacing a
+// default(a, b) call, which only matters because ?? binds looser than arithmetic,
+// equality, and the logical operators. Each case returns a number under the loose
+// grouping and a bool under the tight one, so the kind alone proves the grouping
+func TestCoalesceBindsLooserThanOtherOperators(t *testing.T) {
+	src := `
+let add = 1 ?? 2 + 3
+let eq = 1 ?? 2 == 2
+let alt = 2 ?? 1 or 0
+let both = 1 ?? 2 and 3
+`
+	comp := execModule(t, src)
+	wantNum(t, comp, "add", 1)
+	wantNum(t, comp, "eq", 1)
+	wantNum(t, comp, "alt", 2)
+	wantNum(t, comp, "both", 1)
+}
+
+// the reserved-word parse errors name a replacement syntax, so the replacements
+// have to survive a round trip. A quoted key going in, an index coming back out
+func TestReservedWordKeyRoundTrips(t *testing.T) {
+	src := `
+let cfg = {"default": 1, "range": 2, "plain": 3}
+let a = cfg["default"]
+let b = cfg["range"]
+let c = cfg.plain
+`
+	comp := execModule(t, src)
+	wantNum(t, comp, "a", 1)
+	wantNum(t, comp, "b", 2)
+	wantNum(t, comp, "c", 3)
 }
 
 func TestCoalesceRejectsUndefinedLeftSide(t *testing.T) {

--- a/internal/ui/editor_rts_highlighter.go
+++ b/internal/ui/editor_rts_highlighter.go
@@ -163,10 +163,6 @@ func (s *rtsRuneStyler) computeStyles(line []rune) []lipgloss.Style {
 				i++
 			}
 			token := string(line[start:i])
-			// switch and case are reserved so they classify on their own, but a
-			// switch default label is deliberately left alone: it is an ordinary
-			// identifier, and one line cannot tell "default:" in a clause from
-			// "default:" as a key in a multiline dict
 			class := rts.KeywordClassOf(token)
 			if class != rts.KeywordNone {
 				if style, ok := s.keywordStyleForClass(class); ok {

--- a/internal/ui/editor_rts_highlighter_test.go
+++ b/internal/ui/editor_rts_highlighter_test.go
@@ -68,9 +68,9 @@ func TestRTSRuneStylerHighlightsFnCall(t *testing.T) {
 	}
 }
 
-// default is not a keyword and the line styler cannot tell a switch clause
-// label from a multiline dict key, so it stays unstyled as control everywhere
-func TestRTSRuneStylerLeavesDefaultUnstyledAsControl(t *testing.T) {
+// reserving default removed the ambiguity that used to keep it unstyled: every
+// spelling on any line is now the keyword, so one line is enough to classify it
+func TestRTSRuneStylerHighlightsDefault(t *testing.T) {
 	p := theme.DefaultTheme().EditorMetadata
 	p.RTSKeywordControl = lipgloss.Color("#112233")
 	st := newRTSRuneStyler(p)
@@ -86,20 +86,23 @@ func TestRTSRuneStylerLeavesDefaultUnstyledAsControl(t *testing.T) {
 
 	lines := []string{
 		"  default:",
+		"default:",
 		"  default: 1",
-		"x = default(a, b)",
-		"x = rts.default(a, b)",
 	}
 	for i, src := range lines {
 		styles := rs.StylesForLine([]rune(src), i)
 		idx := strings.Index(src, "default")
-		var fg lipgloss.TerminalColor = lipgloss.NoColor{}
-		if idx < len(styles) {
-			fg = styles[idx].GetForeground()
+		got := styles[idx].GetForeground()
+		if want := control.GetForeground(); got != want {
+			t.Fatalf("%q color: got %v, want %v", src, got, want)
 		}
-		if fg == control.GetForeground() {
-			t.Fatalf("%q: default should not use the control keyword color", src)
-		}
+	}
+
+	// a quoted key is data, so it keeps the string colour
+	styles := rs.StylesForLine([]rune(`{"default": 1}`), 0)
+	idx := strings.Index(`{"default": 1}`, "default")
+	if got := styles[idx].GetForeground(); got == control.GetForeground() {
+		t.Fatalf(`"default" in a quoted key should not use the control keyword color`)
 	}
 }
 


### PR DESCRIPTION
Removes the `default()` stdlib helper and reserves `default` as a keyword.

## Breaking

`default(a, b)`, `rts.default(a, b)`, and `stdlib.default(a, b)` are removed. Replace with `(a ?? b)` - keep the parens, since `??` binds looser than arithmetic, so `a ?? b + c` means `a ?? (b + c)`.

`??` is lazy, so a fallback that fails, calls `uuid()`, or mutates `vars` now runs only when the left side is null. Same value returned, different side effects.

`default` is reserved, so `let default = 1`, `fn default() {}`, `{default: 1}`, and `value.default` are parse errors. Use `{"default": 1}` and `value["default"]`.

Directive bindings (`@use ... as`, `@for-each ... as`) now reject reserved words instead of creating an unreferenceable binding.