### PR TITLE
RST-315: shadow RTS prelude names

### DIFF
--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -551,7 +551,19 @@ RTS provides a small standard library that covers common request needs without e
 
 ## Host objects for request evaluation
 
-Resterm exposes host objects when evaluating templates, directives, `@apply`, assertions, and pre-request scripts. In pre-request scripts, `request` and `vars` expose mutation helpers. Other available objects are read-only. Lookups in `env` and `vars` are case-insensitive. Header lookups are normalized, while query keys and JSON paths are case-sensitive. The TUI also exposes `mock` during request evaluation. Its helpers work while the workspace mock server is running and return an error when it is stopped. A local value named `mock`, such as an `@for-each` loop variable, takes precedence.
+Resterm exposes host objects when evaluating templates, directives, `@apply`, assertions, and pre-request scripts. In pre-request scripts, `request` and `vars` expose mutation helpers. Other available objects are read-only. Lookups in `env` and `vars` are case-insensitive. Header lookups are normalized, while query keys and JSON paths are case-sensitive. The TUI also exposes `mock` during request evaluation. Its helpers work while the workspace mock server is running and return an error when it is stopped.
+
+### Name precedence
+
+Every evaluation binds its names in a fixed order, and a later layer wins:
+
+1. The standard library and the host objects below.
+2. Host extensions such as `mock`. These are additive and cannot reuse a name from the first layer.
+3. `@use` aliases. These cannot reuse a name from either layer above.
+4. Local values, currently the `@for-each` loop variable. These shadow every layer above, so `# @for-each [1,2] as json` makes `json` the loop item for that request and hides the `json` namespace.
+5. The `@assert` shorthands, inside assertions only. `status`, `statusCode`, `statusText`, `header(name)`, and `text()` always refer to the response under test, so a loop variable named `status` remains the loop item everywhere except inside an `@assert`.
+
+Reserved words are never bindable at any layer. The parser rejects them in `@for-each` and `@use`, and the runtime rejects them again.
 
 ### env
 
@@ -719,6 +731,8 @@ These directives route workflow steps and are not the `switch` statement. They s
 ```
 
 The expression must evaluate to a list. It introduces a loop variable that you can use in RestermScript expressions. In workflows, it also sets `vars.workflow.<name>` and `vars.request.<name>` for legacy templates.
+
+The loop variable is a local, so it shadows any standard library, host object, or `@use` alias of the same name for the whole request. See [Name precedence](#name-precedence).
 
 ## Limits and safety
 

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -565,6 +565,8 @@ Every evaluation binds its names in a fixed order, and a later layer wins:
 
 Reserved words are never bindable at any layer. The parser rejects them in `@for-each` and `@use`, and the runtime rejects them again.
 
+Shadowing applies to expressions. A module or an `@rts pre-request` block still cannot declare a name that is already bound, so `let json = 1` has always been an error. A local extends that rule to its own name: a request with `# @for-each [1,2] as item` cannot also declare `let item` in its pre-request block. Rename the declaration or the loop variable.
+
 ### env
 
 `env` provides environment values. You can access values through `env.get("name")`, `env.has("name")`, `env.require("name"[, msg])`, or `env.name`. `require` throws when a value is missing.
@@ -732,7 +734,7 @@ These directives route workflow steps and are not the `switch` statement. They s
 
 The expression must evaluate to a list. It introduces a loop variable that you can use in RestermScript expressions. In workflows, it also sets `vars.workflow.<name>` and `vars.request.<name>` for legacy templates.
 
-The loop variable is a local, so it shadows any standard library, host object, or `@use` alias of the same name for the whole request. See [Name precedence](#name-precedence).
+The loop variable is a local, so it shadows any standard library, host object, or `@use` alias of the same name for the whole request, including `@rts pre-request` blocks. JavaScript pre-request blocks do not see it as a typed value and continue to read `vars.request.<name>`. See [Name precedence](#name-precedence).
 
 ## Limits and safety
 

--- a/internal/engine/core/dep.go
+++ b/internal/engine/core/dep.go
@@ -31,7 +31,7 @@ type Dep interface {
 		base string,
 		spec *restfile.ConditionSpec,
 		vv map[string]string,
-		extra map[string]rts.Value,
+		locals rts.Locals,
 	) (bool, string, error)
 	EvalForEachItems(
 		ctx context.Context,
@@ -41,7 +41,7 @@ type Dep interface {
 		base string,
 		spec request.ForEachSpec,
 		vv map[string]string,
-		extra map[string]rts.Value,
+		locals rts.Locals,
 	) ([]rts.Value, error)
 	EvalValue(ctx context.Context, in request.EvalInput) (rts.Value, error)
 	PosForLine(doc *restfile.Document, req *restfile.Request, line int) rts.Pos

--- a/internal/engine/core/wf.go
+++ b/internal/engine/core/wf.go
@@ -231,7 +231,7 @@ func (r *wfRun) runReqStep(
 			baseDir(r.pl.Doc),
 			step.When,
 			vv,
-			nil,
+			rts.Locals{},
 		)
 		if err != nil {
 			if ctx.Err() != nil {
@@ -260,7 +260,7 @@ func (r *wfRun) runReqStep(
 		})
 	}
 	if spec == nil {
-		out, err := r.executeStepRequest(ctx, step, req, branch, 0, 0, xv, nil)
+		out, err := r.executeStepRequest(ctx, step, req, branch, 0, 0, xv, rts.Locals{})
 		if err != nil {
 			return false, err
 		}
@@ -275,7 +275,7 @@ func (r *wfRun) runReqStep(
 		baseDir(r.pl.Doc),
 		*spec,
 		vv,
-		nil,
+		rts.Locals{},
 	)
 	if err != nil {
 		return r.manualFinish(ctx, step, req, branch, engine.RequestResult{
@@ -328,7 +328,7 @@ func (r *wfRun) runReqStep(
 		if reqKey != "" {
 			loopVars[reqKey] = itemStr
 		}
-		ev := map[string]rts.Value{spec.Var: item}
+		loc := rts.Local(spec.Var, item)
 		vv := r.dep.CollectVariables(r.pl.Doc, req, r.pl.Run.Env, loopVars)
 
 		if step.When != nil {
@@ -340,7 +340,7 @@ func (r *wfRun) runReqStep(
 				baseDir(r.pl.Doc),
 				step.When,
 				vv,
-				ev,
+				loc,
 			)
 			if err != nil {
 				if ctx.Err() != nil {
@@ -393,7 +393,7 @@ func (r *wfRun) runReqStep(
 			i+1,
 			len(items),
 			loopVars,
-			ev,
+			loc,
 		)
 		if err != nil {
 			return false, err
@@ -444,7 +444,7 @@ func (r *wfRun) runIf(ctx context.Context, step restfile.WorkflowStep) (bool, er
 		})
 	}
 
-	out, err := r.executeStepRequest(ctx, step, req, branch, 0, 0, xv, nil)
+	out, err := r.executeStepRequest(ctx, step, req, branch, 0, 0, xv, rts.Locals{})
 	if err != nil {
 		return false, err
 	}
@@ -487,7 +487,7 @@ func (r *wfRun) runSwitch(ctx context.Context, step restfile.WorkflowStep) (bool
 		})
 	}
 
-	out, err := r.executeStepRequest(ctx, step, req, branch, 0, 0, xv, nil)
+	out, err := r.executeStepRequest(ctx, step, req, branch, 0, 0, xv, rts.Locals{})
 	if err != nil {
 		return false, err
 	}
@@ -503,7 +503,7 @@ func (r *wfRun) execReq(
 	iter int,
 	total int,
 	extra map[string]string,
-	vals map[string]rts.Value,
+	locals rts.Locals,
 ) (engine.RequestResult, error) {
 	clone := request.CloneRequest(req)
 	if err := r.emitReqStart(ctx, i, step, clone, branch, iter, total); err != nil {
@@ -515,7 +515,7 @@ func (r *wfRun) execReq(
 		r.pl.Run.Env,
 		request.ExecOptions{
 			Extra:  extra,
-			Values: vals,
+			Locals: locals,
 			Record: r.pl.Run.Mode == ModeForEach,
 			Ctx:    ctx,
 		},
@@ -585,12 +585,12 @@ func (r *wfRun) executeStepRequest(
 	iter int,
 	total int,
 	extra map[string]string,
-	vals map[string]rts.Value,
+	locals rts.Locals,
 ) (stepOutcome, error) {
 	if err := r.emitStepStart(ctx, r.idx, step, req, branch, iter, total); err != nil {
 		return stepFailed, err
 	}
-	res, err := r.execReq(ctx, r.idx, step, req, branch, iter, total, extra, vals)
+	res, err := r.execReq(ctx, r.idx, step, req, branch, iter, total, extra, locals)
 	if err != nil {
 		return stepFailed, err
 	}
@@ -622,22 +622,22 @@ func (r *wfRun) evalStepValue(
 	tag string,
 	expr string,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 ) (rts.Value, error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
 		return rts.Value{}, fmt.Errorf("%s expression missing", tag)
 	}
 	return r.dep.EvalValue(ctx, request.EvalInput{
-		Doc:   r.pl.Doc,
-		Req:   req,
-		Env:   r.pl.Run.Env,
-		Base:  baseDir(r.pl.Doc),
-		Expr:  expr,
-		Site:  tag + " " + str.FoldLines(expr),
-		Pos:   r.dep.PosForLine(r.pl.Doc, req, line),
-		Vars:  vv,
-		Extra: extra,
+		Doc:    r.pl.Doc,
+		Req:    req,
+		Env:    r.pl.Run.Env,
+		Base:   baseDir(r.pl.Doc),
+		Expr:   expr,
+		Site:   tag + " " + str.FoldLines(expr),
+		Pos:    r.dep.PosForLine(r.pl.Doc, req, line),
+		Vars:   vv,
+		Locals: locals,
 	})
 }
 
@@ -648,9 +648,9 @@ func (r *wfRun) evalStepBool(
 	tag string,
 	expr string,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 ) (bool, error) {
-	val, err := r.evalStepValue(ctx, req, line, tag, expr, vv, extra)
+	val, err := r.evalStepValue(ctx, req, line, tag, expr, vv, locals)
 	if err != nil {
 		return false, err
 	}
@@ -670,7 +670,7 @@ func (r *wfRun) selectIfBranch(
 	step restfile.WorkflowStep,
 	vv map[string]string,
 ) (*restfile.WorkflowIfBranch, error) {
-	ok, err := r.evalStepBool(ctx, nil, step.If.Then.Line, wfTagIf, step.If.Then.Cond, vv, nil)
+	ok, err := r.evalStepBool(ctx, nil, step.If.Then.Line, wfTagIf, step.If.Then.Cond, vv, rts.Locals{})
 	if err != nil {
 		return nil, diag.WrapAs(diag.ClassScript, err, wfTagIf)
 	}
@@ -679,7 +679,7 @@ func (r *wfRun) selectIfBranch(
 	}
 	for i := range step.If.Elifs {
 		item := &step.If.Elifs[i]
-		ok, err = r.evalStepBool(ctx, nil, item.Line, wfTagElif, item.Cond, vv, nil)
+		ok, err = r.evalStepBool(ctx, nil, item.Line, wfTagElif, item.Cond, vv, rts.Locals{})
 		if err != nil {
 			return nil, diag.WrapAs(diag.ClassScript, err, wfTagElif)
 		}
@@ -708,7 +708,7 @@ func (r *wfRun) selectSwitchCase(
 		wfTagSwitch,
 		step.Switch.Expr,
 		vv,
-		nil,
+		rts.Locals{},
 	)
 	if err != nil {
 		return nil, diag.WrapAs(diag.ClassScript, err, wfTagSwitch)
@@ -719,7 +719,7 @@ func (r *wfRun) selectSwitchCase(
 		if expr == "" {
 			continue
 		}
-		val, err := r.evalStepValue(ctx, nil, item.Line, wfTagCase, expr, vv, nil)
+		val, err := r.evalStepValue(ctx, nil, item.Line, wfTagCase, expr, vv, rts.Locals{})
 		if err != nil {
 			return nil, diag.WrapAs(diag.ClassScript, err, wfTagCase)
 		}

--- a/internal/engine/core/wf_test.go
+++ b/internal/engine/core/wf_test.go
@@ -297,7 +297,7 @@ func (d *fakeDep) EvalCondition(
 	base string,
 	spec *restfile.ConditionSpec,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 ) (bool, string, error) {
 	if spec == nil || strings.TrimSpace(spec.Expression) == "" {
 		return true, "", nil
@@ -320,7 +320,7 @@ func (d *fakeDep) EvalForEachItems(
 	base string,
 	spec request.ForEachSpec,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 ) ([]rts.Value, error) {
 	if items := d.each[strings.TrimSpace(spec.Expr)]; len(items) > 0 {
 		return append([]rts.Value(nil), items...), nil

--- a/internal/engine/request/apply_extras_test.go
+++ b/internal/engine/request/apply_extras_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/rts"
 )
 
-// @for-each binds its item as a typed value in ExecOptions.Values. Every other
+// @for-each binds its item as a typed value in ExecOptions.Locals. Every other
 // expression in the run reads it, and @apply used to be handed nil instead, so a
 // patch dereferencing the loop item failed with an undefined name.
 func TestApplySeesTypedForEachValues(t *testing.T) {
@@ -64,10 +64,10 @@ func TestApplySeesTypedForEachValues(t *testing.T) {
 			}
 
 			res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{
-				Values: map[string]rts.Value{
+				Locals: rts.NewLocals(map[string]rts.Value{
 					"item": rts.Dict(map[string]rts.Value{"id": rts.Str("42")}),
 					"list": rts.List([]rts.Value{rts.Str("first"), rts.Str("second")}),
-				},
+				}),
 			})
 			if err != nil {
 				t.Fatalf("ExecuteWith: %v", err)

--- a/internal/engine/request/capture.go
+++ b/internal/engine/request/capture.go
@@ -46,7 +46,7 @@ type captureRun struct {
 	out    *captureResult
 	env    vars.Environment
 	v      map[string]string
-	x      map[string]rts.Value
+	locals rts.Locals
 }
 
 type captureExpr struct {
@@ -56,15 +56,15 @@ type captureExpr struct {
 }
 
 type captureScope struct {
-	ctx  context.Context
-	base string
-	doc  *restfile.Document
-	req  *restfile.Request
-	env  vars.Environment
-	v    map[string]string
-	x    map[string]rts.Value
-	rr   *rts.Resp
-	rs   *rts.Stream
+	ctx    context.Context
+	base   string
+	doc    *restfile.Document
+	req    *restfile.Request
+	env    vars.Environment
+	v      map[string]string
+	locals rts.Locals
+	rr     *rts.Resp
+	rs     *rts.Stream
 }
 
 type captureValueIn struct {
@@ -128,15 +128,15 @@ func (e *Engine) applyCaptures(in captureRun) error {
 		in.v = e.collectVariables(in.doc, in.req, in.env)
 	}
 	sc := captureScope{
-		ctx:  in.ctx,
-		base: in.base,
-		doc:  in.doc,
-		req:  in.req,
-		env:  in.env,
-		v:    in.v,
-		x:    in.x,
-		rr:   rtsScriptResp(in.resp),
-		rs:   rtsStream(in.stream),
+		ctx:    in.ctx,
+		base:   in.base,
+		doc:    in.doc,
+		req:    in.req,
+		env:    in.env,
+		v:      in.v,
+		locals: in.locals,
+		rr:     rtsScriptResp(in.resp),
+		rs:     rtsStream(in.stream),
 	}
 	res := e.captureResolver(in.res, sc)
 	for _, c := range in.req.Metadata.Captures {
@@ -189,7 +189,7 @@ func (e *Engine) captureResolver(res *vars.Resolver, sc captureScope) *vars.Reso
 		Vars:     sc.v,
 		Response: sc.rr,
 		Stream:   sc.rs,
-		Extra:    sc.x,
+		Locals:   sc.locals,
 	}))
 }
 
@@ -222,7 +222,7 @@ func (e *Engine) captureRTSValue(in captureRTSIn) (string, error) {
 		env:     in.env,
 		base:    in.base,
 		vars:    in.v,
-		x:       in.x,
+		locals:  in.locals,
 		site:    directive.Capture.Tag() + " " + str.FoldLines(in.ex),
 		resp:    in.rr,
 		res:     in.rr,

--- a/internal/engine/request/capture_test.go
+++ b/internal/engine/request/capture_test.go
@@ -10,6 +10,7 @@ import (
 	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
 	rtrun "github.com/unkn0wn-root/resterm/internal/engine/runtime"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
 	"github.com/unkn0wn-root/resterm/internal/scripts"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
@@ -58,7 +59,7 @@ func TestApplyCapturesStoresValues(t *testing.T) {
 		},
 	}
 
-	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, nil)
+	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, rts.Locals{})
 	var captures captureResult
 	if err := eng.applyCaptures(captureRun{
 		doc:  doc,
@@ -871,7 +872,7 @@ func TestApplyCapturesWithStreamData(t *testing.T) {
 	}
 
 	doc := &restfile.Document{Path: "./stream.http"}
-	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, nil)
+	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, rts.Locals{})
 	var captures captureResult
 	if err := eng.applyCaptures(captureRun{
 		doc:    doc,

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -559,6 +559,7 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 		x.env,
 		x.opts.BaseDir,
 		vv,
+		x.locals,
 		cloneGlobalValues(x.currentGlobals()),
 	)
 	if err != nil {

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -59,7 +59,7 @@ const WarningSSHHostKeyVerificationDisabled Warning = "@ssh strict_hostkey=false
 
 type ExecOptions struct {
 	Extra      map[string]string
-	Values     map[string]rts.Value
+	Locals     rts.Locals
 	Record     bool
 	Ctx        context.Context
 	Mode       ExecMode
@@ -267,7 +267,7 @@ type execCtx struct {
 	hasJSPre  bool
 	scriptV   map[string]string
 	extraV    map[string]string
-	extraX    map[string]rts.Value
+	locals    rts.Locals
 
 	res     *vars.Resolver
 	mset    map[string]string
@@ -324,7 +324,7 @@ func newExec(
 		hasRTSPre: hasRTS,
 		hasJSPre:  hasJS,
 		extraV:    cloneStringMap(opt.Extra),
-		extraX:    cloneValueMap(opt.Values),
+		locals:    opt.Locals,
 		exp:       exp,
 		onWarning: opt.OnWarning,
 		onSSE:     opt.AttachSSE,
@@ -481,7 +481,7 @@ func (f flow) EvaluateCondition() *xexec.RequestResult {
 		x.opts.BaseDir,
 		x.req.Metadata.When,
 		x.baseVars,
-		x.extraX,
+		x.locals,
 	)
 	if err != nil {
 		tag := directive.When.Tag()
@@ -525,7 +525,7 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 	}
 	// @for-each binds its item as a typed value, and @apply reads it the same way
 	// every other expression in the run does.
-	err := x.eng.runRTSApply(x.sendCtx, x.doc, x.req, x.env, x.opts.BaseDir, vv, x.extraX)
+	err := x.eng.runRTSApply(x.sendCtx, x.doc, x.req, x.env, x.opts.BaseDir, vv, x.locals)
 	if err != nil {
 		x.exp.stage(
 			xplain.StageApply,
@@ -669,7 +669,7 @@ func (x *execCtx) buildResolver() {
 		x.env,
 		x.opts.BaseDir,
 		x.storeG,
-		x.extraX,
+		x.locals,
 		extra...,
 	)
 	x.trace = vars.NewTrace()
@@ -1055,7 +1055,7 @@ func (f flow) ExecuteGRPC() xexec.RequestResult {
 		out:    &caps,
 		env:    x.env,
 		v:      x.captureVariables(),
-		x:      x.extraX,
+		locals: x.locals,
 	}); err != nil {
 		x.exp.stage(
 			xplain.StageCaptures,
@@ -1085,7 +1085,7 @@ func (f flow) ExecuteGRPC() xexec.RequestResult {
 		x.env,
 		x.opts.BaseDir,
 		testV,
-		x.extraX,
+		x.locals,
 		rtsGRPC(resp),
 		nil,
 		rtsStream(info),
@@ -1130,7 +1130,7 @@ func (f flow) ExecuteHTTP() xexec.RequestResult {
 		Options:          x.opts,
 		EffectiveTimeout: x.timeout,
 		ScriptVars:       x.scriptV,
-		ExtraVals:        x.extraX,
+		Locals:           x.locals,
 	})
 	return x.finishHTTP(res)
 }
@@ -1153,7 +1153,7 @@ func (x *execCtx) httpRunner() xexec.Runner {
 					out:    &caps,
 					env:    x.env,
 					v:      in.Vars,
-					x:      in.ExtraVals,
+					locals: in.Locals,
 				})
 			},
 			CollectVariables: func(doc *restfile.Document, req *restfile.Request) map[string]string {
@@ -1170,7 +1170,7 @@ func (x *execCtx) httpRunner() xexec.Runner {
 					x.env,
 					in.BaseDir,
 					in.Vars,
-					in.ExtraVals,
+					in.Locals,
 					rtsHTTP(in.HTTP),
 					rtsTrace(in.HTTP),
 					rtsStream(in.Stream),

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -209,7 +209,7 @@ type rtIn struct {
 	res     *rts.Resp
 	tr      *rts.Trace
 	st      *rts.Stream
-	x       map[string]rts.Value
+	locals  rts.Locals
 	secrets rtshost.SecretPolicy
 }
 
@@ -240,23 +240,19 @@ func (e *Engine) buildRT(in rtIn) rts.RT {
 		AllowRandom: true,
 		Site:        in.site,
 		Uses:        e.rtsUses(in.doc, in.req),
-		Extra:       e.rtsExtra(in.x),
+		Extensions:  e.rtsExtensions(),
+		Locals:      in.locals,
 	}
 }
 
-func (e *Engine) rtsExtra(src map[string]rts.Value) map[string]rts.Value {
+// The inspector is a host extension, so it is additive and never shadows a
+// standard library name. Locals are overlaid after it, which is what lets an
+// @for-each variable named mock win without a special case here.
+func (e *Engine) rtsExtensions() rts.Extensions {
 	if e.cfg.MockInspector == nil {
-		return src
+		return rts.Extensions{}
 	}
-	out := maps.Clone(src)
-	if out == nil {
-		out = make(map[string]rts.Value, 1)
-	}
-	// explicit runtime bindings, including @for-each variables, shadow host objects.
-	if _, exists := out["mock"]; !exists {
-		out["mock"] = mock.RTSValue(e.cfg.MockInspector)
-	}
-	return out
+	return rts.Extension("mock", mock.RTSValue(e.cfg.MockInspector))
 }
 
 // ExprInput binds a {{= expr }} evaluator to one request: the environment it
@@ -271,21 +267,21 @@ type ExprInput struct {
 	Vars     map[string]string
 	Response *rts.Resp
 	Stream   *rts.Stream
-	Extra    map[string]rts.Value
+	Locals   rts.Locals
 }
 
 // EvalInput is one expression evaluation. Expr is the source to evaluate, Site
 // is the directive text it came from, used in diagnostics.
 type EvalInput struct {
-	Doc   *restfile.Document
-	Req   *restfile.Request
-	Env   vars.Environment
-	Base  string
-	Expr  string
-	Site  string
-	Pos   rts.Pos
-	Vars  map[string]string
-	Extra map[string]rts.Value
+	Doc    *restfile.Document
+	Req    *restfile.Request
+	Env    vars.Environment
+	Base   string
+	Expr   string
+	Site   string
+	Pos    rts.Pos
+	Vars   map[string]string
+	Locals rts.Locals
 }
 
 func (e *Engine) rtsEval(
@@ -294,7 +290,7 @@ func (e *Engine) rtsEval(
 	req *restfile.Request,
 	env vars.Environment,
 	base string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 	extras ...map[string]string,
 ) vars.ExprEval {
 	vv := e.collectVariables(doc, req, env)
@@ -302,12 +298,12 @@ func (e *Engine) rtsEval(
 		maps.Copy(vv, overlay)
 	}
 	return e.ExprEval(ctx, ExprInput{
-		Doc:   doc,
-		Req:   req,
-		Env:   env,
-		Base:  base,
-		Vars:  vv,
-		Extra: extra,
+		Doc:    doc,
+		Req:    req,
+		Env:    env,
+		Base:   base,
+		Vars:   vv,
+		Locals: locals,
 	})
 }
 
@@ -344,7 +340,7 @@ func (e *Engine) ExprEvalWithOptions(
 			// res binds response. resp remains the previous response used by last.
 			res:     in.Response,
 			st:      in.Stream,
-			x:       in.Extra,
+			locals:  in.Locals,
 			secrets: secrets,
 		})
 		return e.evalRTSString(
@@ -365,6 +361,17 @@ func (e *Engine) evalRTSValue(
 	pos rts.Pos,
 ) (rts.Value, error) {
 	v, err := e.re.Eval(ctx, rt, expr, pos)
+	return v, e.rtsErr(err, doc)
+}
+
+func (e *Engine) evalRTSAssert(
+	ctx context.Context,
+	doc *restfile.Document,
+	rt rts.RT,
+	expr string,
+	pos rts.Pos,
+) (rts.Value, error) {
+	v, err := e.re.EvalAssertion(ctx, rt, expr, pos)
 	return v, e.rtsErr(err, doc)
 }
 
@@ -391,7 +398,7 @@ func (e *Engine) rtsEvalValue(ctx context.Context, in EvalInput) (rts.Value, err
 		base:    in.Base,
 		vars:    vv,
 		site:    in.Site,
-		x:       in.Extra,
+		locals:  in.Locals,
 		secrets: rtshost.IncludeSecrets,
 	})
 	return e.evalRTSValue(ctx, in.Doc, rt, in.Expr, in.Pos)
@@ -428,7 +435,7 @@ func (e *Engine) EvalCondition(
 	base string,
 	spec *restfile.ConditionSpec,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 ) (bool, string, error) {
 	if spec == nil {
 		return true, "", nil
@@ -443,15 +450,15 @@ func (e *Engine) EvalCondition(
 	}
 	flat := str.FoldLines(expr)
 	val, err := e.rtsEvalValue(ctx, EvalInput{
-		Doc:   doc,
-		Req:   req,
-		Env:   env,
-		Base:  base,
-		Expr:  expr,
-		Site:  tag + " " + flat,
-		Pos:   e.rtsPosForLineCol(doc, req, spec.Line, spec.Col),
-		Vars:  vv,
-		Extra: extra,
+		Doc:    doc,
+		Req:    req,
+		Env:    env,
+		Base:   base,
+		Expr:   expr,
+		Site:   tag + " " + flat,
+		Pos:    e.rtsPosForLineCol(doc, req, spec.Line, spec.Col),
+		Vars:   vv,
+		Locals: locals,
 	})
 	if err != nil {
 		return false, "", err
@@ -472,22 +479,22 @@ func (e *Engine) EvalForEachItems(
 	base string,
 	spec ForEachSpec,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 ) ([]rts.Value, error) {
 	expr := strings.TrimSpace(spec.Expr)
 	if expr == "" {
 		return nil, fmt.Errorf("@for-each expression missing")
 	}
 	val, err := e.rtsEvalValue(ctx, EvalInput{
-		Doc:   doc,
-		Req:   req,
-		Env:   env,
-		Base:  base,
-		Expr:  expr,
-		Site:  directive.ForEach.Tag() + " " + str.FoldLines(expr),
-		Pos:   e.rtsPosForLine(doc, req, spec.Line),
-		Vars:  vv,
-		Extra: extra,
+		Doc:    doc,
+		Req:    req,
+		Env:    env,
+		Base:   base,
+		Expr:   expr,
+		Site:   directive.ForEach.Tag() + " " + str.FoldLines(expr),
+		Pos:    e.rtsPosForLine(doc, req, spec.Line),
+		Vars:   vv,
+		Locals: locals,
 	})
 	if err != nil {
 		return nil, err
@@ -510,7 +517,7 @@ func (e *Engine) runAsserts(
 	env vars.Environment,
 	base string,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 	resp *rts.Resp,
 	tr *rts.Trace,
 	st *rts.Stream,
@@ -521,14 +528,6 @@ func (e *Engine) runAsserts(
 	if vv == nil {
 		vv = e.collectVariables(doc, req, env)
 	}
-	ex := make(map[string]rts.Value)
-	for k, v := range extra {
-		if k == "" {
-			continue
-		}
-		ex[k] = v
-	}
-	maps.Copy(ex, rts.AssertExtra(resp))
 	rt := e.buildRT(rtIn{
 		doc:     doc,
 		req:     req,
@@ -539,7 +538,7 @@ func (e *Engine) runAsserts(
 		res:     resp,
 		tr:      tr,
 		st:      st,
-		x:       ex,
+		locals:  locals,
 		secrets: rtshost.IncludeSecrets,
 	})
 	out := make([]scripts.TestResult, 0, len(req.Metadata.Asserts))
@@ -551,7 +550,7 @@ func (e *Engine) runAsserts(
 		name := str.FoldLines(expr)
 		rt.Site = directive.Assert.Tag() + " " + name
 		start := time.Now()
-		val, err := e.evalRTSValue(ctx, doc, rt, expr, e.rtsPosForLineCol(doc, req, as.Line, as.Col))
+		val, err := e.evalRTSAssert(ctx, doc, rt, expr, e.rtsPosForLineCol(doc, req, as.Line, as.Col))
 		if err != nil {
 			return out, err
 		}
@@ -622,7 +621,7 @@ func (e *Engine) runRTSPreRequest(
 				ReadFile:    os.ReadFile,
 				AllowRandom: true,
 				Site:        "@script pre-request",
-				Extra:       e.rtsExtra(nil),
+				Extensions:  e.rtsExtensions(),
 			}
 		},
 	})
@@ -1147,7 +1146,7 @@ func (e *Engine) runRTSApply(
 	env vars.Environment,
 	base string,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 ) error {
 	if req == nil || len(req.Metadata.Applies) == 0 {
 		return nil
@@ -1165,15 +1164,15 @@ func (e *Engine) runRTSApply(
 				return err
 			}
 			val, err := e.rtsEvalValue(ctx, EvalInput{
-				Doc:   doc,
-				Req:   req,
-				Env:   env,
-				Base:  base,
-				Expr:  ex.ex,
-				Site:  ex.st,
-				Pos:   ex.ps,
-				Vars:  vv,
-				Extra: extra,
+				Doc:    doc,
+				Req:    req,
+				Env:    env,
+				Base:   base,
+				Expr:   ex.ex,
+				Site:   ex.st,
+				Pos:    ex.ps,
+				Vars:   vv,
+				Locals: locals,
 			})
 			if err != nil {
 				return err
@@ -1198,9 +1197,9 @@ func (e *Engine) ApplyPatches(
 	env vars.Environment,
 	base string,
 	vv map[string]string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 ) error {
-	return e.runRTSApply(ctx, doc, req, env, base, vv, extra)
+	return e.runRTSApply(ctx, doc, req, env, base, vv, locals)
 }
 
 func joinErr(a, b error) error {

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -575,9 +575,10 @@ func (e *Engine) RunPreRequest(
 	env vars.Environment,
 	base string,
 	vv map[string]string,
+	locals rts.Locals,
 	globals map[string]vars.GlobalMutation,
 ) (prerequest.Output, error) {
-	return e.runRTSPreRequest(ctx, doc, req, env, base, vv, globals)
+	return e.runRTSPreRequest(ctx, doc, req, env, base, vv, locals, globals)
 }
 
 func (e *Engine) runRTSPreRequest(
@@ -587,6 +588,7 @@ func (e *Engine) runRTSPreRequest(
 	env vars.Environment,
 	base string,
 	vv map[string]string,
+	locals rts.Locals,
 	globs map[string]vars.GlobalMutation,
 ) (prerequest.Output, error) {
 	var out prerequest.Output
@@ -622,6 +624,7 @@ func (e *Engine) runRTSPreRequest(
 				AllowRandom: true,
 				Site:        "@script pre-request",
 				Extensions:  e.rtsExtensions(),
+				Locals:      locals,
 			}
 		},
 	})

--- a/internal/engine/request/rts_test.go
+++ b/internal/engine/request/rts_test.go
@@ -21,43 +21,35 @@ func (testMockInspector) Count(context.Context, mock.RequestPattern) (uint64, er
 	return 0, nil
 }
 
-func TestRTSExtraClonesCallerValues(t *testing.T) {
+func TestRTSExtensionsBindMockAndYieldToLocals(t *testing.T) {
 	e := New(engcfg.Config{MockInspector: testMockInspector{}}, nil)
-	src := map[string]rts.Value{"custom": rts.Str("original")}
+	pos := rts.Pos{Path: "test", Line: 1, Col: 1}
 
-	got := e.rtsExtra(src)
-
-	if value := got["custom"].S; value != "original" {
-		t.Fatalf("custom value = %q, want %q", value, "original")
+	bound, err := e.re.Eval(context.Background(), rts.RT{Extensions: e.rtsExtensions()}, "mock", pos)
+	if err != nil {
+		t.Fatalf("eval mock: %v", err)
 	}
-	if _, ok := got["mock"]; !ok {
-		t.Fatal("mock value is missing")
-	}
-	if _, ok := src["mock"]; ok {
-		t.Fatal("rtsExtra mutated its source map")
-	}
-	got["custom"] = rts.Str("changed")
-	if value := src["custom"].S; value != "original" {
-		t.Fatalf("source value = %q after output mutation, want %q", value, "original")
+	if bound.K != rts.VObj {
+		t.Fatalf("mock = %+v, want the inspector object", bound)
 	}
 
-	if got := e.rtsExtra(nil); len(got) != 1 {
-		t.Fatalf("rtsExtra(nil) has %d values, want the mock value only", len(got))
+	rt := rts.RT{Extensions: e.rtsExtensions(), Locals: rts.Local("mock", rts.Str("loop item"))}
+	shadowed, err := e.re.Eval(context.Background(), rt, "mock", pos)
+	if err != nil {
+		t.Fatalf("eval shadowed mock: %v", err)
+	}
+	if shadowed.K != rts.VStr || shadowed.S != "loop item" {
+		t.Fatalf("mock = %+v, want the loop item to win", shadowed)
 	}
 }
 
-func TestRTSExtraPreservesCallerMockValue(t *testing.T) {
-	e := New(engcfg.Config{MockInspector: testMockInspector{}}, nil)
-	src := map[string]rts.Value{"mock": rts.Str("loop item")}
+func TestRTSExtensionsAreEmptyWithoutAnInspector(t *testing.T) {
+	e := New(engcfg.Config{}, nil)
+	pos := rts.Pos{Path: "test", Line: 1, Col: 1}
 
-	got := e.rtsExtra(src)
-
-	if value := got["mock"]; value.K != rts.VStr || value.S != "loop item" {
-		t.Fatalf("mock value = %+v, want caller value", value)
-	}
-	got["mock"] = rts.Str("changed")
-	if value := src["mock"].S; value != "loop item" {
-		t.Fatalf("source mock value = %q after output mutation, want %q", value, "loop item")
+	_, err := e.re.Eval(context.Background(), rts.RT{Extensions: e.rtsExtensions()}, "mock", pos)
+	if err == nil || !strings.Contains(err.Error(), `undefined name "mock"`) {
+		t.Fatalf("eval mock without an inspector: error = %v, want it undefined", err)
 	}
 }
 
@@ -163,7 +155,7 @@ GET https://example.com
 		"",
 		ForEachSpec{Expr: "missing.value", Line: 2},
 		nil,
-		nil,
+		rts.Locals{},
 	)
 	if err == nil {
 		t.Fatalf("expected for-each error")

--- a/internal/engine/request/rts_test.go
+++ b/internal/engine/request/rts_test.go
@@ -72,6 +72,7 @@ GET https://example.com
 		testEnv(""),
 		"",
 		nil,
+		rts.Locals{},
 		nil,
 	)
 	if err == nil {
@@ -124,6 +125,7 @@ func TestRunRTSPreRequestRejectsResponse(t *testing.T) {
 				testEnv(""),
 				"",
 				nil,
+				rts.Locals{},
 				nil,
 			)
 			if err == nil {

--- a/internal/engine/request/util.go
+++ b/internal/engine/request/util.go
@@ -1,19 +1,6 @@
 package request
 
-import (
-	"maps"
-
-	"github.com/unkn0wn-root/resterm/internal/rts"
-)
-
-func cloneValueMap(src map[string]rts.Value) map[string]rts.Value {
-	if len(src) == 0 {
-		return nil
-	}
-	out := make(map[string]rts.Value, len(src))
-	maps.Copy(out, src)
-	return out
-}
+import "maps"
 
 func copyBytes(src []byte) []byte {
 	if len(src) == 0 {

--- a/internal/engine/request/vars.go
+++ b/internal/engine/request/vars.go
@@ -174,12 +174,12 @@ func (e *Engine) buildResolver(
 	env vars.Environment,
 	base string,
 	globs map[string]vars.GlobalMutation,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 	extras ...map[string]string,
 ) *vars.Resolver {
 	res := vars.NewResolver(e.providers(doc, req, env, globs, keepSecrets, extras...)...)
 	res.AddRefResolver(vars.EnvRefResolver)
-	res.SetExprEval(e.rtsEval(ctx, doc, req, env, base, extra, extras...))
+	res.SetExprEval(e.rtsEval(ctx, doc, req, env, base, locals, extras...))
 	res.SetExprPos(e.rtsPos(doc, req))
 	return res
 }
@@ -192,7 +192,7 @@ func (e *Engine) DisplayResolver(
 	req *restfile.Request,
 	env vars.Environment,
 	base string,
-	extra map[string]rts.Value,
+	locals rts.Locals,
 	extras ...map[string]string,
 ) *vars.Resolver {
 	base = e.rtsBase(doc, base)
@@ -204,7 +204,7 @@ func (e *Engine) DisplayResolver(
 	vv := e.collectVariablesWithGlobals(doc, req, env, globs, omitSecrets, extras...)
 	res.SetExprEval(e.ExprEvalWithOptions(
 		ctx,
-		ExprInput{Doc: doc, Req: req, Env: env, Base: base, Vars: vv, Extra: extra},
+		ExprInput{Doc: doc, Req: req, Env: env, Base: base, Vars: vv, Locals: locals},
 		ExprEvalOptions{OmitSecretGlobals: true},
 	))
 	res.SetExprPos(e.rtsPos(doc, req))

--- a/internal/engine/request/vars_test.go
+++ b/internal/engine/request/vars_test.go
@@ -9,6 +9,7 @@ import (
 	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -137,7 +138,7 @@ func TestRunRTSApplyUsesDocumentGlobalPatchProfiles(t *testing.T) {
 		testEnv(""),
 		"",
 		nil,
-		nil,
+		rts.Locals{},
 	); err != nil {
 		t.Fatalf("runRTSApply() error = %v", err)
 	}

--- a/internal/exec/http.go
+++ b/internal/exec/http.go
@@ -27,28 +27,28 @@ type HTTPInput struct {
 	Options          httpx.Options
 	EffectiveTimeout time.Duration
 	ScriptVars       map[string]string
-	ExtraVals        map[string]rts.Value
+	Locals           rts.Locals
 }
 
 type CaptureInput struct {
-	Doc       *restfile.Document
-	Req       *restfile.Request
-	Resolver  *vars.Resolver
-	Response  *scripts.Response
-	Stream    *scripts.StreamInfo
-	Vars      map[string]string
-	ExtraVals map[string]rts.Value
+	Doc      *restfile.Document
+	Req      *restfile.Request
+	Resolver *vars.Resolver
+	Response *scripts.Response
+	Stream   *scripts.StreamInfo
+	Vars     map[string]string
+	Locals   rts.Locals
 }
 
 type AssertInput struct {
-	Context   context.Context
-	Doc       *restfile.Document
-	Req       *restfile.Request
-	BaseDir   string
-	Vars      map[string]string
-	ExtraVals map[string]rts.Value
-	HTTP      *httpx.Response
-	Stream    *scripts.StreamInfo
+	Context context.Context
+	Doc     *restfile.Document
+	Req     *restfile.Request
+	BaseDir string
+	Vars    map[string]string
+	Locals  rts.Locals
+	HTTP    *httpx.Response
+	Stream  *scripts.StreamInfo
 }
 
 type HTTPHooks struct {
@@ -173,13 +173,13 @@ func (r Runner) RunHTTP(in HTTPInput) HTTPResult {
 	respForScripts := httpScriptResponse(resp)
 	if r.Hooks.ApplyCaptures != nil {
 		err := r.Hooks.ApplyCaptures(CaptureInput{
-			Doc:       in.Doc,
-			Req:       in.Req,
-			Resolver:  in.Resolver,
-			Response:  respForScripts,
-			Stream:    streamInfo,
-			Vars:      r.captureVars(in.Doc, in.Req, in.ScriptVars),
-			ExtraVals: in.ExtraVals,
+			Doc:      in.Doc,
+			Req:      in.Req,
+			Resolver: in.Resolver,
+			Response: respForScripts,
+			Stream:   streamInfo,
+			Vars:     r.captureVars(in.Doc, in.Req, in.ScriptVars),
+			Locals:   in.Locals,
 		})
 		if err != nil {
 			res.Err = err
@@ -196,14 +196,14 @@ func (r Runner) RunHTTP(in HTTPInput) HTTPResult {
 	var assertErr error
 	if r.Hooks.RunAsserts != nil {
 		res.Tests, assertErr = r.Hooks.RunAsserts(AssertInput{
-			Context:   ctx,
-			Doc:       in.Doc,
-			Req:       in.Req,
-			BaseDir:   in.Options.BaseDir,
-			Vars:      testVars,
-			ExtraVals: in.ExtraVals,
-			HTTP:      resp,
-			Stream:    streamInfo,
+			Context: ctx,
+			Doc:     in.Doc,
+			Req:     in.Req,
+			BaseDir: in.Options.BaseDir,
+			Vars:    testVars,
+			Locals:  in.Locals,
+			HTTP:    resp,
+			Stream:  streamInfo,
 		})
 	}
 

--- a/internal/mock/rts_test.go
+++ b/internal/mock/rts_test.go
@@ -29,7 +29,7 @@ func (unavailableInspector) Count(context.Context, RequestPattern) (uint64, erro
 func TestRTSInspectorCountAndReceived(t *testing.T) {
 	inspector := &recordingInspector{count: 3}
 	engine := rts.NewEng(nil)
-	runtime := rts.RT{Extra: map[string]rts.Value{"mock": RTSValue(inspector)}}
+	runtime := rts.RT{Extensions: rts.Extension("mock", RTSValue(inspector))}
 	value, err := engine.Eval(context.Background(), runtime, `mock.count({
   method: "POST",
   path: "/webhooks/{id}",
@@ -120,21 +120,17 @@ func TestRTSInspectorReportsUnavailableAndInvalidPatterns(t *testing.T) {
 	}{
 		{
 			name: "unavailable",
-			rt:   rts.RT{Extra: map[string]rts.Value{"mock": RTSValue(unavailableInspector{})}},
+			rt:   rts.RT{Extensions: rts.Extension("mock", RTSValue(unavailableInspector{}))},
 			expr: `mock.count({})`,
 		},
 		{
 			name: "invalid header rule",
-			rt: rts.RT{Extra: map[string]rts.Value{
-				"mock": RTSValue(&recordingInspector{}),
-			}},
+			rt:   rts.RT{Extensions: rts.Extension("mock", RTSValue(&recordingInspector{}))},
 			expr: `mock.count({headers: {Authorization: {prefix: ""}}})`,
 		},
 		{
 			name: "unknown field",
-			rt: rts.RT{Extra: map[string]rts.Value{
-				"mock": RTSValue(&recordingInspector{}),
-			}},
+			rt:   rts.RT{Extensions: rts.Extension("mock", RTSValue(&recordingInspector{}))},
 			expr: `mock.count({verb: "GET"})`,
 		},
 	} {

--- a/internal/rts/assert.go
+++ b/internal/rts/assert.go
@@ -1,6 +1,9 @@
 package rts
 
-func AssertExtra(r *Resp) map[string]Value {
+// overlayAsserts binds the @assert shorthands for the response under test.
+// They sit above the locals so an @for-each variable named status does not hide
+// the status the assertion is written against.
+func (p pre) overlayAsserts(r *Resp) {
 	o := newRespObj("response", r)
 	code := 0
 	status := ""
@@ -8,11 +11,9 @@ func AssertExtra(r *Resp) map[string]Value {
 		code = r.Code
 		status = r.Status
 	}
-	return map[string]Value{
-		"status":     Num(float64(code)),
-		"statusCode": Num(float64(code)),
-		"statusText": Str(status),
-		"header":     NativeNamed("header", o.headerFn),
-		"text":       NativeNamed("text", o.textFn),
-	}
+	p.values["status"] = Num(float64(code))
+	p.values["statusCode"] = Num(float64(code))
+	p.values["statusText"] = Str(status)
+	p.values["header"] = NativeNamed("header", o.headerFn)
+	p.values["text"] = NativeNamed("text", o.textFn)
 }

--- a/internal/rts/engine.go
+++ b/internal/rts/engine.go
@@ -48,8 +48,17 @@ type RT struct {
 	ReadFile    func(string) ([]byte, error)
 	AllowRandom bool
 	Site        string
-	Extra       map[string]Value
+	Extensions  Extensions
+	Locals      Locals
 }
+
+// evalKind selects which binding layers an evaluation gets.
+type evalKind uint8
+
+const (
+	evalBase evalKind = iota
+	evalAssert
+)
 
 // Eng evaluates RTS expressions and modules.
 // It is not safe for concurrent use because evaluation updates shared request
@@ -73,6 +82,17 @@ func NewEng(std func() map[string]Value) *Eng {
 }
 
 func (e *Eng) Eval(ctx context.Context, rt RT, src string, pos Pos) (Value, error) {
+	return e.eval(ctx, rt, src, pos, evalBase)
+}
+
+// EvalAssertion evaluates an @assert expression. Assertions add response
+// shorthands such as status and header(name) that are not visible anywhere
+// else, which is why the host cannot supply them itself.
+func (e *Eng) EvalAssertion(ctx context.Context, rt RT, src string, pos Pos) (Value, error) {
+	return e.eval(ctx, rt, src, pos, evalAssert)
+}
+
+func (e *Eng) eval(ctx context.Context, rt RT, src string, pos Pos, kind evalKind) (Value, error) {
 	if e == nil {
 		return Null(), fmt.Errorf("nil engine")
 	}
@@ -83,7 +103,7 @@ func (e *Eng) Eval(ctx context.Context, rt RT, src string, pos Pos) (Value, erro
 	}
 
 	cx := e.newCtx(ctx, rt)
-	pre, err := e.buildPre(cx, rt, pos)
+	pre, err := e.buildPre(cx, rt, pos, kind)
 	if err != nil {
 		return Null(), err
 	}
@@ -132,7 +152,7 @@ func (e *Eng) ExecModule(ctx context.Context, rt RT, src string, pos Pos) (*Comp
 	}
 
 	cx := e.newCtx(ctx, rt)
-	pre, err := e.buildPre(cx, rt, pos)
+	pre, err := e.buildPre(cx, rt, pos, evalBase)
 	if err != nil {
 		return nil, err
 	}
@@ -181,41 +201,51 @@ func responseObj(r *Resp) *respObj {
 	return newRespObj("response", r)
 }
 
-func (e *Eng) buildPre(cx *Ctx, rt RT, pos Pos) (map[string]Value, error) {
-	pre := e.modulePre()
-	pre["env"] = Obj(newEnvObj(rt.Env, rt.EnvGroups))
-	pre["vars"] = Obj(newVarsObj("vars", rt.Vars, rt.Globals, rt.VarsMut, rt.GlobalMut))
-	pre["last"] = Obj(newRespObj("last", rt.Resp))
-
-	pre["response"] = Obj(responseObj(rt.Res))
-	pre["trace"] = Obj(newTraceObj(rt.Trace))
-	pre["stream"] = Obj(newStreamObj(rt.Stream))
-
-	for k, v := range rt.Extra {
-		if k == "" {
-			continue
-		}
-		if IsKeyword(k) {
-			return nil, Errf(cx, pos, "name is a reserved word: %s", k)
-		}
-		if _, ok := pre[k]; ok {
-			return nil, Errf(cx, pos, "name already defined: %s", k)
-		}
-		pre[k] = v
-	}
-
-	uses, err := e.resolveUses(cx, rt, pre, pos)
-	if err != nil {
+// buildPre assembles the bindings one evaluation sees. The prelude is the only
+// source of truth for what a local may shadow, so binding a new host object
+// here is all it takes to make it shadowable.
+func (e *Eng) buildPre(cx *Ctx, rt RT, pos Pos, kind evalKind) (map[string]Value, error) {
+	p := e.basePre(rt)
+	if err := p.addExtensions(cx, pos, rt.Extensions); err != nil {
 		return nil, err
+	}
+	if err := e.addUses(cx, rt, p, pos); err != nil {
+		return nil, err
+	}
+	if err := p.overlayLocals(cx, pos, rt.Locals); err != nil {
+		return nil, err
+	}
+	if kind == evalAssert {
+		p.overlayAsserts(rt.Res)
+	}
+	return p.values, nil
+}
+
+func (e *Eng) basePre(rt RT) pre {
+	p := pre{values: e.modulePre()}
+	p.values["env"] = Obj(newEnvObj(rt.Env, rt.EnvGroups))
+	p.values["vars"] = Obj(newVarsObj("vars", rt.Vars, rt.Globals, rt.VarsMut, rt.GlobalMut))
+	p.values["last"] = Obj(newRespObj("last", rt.Resp))
+
+	p.values["response"] = Obj(responseObj(rt.Res))
+	p.values["trace"] = Obj(newTraceObj(rt.Trace))
+	p.values["stream"] = Obj(newStreamObj(rt.Stream))
+	return p
+}
+
+func (e *Eng) addUses(cx *Ctx, rt RT, p pre, pos Pos) error {
+	uses, err := e.resolveUses(cx, rt, p.values, pos)
+	if err != nil {
+		return err
 	}
 	for _, u := range uses {
 		cp, _, err := e.C.Load(cx, rt.BaseDir, u.Path)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		pre[u.Alias] = Obj(NewModObj(u.Alias, cp.Exp))
+		p.values[u.Alias] = Obj(NewModObj(u.Alias, cp.Exp))
 	}
-	return pre, nil
+	return nil
 }
 
 func (e *Eng) modulePre() map[string]Value {

--- a/internal/rts/engine.go
+++ b/internal/rts/engine.go
@@ -223,13 +223,12 @@ func (e *Eng) buildPre(cx *Ctx, rt RT, pos Pos, kind evalKind) (map[string]Value
 
 func (e *Eng) basePre(rt RT) pre {
 	p := pre{values: e.modulePre()}
-	p.values["env"] = Obj(newEnvObj(rt.Env, rt.EnvGroups))
-	p.values["vars"] = Obj(newVarsObj("vars", rt.Vars, rt.Globals, rt.VarsMut, rt.GlobalMut))
-	p.values["last"] = Obj(newRespObj("last", rt.Resp))
-
-	p.values["response"] = Obj(responseObj(rt.Res))
-	p.values["trace"] = Obj(newTraceObj(rt.Trace))
-	p.values["stream"] = Obj(newStreamObj(rt.Stream))
+	p.bind(newEnvObj(rt.Env, rt.EnvGroups))
+	p.bind(newVarsObj("vars", rt.Vars, rt.Globals, rt.VarsMut, rt.GlobalMut))
+	p.bind(newRespObj("last", rt.Resp))
+	p.bind(responseObj(rt.Res))
+	p.bind(newTraceObj(rt.Trace))
+	p.bind(newStreamObj(rt.Stream))
 	return p
 }
 
@@ -243,17 +242,19 @@ func (e *Eng) addUses(cx *Ctx, rt RT, p pre, pos Pos) error {
 		if err != nil {
 			return err
 		}
+		// Not p.bind: a module reports itself as module:<name>, while the alias
+		// is the name the file wrote.
 		p.values[u.Alias] = Obj(NewModObj(u.Alias, cp.Exp))
 	}
 	return nil
 }
 
 func (e *Eng) modulePre() map[string]Value {
-	pre := cloneVals(e.Stdlib())
+	p := pre{values: cloneVals(e.Stdlib())}
 	if e.reqObj != nil {
-		pre["request"] = Obj(e.reqObj)
+		p.bind(e.reqObj)
 	}
-	return pre
+	return p.values
 }
 
 func cloneVals(src map[string]Value) map[string]Value {

--- a/internal/rts/module_test.go
+++ b/internal/rts/module_test.go
@@ -134,13 +134,23 @@ func TestEngineRejectsReservedBindings(t *testing.T) {
 			"alias is a reserved word: default",
 		},
 		{
-			"extra binding",
-			RT{BaseDir: dir, Extra: map[string]Value{"default": Num(1)}},
+			"extension",
+			RT{BaseDir: dir, Extensions: Extension("default", Num(1))},
 			"name is a reserved word: default",
 		},
 		{
-			"extra binding other keyword",
-			RT{BaseDir: dir, Extra: map[string]Value{"range": Num(1)}},
+			"extension other keyword",
+			RT{BaseDir: dir, Extensions: Extension("range", Num(1))},
+			"name is a reserved word: range",
+		},
+		{
+			"local",
+			RT{BaseDir: dir, Locals: Local("default", Num(1))},
+			"name is a reserved word: default",
+		},
+		{
+			"local other keyword",
+			RT{BaseDir: dir, Locals: Local("range", Num(1))},
 			"name is a reserved word: range",
 		},
 	}

--- a/internal/rts/response_test.go
+++ b/internal/rts/response_test.go
@@ -16,6 +16,16 @@ func evalRT2(t *testing.T, rt RT, src string) Value {
 	return v
 }
 
+func assertRT(t *testing.T, rt RT, src string) Value {
+	t.Helper()
+	e := NewEng(testStdlib)
+	v, err := e.EvalAssertion(context.Background(), rt, src, Pos{Path: "test", Line: 1, Col: 1})
+	if err != nil {
+		t.Fatalf("assert %q: %v", src, err)
+	}
+	return v
+}
+
 func TestResponseObject(t *testing.T) {
 	resp := &Resp{
 		Status: "200 OK",
@@ -91,10 +101,10 @@ func TestUnboundResponseRejectsEveryRead(t *testing.T) {
 // member and index paths have to stop it themselves.
 func TestUnboundObjectAbortsThroughMemberAndIndex(t *testing.T) {
 	unbound := func() Value { return Obj(newUnboundRespObj("response", unboundResponse)) }
-	rt := RT{Extra: map[string]Value{
+	rt := RT{Locals: NewLocals(map[string]Value{
 		"holder": Dict(map[string]Value{"resp": unbound()}),
 		"items":  List([]Value{unbound()}),
-	}}
+	})}
 
 	tests := map[string]string{
 		"member through a dict": `holder.resp.statusCode`,
@@ -122,24 +132,35 @@ func TestUnboundObjectAbortsThroughMemberAndIndex(t *testing.T) {
 	}
 }
 
-func TestAssertExtra(t *testing.T) {
+func TestAssertionShorthands(t *testing.T) {
 	resp := &Resp{
 		Status: "201 Created",
 		Code:   201,
 		H:      map[string][]string{"Content-Type": {"application/json"}},
 		Body:   []byte(`{"ok":true}`),
 	}
-	rt := RT{Res: resp, Extra: AssertExtra(resp)}
-	v := evalRT2(t, rt, "status == 201")
+	rt := RT{Res: resp}
+	v := assertRT(t, rt, "status == 201")
 	if v.K != VBool || v.B != true {
 		t.Fatalf("expected status == 201, got %+v", v)
 	}
-	v = evalRT2(t, rt, "header(\"Content-Type\") == \"application/json\"")
+	v = assertRT(t, rt, "header(\"Content-Type\") == \"application/json\"")
 	if v.K != VBool || v.B != true {
 		t.Fatalf("expected header match, got %+v", v)
 	}
-	v = evalRT2(t, rt, "text() == \"{\\\"ok\\\":true}\"")
+	v = assertRT(t, rt, "text() == \"{\\\"ok\\\":true}\"")
 	if v.K != VBool || v.B != true {
 		t.Fatalf("expected text match, got %+v", v)
+	}
+}
+
+// Outside an assertion the shorthands stay unbound, so a plain expression
+// cannot read status without naming the response it belongs to.
+func TestAssertionShorthandsAreAssertionOnly(t *testing.T) {
+	e := NewEng(testStdlib)
+	rt := RT{Res: &Resp{Status: "201 Created", Code: 201}}
+	_, err := e.Eval(context.Background(), rt, "status", Pos{Path: "test", Line: 1, Col: 1})
+	if err == nil || !strings.Contains(err.Error(), `undefined name "status"`) {
+		t.Fatalf("eval status outside an assertion: error = %v, want it undefined", err)
 	}
 }

--- a/internal/rts/shadow.go
+++ b/internal/rts/shadow.go
@@ -1,0 +1,101 @@
+package rts
+
+import (
+	"iter"
+	"maps"
+	"slices"
+)
+
+// Extensions are host objects a caller adds to the base runtime, such as the
+// TUI's mock inspector.
+//
+// An evaluation's prelude is assembled one layer at a time and later layers
+// win:
+//
+//	standard library and host objects   the base runtime
+//	Extensions                          added, must not collide with the base
+//	@use aliases                        added, must not collide with either
+//	Locals                              shadow everything before them
+//	assertion shorthands                shadow locals, inside an assertion only
+//
+// Extensions sit on the additive side of that rule, so a name the base runtime
+// already binds is a host bug rather than a shadow.
+type Extensions struct{ binds }
+
+// NewExtensions binds a copy of values as host extensions.
+func NewExtensions(values map[string]Value) Extensions { return Extensions{newBinds(values)} }
+
+// Extension binds a single host extension.
+func Extension(name string, value Value) Extensions { return Extensions{oneBind(name, value)} }
+
+// Locals are lexical bindings for one evaluation, such as an @for-each item.
+// They shadow the standard library, host objects, extensions, and @use aliases,
+// so a loop variable named json refers to the item and not to the namespace.
+// Being a distinct type from Extensions is what keeps a caller from handing
+// lexical values to the layer that refuses to shadow.
+type Locals struct{ binds }
+
+// NewLocals binds a copy of values as lexical locals.
+func NewLocals(values map[string]Value) Locals { return Locals{newBinds(values)} }
+
+// Local binds a single lexical local.
+func Local(name string, value Value) Locals { return Locals{oneBind(name, value)} }
+
+// binds is the storage shared by every binding layer. A constructor copies the
+// caller's values and nothing writes to the layer afterwards.
+type binds struct{ values map[string]Value }
+
+func newBinds(values map[string]Value) binds {
+	return binds{values: CloneDict(values)}
+}
+
+func oneBind(name string, value Value) binds {
+	return binds{values: map[string]Value{name: value}}
+}
+
+// all walks the layer by name so a rejected binding is always the same one.
+func (b binds) all() iter.Seq2[string, Value] {
+	return func(yield func(string, Value) bool) {
+		for _, k := range slices.Sorted(maps.Keys(b.values)) {
+			if !yield(k, b.values[k]) {
+				return
+			}
+		}
+	}
+}
+
+// pre is a prelude under construction. Callers hold it by value and share the
+// map, so a layer applied to a copy is visible to the builder.
+type pre struct{ values map[string]Value }
+
+func (p pre) addExtensions(cx *Ctx, pos Pos, ext Extensions) error {
+	for name, v := range ext.all() {
+		if name == "" {
+			continue
+		}
+		if IsKeyword(name) {
+			return Errf(cx, pos, "name is a reserved word: %s", name)
+		}
+		if _, ok := p.values[name]; ok {
+			return Errf(cx, pos, "name already defined: %s", name)
+		}
+		p.values[name] = v
+	}
+	return nil
+}
+
+// overlayLocals binds lexical values last. The parser already rejects a
+// reserved word as a loop variable. Checking again here stops a host that
+// builds locals by hand from creating a binding no expression could name.
+func (p pre) overlayLocals(cx *Ctx, pos Pos, loc Locals) error {
+	for name, v := range loc.all() {
+		if name == "" {
+			continue
+		}
+		if IsKeyword(name) {
+			return Errf(cx, pos, "name is a reserved word: %s", name)
+		}
+		p.values[name] = v
+	}
+	return nil
+}

--- a/internal/rts/shadow.go
+++ b/internal/rts/shadow.go
@@ -68,6 +68,12 @@ func (b binds) all() iter.Seq2[string, Value] {
 // map, so a layer applied to a copy is visible to the builder.
 type pre struct{ values map[string]Value }
 
+// bind binds a host object under the name it reports. That name is also the one
+// the object's own errors and signatures use, so the two cannot drift apart.
+func (p pre) bind(o Object) {
+	p.values[o.TypeName()] = Obj(o)
+}
+
 func (p pre) addExtensions(cx *Ctx, pos Pos, ext Extensions) error {
 	for name, v := range ext.all() {
 		if name == "" {

--- a/internal/rts/shadow_test.go
+++ b/internal/rts/shadow_test.go
@@ -1,0 +1,146 @@
+package rts
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+var shadowPos = Pos{Path: "test", Line: 1, Col: 1}
+
+// shadowRT binds every host object so the prelude under test is the full one an
+// expression really sees.
+func shadowRT() RT {
+	return RT{
+		Env:    map[string]string{"host": "example.test"},
+		Vars:   map[string]string{"token": "abc"},
+		Resp:   &Resp{Status: "200 OK", Code: 200},
+		Res:    &Resp{Status: "201 Created", Code: 201},
+		Trace:  &Trace{},
+		Stream: &Stream{Kind: "sse"},
+		Req:    &Req{Method: "GET", URL: "https://example.test"},
+	}
+}
+
+func preludeNames(t *testing.T, e *Eng, rt RT) []string {
+	t.Helper()
+	cx := NewCtx(context.Background(), e.Lim)
+	pre, err := e.buildPre(cx, rt, shadowPos, evalBase)
+	if err != nil {
+		t.Fatalf("build prelude: %v", err)
+	}
+	if len(pre) == 0 {
+		t.Fatal("prelude is empty")
+	}
+	names := make([]string, 0, len(pre))
+	for name := range pre {
+		names = append(names, name)
+	}
+	return names
+}
+
+// The prelude is the only list of what a local may shadow. Walking the
+// generated one keeps a newly bound host object from quietly staying immune.
+func TestLocalsShadowEveryPreludeName(t *testing.T) {
+	e := NewEng(testStdlib)
+	rt := shadowRT()
+
+	for _, name := range preludeNames(t, e, rt) {
+		t.Run(name, func(t *testing.T) {
+			rt := rt
+			rt.Locals = Local(name, Str("loop item"))
+			v, err := e.Eval(context.Background(), rt, name, shadowPos)
+			if err != nil {
+				t.Fatalf("eval %s: %v", name, err)
+			}
+			if v.K != VStr || v.S != "loop item" {
+				t.Fatalf("%s = %+v, want the local to win", name, v)
+			}
+		})
+	}
+}
+
+func TestExtensionsRejectEveryPreludeName(t *testing.T) {
+	e := NewEng(testStdlib)
+	rt := shadowRT()
+
+	for _, name := range preludeNames(t, e, rt) {
+		t.Run(name, func(t *testing.T) {
+			rt := rt
+			rt.Extensions = Extension(name, Str("host object"))
+			_, err := e.Eval(context.Background(), rt, "1", shadowPos)
+			want := "name already defined: " + name
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("eval with extension %s: error = %v, want %q", name, err, want)
+			}
+		})
+	}
+}
+
+// A loop variable named status is the item outside assertions and the response
+// status inside them. Both readings have to keep working.
+func TestAssertionShorthandsShadowLocals(t *testing.T) {
+	e := NewEng(testStdlib)
+	rt := shadowRT()
+	rt.Locals = Local("status", Num(11))
+
+	v, err := e.Eval(context.Background(), rt, "status", shadowPos)
+	if err != nil {
+		t.Fatalf("eval status: %v", err)
+	}
+	if v.K != VNum || v.N != 11 {
+		t.Fatalf("status outside an assertion = %+v, want the loop item", v)
+	}
+
+	v, err = e.EvalAssertion(context.Background(), rt, "status", shadowPos)
+	if err != nil {
+		t.Fatalf("assert status: %v", err)
+	}
+	if v.K != VNum || v.N != 201 {
+		t.Fatalf("status inside an assertion = %+v, want the response status", v)
+	}
+}
+
+func TestLocalsShadowUseAliases(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "users.rts")
+	fs := &memFS{files: map[string]*memFile{
+		p: {data: []byte("module users\nexport let x = 1\n"), mod: time.Unix(10, 0)},
+	}}
+
+	e := NewEng(testStdlib)
+	e.C = NewCache(fs, e.modulePre)
+	rt := RT{
+		BaseDir: dir,
+		Uses:    []Use{{Path: "users.rts"}},
+		Locals:  Local("users", Str("loop item")),
+	}
+
+	v, err := e.Eval(context.Background(), rt, "users", shadowPos)
+	if err != nil {
+		t.Fatalf("eval users: %v", err)
+	}
+	if v.K != VStr || v.S != "loop item" {
+		t.Fatalf("users = %+v, want the local to win over the alias", v)
+	}
+}
+
+func TestBindingConstructorsCopyTheirInput(t *testing.T) {
+	src := map[string]Value{"item": Str("original")}
+	ext := NewExtensions(src)
+	loc := NewLocals(src)
+
+	src["item"] = Str("changed")
+	src["added"] = Str("late")
+
+	for name, layer := range map[string]binds{"extensions": ext.binds, "locals": loc.binds} {
+		if got := layer.values["item"]; got.S != "original" {
+			t.Fatalf("%s item = %q, want %q", name, got.S, "original")
+		}
+		if _, ok := layer.values["added"]; ok {
+			t.Fatalf("%s picked up a name added after construction", name)
+		}
+	}
+}

--- a/internal/runner/run_test.go
+++ b/internal/runner/run_test.go
@@ -1050,6 +1050,64 @@ func TestRunExecutesRTSPreRequestDirective(t *testing.T) {
 	}
 }
 
+func TestRunPassesForEachLocalToRTSPreRequest(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rts-pre-request-for-each.http")
+	src := strings.Join([]string{
+		"# @name each",
+		"# @for-each [11, 22] as json",
+		"# @rts pre-request",
+		`> request.setHeader("X-Loop", str(json))`,
+		"GET https://example.com/items/{{vars.request.json}}",
+		"",
+	}, "\n")
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var got []string
+	client := newHTTPClientWithFactory(func(httpx.Options) (*http.Client, error) {
+		return &http.Client{
+			Transport: transportFunc(func(req *http.Request) (*http.Response, error) {
+				got = append(got, req.Header.Get("X-Loop")+" "+req.URL.Path)
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Proto:      "HTTP/1.1",
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("{}")),
+					Request:    req,
+				}, nil
+			}),
+		}, nil
+	})
+
+	rep, err := RunContext(context.Background(), Options{
+		FilePath:      file,
+		WorkspaceRoot: dir,
+		Client:        client,
+		Select:        Select{All: true},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Total != 1 || rep.Passed != 1 {
+		t.Fatalf("unexpected report counts: %+v", rep)
+	}
+	if len(rep.Results) != 1 || len(rep.Results[0].Steps) != 2 {
+		t.Fatalf("expected two loop steps, got %+v", rep.Results)
+	}
+	want := []string{"11 /items/11", "22 /items/22"}
+	if len(got) != len(want) {
+		t.Fatalf("requests = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("request %d = %q, want %q", i+1, got[i], want[i])
+		}
+	}
+}
+
 func TestReportWriteJSON(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "json.http")

--- a/internal/ui/rts_apply_test.go
+++ b/internal/ui/rts_apply_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
 )
 
 func TestRunRTSApplyPatch(t *testing.T) {
@@ -36,7 +37,7 @@ func TestRunRTSApplyPatch(t *testing.T) {
 	vars := map[string]string{"existing": "1"}
 
 	if err := model.requestSvc(httpx.Options{}).ApplyPatches(
-		context.Background(), nil, req, testEnv(""), "", vars, nil,
+		context.Background(), nil, req, testEnv(""), "", vars, rts.Locals{},
 	); err != nil {
 		t.Fatalf("ApplyPatches: %v", err)
 	}
@@ -131,7 +132,7 @@ func TestRunRTSApplyOrder(t *testing.T) {
 		testEnv(""),
 		"",
 		map[string]string{},
-		nil,
+		rts.Locals{},
 	); err != nil {
 		t.Fatalf("ApplyPatches: %v", err)
 	}
@@ -164,7 +165,7 @@ func TestRunRTSApplyClearsAuthAndDeletesSetting(t *testing.T) {
 	}
 
 	if err := m.requestSvc(httpx.Options{}).ApplyPatches(
-		context.Background(), nil, req, testEnv(""), "", nil, nil,
+		context.Background(), nil, req, testEnv(""), "", nil, rts.Locals{},
 	); err != nil {
 		t.Fatalf("ApplyPatches: %v", err)
 	}
@@ -192,7 +193,7 @@ func TestRunRTSApplyTemplatedURLQuery(t *testing.T) {
 	}
 
 	if err := model.requestSvc(httpx.Options{}).ApplyPatches(
-		context.Background(), nil, req, testEnv(""), "", nil, nil,
+		context.Background(), nil, req, testEnv(""), "", nil, rts.Locals{},
 	); err != nil {
 		t.Fatalf("ApplyPatches: %v", err)
 	}
@@ -231,7 +232,7 @@ func TestRunRTSApplyTemplatedQueryPreservesTemplate(t *testing.T) {
 	}
 
 	if err := model.requestSvc(httpx.Options{}).ApplyPatches(
-		context.Background(), nil, req, testEnv(""), "", nil, nil,
+		context.Background(), nil, req, testEnv(""), "", nil, rts.Locals{},
 	); err != nil {
 		t.Fatalf("ApplyPatches: %v", err)
 	}
@@ -289,7 +290,7 @@ func TestRunRTSApplyUseProfiles(t *testing.T) {
 	}
 
 	if err := m.requestSvc(httpx.Options{}).ApplyPatches(
-		context.Background(), doc, req, testEnv(""), "", nil, nil,
+		context.Background(), doc, req, testEnv(""), "", nil, rts.Locals{},
 	); err != nil {
 		t.Fatalf("ApplyPatches: %v", err)
 	}
@@ -320,7 +321,7 @@ func TestRunRTSApplyUseMissingProfile(t *testing.T) {
 	}
 
 	err := m.requestSvc(httpx.Options{}).ApplyPatches(
-		context.Background(), nil, req, testEnv(""), "", nil, nil,
+		context.Background(), nil, req, testEnv(""), "", nil, rts.Locals{},
 	)
 	if err == nil {
 		t.Fatalf("expected missing profile error")

--- a/internal/ui/rts_directives_test.go
+++ b/internal/ui/rts_directives_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
 )
 
 // Directive evaluation is delegated to the request engine, so a @when error must
@@ -22,7 +23,7 @@ func TestEvalConditionErrorCarriesSource(t *testing.T) {
 	spec := &restfile.ConditionSpec{Expression: "missing.value", Line: 2}
 
 	_, _, err := model.requestSvc(httpx.Options{}).EvalCondition(
-		context.Background(), doc, req, testEnv(""), "", spec, nil, nil,
+		context.Background(), doc, req, testEnv(""), "", spec, nil, rts.Locals{},
 	)
 	if err == nil {
 		t.Fatalf("expected @when condition error")

--- a/internal/ui/rts_prerequest_test.go
+++ b/internal/ui/rts_prerequest_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/prerequest"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -47,7 +48,7 @@ vars.global.delete("old")`,
 	}
 
 	out, err := model.requestSvc(httpx.Options{}).
-		RunPreRequest(context.Background(), nil, req, testEnv(""), "", variables, globals)
+		RunPreRequest(context.Background(), nil, req, testEnv(""), "", variables, rts.Locals{}, globals)
 	if err != nil {
 		t.Fatalf("runRTSPreRequest: %v", err)
 	}
@@ -95,7 +96,7 @@ request.setQueryParam("mutated", "true")`,
 	}
 
 	out, err := model.requestSvc(httpx.Options{}).
-		RunPreRequest(context.Background(), nil, req, testEnv(""), "", nil, nil)
+		RunPreRequest(context.Background(), nil, req, testEnv(""), "", nil, rts.Locals{}, nil)
 	if err != nil {
 		t.Fatalf("runRTSPreRequest: %v", err)
 	}
@@ -133,6 +134,7 @@ GET https://example.com
 		testEnv(""),
 		"",
 		nil,
+		rts.Locals{},
 		nil,
 	)
 	if err == nil {
@@ -180,7 +182,7 @@ func TestRunRTSPreRequestErrorRendersIncludedSource(t *testing.T) {
 	}
 
 	_, err := model.requestSvc(httpx.Options{}).
-		RunPreRequest(context.Background(), nil, req, testEnv(""), dir, nil, nil)
+		RunPreRequest(context.Background(), nil, req, testEnv(""), dir, nil, rts.Locals{}, nil)
 	if err == nil {
 		t.Fatalf("expected rts error")
 	}

--- a/internal/ui/status_text.go
+++ b/internal/ui/status_text.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -30,7 +31,7 @@ func (m *Model) statusResolver(
 	extras ...map[string]string,
 ) *vars.Resolver {
 	rq := m.requestSvc(httpx.Options{})
-	return rq.DisplayResolver(context.Background(), doc, req, m.ws.active, "", nil, extras...)
+	return rq.DisplayResolver(context.Background(), doc, req, m.ws.active, "", rts.Locals{}, extras...)
 }
 
 func (m *Model) statusRequestLabel(


### PR DESCRIPTION
* RST-315: split RT.Extra into Extensions and Locals
* RST-315: assemble the prelude in precedence order
* RST-315: move assertion shorthands behind EvalAssertion
* RST-315: propagate rts.Locals through the request pipeline
* docs(rts): document name precedence