### PR TITLE
RST-315: vars plan

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -533,11 +533,11 @@ When expanding `{{variable}}` templates, Resterm looks in:
 8. Selected environment JSON.
 9. OS environment variables (case-sensitive with an uppercase fallback).
 
-One order backs every way of reading a variable: `{{name}}`, `{{= vars.name }}`, the RTS `vars` object, and the JavaScript `vars` API all pick the same source for a name. Two entries are template-only. `@const` and OS environment variables never appear in `vars`, because `vars` names the values a run can override.
+Templates, RestermScript expressions, the RestermScript `vars` object, and the JavaScript `vars` API all use this order. `@const` and OS environment variables are available only to templates. They are not exposed through `vars` because scripts cannot override them.
 
-Names match case-insensitively and only the winning declaration survives, so a file-scope `token` hides an environment `TOKEN` on every path, including `vars.get("TOKEN")` in a script. When one source declares both forms, the last one wins: the later `@var` line, or the later `vars.set` call when a script writes both.
+Variable names are case-insensitive and ignore surrounding whitespace. A file variable named `token`, for example, takes precedence over an environment variable named `TOKEN`. When the same source defines a name more than once, the last declaration or script write wins. Global deletes also ignore case.
 
-Surrounding whitespace is not part of a name either, so `vars.set(" token ")` updates `token` rather than declaring a second variable. A name that is blank once trimmed identifies nothing, so a write under one is ignored and reads back as unset.
+Blank names are invalid. RestermScript and `@apply` report an error, while JavaScript and runtime stores ignore the write.
 
 Dynamic helpers are also available: `{{$uuid}}` (alias `{{$guid}}`), `{{$timestamp}}` (Unix seconds), `{{$timestampMs}}` (Unix milliseconds), `{{$timestampISO8601}}`, and `{{$randomInt}}`.
 
@@ -1215,13 +1215,21 @@ Values are taken verbatim which means that quotes are not special, so `# @file g
 
 Declared values may reference other variables and dynamic helpers, so `# @request trace.id {{$uuid}}` works as expected. Nested references expand when the request runs, and a declared dynamic such as `{{$uuid}}` is generated once per execution, so every reference to `{{trace.id}}` in the same request sees the same value. Values captured at runtime (captures, script `vars.set`) are data and are never re-expanded. Self- or mutually-referencing variables fail the request with a `variable cycle` error that lists the reference chain.
 
-You can also use shorthand assignments outside comment blocks: `@requestId = {{$uuid}}`. Shorthand defaults to request scope while you're inside a request block and to file scope elsewhere; add a prefix to override (`@global api.token abc`, `@request trace.id {{$uuid}}`, or `@file base.url https://example.com`).
+You can also use shorthand assignments outside comment blocks: `@requestId = {{$uuid}}`. Shorthand defaults to request scope while you're inside a request block and to file scope elsewhere. Add a prefix to override it (`@global api.token abc`, `@request trace.id {{$uuid}}`, or `@file base.url https://example.com`).
 
-Append `-secret` (`global-secret`, `file-secret`, `request-secret`) to mask stored values in summaries; this works for both comment directives and shorthand lines (`@global-secret token xyz`, `@file-secret base.url ...`, `@request-secret trace.id ...`).
+Append `-secret` (`global-secret`, `file-secret`, `request-secret`) to mask stored values in summaries. This works for both comment directives and shorthand lines (`@global-secret token xyz`, `@file-secret base.url ...`, `@request-secret trace.id ...`).
+
+### Secret redaction
+
+Secret values are masked in errors, script failures, and failed test output before those messages reach the response pane, workflow summaries, or workflow history. A value remains masked for the rest of the run if it is deleted, replaced with a public value, or produced by a script or capture that later fails.
+
+Diagnostic source excerpts show the request file as written. Avoid placing literal secrets in script source. Response bodies are also stored as received unless the request uses `@no-log` or the payload is redacted before it is returned.
 
 ### Captures
 
 `@capture <scope> <name> <expression>` evaluates after the response arrives and stores the result for reuse.
+
+Captures run in declaration order. A capture can read values produced earlier in the same batch through `vars.get`, `{{= ... }}`, or `{{name}}`. Values are stored only after every capture succeeds, so a failed batch leaves request, file, and global values unchanged.
 
 Expressions can reference:
 
@@ -2241,8 +2249,8 @@ Open one in Resterm, switch to the appropriate environment (`resterm.env.json`),
 - Use `Ctrl+P` to force a reparse if the navigator seems out of sync with editor changes.
 - If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, expanded bodies, gRPC targets and messages, and WebSocket steps. Explain previews keep the placeholder intact and list the unresolved names.
 - Combine `@capture request ...` with test scripts to assert on response headers without cluttering file/global scopes.
-- Inline curl import works best with single commands; complex shell pipelines may need manual cleanup.
-- `Ctrl+Shift+V` pins the focused response pane-ideal for diffing the last good response against the current attempt.
-- Keep secrets in environment files or runtime globals marked as `-secret`. Remember that history stores the raw response unless you add `@no-log` or redact the payload yourself.
+- Inline curl import works best with single commands. Complex shell pipelines may need manual cleanup.
+- `Ctrl+Shift+V` pins the focused response pane, which is useful for comparing the last good response with the current attempt.
+- Keep secrets in environment files or runtime globals marked as `-secret`.
 
 For additional questions or feature requests, open an issue on GitHub.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -537,6 +537,8 @@ One order backs every way of reading a variable: `{{name}}`, `{{= vars.name }}`,
 
 Names match case-insensitively and only the winning declaration survives, so a file-scope `token` hides an environment `TOKEN` on every path, including `vars.get("TOKEN")` in a script. When one source declares both forms, the last one wins: the later `@var` line, or the later `vars.set` call when a script writes both.
 
+Surrounding whitespace is not part of a name either, so `vars.set(" token ")` updates `token` rather than declaring a second variable. A name that is blank once trimmed identifies nothing, so a write under one is ignored and reads back as unset.
+
 Dynamic helpers are also available: `{{$uuid}}` (alias `{{$guid}}`), `{{$timestamp}}` (Unix seconds), `{{$timestampMs}}` (Unix milliseconds), `{{$timestampISO8601}}`, and `{{$randomInt}}`.
 
 Timestamp helpers accept optional offsets: `{{$timestamp + 6d}}`, `{{$timestampISO8601 - 90m}}`, `{{$timestampMs + 2h}}`. Supported units are the standard Go duration units plus `d` (days) and `w` (weeks).

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -525,12 +525,17 @@ When expanding `{{variable}}` templates, Resterm looks in:
 
 1. *File constants* (`@const`).
 2. Values set by scripts for the current execution (`vars.set` in pre-request or test scripts).
-3. *Request-scope* variables (`@var request`, `@capture request`).
-4. *Runtime globals* stored via captures or scripts (per environment).
-5. *Document globals* (`@global`, `@var global`).
-6. *File scope* declarations and `@capture file` values.
-7. Selected environment JSON.
-8. OS environment variables (case-sensitive with an uppercase fallback).
+3. Workflow step variables and the `@for-each` value bound for the current iteration.
+4. *Request-scope* variables (`@var request`, `@capture request`).
+5. *Runtime globals* stored via captures or scripts (per environment).
+6. *Document globals* (`@global`, `@var global`).
+7. *File scope* declarations and `@capture file` values.
+8. Selected environment JSON.
+9. OS environment variables (case-sensitive with an uppercase fallback).
+
+One order backs every way of reading a variable: `{{name}}`, `{{= vars.name }}`, the RTS `vars` object, and the JavaScript `vars` API all pick the same source for a name. Two entries are template-only. `@const` and OS environment variables never appear in `vars`, because `vars` names the values a run can override.
+
+Names match case-insensitively and only the winning declaration survives, so a file-scope `token` hides an environment `TOKEN` on every path, including `vars.get("TOKEN")` in a script. When one source declares both forms, the last one wins: the later `@var` line, or the later `vars.set` call when a script writes both.
 
 Dynamic helpers are also available: `{{$uuid}}` (alias `{{$guid}}`), `{{$timestamp}}` (Unix seconds), `{{$timestampMs}}` (Unix milliseconds), `{{$timestampISO8601}}`, and `{{$randomInt}}`.
 

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -535,6 +535,8 @@ When expanding `{{variable}}` templates, Resterm looks in:
 
 Templates, RestermScript expressions, the RestermScript `vars` object, and the JavaScript `vars` API all use this order. `@const` and OS environment variables are available only to templates. They are not exposed through `vars` because scripts cannot override them.
 
+Scripts receive declared values with ordinary variable references already expanded. For example, `vars.get("name")` returns the same value as `{{name}}`. Dynamic helpers and `{{= ... }}` expressions are left unchanged because they are evaluated later, when the request runs. Captured values and values written by scripts are treated as data and are not expanded.
+
 Variable names are case-insensitive and ignore surrounding whitespace. A file variable named `token`, for example, takes precedence over an environment variable named `TOKEN`. When the same source defines a name more than once, the last declaration or script write wins. Global deletes also ignore case.
 
 Blank names are invalid. RestermScript and `@apply` report an error, while JavaScript and runtime stores ignore the write.
@@ -1213,7 +1215,7 @@ Accept: application/json
 
 Values are taken verbatim which means that quotes are not special, so `# @file greeting "hello world"` stores the quotes as part of the value. If you need spaces, just write them directly: `# @file greeting hello world`.
 
-Declared values may reference other variables and dynamic helpers, so `# @request trace.id {{$uuid}}` works as expected. Nested references expand when the request runs, and a declared dynamic such as `{{$uuid}}` is generated once per execution, so every reference to `{{trace.id}}` in the same request sees the same value. Values captured at runtime (captures, script `vars.set`) are data and are never re-expanded. Self- or mutually-referencing variables fail the request with a `variable cycle` error that lists the reference chain.
+Declared values can reference other variables and dynamic helpers. For example, `# @request trace.id {{$uuid}}` generates one value per execution, so every `{{trace.id}}` reference in that request sees the same value. Captures and values written with `vars.set` are treated as data and are not expanded again. A self-reference or a cycle between variables fails the request with a `variable cycle` error that lists the reference chain. See [Variable resolution order](#variable-resolution-order) for how declared values are exposed to scripts.
 
 You can also use shorthand assignments outside comment blocks: `@requestId = {{$uuid}}`. Shorthand defaults to request scope while you're inside a request block and to file scope elsewhere. Add a prefix to override it (`@global api.token abc`, `@request trace.id {{$uuid}}`, or `@file base.url https://example.com`).
 
@@ -1726,7 +1728,9 @@ Objects:
   - `global.get(name)`, `global.set(name, value, options)`, `global.has(name)`, `global.delete(name)` (`options.secret` masks values)
 - `console.log/warn/error` (no-op placeholders for compatibility)
 
-Return values from `set*` helpers are ignored; side effects apply to the outgoing request.
+The `set*` helpers do not return a value, but their changes still apply to the outgoing request. `removeHeader` can also remove headers declared in the request itself.
+
+All `@script pre-request` blocks for a request share the same state. Each block sees changes made by earlier blocks through `vars.get`, `vars.global.get`, `getURL`, `getMethod`, and `getHeader`. RTS pre-request blocks run before JavaScript blocks, so their changes are visible too. Query parameters are different because they are merged into the URL after the scripts finish. This means `getURL` does not show changes made by `setQueryParam`.
 
 ### Test scripts (`@script test`)
 

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -588,6 +588,8 @@ For named environments, `env.name` is unchanged and `env.groups` is empty.
 
 `vars` provides request runtime variables, including globals and workflow overrides. You can access values through `vars.get("key")`, `vars.has("key")`, `vars.require("key"[, msg])`, or `vars.key`. `vars.global` provides global reads and writes in pre-request scripts through `get`, `has`, `require`, `set`, and `delete`.
 
+`vars` names the values a run can override, so `@const` values and OS environment variables are not in it even though `{{name}}` resolves them. Everything else follows the same precedence a template does, and a name resolves to one source through both. See [Variable resolution order](resterm.md#variable-resolution-order).
+
 ### request
 
 `request` provides a summary of the current request. It exposes `method`, `url`, `headers`, `header(name)`, and `query`. `headers` contains the first value per header (lowercased keys), while `header(name)` is case-insensitive. `query` returns strings or lists when a key has multiple values. In `@rts pre-request` blocks, mutation helpers are available, including `request.setMethod`, `request.setURL`, `request.setHeader`, `request.addHeader`, `request.removeHeader`, `request.setQueryParam`, and `request.setBody`. The full `@script pre-request lang=rts` form is equivalent. In `@apply`, the request object is read only, so you return a patch dict instead of mutating it.

--- a/internal/diag/redact.go
+++ b/internal/diag/redact.go
@@ -1,0 +1,55 @@
+package diag
+
+// Redact masks diagnostic text without changing the original report or its
+// source excerpt. Spans refer to the caller's source and would become invalid
+// if that text were rewritten.
+func (r Report) Redact(mask func(string) string) Report {
+	if mask == nil {
+		return r
+	}
+	r.Items = redactEach(r.Items, func(d Diagnostic) Diagnostic {
+		d.Message = mask(d.Message)
+		d.Span = redactSpan(d.Span, mask)
+		d.Labels = redactEach(d.Labels, func(l Label) Label {
+			l.Message = mask(l.Message)
+			l.Span = redactSpan(l.Span, mask)
+			return l
+		})
+		d.Notes = redactEach(d.Notes, func(n Note) Note {
+			n.Message = mask(n.Message)
+			n.Span = redactSpan(n.Span, mask)
+			return n
+		})
+		d.Chain = redactChain(d.Chain, mask)
+		d.Frames = redactEach(d.Frames, func(f StackFrame) StackFrame {
+			f.Name = mask(f.Name)
+			return f
+		})
+		return d
+	})
+	return r
+}
+
+func redactChain(src []ChainEntry, mask func(string) string) []ChainEntry {
+	return redactEach(src, func(e ChainEntry) ChainEntry {
+		e.Message = mask(e.Message)
+		e.Children = redactChain(e.Children, mask)
+		return e
+	})
+}
+
+func redactSpan(s Span, mask func(string) string) Span {
+	s.Label = mask(s.Label)
+	return s
+}
+
+func redactEach[T any](src []T, fn func(T) T) []T {
+	if src == nil {
+		return nil
+	}
+	out := make([]T, len(src))
+	for i, v := range src {
+		out[i] = fn(v)
+	}
+	return out
+}

--- a/internal/engine/core/dep.go
+++ b/internal/engine/core/dep.go
@@ -11,11 +11,13 @@ import (
 )
 
 type Dep interface {
+	// overlay contains workflow step and @for-each bindings. Its values rank
+	// below script values and above request variables.
 	CollectVariables(
 		doc *restfile.Document,
 		req *restfile.Request,
 		env vars.Environment,
-		extras ...map[string]string,
+		overlay map[string]string,
 	) map[string]string
 	ExecuteWith(
 		doc *restfile.Document,

--- a/internal/engine/core/wf.go
+++ b/internal/engine/core/wf.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -52,7 +53,7 @@ type wfRun struct {
 	pl       *WorkflowPlan
 	idx      int
 	seq      int
-	vars     map[string]string
+	vars     vars.NameMap[string]
 	done     bool
 	seen     bool
 	skip     bool
@@ -154,11 +155,8 @@ func RunPlan(ctx context.Context, dep Dep, sink Sink, pl *WorkflowPlan) error {
 		dep:  dep,
 		sink: sink,
 		pl:   pl,
-		vars: cloneStrMap(pl.Vars),
+		vars: vars.CollectNames(pl.Vars),
 		skip: true,
-	}
-	if r.vars == nil {
-		r.vars = make(map[string]string)
 	}
 	if err := r.emitRunStart(ctx); err != nil {
 		return err
@@ -318,19 +316,16 @@ func (r *wfRun) runReqStep(
 			continue
 		}
 
-		loopVars := cloneStrMap(xv)
-		if loopVars == nil {
-			loopVars = make(map[string]string)
-		}
+		loopVars := xv.Clone()
 		if wfKey != "" {
-			vars.Upsert(r.vars, wfKey, itemStr)
-			vars.Upsert(loopVars, wfKey, itemStr)
+			r.vars.Set(wfKey, itemStr)
+			loopVars.Set(wfKey, itemStr)
 		}
 		if reqKey != "" {
-			vars.Upsert(loopVars, reqKey, itemStr)
+			loopVars.Set(reqKey, itemStr)
 		}
 		loc := rts.Local(spec.Var, item)
-		vv := r.dep.CollectVariables(r.pl.Doc, req, r.pl.Run.Env, loopVars)
+		vv := r.dep.CollectVariables(r.pl.Doc, req, r.pl.Run.Env, loopVars.Map())
 
 		if step.When != nil {
 			ok, reason, err := r.dep.EvalCondition(
@@ -503,7 +498,7 @@ func (r *wfRun) execReq(
 	branch string,
 	iter int,
 	total int,
-	extra map[string]string,
+	extra vars.NameMap[string],
 	locals rts.Locals,
 ) (engine.RequestResult, error) {
 	clone := request.CloneRequest(req)
@@ -515,7 +510,7 @@ func (r *wfRun) execReq(
 		clone,
 		r.pl.Run.Env,
 		request.ExecOptions{
-			Extra:  extra,
+			Extra:  extra.Map(),
 			Locals: locals,
 			Record: r.pl.Run.Mode == ModeForEach,
 			Ctx:    ctx,
@@ -534,10 +529,10 @@ func (r *wfRun) stepScope(
 	step restfile.WorkflowStep,
 	req *restfile.Request,
 	extra map[string]string,
-) (map[string]string, map[string]string) {
-	applyVars(r.vars, step.Vars)
+) (vars.NameMap[string], map[string]string) {
+	applyVars(&r.vars, step.Vars)
 	xv := stepExtras(r.vars, step.Vars, extra)
-	vv := r.dep.CollectVariables(r.pl.Doc, req, r.pl.Run.Env, xv)
+	vv := r.dep.CollectVariables(r.pl.Doc, req, r.pl.Run.Env, xv.Map())
 	return xv, vv
 }
 
@@ -585,7 +580,7 @@ func (r *wfRun) executeStepRequest(
 	branch string,
 	iter int,
 	total int,
-	extra map[string]string,
+	extra vars.NameMap[string],
 	locals rts.Locals,
 ) (stepOutcome, error) {
 	if err := r.emitStepStart(ctx, r.idx, step, req, branch, iter, total); err != nil {
@@ -991,35 +986,23 @@ func normWfStep(step *restfile.WorkflowStep, fail restfile.WorkflowFailureMode) 
 	}
 }
 
-func applyVars(dst map[string]string, vals map[string]string) {
-	if len(vals) == 0 {
-		return
-	}
-	if dst == nil {
-		return
-	}
-	for k, v := range vals {
+func applyVars(dst *vars.NameMap[string], vals map[string]string) {
+	for _, k := range slices.Sorted(maps.Keys(vals)) {
 		if restfile.IsWorkflowScopedVar(k) {
-			vars.Upsert(dst, k, v)
+			dst.Set(k, vals[k])
 		}
 	}
 }
 
+// stepExtras applies vals, then extra, so later layers take precedence.
 func stepExtras(
-	base map[string]string,
+	base vars.NameMap[string],
 	vals map[string]string,
 	extra map[string]string,
-) map[string]string {
-	n := len(base) + len(vals) + len(extra)
-	if n == 0 {
-		return nil
-	}
-	// Later layers win, including over another form of a name an earlier one
-	// set, so the overlay the engine receives holds one value per variable.
-	out := make(map[string]string, n)
-	vars.Merge(out, base)
-	vars.Merge(out, vals)
-	vars.Merge(out, extra)
+) vars.NameMap[string] {
+	out := base.Clone()
+	out.SetMap(vals)
+	out.SetMap(extra)
 	return out
 }
 
@@ -1060,13 +1043,4 @@ func stepMeta(
 		Iter:   iter,
 		Total:  total,
 	}
-}
-
-func cloneStrMap(src map[string]string) map[string]string {
-	if len(src) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(src))
-	maps.Copy(out, src)
-	return out
 }

--- a/internal/engine/core/wf.go
+++ b/internal/engine/core/wf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/rts"
 	str "github.com/unkn0wn-root/resterm/internal/util"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 type WorkflowPlan struct {
@@ -322,11 +323,11 @@ func (r *wfRun) runReqStep(
 			loopVars = make(map[string]string)
 		}
 		if wfKey != "" {
-			r.vars[wfKey] = itemStr
-			loopVars[wfKey] = itemStr
+			vars.Upsert(r.vars, wfKey, itemStr)
+			vars.Upsert(loopVars, wfKey, itemStr)
 		}
 		if reqKey != "" {
-			loopVars[reqKey] = itemStr
+			vars.Upsert(loopVars, reqKey, itemStr)
 		}
 		loc := rts.Local(spec.Var, item)
 		vv := r.dep.CollectVariables(r.pl.Doc, req, r.pl.Run.Env, loopVars)
@@ -999,7 +1000,7 @@ func applyVars(dst map[string]string, vals map[string]string) {
 	}
 	for k, v := range vals {
 		if restfile.IsWorkflowScopedVar(k) {
-			dst[k] = v
+			vars.Upsert(dst, k, v)
 		}
 	}
 }
@@ -1013,10 +1014,12 @@ func stepExtras(
 	if n == 0 {
 		return nil
 	}
+	// Later layers win, including over another form of a name an earlier one
+	// set, so the overlay the engine receives holds one value per variable.
 	out := make(map[string]string, n)
-	maps.Copy(out, base)
-	maps.Copy(out, vals)
-	maps.Copy(out, extra)
+	vars.Merge(out, base)
+	vars.Merge(out, vals)
+	vars.Merge(out, extra)
 	return out
 }
 

--- a/internal/engine/core/wf_test.go
+++ b/internal/engine/core/wf_test.go
@@ -243,7 +243,7 @@ func (d *fakeDep) CollectVariables(
 	doc *restfile.Document,
 	req *restfile.Request,
 	env vars.Environment,
-	extra ...map[string]string,
+	overlay map[string]string,
 ) map[string]string {
 	out := make(map[string]string)
 	if doc != nil {
@@ -251,9 +251,7 @@ func (d *fakeDep) CollectVariables(
 			out[v.Name] = v.Value
 		}
 	}
-	for _, x := range extra {
-		maps.Copy(out, x)
-	}
+	maps.Copy(out, overlay)
 	return out
 }
 

--- a/internal/engine/headless/wf.go
+++ b/internal/engine/headless/wf.go
@@ -242,7 +242,8 @@ func workflowSummary(st *wfState) string {
 	ok := 0
 	skip := 0
 	fail := 0
-	for _, res := range st.res {
+	lastFail := -1
+	for i, res := range st.res {
 		switch {
 		case res.skip:
 			skip++
@@ -250,6 +251,7 @@ func workflowSummary(st *wfState) string {
 			ok++
 		default:
 			fail++
+			lastFail = i
 		}
 	}
 	if fail == 0 {
@@ -258,7 +260,12 @@ func workflowSummary(st *wfState) string {
 		}
 		return fmt.Sprintf("%s completed: %d/%d steps passed", title, ok, len(st.res))
 	}
-	last := st.res[len(st.res)-1]
+	// A workflow may continue after a failure and end on a successful step. In
+	// that case there is no failed step where it stopped, so use a general summary.
+	if lastFail != len(st.res)-1 {
+		return fmt.Sprintf("%s finished with %d failure(s)", title, fail)
+	}
+	last := st.res[lastFail]
 	reason := strings.TrimSpace(last.msg)
 	if reason == "" {
 		reason = "step failed"

--- a/internal/engine/headless/wf_failure_test.go
+++ b/internal/engine/headless/wf_failure_test.go
@@ -58,4 +58,7 @@ GET %s/cleanup
 	if out.Success {
 		t.Fatal("a continued failure still has to mark the run unsuccessful")
 	}
+	if want := "Workflow demo finished with 1 failure(s)"; out.Summary != want {
+		t.Fatalf("summary = %q, want %q", out.Summary, want)
+	}
 }

--- a/internal/engine/headless/wf_result_test.go
+++ b/internal/engine/headless/wf_result_test.go
@@ -38,6 +38,41 @@ func TestEvaluateStepStatusCode(t *testing.T) {
 	}
 }
 
+func TestWorkflowSummaryNamesOnlyATrailingFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		res  []wfStepRes
+		want string
+	}{
+		{
+			name: "continued past the failure",
+			res: []wfStepRes{
+				{name: "Seed", ok: true},
+				{name: "Failure", msg: "unexpected status code 500"},
+				{name: "Check", ok: true},
+			},
+			want: "Workflow Atomic finished with 1 failure(s)",
+		},
+		{
+			name: "stopped at the failure",
+			res: []wfStepRes{
+				{name: "Seed", ok: true},
+				{name: "Failure", msg: "unexpected status code 500"},
+			},
+			want: "Workflow Atomic failed at step Failure: unexpected status code 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &wfState{wf: restfile.Workflow{Name: "Atomic"}, res: tt.res}
+			if got := workflowSummary(st); got != tt.want {
+				t.Fatalf("workflowSummary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateStepScriptErr(t *testing.T) {
 	res := wfStepRes{
 		http: &httpx.Response{

--- a/internal/engine/headless/wf_secret_test.go
+++ b/internal/engine/headless/wf_secret_test.go
@@ -1,0 +1,76 @@
+package headless
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/parser"
+)
+
+func TestExecuteWorkflowMasksSecretInFailureText(t *testing.T) {
+	const secret = "workflow-error-secret"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{"ok":true}`); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	src := fmt.Sprintf(`### flow
+# @workflow smoke
+# @step Probe using=Probe
+
+### Probe
+# @name Probe
+GET %s/probe
+> {%%
+vars.global.set("token", "%s", true);
+throw new Error(vars.global.get("token"));
+%%}
+`, srv.URL, secret)
+
+	doc := parser.Parse("workflow.http", []byte(src))
+	if len(doc.Workflows) != 1 {
+		t.Fatalf("expected 1 workflow, got %d", len(doc.Workflows))
+	}
+
+	out, err := New(engine.Config{}).ExecuteWorkflow(doc, &doc.Workflows[0], testSelection(""))
+	if err != nil {
+		t.Fatalf("ExecuteWorkflow: %v", err)
+	}
+	if len(out.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(out.Steps))
+	}
+
+	step := out.Steps[0]
+	texts := map[string]string{
+		"summary":      out.Summary,
+		"report":       out.Report,
+		"step summary": step.Summary,
+		"step error":   errText(step.Err),
+		"script error": errText(step.ScriptErr),
+	}
+	for _, tc := range step.Tests {
+		texts["test "+tc.Name] = tc.Name + " " + tc.Message
+	}
+	for field, text := range texts {
+		if strings.Contains(text, secret) {
+			t.Fatalf("workflow %s contains the plaintext secret: %s", field, text)
+		}
+	}
+	if !strings.Contains(out.Report, "•••") {
+		t.Fatalf("expected the failure to still be reported, got:\n%s", out.Report)
+	}
+}
+
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/engine/request/capture.go
+++ b/internal/engine/request/capture.go
@@ -125,7 +125,7 @@ func (e *Engine) applyCaptures(in captureRun) error {
 
 	lc := newCaptureContext(in.resp, in.stream, capture.StrictEnabled(in.req.Settings))
 	if in.v == nil {
-		in.v = e.collectVariables(in.doc, in.req, in.env)
+		in.v = e.collectVariables(in.doc, in.req, in.env, runVars{})
 	}
 	sc := captureScope{
 		ctx:    in.ctx,

--- a/internal/engine/request/capture.go
+++ b/internal/engine/request/capture.go
@@ -31,22 +31,25 @@ const (
 )
 
 type captureResult struct {
-	requestVars map[string]restfile.Variable
-	fileVars    map[string]restfile.Variable
+	requestVars vars.NameMap[restfile.Variable]
+	fileVars    vars.NameMap[restfile.Variable]
+	globals     vars.Globals
 }
 
 type captureRun struct {
-	ctx    context.Context
-	base   string
-	doc    *restfile.Document
-	req    *restfile.Request
-	res    *vars.Resolver
-	resp   *scripts.Response
-	stream *scripts.StreamInfo
-	out    *captureResult
-	env    vars.Environment
-	v      map[string]string
-	locals rts.Locals
+	ctx     context.Context
+	base    string
+	doc     *restfile.Document
+	req     *restfile.Request
+	res     *vars.Resolver
+	resp    *scripts.Response
+	stream  *scripts.StreamInfo
+	out     *captureResult
+	env     vars.Environment
+	store   vars.Globals
+	secrets *vars.Secrets
+	locals  rts.Locals
+	run     runVars
 }
 
 type captureExpr struct {
@@ -56,12 +59,12 @@ type captureExpr struct {
 }
 
 type captureScope struct {
-	ctx    context.Context
-	base   string
-	doc    *restfile.Document
-	req    *restfile.Request
-	env    vars.Environment
-	v      map[string]string
+	ctx  context.Context
+	base string
+	doc  *restfile.Document
+	req  *restfile.Request
+	env  vars.Environment
+	evalScope
 	locals rts.Locals
 	rr     *rts.Resp
 	rs     *rts.Stream
@@ -81,65 +84,47 @@ type captureRTSIn struct {
 }
 
 func (r *captureResult) addRequest(name, value string, secret bool) {
-	if r == nil {
-		return
-	}
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return
-	}
-	if r.requestVars == nil {
-		r.requestVars = make(map[string]restfile.Variable)
-	}
-	r.requestVars[strings.ToLower(name)] = restfile.Variable{
-		Name:   name,
+	r.requestVars.Set(name, restfile.Variable{
+		Name:   strings.TrimSpace(name),
 		Value:  value,
 		Secret: secret,
 		Scope:  directive.ScopeRequest,
-	}
+	})
 }
 
 func (r *captureResult) addFile(name, value string, secret bool) {
-	if r == nil {
-		return
-	}
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return
-	}
-	if r.fileVars == nil {
-		r.fileVars = make(map[string]restfile.Variable)
-	}
-	r.fileVars[strings.ToLower(name)] = restfile.Variable{
-		Name:   name,
+	r.fileVars.Set(name, restfile.Variable{
+		Name:   strings.TrimSpace(name),
 		Value:  value,
 		Secret: secret,
 		Scope:  directive.ScopeFile,
-	}
+	})
 }
 
+// Captures are evaluated in declaration order against staged values and commit
+// only after the entire batch succeeds. Staged values retain their normal
+// precedence. Reusing the resolver memo keeps dynamic values stable between the
+// request and its captures. Secret values enter the redaction set before commit
+// so a later failure cannot expose them.
 func (e *Engine) applyCaptures(in captureRun) error {
 	if in.req == nil || in.resp == nil || len(in.req.Metadata.Captures) == 0 {
 		return nil
 	}
 
 	lc := newCaptureContext(in.resp, in.stream, capture.StrictEnabled(in.req.Settings))
-	if in.v == nil {
-		in.v = e.collectVariables(in.doc, in.req, in.env, runVars{})
-	}
 	sc := captureScope{
 		ctx:    in.ctx,
 		base:   in.base,
 		doc:    in.doc,
 		req:    in.req,
 		env:    in.env,
-		v:      in.v,
 		locals: in.locals,
 		rr:     rtsScriptResp(in.resp),
 		rs:     rtsStream(in.stream),
 	}
-	res := e.captureResolver(in.res, sc)
+	work := &captureResult{}
 	for _, c := range in.req.Metadata.Captures {
+		res := e.refreshCaptureScope(in, &sc, work)
 		val, ex, err := e.captureValue(captureValueIn{
 			captureScope: sc,
 			resolver:     res,
@@ -149,48 +134,96 @@ func (e *Engine) applyCaptures(in captureRun) error {
 		if err != nil {
 			return diag.WrapAsf(diag.ClassScript, err, "%s", captureErrCtx(in.req, c, ex))
 		}
+		if c.Secret {
+			in.secrets.Add(val)
+		}
 		switch c.Scope {
 		case directive.ScopeRequest:
-			upsertVariable(&in.req.Variables, directive.ScopeRequest, c.Name, val, c.Secret)
-			if in.out != nil {
-				in.out.addRequest(c.Name, val, c.Secret)
-			}
+			work.addRequest(c.Name, val, c.Secret)
 		case directive.ScopeFile:
-			if in.doc != nil {
-				upsertVariable(&in.doc.Variables, directive.ScopeFile, c.Name, val, c.Secret)
-			}
-			if in.out != nil {
-				in.out.addFile(c.Name, val, c.Secret)
-			}
+			work.addFile(c.Name, val, c.Secret)
 		case directive.ScopeGlobal:
-			if gs := e.rt.Globals(); gs != nil {
-				gs.Set(in.env.Scope(), c.Name, val, c.Secret)
-			}
+			work.globals.Set(c.Name, vars.GlobalMutation{Name: c.Name, Value: val, Secret: c.Secret})
 		}
 	}
 
-	if fs := e.rt.Files(); in.out != nil && len(in.out.fileVars) > 0 && fs != nil {
-		path := e.filePath(in.doc)
-		for _, v := range in.out.fileVars {
-			fs.Set(in.env.Scope(), path, v.Name, v.Value, v.Secret)
-		}
+	e.commitCaptures(in, work)
+	if in.out != nil {
+		*in.out = *work
 	}
 	return nil
 }
 
-// captureResolver derives from the request resolver to keep existing values pinned.
-// It binds the current response and keeps the request context and base directory.
-func (e *Engine) captureResolver(res *vars.Resolver, sc captureScope) *vars.Resolver {
-	return res.WithExprEval(e.ExprEval(sc.ctx, ExprInput{
+func (e *Engine) refreshCaptureScope(
+	in captureRun,
+	sc *captureScope,
+	work *captureResult,
+) *vars.Resolver {
+	runtime := mergeGlobalValues(in.store, work.globals)
+	plan := e.buildVariablePlan(varSources{
+		doc:     in.doc,
+		req:     in.req,
+		env:     in.env,
+		globals: runtime,
+		sec:     keepSecrets,
+		run:     in.run,
+	})
+	plan.overlay(sourceRequestCapture, capturedValues(work.requestVars))
+	plan.overlay(sourceRuntimeFile, capturedValues(work.fileVars))
+	sc.vars = plan.values()
+	sc.globals = effectiveGlobalValues(in.doc, runtime)
+
+	ei := ExprInput{
 		Doc:      sc.doc,
 		Req:      sc.req,
 		Env:      sc.env,
 		Base:     sc.base,
-		Vars:     sc.v,
+		Vars:     sc.vars,
 		Response: sc.rr,
 		Stream:   sc.rs,
 		Locals:   sc.locals,
-	}))
+		globals:  sc.globals,
+	}
+	if in.res == nil {
+		return e.planResolver(sc.ctx, plan, ei, ExprEvalOptions{})
+	}
+	res := in.res.WithProviders(plan.providers()...)
+	return res.WithExprEval(e.ExprEval(sc.ctx, ei))
+}
+
+func capturedValues(src vars.NameMap[restfile.Variable]) vars.NameMap[string] {
+	var out vars.NameMap[string]
+	for name, v := range src.All() {
+		out.Set(name, v.Value)
+	}
+	return out
+}
+
+func (e *Engine) commitCaptures(in captureRun, work *captureResult) {
+	for _, c := range in.req.Metadata.Captures {
+		switch c.Scope {
+		case directive.ScopeRequest:
+			if v, ok := work.requestVars.Get(c.Name); ok {
+				upsertVariable(&in.req.Variables, directive.ScopeRequest, v.Name, v.Value, v.Secret)
+			}
+		case directive.ScopeFile:
+			if in.doc == nil {
+				continue
+			}
+			if v, ok := work.fileVars.Get(c.Name); ok {
+				upsertVariable(&in.doc.Variables, directive.ScopeFile, v.Name, v.Value, v.Secret)
+			}
+		}
+	}
+
+	fs := e.rt.Files()
+	if fs == nil || work.fileVars.Len() == 0 {
+		return
+	}
+	path := e.filePath(in.doc)
+	for _, v := range work.fileVars.All() {
+		fs.Set(in.env.Scope(), path, v.Name, v.Value, v.Secret)
+	}
 }
 
 func (e *Engine) captureValue(in captureValueIn) (string, captureExpr, error) {
@@ -221,7 +254,8 @@ func (e *Engine) captureRTSValue(in captureRTSIn) (string, error) {
 		req:     in.req,
 		env:     in.env,
 		base:    in.base,
-		vars:    in.v,
+		vars:    in.vars,
+		globals: in.globals,
 		locals:  in.locals,
 		site:    directive.Capture.Tag() + " " + str.FoldLines(in.ex),
 		resp:    in.rr,

--- a/internal/engine/request/capture_scope_test.go
+++ b/internal/engine/request/capture_scope_test.go
@@ -1,0 +1,298 @@
+package request
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/scripts"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+func executedVar(t *testing.T, req *restfile.Request, name string) string {
+	t.Helper()
+
+	for _, v := range req.Variables {
+		if vars.NameKey(v.Name) == vars.NameKey(name) {
+			return v.Value
+		}
+	}
+	t.Fatalf("variable %q not captured: %#v", name, req.Variables)
+	return ""
+}
+
+func TestCaptureWritesReachEveryLaterReader(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Captures: []restfile.CaptureSpec{
+				{
+					Scope:      directive.ScopeGlobal,
+					Name:       "first",
+					Expression: `"one"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "viaVars",
+					Expression: `vars.get("first") ?? "missing"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "viaExpr",
+					Expression: `{{= vars.get("first") ?? "missing" }}`,
+					Mode:       restfile.CaptureExprModeTemplate,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "viaTpl",
+					Expression: `{{first}}`,
+					Mode:       restfile.CaptureExprModeTemplate,
+				},
+			},
+		},
+	}
+
+	sent := sendRequest(t, nil, req, envWith(t, "dev", nil), ExecOptions{})
+	for _, name := range []string{"viaVars", "viaExpr", "viaTpl"} {
+		if got := executedVar(t, sent.executed, name); got != "one" {
+			t.Fatalf("%s = %q, want %q", name, got, "one")
+		}
+	}
+}
+
+func TestRequestAndFileCapturesReachLaterCaptures(t *testing.T) {
+	doc := &restfile.Document{Path: "cap.http"}
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Captures: []restfile.CaptureSpec{
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "base",
+					Expression: `"r1"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeFile,
+					Name:       "fbase",
+					Expression: `"f1"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "echoReq",
+					Expression: `vars.get("base") ?? "missing"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "echoFile",
+					Expression: `{{fbase}}`,
+					Mode:       restfile.CaptureExprModeTemplate,
+				},
+			},
+		},
+	}
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if got := executedVar(t, sent.executed, "echoReq"); got != "r1" {
+		t.Fatalf("echoReq = %q, want %q", got, "r1")
+	}
+	if got := executedVar(t, sent.executed, "echoFile"); got != "f1" {
+		t.Fatalf("echoFile = %q, want %q", got, "f1")
+	}
+}
+
+func TestCaptureRefreshKeepsSourcePrecedence(t *testing.T) {
+	doc := &restfile.Document{Path: "cap.http"}
+	req := &restfile.Request{
+		Method:    http.MethodGet,
+		URL:       "http://example.test",
+		Variables: []restfile.Variable{{Name: "reqvar", Value: "from-request", Scope: directive.ScopeRequest}},
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{rtsPre(`vars.set("token", "from-script")`)},
+			Captures: []restfile.CaptureSpec{
+				{
+					Scope:      directive.ScopeFile,
+					Name:       "token",
+					Expression: `"from-file"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeGlobal,
+					Name:       "reqvar",
+					Expression: `"from-global"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "readToken",
+					Expression: `vars.get("token")`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "readReqvar",
+					Expression: `{{reqvar}}`,
+					Mode:       restfile.CaptureExprModeTemplate,
+				},
+			},
+		},
+	}
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if got := executedVar(t, sent.executed, "readToken"); got != "from-script" {
+		t.Fatalf("readToken = %q, want the script write to win", got)
+	}
+	if got := executedVar(t, sent.executed, "readReqvar"); got != "from-request" {
+		t.Fatalf("readReqvar = %q, want the request variable to win", got)
+	}
+}
+
+func TestCapturedValuesStayLiteralInLaterCaptures(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Captures: []restfile.CaptureSpec{
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "raw",
+					Expression: `"{{token}}"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "echo",
+					Expression: `{{raw}}`,
+					Mode:       restfile.CaptureExprModeTemplate,
+				},
+			},
+		},
+	}
+
+	sent := sendRequest(t, nil, req, envWith(t, "dev", nil), ExecOptions{})
+	if got := executedVar(t, sent.executed, "echo"); got != "{{token}}" {
+		t.Fatalf("echo = %q, want the captured text kept literal", got)
+	}
+}
+
+func TestCaptureTemplatesKeepPinnedDynamicValues(t *testing.T) {
+	req := &restfile.Request{
+		Method:    http.MethodGet,
+		URL:       "http://example.test",
+		Headers:   http.Header{"X-Id": []string{"{{id}}"}},
+		Variables: []restfile.Variable{{Name: "id", Value: "{{$uuid}}", Scope: directive.ScopeRequest}},
+		Metadata: restfile.RequestMetadata{
+			Captures: []restfile.CaptureSpec{
+				{
+					Scope:      directive.ScopeGlobal,
+					Name:       "stage",
+					Expression: `"x"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "echo",
+					Expression: `{{id}}`,
+					Mode:       restfile.CaptureExprModeTemplate,
+				},
+			},
+		},
+	}
+
+	sent := sendRequest(t, nil, req, envWith(t, "dev", nil), ExecOptions{})
+	sentID := sent.wire.Header.Get("X-Id")
+	if sentID == "" {
+		t.Fatal("X-Id was not sent")
+	}
+	if got := executedVar(t, sent.executed, "echo"); got != sentID {
+		t.Fatalf("echo = %q, want the sent value %q", got, sentID)
+	}
+}
+
+func TestCaptureExpandsNestedDocumentGlobal(t *testing.T) {
+	doc := &restfile.Document{
+		Path: "caps.http",
+		Globals: []restfile.Variable{
+			{Name: "base", Value: "expanded", Scope: directive.ScopeGlobal},
+			{Name: "nested", Value: "{{base}}", Scope: directive.ScopeGlobal},
+		},
+	}
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Captures: []restfile.CaptureSpec{{
+				Scope:      directive.ScopeRequest,
+				Name:       "echo",
+				Expression: `{{nested}}`,
+				Mode:       restfile.CaptureExprModeTemplate,
+			}},
+		},
+	}
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if got := executedVar(t, sent.executed, "echo"); got != "expanded" {
+		t.Fatalf("echo = %q, want %q", got, "expanded")
+	}
+}
+
+func TestFailedCaptureBatchLeavesNoPartialState(t *testing.T) {
+	eng := newCaptureEngine("dev")
+	resp := &scripts.Response{
+		Kind:   scripts.ResponseKindHTTP,
+		Status: "200 OK",
+		Code:   200,
+		Body:   []byte(`{"token":"abc123"}`),
+	}
+	doc := &restfile.Document{Path: "./caps.http"}
+	req := &restfile.Request{
+		Metadata: restfile.RequestMetadata{
+			Captures: []restfile.CaptureSpec{
+				{
+					Scope:      directive.ScopeFile,
+					Name:       "good",
+					Expression: "{{response.json.token}}",
+				},
+				{
+					Scope:      directive.ScopeRequest,
+					Name:       "keep",
+					Expression: "{{response.json.token}}",
+				},
+				{
+					Scope:      directive.ScopeFile,
+					Name:       "bad",
+					Expression: "{{response.json.missing.x}}",
+				},
+			},
+		},
+		Settings: map[string]string{"capture.strict": "true"},
+	}
+
+	var out captureResult
+	err := eng.applyCaptures(captureRun{
+		doc:  doc,
+		req:  req,
+		resp: resp,
+		out:  &out,
+		env:  testEnv("dev"),
+	})
+	if err == nil {
+		t.Fatal("expected the strict capture batch to fail")
+	}
+	if len(doc.Variables) != 0 {
+		t.Fatalf("doc.Variables = %#v, want the failed batch to stage nothing", doc.Variables)
+	}
+	if len(req.Variables) != 0 {
+		t.Fatalf("req.Variables = %#v, want the failed batch to stage nothing", req.Variables)
+	}
+	if store := eng.rt.Files().Snapshot(testEnv("dev").Scope(), doc.Path); len(store) != 0 {
+		t.Fatalf("file store = %#v, want the failed batch to persist nothing", store)
+	}
+}

--- a/internal/engine/request/capture_test.go
+++ b/internal/engine/request/capture_test.go
@@ -59,7 +59,7 @@ func TestApplyCapturesStoresValues(t *testing.T) {
 		},
 	}
 
-	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, rts.Locals{})
+	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, rts.Locals{}, runVars{})
 	var captures captureResult
 	if err := eng.applyCaptures(captureRun{
 		doc:  doc,
@@ -114,7 +114,7 @@ func TestApplyCapturesStoresValues(t *testing.T) {
 	if req.Variables[0].Name != "recentStatus" || req.Variables[0].Value != "200 OK" {
 		t.Fatalf("unexpected request variable %+v", req.Variables[0])
 	}
-	varsWithReq := eng.collectVariables(doc, req, testEnv("dev"))
+	varsWithReq := eng.collectVariables(doc, req, testEnv("dev"), runVars{})
 	if varsWithReq["recentStatus"] != "200 OK" {
 		t.Fatalf(
 			"expected request capture to be available in collected vars, got %q",
@@ -136,7 +136,7 @@ func TestApplyCapturesStoresValues(t *testing.T) {
 
 	// simulate a fresh parse of the document (no baked-in variables)
 	freshDoc := &restfile.Document{Path: "./sample.http"}
-	vars := eng.collectVariables(freshDoc, nil, testEnv("dev"))
+	vars := eng.collectVariables(freshDoc, nil, testEnv("dev"), runVars{})
 	if vars["lastTrace"] != "abc" {
 		t.Fatalf("expected file capture to be applied via runtime store, got %q", vars["lastTrace"])
 	}
@@ -872,7 +872,7 @@ func TestApplyCapturesWithStreamData(t *testing.T) {
 	}
 
 	doc := &restfile.Document{Path: "./stream.http"}
-	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, rts.Locals{})
+	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, rts.Locals{}, runVars{})
 	var captures captureResult
 	if err := eng.applyCaptures(captureRun{
 		doc:    doc,
@@ -886,7 +886,7 @@ func TestApplyCapturesWithStreamData(t *testing.T) {
 		t.Fatalf("applyCaptures stream: %v", err)
 	}
 
-	vars := eng.collectVariables(doc, req, testEnv("dev"))
+	vars := eng.collectVariables(doc, req, testEnv("dev"), runVars{})
 	if vars["streamKind"] != "websocket" {
 		t.Fatalf("expected stream kind capture, got %q", vars["streamKind"])
 	}

--- a/internal/engine/request/capture_test.go
+++ b/internal/engine/request/capture_test.go
@@ -59,7 +59,16 @@ func TestApplyCapturesStoresValues(t *testing.T) {
 		},
 	}
 
-	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, rts.Locals{}, runVars{})
+	resolver := eng.buildResolver(
+		context.Background(),
+		doc,
+		req,
+		testEnv("dev"),
+		"",
+		vars.Globals{},
+		rts.Locals{},
+		runVars{},
+	)
 	var captures captureResult
 	if err := eng.applyCaptures(captureRun{
 		doc:  doc,
@@ -71,12 +80,13 @@ func TestApplyCapturesStoresValues(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("applyCaptures: %v", err)
 	}
+	eng.applyGlobalMutations(captures.globals, testEnv("dev"))
 
-	if _, ok := captures.requestVars["recentstatus"]; !ok {
-		t.Fatalf("expected request capture to be recorded: %+v", captures.requestVars)
+	if !captures.requestVars.Has("recentStatus") {
+		t.Fatalf("expected request capture to be recorded: %+v", captures.requestVars.Map())
 	}
-	if _, ok := captures.fileVars["lasttrace"]; !ok {
-		t.Fatalf("expected file capture to be recorded: %+v", captures.fileVars)
+	if !captures.fileVars.Has("lastTrace") {
+		t.Fatalf("expected file capture to be recorded: %+v", captures.fileVars.Map())
 	}
 
 	snapshot := eng.rt.Globals().Snapshot(testEnv("dev").Scope())
@@ -191,6 +201,7 @@ func TestApplyCapturesEvaluatesRSTExpressions(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("applyCaptures rst: %v", err)
 	}
+	eng.applyGlobalMutations(captures.globals, testEnv("dev"))
 
 	gl := eng.rt.Globals().Snapshot(testEnv("dev").Scope())
 	if len(gl) != 1 {
@@ -700,6 +711,7 @@ func TestApplyCapturesUsesEnvironmentOverride(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("applyCaptures stage: %v", err)
 	}
+	eng.applyGlobalMutations(captures.globals, testEnv("stage"))
 
 	if len(eng.rt.Globals().Snapshot(testEnv("dev").Scope())) != 0 {
 		t.Fatalf("expected no globals in dev env after stage capture")
@@ -776,6 +788,7 @@ func TestApplyCapturesIsolatesGroupedCredentialProfiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("apply captures for %s: %v", env.Label(), err)
 		}
+		eng.applyGlobalMutations(out.globals, env)
 	}
 	apply(personal, "200 OK")
 	if got := rt.Globals().Snapshot(ci.Scope()); len(got) != 0 {
@@ -872,7 +885,16 @@ func TestApplyCapturesWithStreamData(t *testing.T) {
 	}
 
 	doc := &restfile.Document{Path: "./stream.http"}
-	resolver := eng.buildResolver(context.Background(), doc, req, testEnv("dev"), "", nil, rts.Locals{}, runVars{})
+	resolver := eng.buildResolver(
+		context.Background(),
+		doc,
+		req,
+		testEnv("dev"),
+		"",
+		vars.Globals{},
+		rts.Locals{},
+		runVars{},
+	)
 	var captures captureResult
 	if err := eng.applyCaptures(captureRun{
 		doc:    doc,
@@ -885,6 +907,7 @@ func TestApplyCapturesWithStreamData(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("applyCaptures stream: %v", err)
 	}
+	eng.applyGlobalMutations(captures.globals, testEnv("dev"))
 
 	vars := eng.collectVariables(doc, req, testEnv("dev"), runVars{})
 	if vars["streamKind"] != "websocket" {

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -3,7 +3,6 @@ package request
 import (
 	"context"
 	"errors"
-	"maps"
 	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
@@ -265,8 +264,7 @@ type execCtx struct {
 	storeG    map[string]vars.GlobalMutation
 	hasRTSPre bool
 	hasJSPre  bool
-	scriptV   map[string]string
-	extraV    map[string]string
+	run       runVars
 	locals    rts.Locals
 
 	res     *vars.Resolver
@@ -300,8 +298,7 @@ func newExec(
 		baseCtx = context.Background()
 	}
 	ctx, cancel := context.WithCancel(baseCtx)
-	base := e.collectVariables(doc, req, env)
-	maps.Copy(base, opt.Extra)
+	base := e.collectVariables(doc, req, env, runVars{overlay: opt.Extra})
 	hasRTS, hasJS := detectPreRequestScripts(req)
 	exp := newExplainBuilder(e, doc, req, env, opt.Mode == ExecModePreview)
 	if req != nil &&
@@ -323,7 +320,10 @@ func newExec(
 		storeG:    e.collectStoredGlobalValues(env),
 		hasRTSPre: hasRTS,
 		hasJSPre:  hasJS,
-		extraV:    cloneStringMap(opt.Extra),
+		run: runVars{
+			scripts: make(map[string]string),
+			overlay: cloneStringMap(opt.Extra),
+		},
 		locals:    opt.Locals,
 		exp:       exp,
 		onWarning: opt.OnWarning,
@@ -392,8 +392,16 @@ func (x *execCtx) canceled(err error) *xrunResult {
 
 func (x *execCtx) reqText() string { return renderRequestText(x.req) }
 
+// addScriptVars makes each pre-request script's writes available to the next
+// script at script precedence.
+func (x *execCtx) addScriptVars(set map[string]string) {
+	vars.Merge(x.run.scripts, set)
+}
+
+// currentVariables uses this run's in-memory globals so previews include
+// script changes without persisting them.
 func (x *execCtx) currentVariables() map[string]string {
-	return x.eng.collectVariablesWithGlobals(x.doc, x.req, x.env, x.storeG, false, x.extraV)
+	return x.eng.collectVariablesWithGlobals(x.doc, x.req, x.env, x.storeG, keepSecrets, x.run)
 }
 
 func (x *execCtx) currentGlobals() map[string]vars.GlobalMutation {
@@ -401,7 +409,7 @@ func (x *execCtx) currentGlobals() map[string]vars.GlobalMutation {
 }
 
 func (x *execCtx) captureVariables() map[string]string {
-	return mergeStringMaps(x.eng.collectVariables(x.doc, x.req, x.env, x.extraV), x.scriptV)
+	return x.eng.collectVariables(x.doc, x.req, x.env, x.run)
 }
 
 func (x *execCtx) applyRuntimeGlobals(ch map[string]vars.GlobalMutation) {
@@ -599,6 +607,7 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 	}
 
 	x.applyRuntimeGlobals(rtsOut.Globals)
+	x.addScriptVars(rtsOut.Variables)
 	if len(rtsOut.Globals) > 0 || len(rtsOut.Variables) > 0 {
 		vv = x.currentVariables()
 	}
@@ -651,18 +660,11 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 	}
 
 	x.applyRuntimeGlobals(jsOut.Globals)
-	x.scriptV = mergeStringMaps(rtsOut.Variables, jsOut.Variables)
+	x.addScriptVars(jsOut.Variables)
 	return nil
 }
 
 func (x *execCtx) buildResolver() {
-	extra := make([]map[string]string, 0, 2)
-	if len(x.scriptV) > 0 {
-		extra = append(extra, x.scriptV)
-	}
-	if len(x.extraV) > 0 {
-		extra = append(extra, x.extraV)
-	}
 	x.res = x.eng.buildResolver(
 		x.sendCtx,
 		x.doc,
@@ -671,7 +673,7 @@ func (x *execCtx) buildResolver() {
 		x.opts.BaseDir,
 		x.storeG,
 		x.locals,
-		extra...,
+		x.run,
 	)
 	x.trace = vars.NewTrace()
 	x.res.SetTrace(x.trace)
@@ -1074,8 +1076,7 @@ func (f flow) ExecuteGRPC() xexec.RequestResult {
 		return res
 	}
 
-	vv := x.eng.collectVariables(x.doc, x.req, x.env, x.extraV)
-	testV := mergeStringMaps(vv, x.scriptV)
+	testV := x.captureVariables()
 	testG := x.eng.collectGlobalValues(x.doc, x.env)
 	assertCtx, cancelAsserts := context.WithTimeout(x.sendCtx, x.timeout)
 	defer cancelAsserts()
@@ -1130,7 +1131,7 @@ func (f flow) ExecuteHTTP() xexec.RequestResult {
 		Resolver:         x.res,
 		Options:          x.opts,
 		EffectiveTimeout: x.timeout,
-		ScriptVars:       x.scriptV,
+		ScriptVars:       x.run.scripts,
 		Locals:           x.locals,
 	})
 	return x.finishHTTP(res)
@@ -1157,8 +1158,15 @@ func (x *execCtx) httpRunner() xexec.Runner {
 					locals: in.Locals,
 				})
 			},
-			CollectVariables: func(doc *restfile.Document, req *restfile.Request) map[string]string {
-				return x.eng.collectVariables(doc, req, x.env, x.extraV)
+			CollectVariables: func(
+				doc *restfile.Document,
+				req *restfile.Request,
+				scriptVars map[string]string,
+			) map[string]string {
+				return x.eng.collectVariables(doc, req, x.env, runVars{
+					scripts: scriptVars,
+					overlay: x.run.overlay,
+				})
 			},
 			CollectGlobalValues: func(doc *restfile.Document) map[string]vars.GlobalMutation {
 				return x.eng.collectGlobalValues(doc, x.env)

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -154,7 +154,7 @@ func (e *Engine) ExecuteWith(
 	}
 	if tunnel.HasConflict(req.SSH != nil, req.K8s != nil) {
 		err := diag.New(diag.ClassRoute, "@ssh cannot be combined with @k8s")
-		exp := newExplainBuilder(e, doc, req, env, opt.Mode == ExecModePreview)
+		exp := newExplainBuilder(e, doc, req, env, opt.Mode == ExecModePreview, nil)
 		exp.stage(
 			xplain.StageRoute,
 			xplain.StageError,
@@ -184,6 +184,7 @@ func (e *Engine) ExecuteWith(
 	res := xexec.RunRequest(flow{ctx: x})
 	end := time.Now()
 	res.Timing = requestTiming(start, end, res)
+	res = e.redactResult(res, doc, env)
 	if opt.Record {
 		e.record(doc, req, runResult{
 			Response:       res.Response,
@@ -261,7 +262,7 @@ type execCtx struct {
 	cancel  context.CancelFunc
 
 	baseVars  map[string]string
-	storeG    map[string]vars.GlobalMutation
+	storeG    vars.Globals
 	hasRTSPre bool
 	hasJSPre  bool
 	run       runVars
@@ -276,13 +277,13 @@ type execCtx struct {
 	grpcOpts grpcx.Options
 	timeout  time.Duration
 
-	runtimeSecrets []string
-	trace          *vars.Trace
-	exp            *explainBuilder
-	onWarning      func(Warning)
-	onSSE          func(*httpx.StreamHandle, *restfile.Request)
-	onWS           func(*httpx.WebSocketHandle, *restfile.Request)
-	onGRPC         func(*stream.Session, *restfile.Request)
+	secrets   *vars.Secrets
+	trace     *vars.Trace
+	exp       *explainBuilder
+	onWarning func(Warning)
+	onSSE     func(*httpx.StreamHandle, *restfile.Request)
+	onWS      func(*httpx.WebSocketHandle, *restfile.Request)
+	onGRPC    func(*stream.Session, *restfile.Request)
 }
 
 func newExec(
@@ -301,7 +302,8 @@ func newExec(
 	overlay := vars.CollectNames(opt.Extra)
 	base := e.collectVariables(doc, req, env, runVars{overlay: overlay})
 	hasRTS, hasJS := detectPreRequestScripts(req)
-	exp := newExplainBuilder(e, doc, req, env, opt.Mode == ExecModePreview)
+	secrets := &vars.Secrets{}
+	exp := newExplainBuilder(e, doc, req, env, opt.Mode == ExecModePreview, secrets)
 	if req != nil &&
 		(req.Metadata.When != nil || len(req.Metadata.Applies) > 0 || hasRTS || hasJS) {
 		exp.warn(
@@ -323,6 +325,7 @@ func newExec(
 		hasJSPre:  hasJS,
 		run:       runVars{overlay: overlay},
 		locals:    opt.Locals,
+		secrets:   secrets,
 		exp:       exp,
 		onWarning: opt.OnWarning,
 		onSSE:     opt.AttachSSE,
@@ -355,7 +358,7 @@ func (x *execCtx) base() xrunResult {
 		Executed:       x.req,
 		Environment:    x.env.Label(),
 		Selection:      x.env.Selection(),
-		RuntimeSecrets: append([]string(nil), x.runtimeSecrets...),
+		RuntimeSecrets: x.secrets.Values(),
 		Preview:        x.preview(),
 	}
 }
@@ -396,24 +399,32 @@ func (x *execCtx) addScriptVars(set vars.NameMap[string]) {
 	x.run.scripts.Merge(set)
 }
 
-// currentVariables uses this run's in-memory globals so previews include
-// script changes without persisting them.
+// Variable views use the run's in-memory globals so previews and later phases
+// can observe script changes without persisting them.
 func (x *execCtx) currentVariables() map[string]string {
 	return x.eng.collectVariablesWithGlobals(x.doc, x.req, x.env, x.storeG, keepSecrets, x.run)
 }
 
-func (x *execCtx) currentGlobals() map[string]vars.GlobalMutation {
+func (x *execCtx) currentGlobals() vars.Globals {
 	return effectiveGlobalValues(x.doc, x.storeG)
+}
+
+func (x *execCtx) evalScope(vv map[string]string) evalScope {
+	return evalScope{vars: vv, globals: x.currentGlobals()}
 }
 
 func (x *execCtx) captureVariables() map[string]string {
 	return x.eng.collectVariables(x.doc, x.req, x.env, x.run)
 }
 
-func (x *execCtx) applyRuntimeGlobals(ch map[string]vars.GlobalMutation) {
-	if len(ch) == 0 {
+// Before applying global changes, preserve any secret they replace or delete.
+// The value may already appear in run output and must remain redacted after it
+// leaves the current global view.
+func (x *execCtx) applyRuntimeGlobals(ch vars.Globals) {
+	if ch.Len() == 0 {
 		return
 	}
+	x.recordEvictedSecrets(ch)
 	if x.preview() {
 		x.storeG = mergeGlobalValues(x.storeG, ch)
 	} else {
@@ -422,6 +433,15 @@ func (x *execCtx) applyRuntimeGlobals(ch map[string]vars.GlobalMutation) {
 	}
 	if x.exp != nil {
 		x.exp.globals = effectiveGlobalValues(x.doc, x.storeG)
+	}
+}
+
+func (x *execCtx) recordEvictedSecrets(ch vars.Globals) {
+	cur := x.currentGlobals()
+	for name := range ch.All() {
+		if g, ok := cur.Get(name); ok && g.Secret {
+			x.secrets.Add(g.Value)
+		}
 	}
 }
 
@@ -479,14 +499,14 @@ func (f flow) EvaluateCondition() *xexec.RequestResult {
 	if x.req.Metadata.When == nil {
 		return nil
 	}
-	ok, reason, err := x.eng.EvalCondition(
+	ok, reason, err := x.eng.evalCondition(
 		x.sendCtx,
 		x.doc,
 		x.req,
 		x.env,
 		x.opts.BaseDir,
 		x.req.Metadata.When,
-		x.baseVars,
+		x.evalScope(x.baseVars),
 		x.locals,
 	)
 	if err != nil {
@@ -531,7 +551,7 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 	}
 	// @for-each binds its item as a typed value, and @apply reads it the same way
 	// every other expression in the run does.
-	err := x.eng.runRTSApply(x.sendCtx, x.doc, x.req, x.env, x.opts.BaseDir, vv, x.locals)
+	err := x.eng.runRTSApply(x.sendCtx, x.doc, x.req, x.env, x.opts.BaseDir, x.evalScope(vv), x.locals)
 	if err != nil {
 		x.exp.stage(
 			xplain.StageApply,
@@ -564,9 +584,9 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 		x.req,
 		x.env,
 		x.opts.BaseDir,
-		vv,
+		x.evalScope(vv),
 		x.locals,
-		cloneGlobalValues(x.currentGlobals()),
+		x.secrets,
 	)
 	if err != nil {
 		x.exp.stage(
@@ -606,7 +626,7 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 
 	x.applyRuntimeGlobals(rtsOut.Globals)
 	x.addScriptVars(rtsOut.Variables)
-	if len(rtsOut.Globals) > 0 || rtsOut.Variables.Len() > 0 {
+	if rtsOut.Globals.Len() > 0 || rtsOut.Variables.Len() > 0 {
 		vv = x.currentVariables()
 	}
 
@@ -617,9 +637,10 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 	jsOut, err := x.eng.sc.RunPreRequest(x.req.Metadata.Scripts, prerequest.Input{
 		Request:   x.req,
 		Variables: vv,
-		Globals:   cloneGlobalValues(x.currentGlobals()),
+		Globals:   x.currentGlobals(),
 		BaseDir:   x.opts.BaseDir,
 		Context:   x.sendCtx,
+		Secrets:   x.secrets,
 	})
 	if err != nil {
 		x.exp.stage(
@@ -724,7 +745,7 @@ func (x *execCtx) prepareAuth() *xrunResult {
 	if x.req.Metadata.Auth == nil {
 		return nil
 	}
-	x.exp.addSecrets(AuthSecretValues(x.req.Metadata.Auth, x.res)...)
+	x.secrets.Add(AuthSecretValues(x.req.Metadata.Auth, x.res)...)
 	before := CloneRequest(x.req)
 	if x.preview() {
 		out, err := x.eng.prepareExplainAuthPreview(x.doc, x.req, x.res, x.env)
@@ -754,7 +775,7 @@ func (x *execCtx) prepareAuth() *xrunResult {
 			)
 			return x.fail(err, "Auth preparation failed")
 		}
-		x.exp.addSecrets(out.extraSecrets...)
+		x.secrets.Add(out.extraSecrets...)
 		x.exp.stage(
 			xplain.StageAuth,
 			out.status,
@@ -807,8 +828,7 @@ func (x *execCtx) prepareAuth() *xrunResult {
 		}
 		secs = InjectedAuthSecrets(x.req.Metadata.Auth, before, x.req)
 	}
-	x.exp.addSecrets(secs...)
-	x.runtimeSecrets = append(x.runtimeSecrets, secs...)
+	x.secrets.Add(secs...)
 	x.exp.stage(xplain.StageAuth, xplain.StageOK, xplain.SummaryAuthPrepared, before, x.req)
 	return nil
 }
@@ -1046,17 +1066,19 @@ func (f flow) ExecuteGRPC() xexec.RequestResult {
 	respForScripts := grpcScriptResponse(x.req, resp)
 	var caps captureResult
 	if err := x.eng.applyCaptures(captureRun{
-		ctx:    x.sendCtx,
-		base:   x.opts.BaseDir,
-		doc:    x.doc,
-		req:    x.req,
-		res:    x.res,
-		resp:   respForScripts,
-		stream: info,
-		out:    &caps,
-		env:    x.env,
-		v:      x.captureVariables(),
-		locals: x.locals,
+		ctx:     x.sendCtx,
+		base:    x.opts.BaseDir,
+		doc:     x.doc,
+		req:     x.req,
+		res:     x.res,
+		resp:    respForScripts,
+		stream:  info,
+		out:     &caps,
+		env:     x.env,
+		store:   x.storeG,
+		secrets: x.secrets,
+		locals:  x.locals,
+		run:     x.run,
 	}); err != nil {
 		x.exp.stage(
 			xplain.StageCaptures,
@@ -1074,8 +1096,8 @@ func (f flow) ExecuteGRPC() xexec.RequestResult {
 		return res
 	}
 
-	testV := x.captureVariables()
-	testG := x.eng.collectGlobalValues(x.doc, x.env)
+	x.applyRuntimeGlobals(caps.globals)
+	testScope := x.evalScope(x.captureVariables())
 	assertCtx, cancelAsserts := context.WithTimeout(x.sendCtx, x.timeout)
 	defer cancelAsserts()
 	asserts, assertErr := x.eng.runAsserts(
@@ -1084,23 +1106,24 @@ func (f flow) ExecuteGRPC() xexec.RequestResult {
 		x.req,
 		x.env,
 		x.opts.BaseDir,
-		testV,
+		testScope,
 		x.locals,
 		rtsGRPC(resp),
 		nil,
 		rtsStream(info),
 	)
-	tests, globs, testErr := x.eng.sc.RunTests(
+	tests, globalChanges, testErr := x.eng.sc.RunTests(
 		x.req.Metadata.Scripts,
 		scripts.TestInput{
 			Response:  respForScripts,
-			Variables: testV,
-			Globals:   testG,
+			Variables: testScope.vars,
+			Globals:   testScope.globals,
 			BaseDir:   x.opts.BaseDir,
 			Stream:    info,
+			Secrets:   x.secrets,
 		},
 	)
-	x.applyRuntimeGlobals(globs)
+	x.applyRuntimeGlobals(globalChanges)
 	x.exp.setPrepared(x.req)
 	x.exp.setGRPC(x.req)
 
@@ -1131,6 +1154,7 @@ func (f flow) ExecuteHTTP() xexec.RequestResult {
 		EffectiveTimeout: x.timeout,
 		ScriptVars:       x.run.scripts,
 		Locals:           x.locals,
+		Secrets:          x.secrets,
 	})
 	return x.finishHTTP(res)
 }
@@ -1142,19 +1166,26 @@ func (x *execCtx) httpRunner() xexec.Runner {
 			AttachWebSocketHandle: x.onWS,
 			ApplyCaptures: func(in xexec.CaptureInput) error {
 				var caps captureResult
-				return x.eng.applyCaptures(captureRun{
-					ctx:    x.sendCtx,
-					base:   x.opts.BaseDir,
-					doc:    in.Doc,
-					req:    in.Req,
-					res:    in.Resolver,
-					resp:   in.Response,
-					stream: in.Stream,
-					out:    &caps,
-					env:    x.env,
-					v:      in.Vars,
-					locals: in.Locals,
+				err := x.eng.applyCaptures(captureRun{
+					ctx:     x.sendCtx,
+					base:    x.opts.BaseDir,
+					doc:     in.Doc,
+					req:     in.Req,
+					res:     in.Resolver,
+					resp:    in.Response,
+					stream:  in.Stream,
+					out:     &caps,
+					env:     x.env,
+					store:   x.storeG,
+					secrets: x.secrets,
+					locals:  in.Locals,
+					run:     x.run,
 				})
+				if err != nil {
+					return err
+				}
+				x.applyRuntimeGlobals(caps.globals)
+				return nil
 			},
 			CollectVariables: func(
 				doc *restfile.Document,
@@ -1166,8 +1197,8 @@ func (x *execCtx) httpRunner() xexec.Runner {
 					overlay: x.run.overlay,
 				})
 			},
-			CollectGlobalValues: func(doc *restfile.Document) map[string]vars.GlobalMutation {
-				return x.eng.collectGlobalValues(doc, x.env)
+			CollectGlobalValues: func(doc *restfile.Document) vars.Globals {
+				return effectiveGlobalValues(doc, x.storeG)
 			},
 			RunAsserts: func(in xexec.AssertInput) ([]scripts.TestResult, error) {
 				return x.eng.runAsserts(
@@ -1176,7 +1207,7 @@ func (x *execCtx) httpRunner() xexec.Runner {
 					in.Req,
 					x.env,
 					in.BaseDir,
-					in.Vars,
+					x.evalScope(in.Vars),
 					in.Locals,
 					rtsHTTP(in.HTTP),
 					rtsTrace(in.HTTP),

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -393,8 +393,6 @@ func (x *execCtx) canceled(err error) *xrunResult {
 
 func (x *execCtx) reqText() string { return renderRequestText(x.req) }
 
-// addScriptVars makes each pre-request script's writes available to the next
-// script at script precedence.
 func (x *execCtx) addScriptVars(set vars.NameMap[string]) {
 	x.run.scripts.Merge(set)
 }

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -298,7 +298,8 @@ func newExec(
 		baseCtx = context.Background()
 	}
 	ctx, cancel := context.WithCancel(baseCtx)
-	base := e.collectVariables(doc, req, env, runVars{overlay: opt.Extra})
+	overlay := vars.CollectNames(opt.Extra)
+	base := e.collectVariables(doc, req, env, runVars{overlay: overlay})
 	hasRTS, hasJS := detectPreRequestScripts(req)
 	exp := newExplainBuilder(e, doc, req, env, opt.Mode == ExecModePreview)
 	if req != nil &&
@@ -320,10 +321,7 @@ func newExec(
 		storeG:    e.collectStoredGlobalValues(env),
 		hasRTSPre: hasRTS,
 		hasJSPre:  hasJS,
-		run: runVars{
-			scripts: make(map[string]string),
-			overlay: cloneStringMap(opt.Extra),
-		},
+		run:       runVars{overlay: overlay},
 		locals:    opt.Locals,
 		exp:       exp,
 		onWarning: opt.OnWarning,
@@ -394,8 +392,8 @@ func (x *execCtx) reqText() string { return renderRequestText(x.req) }
 
 // addScriptVars makes each pre-request script's writes available to the next
 // script at script precedence.
-func (x *execCtx) addScriptVars(set map[string]string) {
-	vars.Merge(x.run.scripts, set)
+func (x *execCtx) addScriptVars(set vars.NameMap[string]) {
+	x.run.scripts.Merge(set)
 }
 
 // currentVariables uses this run's in-memory globals so previews include
@@ -608,7 +606,7 @@ func (f flow) RunPreRequest() *xexec.RequestResult {
 
 	x.applyRuntimeGlobals(rtsOut.Globals)
 	x.addScriptVars(rtsOut.Variables)
-	if len(rtsOut.Globals) > 0 || len(rtsOut.Variables) > 0 {
+	if len(rtsOut.Globals) > 0 || rtsOut.Variables.Len() > 0 {
 		vv = x.currentVariables()
 	}
 
@@ -1161,7 +1159,7 @@ func (x *execCtx) httpRunner() xexec.Runner {
 			CollectVariables: func(
 				doc *restfile.Document,
 				req *restfile.Request,
-				scriptVars map[string]string,
+				scriptVars vars.NameMap[string],
 			) map[string]string {
 				return x.eng.collectVariables(doc, req, x.env, runVars{
 					scripts: scriptVars,

--- a/internal/engine/request/explain_build.go
+++ b/internal/engine/request/explain_build.go
@@ -47,23 +47,23 @@ type explainFinalizeInput struct {
 	settings     map[string]string
 	ssh          *ssh.Plan
 	k8s          *k8s.Plan
-	globals      map[string]vars.GlobalMutation
+	globals      vars.Globals
 	extraSecrets []string
 }
 
 type explainBuilder struct {
-	eng          *Engine
-	doc          *restfile.Document
-	req          *restfile.Request
-	env          vars.Environment
-	preview      bool
-	report       *xplain.Report
-	trace        *vars.Trace
-	settings     map[string]string
-	ssh          *ssh.Plan
-	k8s          *k8s.Plan
-	globals      map[string]vars.GlobalMutation
-	extraSecrets []string
+	eng      *Engine
+	doc      *restfile.Document
+	req      *restfile.Request
+	env      vars.Environment
+	preview  bool
+	report   *xplain.Report
+	trace    *vars.Trace
+	settings map[string]string
+	ssh      *ssh.Plan
+	k8s      *k8s.Plan
+	globals  vars.Globals
+	secrets  *vars.Secrets
 }
 
 func newExplainBuilder(
@@ -72,7 +72,11 @@ func newExplainBuilder(
 	req *restfile.Request,
 	env vars.Environment,
 	preview bool,
+	sec *vars.Secrets,
 ) *explainBuilder {
+	if sec == nil {
+		sec = &vars.Secrets{}
+	}
 	b := &explainBuilder{
 		eng:     e,
 		doc:     doc,
@@ -80,6 +84,7 @@ func newExplainBuilder(
 		env:     env,
 		preview: preview,
 		report:  newExplainReport(req, env.Label()),
+		secrets: sec,
 	}
 	if e != nil {
 		b.globals = effectiveGlobalValues(doc, e.collectStoredGlobalValues(env))
@@ -136,15 +141,6 @@ func (b *explainBuilder) setRoute(ssh *ssh.Plan, k8s *k8s.Plan) {
 	b.k8s = k8s
 }
 
-func (b *explainBuilder) addSecrets(vals ...string) {
-	for _, val := range vals {
-		if strings.TrimSpace(val) == "" {
-			continue
-		}
-		b.extraSecrets = append(b.extraSecrets, val)
-	}
-}
-
 func (b *explainBuilder) setPrepared(req *restfile.Request) {
 	setExplainPrepared(b.report, req, b.settings, b.ssh, b.k8s)
 }
@@ -179,7 +175,7 @@ func (b *explainBuilder) finish(
 		ssh:          b.ssh,
 		k8s:          b.k8s,
 		globals:      b.globals,
-		extraSecrets: b.extraSecrets,
+		extraSecrets: b.secrets.Values(),
 	})
 }
 

--- a/internal/engine/request/explain_redact.go
+++ b/internal/engine/request/explain_redact.go
@@ -17,7 +17,7 @@ func (e *Engine) redactExplainReport(
 	doc *restfile.Document,
 	req *restfile.Request,
 	env vars.Environment,
-	globs map[string]vars.GlobalMutation,
+	globs vars.Globals,
 	extra ...string,
 ) *xplain.Report {
 	if rep == nil {
@@ -25,31 +25,31 @@ func (e *Engine) redactExplainReport(
 	}
 	secs := e.explainSecrets(doc, req, env, globs, extra)
 
-	rep.Name = redactExplainText(rep.Name, secs)
-	rep.Method = redactExplainText(rep.Method, secs)
-	rep.URL = redactExplainText(rep.URL, secs)
-	rep.Decision = redactExplainText(rep.Decision, secs)
-	rep.Failure = redactExplainText(rep.Failure, secs)
+	rep.Name = redactSecretText(rep.Name, secs)
+	rep.Method = redactSecretText(rep.Method, secs)
+	rep.URL = redactSecretText(rep.URL, secs)
+	rep.Decision = redactSecretText(rep.Decision, secs)
+	rep.Failure = redactSecretText(rep.Failure, secs)
 
 	for i := range rep.Vars {
-		rep.Vars[i].Value = redactExplainText(rep.Vars[i].Value, secs)
+		rep.Vars[i].Value = redactSecretText(rep.Vars[i].Value, secs)
 	}
 	for i := range rep.Stages {
-		rep.Stages[i].Summary = redactExplainText(rep.Stages[i].Summary, secs)
+		rep.Stages[i].Summary = redactSecretText(rep.Stages[i].Summary, secs)
 		for j := range rep.Stages[i].Changes {
 			ch := &rep.Stages[i].Changes[j]
 			ch.Before = redactExplainChangeValue(ch.Field, ch.Before, secs)
 			ch.After = redactExplainChangeValue(ch.Field, ch.After, secs)
 		}
 		for j := range rep.Stages[i].Notes {
-			rep.Stages[i].Notes[j] = redactExplainText(rep.Stages[i].Notes[j], secs)
+			rep.Stages[i].Notes[j] = redactSecretText(rep.Stages[i].Notes[j], secs)
 		}
 	}
 	if rep.Final != nil {
-		rep.Final.Method = redactExplainText(rep.Final.Method, secs)
-		rep.Final.URL = redactExplainText(rep.Final.URL, secs)
-		rep.Final.Body = redactExplainText(rep.Final.Body, secs)
-		rep.Final.BodyNote = redactExplainText(rep.Final.BodyNote, secs)
+		rep.Final.Method = redactSecretText(rep.Final.Method, secs)
+		rep.Final.URL = redactSecretText(rep.Final.URL, secs)
+		rep.Final.Body = redactSecretText(rep.Final.Body, secs)
+		rep.Final.BodyNote = redactSecretText(rep.Final.BodyNote, secs)
 		for i := range rep.Final.Headers {
 			h := &rep.Final.Headers[i]
 			if shouldMaskExplainHeader(h.Name) {
@@ -58,36 +58,36 @@ func (e *Engine) redactExplainReport(
 				}
 				continue
 			}
-			h.Value = redactExplainText(h.Value, secs)
+			h.Value = redactSecretText(h.Value, secs)
 		}
 		for i := range rep.Final.Settings {
-			rep.Final.Settings[i].Value = redactExplainText(rep.Final.Settings[i].Value, secs)
+			rep.Final.Settings[i].Value = redactSecretText(rep.Final.Settings[i].Value, secs)
 		}
 		for i := range rep.Final.Details {
 			d := &rep.Final.Details[i]
 			key := d.Key
 			val := d.Value
-			d.Key = redactExplainText(key, secs)
+			d.Key = redactSecretText(key, secs)
 			if shouldMaskExplainPair(key, val) {
 				if strings.TrimSpace(val) != "" {
 					d.Value = explainMask
 				}
 				continue
 			}
-			d.Value = redactExplainText(val, secs)
+			d.Value = redactSecretText(val, secs)
 		}
 		for i := range rep.Final.Steps {
-			rep.Final.Steps[i] = redactExplainText(rep.Final.Steps[i], secs)
+			rep.Final.Steps[i] = redactSecretText(rep.Final.Steps[i], secs)
 		}
 		if rep.Final.Route != nil {
-			rep.Final.Route.Summary = redactExplainText(rep.Final.Route.Summary, secs)
+			rep.Final.Route.Summary = redactSecretText(rep.Final.Route.Summary, secs)
 			for i := range rep.Final.Route.Notes {
-				rep.Final.Route.Notes[i] = redactExplainText(rep.Final.Route.Notes[i], secs)
+				rep.Final.Route.Notes[i] = redactSecretText(rep.Final.Route.Notes[i], secs)
 			}
 		}
 	}
 	for i := range rep.Warnings {
-		rep.Warnings[i] = redactExplainText(rep.Warnings[i], secs)
+		rep.Warnings[i] = redactSecretText(rep.Warnings[i], secs)
 	}
 	return rep
 }
@@ -96,7 +96,7 @@ func (e *Engine) explainSecrets(
 	doc *restfile.Document,
 	req *restfile.Request,
 	env vars.Environment,
-	globs map[string]vars.GlobalMutation,
+	globs vars.Globals,
 	extra []string,
 ) []string {
 	vals := make(map[string]struct{})
@@ -110,7 +110,7 @@ func (e *Engine) explainSecrets(
 	for _, v := range e.secretValues(doc, req, env, extra...) {
 		add(v)
 	}
-	for _, gv := range globs {
+	for _, gv := range globs.All() {
 		if gv.Secret && !gv.Delete {
 			add(gv.Value)
 		}
@@ -133,10 +133,10 @@ func redactExplainChangeValue(field, val string, secs []string) string {
 		}
 		return explainMask
 	}
-	return redactExplainText(val, secs)
+	return redactSecretText(val, secs)
 }
 
-func redactExplainText(s string, secs []string) string {
+func redactSecretText(s string, secs []string) string {
 	if strings.TrimSpace(s) == "" || len(secs) == 0 {
 		return s
 	}

--- a/internal/engine/request/explain_redact_test.go
+++ b/internal/engine/request/explain_redact_test.go
@@ -6,6 +6,7 @@ import (
 
 	xplain "github.com/unkn0wn-root/resterm/internal/explain"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 // Nothing else stops a secret variable from reaching the explain output, so
@@ -62,7 +63,7 @@ func TestRedactExplainReportMasksSecretsAndSensitiveHeaders(t *testing.T) {
 		Warnings: []string{"warn top-secret"},
 	}
 
-	got := eng.redactExplainReport(rep, nil, req, testEnv(""), nil)
+	got := eng.redactExplainReport(rep, nil, req, testEnv(""), vars.Globals{})
 	if got.Final == nil {
 		t.Fatal("expected final report section")
 	}

--- a/internal/engine/request/globals_test.go
+++ b/internal/engine/request/globals_test.go
@@ -1,0 +1,346 @@
+package request
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
+	xplain "github.com/unkn0wn-root/resterm/internal/explain"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+var globalReaders = map[string]string{
+	"X-Template": "{{token}}",
+	"X-Vars":     `{{= vars.get("token") }}`,
+	"X-Global":   `{{= vars.global.get("token") ?? "missing" }}`,
+}
+
+func globalReaderRequest(scripts ...restfile.ScriptBlock) *restfile.Request {
+	req := &restfile.Request{
+		Method:   http.MethodGet,
+		URL:      "http://example.test",
+		Headers:  http.Header{},
+		Metadata: restfile.RequestMetadata{Scripts: scripts},
+	}
+	for name, tpl := range globalReaders {
+		req.Headers.Set(name, tpl)
+	}
+	return req
+}
+
+func assertGlobalReaders(t *testing.T, header http.Header, want string) {
+	t.Helper()
+
+	for name := range globalReaders {
+		if got := header.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func docWithGlobals(vs ...restfile.Variable) *restfile.Document {
+	for i := range vs {
+		vs[i].Scope = directive.ScopeGlobal
+	}
+	return &restfile.Document{Path: "globals.http", Globals: vs}
+}
+
+func TestDocumentGlobalCaseVariantsResolveToTheLastDeclaration(t *testing.T) {
+	tests := []struct {
+		name  string
+		first string
+		last  string
+	}{
+		{name: "lower then upper", first: "token", last: "TOKEN"},
+		{name: "upper then lower", first: "TOKEN", last: "token"},
+		{name: "mixed then lower", first: "ToKeN", last: "token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := docWithGlobals(
+				restfile.Variable{Name: tt.first, Value: "first"},
+				restfile.Variable{Name: tt.last, Value: "second"},
+			)
+
+			sent := sendRequest(t, doc, globalReaderRequest(), testEnv(""), ExecOptions{})
+			assertGlobalReaders(t, sent.wire.Header, "second")
+		})
+	}
+}
+
+func TestRTSGlobalCaseVariantsResolveToTheLastWrite(t *testing.T) {
+	req := globalReaderRequest(rtsPre(`vars.global.set("token", "first", false)
+vars.global.set("TOKEN", "second", false)`))
+
+	sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{})
+	assertGlobalReaders(t, sent.wire.Header, "second")
+}
+
+func TestJSGlobalCaseVariantsResolveToTheLastWrite(t *testing.T) {
+	req := globalReaderRequest(jsPre(`vars.global.set("token", "first");
+		vars.global.set("TOKEN", "second");`))
+
+	sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{})
+	assertGlobalReaders(t, sent.wire.Header, "second")
+}
+
+func TestRTSGlobalDeleteAndSetFollowCallOrder(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		want   string
+	}{
+		{
+			name: "delete after set",
+			script: `vars.global.set("token", "written", false)
+vars.global.delete("TOKEN")`,
+			want: "missing",
+		},
+		{
+			name: "set after delete",
+			script: `vars.global.delete("token")
+vars.global.set("TOKEN", "rewritten", false)`,
+			want: "rewritten",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := globalReaderRequest(rtsPre(tt.script))
+			req.Headers.Del("X-Template")
+			req.Headers.Set("X-Vars", `{{= vars.get("token") ?? "missing" }}`)
+
+			eng, st := newStubEngine(t)
+			env := envWith(t, "dev", nil)
+			eng.rt.Globals().Set(env.Scope(), "token", "seed", false)
+			sent := sendWith(t, eng, st, nil, req, env, ExecOptions{})
+
+			for _, name := range []string{"X-Vars", "X-Global"} {
+				if got := sent.wire.Header.Get(name); got != tt.want {
+					t.Fatalf("%s = %q, want %q", name, got, tt.want)
+				}
+			}
+			snap := eng.rt.Globals().Snapshot(env.Scope())
+			if tt.want == "missing" {
+				if len(snap) != 0 {
+					t.Fatalf("store = %#v, want the global deleted", snap)
+				}
+				return
+			}
+			if len(snap) != 1 {
+				t.Fatalf("store = %#v, want one entry", snap)
+			}
+			if got := snap["token"].Value; got != tt.want {
+				t.Fatalf("store token = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreviewReadsGlobalsScriptsSetInMemory(t *testing.T) {
+	tests := []struct {
+		name   string
+		script restfile.ScriptBlock
+	}{
+		{name: "rts", script: rtsPre(`vars.global.set("token", "in-memory", false)`)},
+		{name: "js", script: jsPre(`vars.global.set("token", "in-memory");`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eng := New(engcfg.Config{}, nil)
+			env := envWith(t, "dev", nil)
+
+			res, err := eng.ExecuteWith(nil, globalReaderRequest(tt.script), env, ExecOptions{
+				Mode: ExecModePreview,
+			})
+			if err != nil {
+				t.Fatalf("ExecuteWith() error = %v", err)
+			}
+			if res.Err != nil {
+				t.Fatalf("ExecuteWith() result error = %v", res.Err)
+			}
+			if res.Explain == nil || res.Explain.Final == nil {
+				t.Fatalf("expected a prepared preview, got %#v", res.Explain)
+			}
+			assertGlobalReaders(t, previewHeaders(res.Explain.Final.Headers), "in-memory")
+			if snap := eng.rt.Globals().Snapshot(env.Scope()); len(snap) != 0 {
+				t.Fatalf("store = %#v, want a preview to persist nothing", snap)
+			}
+		})
+	}
+}
+
+func TestEveryRTSDirectiveReadsRunGlobals(t *testing.T) {
+	doc := docWithGlobals(restfile.Variable{Name: "token", Value: "doc-token"})
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			When: &restfile.ConditionSpec{Expression: `vars.global.get("token") == "doc-token"`},
+			Applies: []restfile.ApplySpec{{
+				Expression: `{headers: {"X-Applied": vars.global.get("token")}}`,
+			}},
+			Captures: []restfile.CaptureSpec{{
+				Scope:      directive.ScopeRequest,
+				Name:       "captured",
+				Expression: `vars.global.get("token")`,
+				Mode:       restfile.CaptureExprModeRTS,
+			}},
+			Asserts: []restfile.AssertSpec{{
+				Expression: `vars.global.get("token") == "doc-token"`,
+				Message:    "assert reads the run's globals",
+			}},
+		},
+	}
+
+	eng, st := newStubEngine(t)
+	res, err := eng.ExecuteWith(doc, req, testEnv(""), ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("ExecuteWith() result error = %v", res.Err)
+	}
+	if res.Skipped {
+		t.Fatalf("@when skipped the request: %s", res.SkipReason)
+	}
+	if got := st.wire.Header.Get("X-Applied"); got != "doc-token" {
+		t.Fatalf("@apply header = %q, want %q", got, "doc-token")
+	}
+	for _, tc := range res.Tests {
+		if !tc.Passed {
+			t.Fatalf("@assert failed: %s", tc.Name)
+		}
+	}
+	if len(res.Tests) != 1 {
+		t.Fatalf("res.Tests = %#v, want the one assert", res.Tests)
+	}
+
+	captured := ""
+	for _, v := range res.Executed.Variables {
+		if vars.NameKey(v.Name) == "captured" {
+			captured = v.Value
+		}
+	}
+	if captured != "doc-token" {
+		t.Fatalf("@capture value = %q, want %q", captured, "doc-token")
+	}
+}
+
+func previewHeaders(hs []xplain.Header) http.Header {
+	out := make(http.Header, len(hs))
+	for _, h := range hs {
+		out.Add(h.Name, h.Value)
+	}
+	return out
+}
+
+func TestGlobalCaptureReachesLaterReadersInTheSameRequest(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Captures: []restfile.CaptureSpec{{
+				Scope:      directive.ScopeGlobal,
+				Name:       "token",
+				Expression: `"captured"`,
+				Mode:       restfile.CaptureExprModeRTS,
+			}},
+			Asserts: []restfile.AssertSpec{
+				{Expression: `vars.global.get("token") == "captured"`},
+				{Expression: `vars.get("token") == "captured"`},
+			},
+			Scripts: []restfile.ScriptBlock{{
+				Kind: "test",
+				Body: `client.test("global capture", function () {
+					tests.assert(vars.global.get("token") === "captured", "test script sees the capture");
+				});`,
+			}},
+		},
+	}
+
+	eng, st := newStubEngine(t)
+	env := envWith(t, "dev", nil)
+	res, err := eng.ExecuteWith(nil, req, env, ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("ExecuteWith() result error = %v", res.Err)
+	}
+	if res.ScriptErr != nil {
+		t.Fatalf("ExecuteWith() script error = %v", res.ScriptErr)
+	}
+	seen := make(map[string]bool, len(res.Tests))
+	for _, tc := range res.Tests {
+		if !tc.Passed {
+			t.Fatalf("%s failed: %s", tc.Name, tc.Message)
+		}
+		seen[tc.Name] = true
+	}
+	for _, name := range []string{
+		`vars.global.get("token") == "captured"`,
+		`vars.get("token") == "captured"`,
+		"test script sees the capture",
+	} {
+		if !seen[name] {
+			t.Fatalf("res.Tests = %#v, want a result named %q", res.Tests, name)
+		}
+	}
+	if got := eng.rt.Globals().Snapshot(env.Scope())["token"].Value; got != "captured" {
+		t.Fatalf("store token = %q, want %q", got, "captured")
+	}
+	if st.wire == nil {
+		t.Fatal("request was never sent")
+	}
+}
+
+func TestGlobalCaptureIsVisibleToLaterCaptures(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Captures: []restfile.CaptureSpec{
+				{
+					Scope:      directive.ScopeGlobal,
+					Name:       "first",
+					Expression: `"one"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeGlobal,
+					Name:       "second",
+					Expression: `vars.global.get("first") + "-two"`,
+					Mode:       restfile.CaptureExprModeRTS,
+				},
+				{
+					Scope:      directive.ScopeGlobal,
+					Name:       "third",
+					Expression: `{{= vars.global.get("second") }}-three`,
+					Mode:       restfile.CaptureExprModeTemplate,
+				},
+			},
+		},
+	}
+
+	eng, _ := newStubEngine(t)
+	env := envWith(t, "dev", nil)
+	if _, err := eng.ExecuteWith(nil, req, env, ExecOptions{}); err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+
+	snap := eng.rt.Globals().Snapshot(env.Scope())
+	for name, want := range map[string]string{
+		"first":  "one",
+		"second": "one-two",
+		"third":  "one-two-three",
+	} {
+		if got := snap[name].Value; got != want {
+			t.Fatalf("global %s = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/internal/engine/request/redact.go
+++ b/internal/engine/request/redact.go
@@ -1,0 +1,67 @@
+package request
+
+import (
+	"strings"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+// Results are redacted at the engine boundary because errors and test output
+// can be rendered directly by the UI, workflows, and history. The complete
+// secret set is returned for callers that render additional text. Wrapped
+// errors retain their original cause for errors.Is and errors.As.
+func (e *Engine) redactResult(
+	res xrunResult,
+	doc *restfile.Document,
+	env vars.Environment,
+) xrunResult {
+	secs := e.secretValues(doc, res.Executed, env, res.RuntimeSecrets...)
+	if len(secs) == 0 {
+		return res
+	}
+	res.RuntimeSecrets = secs
+	res.Err = redactErr(res.Err, secs)
+	res.ScriptErr = redactErr(res.ScriptErr, secs)
+	for i := range res.Tests {
+		res.Tests[i].Name = redactSecretText(res.Tests[i].Name, secs)
+		res.Tests[i].Message = redactSecretText(res.Tests[i].Message, secs)
+	}
+	return res
+}
+
+type redactedError struct {
+	err  error
+	text string
+	rep  diag.Report
+}
+
+func (e *redactedError) Error() string           { return e.text }
+func (e *redactedError) Unwrap() error           { return e.err }
+func (e *redactedError) Diagnostic() diag.Report { return e.rep }
+
+func redactErr(err error, secs []string) error {
+	if err == nil {
+		return nil
+	}
+	text := err.Error()
+	if !containsSecret(text, secs) && !containsSecret(diag.Render(err), secs) {
+		return err
+	}
+	mask := func(s string) string { return redactSecretText(s, secs) }
+	return &redactedError{
+		err:  err,
+		text: mask(text),
+		rep:  diag.ReportOf(err).Redact(mask),
+	}
+}
+
+func containsSecret(s string, secs []string) bool {
+	for _, sec := range secs {
+		if sec != "" && strings.Contains(s, sec) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -284,29 +284,6 @@ type EvalInput struct {
 	Locals rts.Locals
 }
 
-func (e *Engine) rtsEval(
-	ctx context.Context,
-	doc *restfile.Document,
-	req *restfile.Request,
-	env vars.Environment,
-	base string,
-	locals rts.Locals,
-	extras ...map[string]string,
-) vars.ExprEval {
-	vv := e.collectVariables(doc, req, env)
-	for _, overlay := range extras {
-		maps.Copy(vv, overlay)
-	}
-	return e.ExprEval(ctx, ExprInput{
-		Doc:    doc,
-		Req:    req,
-		Env:    env,
-		Base:   base,
-		Vars:   vv,
-		Locals: locals,
-	})
-}
-
 // ExprEvalOptions tunes how a {{= expr }} evaluator treats the RTS runtime.
 type ExprEvalOptions struct {
 	// OmitSecretGlobals drops secret global values from the runtime so preview
@@ -389,7 +366,7 @@ func (e *Engine) evalRTSString(
 func (e *Engine) rtsEvalValue(ctx context.Context, in EvalInput) (rts.Value, error) {
 	vv := in.Vars
 	if vv == nil {
-		vv = e.collectVariables(in.Doc, in.Req, in.Env)
+		vv = e.collectVariables(in.Doc, in.Req, in.Env, runVars{})
 	}
 	rt := e.buildRT(rtIn{
 		doc:     in.Doc,
@@ -412,9 +389,9 @@ func (e *Engine) CollectVariables(
 	doc *restfile.Document,
 	req *restfile.Request,
 	env vars.Environment,
-	extras ...map[string]string,
+	overlay map[string]string,
 ) map[string]string {
-	return e.collectVariables(doc, req, env, extras...)
+	return e.collectVariables(doc, req, env, runVars{overlay: overlay})
 }
 
 func (e *Engine) EvalValue(ctx context.Context, in EvalInput) (rts.Value, error) {
@@ -526,7 +503,7 @@ func (e *Engine) runAsserts(
 		return nil, nil
 	}
 	if vv == nil {
-		vv = e.collectVariables(doc, req, env)
+		vv = e.collectVariables(doc, req, env, runVars{})
 	}
 	rt := e.buildRT(rtIn{
 		doc:     doc,
@@ -1050,33 +1027,11 @@ func applyPatchVars(req *restfile.Request, vv map[string]string, in map[string]s
 	if req == nil || len(in) == 0 {
 		return
 	}
-	setRequestVars(req, in)
+	prerequest.SetRequestVars(req, in)
 	if vv == nil {
 		return
 	}
-	maps.Copy(vv, in)
-}
-
-func setRequestVars(req *restfile.Request, vv map[string]string) {
-	if req == nil || len(vv) == 0 {
-		return
-	}
-	idxs := make(map[string]int)
-	for i, v := range req.Variables {
-		idxs[strings.ToLower(v.Name)] = i
-	}
-	for name, val := range vv {
-		key := strings.ToLower(name)
-		if idx, ok := idxs[key]; ok {
-			req.Variables[idx].Value = val
-			continue
-		}
-		req.Variables = append(req.Variables, restfile.Variable{
-			Name:  name,
-			Value: val,
-			Scope: directive.ScopeRequest,
-		})
-	}
+	vars.Merge(vv, in)
 }
 
 func applyKey(key string) string { return strings.ToLower(strings.TrimSpace(key)) }

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -199,12 +199,26 @@ func rtsStream(info *scripts.StreamInfo) *rts.Stream {
 	return &rts.Stream{Kind: info.Kind, Summary: sum, Events: evs}
 }
 
+type evalScope struct {
+	vars    map[string]string
+	globals vars.Globals
+}
+
+func (e *Engine) storedScope(
+	doc *restfile.Document,
+	env vars.Environment,
+	vv map[string]string,
+) evalScope {
+	return evalScope{vars: vv, globals: e.collectGlobalValues(doc, env)}
+}
+
 type rtIn struct {
 	doc     *restfile.Document
 	req     *restfile.Request
 	env     vars.Environment
 	base    string
 	vars    map[string]string
+	globals vars.Globals
 	site    string
 	resp    *rts.Resp
 	res     *rts.Resp
@@ -230,7 +244,7 @@ func (e *Engine) buildRT(in rtIn) rts.RT {
 		Env:         e.rtsEnv(in.env),
 		EnvGroups:   in.env.Selection().Groups(),
 		Vars:        in.vars,
-		Globals:     rtshost.RuntimeGlobals(e.collectGlobalValues(in.doc, in.env), in.secrets),
+		Globals:     rtshost.RuntimeGlobals(in.globals, in.secrets),
 		Resp:        resp,
 		Res:         in.res,
 		Trace:       tr,
@@ -269,20 +283,22 @@ type ExprInput struct {
 	Response *rts.Resp
 	Stream   *rts.Stream
 	Locals   rts.Locals
+	globals  vars.Globals
 }
 
 // EvalInput is one expression evaluation. Expr is the source to evaluate, Site
 // is the directive text it came from, used in diagnostics.
 type EvalInput struct {
-	Doc    *restfile.Document
-	Req    *restfile.Request
-	Env    vars.Environment
-	Base   string
-	Expr   string
-	Site   string
-	Pos    rts.Pos
-	Vars   map[string]string
-	Locals rts.Locals
+	Doc     *restfile.Document
+	Req     *restfile.Request
+	Env     vars.Environment
+	Base    string
+	Expr    string
+	Site    string
+	Pos     rts.Pos
+	Vars    map[string]string
+	Locals  rts.Locals
+	globals vars.Globals
 }
 
 // ExprEvalOptions tunes how a {{= expr }} evaluator treats the RTS runtime.
@@ -309,12 +325,13 @@ func (e *Engine) ExprEvalWithOptions(
 	}
 	return func(expr string, pos vars.ExprPos) (string, error) {
 		rt := e.buildRT(rtIn{
-			doc:  in.Doc,
-			req:  in.Req,
-			env:  in.Env,
-			base: in.Base,
-			vars: in.Vars,
-			site: "{{= " + expr + " }}",
+			doc:     in.Doc,
+			req:     in.Req,
+			env:     in.Env,
+			base:    in.Base,
+			vars:    in.Vars,
+			globals: in.globals,
+			site:    "{{= " + expr + " }}",
 			// res binds response. resp remains the previous response used by last.
 			res:     in.Response,
 			st:      in.Stream,
@@ -375,6 +392,7 @@ func (e *Engine) rtsEvalValue(ctx context.Context, in EvalInput) (rts.Value, err
 		env:     in.Env,
 		base:    in.Base,
 		vars:    vv,
+		globals: in.globals,
 		site:    in.Site,
 		locals:  in.Locals,
 		secrets: rtshost.IncludeSecrets,
@@ -396,6 +414,7 @@ func (e *Engine) CollectVariables(
 }
 
 func (e *Engine) EvalValue(ctx context.Context, in EvalInput) (rts.Value, error) {
+	in.globals = e.collectGlobalValues(in.Doc, in.Env)
 	return e.rtsEvalValue(ctx, in)
 }
 
@@ -415,6 +434,19 @@ func (e *Engine) EvalCondition(
 	vv map[string]string,
 	locals rts.Locals,
 ) (bool, string, error) {
+	return e.evalCondition(ctx, doc, req, env, base, spec, e.storedScope(doc, env, vv), locals)
+}
+
+func (e *Engine) evalCondition(
+	ctx context.Context,
+	doc *restfile.Document,
+	req *restfile.Request,
+	env vars.Environment,
+	base string,
+	spec *restfile.ConditionSpec,
+	sc evalScope,
+	locals rts.Locals,
+) (bool, string, error) {
 	if spec == nil {
 		return true, "", nil
 	}
@@ -428,15 +460,16 @@ func (e *Engine) EvalCondition(
 	}
 	flat := str.FoldLines(expr)
 	val, err := e.rtsEvalValue(ctx, EvalInput{
-		Doc:    doc,
-		Req:    req,
-		Env:    env,
-		Base:   base,
-		Expr:   expr,
-		Site:   tag + " " + flat,
-		Pos:    e.rtsPosForLineCol(doc, req, spec.Line, spec.Col),
-		Vars:   vv,
-		Locals: locals,
+		Doc:     doc,
+		Req:     req,
+		Env:     env,
+		Base:    base,
+		Expr:    expr,
+		Site:    tag + " " + flat,
+		Pos:     e.rtsPosForLineCol(doc, req, spec.Line, spec.Col),
+		Vars:    sc.vars,
+		Locals:  locals,
+		globals: sc.globals,
 	})
 	if err != nil {
 		return false, "", err
@@ -463,16 +496,18 @@ func (e *Engine) EvalForEachItems(
 	if expr == "" {
 		return nil, fmt.Errorf("@for-each expression missing")
 	}
+	sc := e.storedScope(doc, env, vv)
 	val, err := e.rtsEvalValue(ctx, EvalInput{
-		Doc:    doc,
-		Req:    req,
-		Env:    env,
-		Base:   base,
-		Expr:   expr,
-		Site:   directive.ForEach.Tag() + " " + str.FoldLines(expr),
-		Pos:    e.rtsPosForLine(doc, req, spec.Line),
-		Vars:   vv,
-		Locals: locals,
+		Doc:     doc,
+		Req:     req,
+		Env:     env,
+		Base:    base,
+		Expr:    expr,
+		Site:    directive.ForEach.Tag() + " " + str.FoldLines(expr),
+		Pos:     e.rtsPosForLine(doc, req, spec.Line),
+		Vars:    sc.vars,
+		Locals:  locals,
+		globals: sc.globals,
 	})
 	if err != nil {
 		return nil, err
@@ -494,7 +529,7 @@ func (e *Engine) runAsserts(
 	req *restfile.Request,
 	env vars.Environment,
 	base string,
-	vv map[string]string,
+	sc evalScope,
 	locals rts.Locals,
 	resp *rts.Resp,
 	tr *rts.Trace,
@@ -503,6 +538,7 @@ func (e *Engine) runAsserts(
 	if req == nil || len(req.Metadata.Asserts) == 0 {
 		return nil, nil
 	}
+	vv := sc.vars
 	if vv == nil {
 		vv = e.collectVariables(doc, req, env, runVars{})
 	}
@@ -512,6 +548,7 @@ func (e *Engine) runAsserts(
 		env:     env,
 		base:    base,
 		vars:    vv,
+		globals: sc.globals,
 		resp:    resp,
 		res:     resp,
 		tr:      tr,
@@ -545,7 +582,6 @@ func (e *Engine) runAsserts(
 	return out, nil
 }
 
-// RunPreRequest runs the request's @rts pre-request scripts.
 func (e *Engine) RunPreRequest(
 	ctx context.Context,
 	doc *restfile.Document,
@@ -554,9 +590,10 @@ func (e *Engine) RunPreRequest(
 	base string,
 	vv map[string]string,
 	locals rts.Locals,
-	globals map[string]vars.GlobalMutation,
+	globals vars.Globals,
 ) (prerequest.Output, error) {
-	return e.runRTSPreRequest(ctx, doc, req, env, base, vv, locals, globals)
+	sc := evalScope{vars: vv, globals: globals}
+	return e.runRTSPreRequest(ctx, doc, req, env, base, sc, locals, nil)
 }
 
 func (e *Engine) runRTSPreRequest(
@@ -565,10 +602,11 @@ func (e *Engine) runRTSPreRequest(
 	req *restfile.Request,
 	env vars.Environment,
 	base string,
-	vv map[string]string,
+	sc evalScope,
 	locals rts.Locals,
-	globs map[string]vars.GlobalMutation,
+	secrets *vars.Secrets,
 ) (prerequest.Output, error) {
+	vv := sc.vars
 	var out prerequest.Output
 	if req == nil {
 		return out, nil
@@ -577,8 +615,8 @@ func (e *Engine) runRTSPreRequest(
 	envs := e.rtsEnv(env)
 	groups := env.Selection().Groups()
 	base = e.rtsBase(doc, base)
-	gv := rtshost.RuntimeGlobals(globs, rtshost.IncludeSecrets)
-	mut := rtshost.NewMutator(&out, e.rtsReq(req), vv, gv)
+	gv := rtshost.RuntimeGlobals(sc.globals, rtshost.IncludeSecrets)
+	mut := rtshost.NewMutator(&out, e.rtsReq(req), vv, gv, secrets)
 
 	err := rtshost.RunPreRequest(ctx, e.re, rtshost.PreRequest{
 		Doc:     doc,
@@ -1102,9 +1140,10 @@ func (e *Engine) runRTSApply(
 	req *restfile.Request,
 	env vars.Environment,
 	base string,
-	vv map[string]string,
+	sc evalScope,
 	locals rts.Locals,
 ) error {
+	vv := sc.vars
 	if req == nil || len(req.Metadata.Applies) == 0 {
 		return nil
 	}
@@ -1121,15 +1160,16 @@ func (e *Engine) runRTSApply(
 				return err
 			}
 			val, err := e.rtsEvalValue(ctx, EvalInput{
-				Doc:    doc,
-				Req:    req,
-				Env:    env,
-				Base:   base,
-				Expr:   ex.ex,
-				Site:   ex.st,
-				Pos:    ex.ps,
-				Vars:   vv,
-				Locals: locals,
+				Doc:     doc,
+				Req:     req,
+				Env:     env,
+				Base:    base,
+				Expr:    ex.ex,
+				Site:    ex.st,
+				Pos:     ex.ps,
+				Vars:    vv,
+				Locals:  locals,
+				globals: sc.globals,
 			})
 			if err != nil {
 				return err
@@ -1146,7 +1186,6 @@ func (e *Engine) runRTSApply(
 	return nil
 }
 
-// ApplyPatches runs the request's @apply directives, mutating req in place.
 func (e *Engine) ApplyPatches(
 	ctx context.Context,
 	doc *restfile.Document,
@@ -1156,7 +1195,7 @@ func (e *Engine) ApplyPatches(
 	vv map[string]string,
 	locals rts.Locals,
 ) error {
-	return e.runRTSApply(ctx, doc, req, env, base, vv, locals)
+	return e.runRTSApply(ctx, doc, req, env, base, e.storedScope(doc, env, vv), locals)
 }
 
 func joinErr(a, b error) error {

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -391,7 +392,7 @@ func (e *Engine) CollectVariables(
 	env vars.Environment,
 	overlay map[string]string,
 ) map[string]string {
-	return e.collectVariables(doc, req, env, runVars{overlay: overlay})
+	return e.collectVariables(doc, req, env, runVars{overlay: vars.CollectNames(overlay)})
 }
 
 func (e *Engine) EvalValue(ctx context.Context, in EvalInput) (rts.Value, error) {
@@ -622,7 +623,7 @@ type applyPatch struct {
 	auth       *restfile.AuthSpec
 	authSet    bool
 	settings   map[string]*string
-	vars       map[string]string
+	vars       vars.NameMap[string]
 }
 
 func (e *Engine) parseApplyPatch(
@@ -804,28 +805,26 @@ func (e *Engine) parseApplyQuery(
 	return out, nil
 }
 
+// parseApplyVars sorts keys so equivalent names and validation errors resolve deterministically.
 func (e *Engine) parseApplyVars(
 	ctx context.Context,
 	pos rts.Pos,
 	v rts.Value,
-) (map[string]string, error) {
+) (vars.NameMap[string], error) {
+	var out vars.NameMap[string]
 	if v.K != rts.VDict {
-		return nil, applyErr("vars", "expects dict")
+		return out, applyErr("vars", "expects dict")
 	}
-	out := make(map[string]string)
-	for key, val := range v.M {
+	for _, key := range slices.Sorted(maps.Keys(v.M)) {
 		name := strings.TrimSpace(key)
 		if name == "" {
-			return nil, applyErr("vars", "expects non-empty name")
+			return out, applyErr("vars", "expects non-empty name")
 		}
-		s, err := e.applyScalar(ctx, pos, val, "vars."+name)
+		s, err := e.applyScalar(ctx, pos, v.M[key], "vars."+name)
 		if err != nil {
-			return nil, err
+			return out, err
 		}
-		out[name] = s
-	}
-	if len(out) == 0 {
-		return nil, nil
+		out.Set(name, s)
 	}
 	return out, nil
 }
@@ -1023,15 +1022,15 @@ func applyPatchSettings(req *restfile.Request, in map[string]*string) {
 	}
 }
 
-func applyPatchVars(req *restfile.Request, vv map[string]string, in map[string]string) {
-	if req == nil || len(in) == 0 {
+func applyPatchVars(req *restfile.Request, vv map[string]string, in vars.NameMap[string]) {
+	if req == nil || in.Len() == 0 {
 		return
 	}
 	prerequest.SetRequestVars(req, in)
 	if vv == nil {
 		return
 	}
-	vars.Merge(vv, in)
+	vars.MergeInto(vv, in)
 }
 
 func applyKey(key string) string { return strings.ToLower(strings.TrimSpace(key)) }

--- a/internal/engine/request/rts_test.go
+++ b/internal/engine/request/rts_test.go
@@ -71,7 +71,7 @@ GET https://example.com
 		doc.Requests[0],
 		testEnv(""),
 		"",
-		nil,
+		evalScope{},
 		rts.Locals{},
 		nil,
 	)
@@ -124,7 +124,7 @@ func TestRunRTSPreRequestRejectsResponse(t *testing.T) {
 				doc.Requests[0],
 				testEnv(""),
 				"",
-				nil,
+				evalScope{},
 				rts.Locals{},
 				nil,
 			)

--- a/internal/engine/request/script_vars_test.go
+++ b/internal/engine/request/script_vars_test.go
@@ -45,21 +45,14 @@ type sentRequest struct {
 	executed *restfile.Request
 }
 
-func sendRequest(
-	t *testing.T,
-	doc *restfile.Document,
-	req *restfile.Request,
-	env vars.Environment,
-	opt ExecOptions,
-) sentRequest {
-	t.Helper()
+type stubTransport struct{ wire *http.Request }
 
-	var sent *http.Request
-	client := httpx.NewClientWithOptions(
+func (s *stubTransport) client() *httpx.Client {
+	return httpx.NewClientWithOptions(
 		httpx.WithHTTPFactory(func(httpx.Options) (*http.Client, error) {
 			return &http.Client{
 				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-					sent = r
+					s.wire = r
 					return &http.Response{
 						Status:     "200 OK",
 						StatusCode: http.StatusOK,
@@ -71,18 +64,50 @@ func sendRequest(
 			}, nil
 		}),
 	)
+}
 
-	res, err := New(engcfg.Config{Client: client}, nil).ExecuteWith(doc, req, env, opt)
+func newStubEngine(t *testing.T) (*Engine, *stubTransport) {
+	t.Helper()
+
+	st := &stubTransport{}
+	return New(engcfg.Config{Client: st.client()}, nil), st
+}
+
+func sendRequest(
+	t *testing.T,
+	doc *restfile.Document,
+	req *restfile.Request,
+	env vars.Environment,
+	opt ExecOptions,
+) sentRequest {
+	t.Helper()
+
+	eng, st := newStubEngine(t)
+	return sendWith(t, eng, st, doc, req, env, opt)
+}
+
+func sendWith(
+	t *testing.T,
+	eng *Engine,
+	st *stubTransport,
+	doc *restfile.Document,
+	req *restfile.Request,
+	env vars.Environment,
+	opt ExecOptions,
+) sentRequest {
+	t.Helper()
+
+	res, err := eng.ExecuteWith(doc, req, env, opt)
 	if err != nil {
 		t.Fatalf("ExecuteWith() error = %v", err)
 	}
 	if res.Err != nil {
 		t.Fatalf("ExecuteWith() result error = %v", res.Err)
 	}
-	if sent == nil {
+	if st.wire == nil {
 		t.Fatal("request was never sent")
 	}
-	return sentRequest{wire: sent, executed: res.Executed}
+	return sentRequest{wire: st.wire, executed: res.Executed}
 }
 
 func TestJSPreRequestReadsVariablesCaseInsensitively(t *testing.T) {

--- a/internal/engine/request/script_vars_test.go
+++ b/internal/engine/request/script_vars_test.go
@@ -158,6 +158,80 @@ func TestJSPreRequestSeesRTSValueOverWorkflowValue(t *testing.T) {
 	}
 }
 
+func TestJSPreRequestBlocksShareWrites(t *testing.T) {
+	req := &restfile.Request{
+		Method:  http.MethodGet,
+		URL:     "http://example.test",
+		Headers: http.Header{"X-Template": []string{"{{block.chain}}"}},
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{
+				jsPre(`vars.set("block.chain", "first");`),
+				jsPre(`request.setHeader("X-Read", vars.get("block.chain"));`),
+			},
+		},
+	}
+
+	sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{})
+	for _, name := range []string{"X-Read", "X-Template"} {
+		if got := sent.wire.Header.Get(name); got != "first" {
+			t.Fatalf("%s = %q, want %q", name, got, "first")
+		}
+	}
+}
+
+// Checking the value directly would expand it again when the header is built.
+// The length shows what the scripts saw without triggering another expansion.
+func TestScriptsReadNestedAuthoredValuesExpanded(t *testing.T) {
+	doc := &restfile.Document{
+		Path: "nested.http",
+		Variables: []restfile.Variable{
+			{Name: "nested.base", Value: "inner"},
+			{Name: "nested.derived", Value: "{{nested.base}}"},
+		},
+	}
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{
+				rtsPre(`request.setHeader("X-RTS", str(len(vars.get("nested.derived"))))`),
+				jsPre(`request.setHeader("X-JS", String(vars.get("nested.derived").length));`),
+			},
+		},
+	}
+
+	sent := sendRequest(t, doc, req, testEnv(""), ExecOptions{})
+	for _, name := range []string{"X-RTS", "X-JS"} {
+		if got := sent.wire.Header.Get(name); got != "5" {
+			t.Fatalf("%s = %q, want the length of the expanded value", name, got)
+		}
+	}
+}
+
+func TestPreRequestScriptsRemoveDeclaredHeaders(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Headers: http.Header{
+			"X-Rts": []string{"declared"},
+			"X-Js":  []string{"declared"},
+		},
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{
+				rtsPre(`request.removeHeader("X-Rts")`),
+				jsPre(`request.removeHeader("X-Js");`),
+			},
+		},
+	}
+
+	sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{})
+	for _, name := range []string{"X-Rts", "X-Js"} {
+		if got := sent.wire.Header.Get(name); got != "" {
+			t.Fatalf("%s = %q, want it removed", name, got)
+		}
+	}
+}
+
 func TestScriptCaseVariantsResolveToTheLastWrite(t *testing.T) {
 	tests := []struct {
 		name string
@@ -245,6 +319,26 @@ vars.set("TOKEN", "second")`)},
 	sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{})
 	if got := sent.wire.Header.Get("X-Template"); got != "second" {
 		t.Fatalf("X-Template = %q, want %q", got, "second")
+	}
+}
+
+func TestDisplayResolverKeepsNestedSecretsUnexpanded(t *testing.T) {
+	doc := &restfile.Document{
+		Path: "secrets.http",
+		Variables: []restfile.Variable{
+			{Name: "token", Value: "file-secret", Secret: true},
+			{Name: "auth.header", Value: "Bearer {{token}}"},
+		},
+	}
+
+	eng := New(engcfg.Config{}, nil)
+	res := eng.DisplayResolver(context.Background(), doc, nil, envWith(t, "dev", nil), "", rts.Locals{})
+	got, err := res.ExpandTemplates(`{{= vars.get("auth.header") }}`)
+	if err != nil {
+		t.Fatalf(`vars.get("auth.header") error = %v`, err)
+	}
+	if got != "Bearer {{token}}" {
+		t.Fatalf(`vars.get("auth.header") = %q, want the secret left unexpanded`, got)
 	}
 }
 

--- a/internal/engine/request/script_vars_test.go
+++ b/internal/engine/request/script_vars_test.go
@@ -1,0 +1,261 @@
+package request
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+func rtsPre(body string) restfile.ScriptBlock {
+	return restfile.ScriptBlock{Kind: "pre-request", Lang: "rts", Body: body}
+}
+
+func jsPre(body string) restfile.ScriptBlock {
+	return restfile.ScriptBlock{Kind: "pre-request", Lang: "js", Body: body}
+}
+
+func envWith(t *testing.T, name string, values map[string]string) vars.Environment {
+	t.Helper()
+
+	cat, err := vars.NewCatalog(vars.EnvironmentSet{name: values})
+	if err != nil {
+		t.Fatalf("NewCatalog() error = %v", err)
+	}
+	sel, err := cat.Select(name, nil)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	env, err := cat.Resolve(sel)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	return env
+}
+
+type sentRequest struct {
+	wire     *http.Request
+	executed *restfile.Request
+}
+
+func sendRequest(
+	t *testing.T,
+	doc *restfile.Document,
+	req *restfile.Request,
+	env vars.Environment,
+	opt ExecOptions,
+) sentRequest {
+	t.Helper()
+
+	var sent *http.Request
+	client := httpx.NewClientWithOptions(
+		httpx.WithHTTPFactory(func(httpx.Options) (*http.Client, error) {
+			return &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					sent = r
+					return &http.Response{
+						Status:     "200 OK",
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader("ok")),
+						Request:    r,
+					}, nil
+				}),
+			}, nil
+		}),
+	)
+
+	res, err := New(engcfg.Config{Client: client}, nil).ExecuteWith(doc, req, env, opt)
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("ExecuteWith() result error = %v", res.Err)
+	}
+	if sent == nil {
+		t.Fatal("request was never sent")
+	}
+	return sentRequest{wire: sent, executed: res.Executed}
+}
+
+func TestJSPreRequestReadsVariablesCaseInsensitively(t *testing.T) {
+	doc := &restfile.Document{
+		Path:      "scripts.http",
+		Variables: []restfile.Variable{{Name: "token", Value: "file-token"}},
+	}
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{jsPre(`
+				request.setHeader("X-Upper", vars.get("TOKEN"));
+				request.setHeader("X-Mixed", vars.get("ToKeN"));
+				request.setHeader("X-Has", String(vars.has("TOKEN")));
+			`)},
+		},
+	}
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", map[string]string{"TOKEN": "env-token"}), ExecOptions{})
+	for _, name := range []string{"X-Upper", "X-Mixed"} {
+		if got := sent.wire.Header.Get(name); got != "file-token" {
+			t.Fatalf("%s = %q, want %q", name, got, "file-token")
+		}
+	}
+	if got := sent.wire.Header.Get("X-Has"); got != "true" {
+		t.Fatalf("X-Has = %q, want %q", got, "true")
+	}
+}
+
+func TestJSPreRequestSeesRTSValueOverWorkflowValue(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{
+				rtsPre(`vars.set("token", "rts")`),
+				jsPre(`request.setHeader("X-Seen", vars.get("token"));`),
+			},
+		},
+	}
+
+	sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{
+		Extra: map[string]string{"token": "workflow"},
+	})
+	if got := sent.wire.Header.Get("X-Seen"); got != "rts" {
+		t.Fatalf("X-Seen = %q, want %q", got, "rts")
+	}
+}
+
+func TestScriptCaseVariantsResolveToTheLastWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		rts  string
+		js   string
+	}{
+		{name: "rts lower then js upper", rts: "token", js: "TOKEN"},
+		{name: "rts upper then js lower", rts: "TOKEN", js: "token"},
+		{name: "rts mixed then js mixed", rts: "ToKeN", js: "toKEN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &restfile.Request{
+				Method: http.MethodGet,
+				URL:    "http://example.test",
+				Headers: http.Header{
+					"X-Template": []string{"{{token}}"},
+				},
+				Metadata: restfile.RequestMetadata{
+					Scripts: []restfile.ScriptBlock{
+						rtsPre(`vars.set("` + tt.rts + `", "from-rts")`),
+						jsPre(`vars.set("` + tt.js + `", "from-js");
+							request.setHeader("X-Read", vars.get("token"));`),
+					},
+				},
+			}
+
+			sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{})
+			if got := sent.wire.Header.Get("X-Read"); got != "from-js" {
+				t.Fatalf("X-Read = %q, want %q", got, "from-js")
+			}
+			if got := sent.wire.Header.Get("X-Template"); got != "from-js" {
+				t.Fatalf("X-Template = %q, want %q", got, "from-js")
+			}
+		})
+	}
+}
+
+func TestScriptRepeatedCaseVariantsKeepTheLastWrite(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Headers: http.Header{
+			"X-Template": []string{"{{token}}"},
+		},
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{jsPre(`
+				vars.set("token", "first");
+				vars.set("TOKEN", "second");
+				vars.set("ToKeN", "third");
+			`)},
+		},
+	}
+
+	sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{})
+	if got := sent.wire.Header.Get("X-Template"); got != "third" {
+		t.Fatalf("X-Template = %q, want %q", got, "third")
+	}
+
+	named := 0
+	for _, v := range sent.executed.Variables {
+		if vars.NameKey(v.Name) == "token" {
+			named++
+		}
+	}
+	if named != 1 {
+		t.Fatalf("request holds %d forms of token, want 1: %#v", named, sent.executed.Variables)
+	}
+}
+
+func TestRTSRepeatedCaseVariantsKeepTheLastWrite(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Headers: http.Header{
+			"X-Template": []string{"{{token}}"},
+		},
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{rtsPre(`vars.set("token", "first")
+vars.set("TOKEN", "second")`)},
+		},
+	}
+
+	sent := sendRequest(t, nil, req, testEnv(""), ExecOptions{})
+	if got := sent.wire.Header.Get("X-Template"); got != "second" {
+		t.Fatalf("X-Template = %q, want %q", got, "second")
+	}
+}
+
+func TestDisplayResolverOmitsSecretsFromBothPaths(t *testing.T) {
+	eng := New(engcfg.Config{}, nil)
+	env := envWith(t, "dev", nil)
+	eng.rt.Globals().Set(env.Scope(), "gsecret", "global-secret", true)
+
+	doc := &restfile.Document{
+		Path: "secrets.http",
+		Variables: []restfile.Variable{
+			{Name: "fsecret", Value: "file-secret", Secret: true},
+			{Name: "shown", Value: "visible"},
+		},
+		Globals: []restfile.Variable{{Name: "dsecret", Value: "doc-secret", Secret: true}},
+	}
+	req := &restfile.Request{
+		Method:    http.MethodGet,
+		URL:       "http://example.test",
+		Variables: []restfile.Variable{{Name: "rsecret", Value: "request-secret", Secret: true}},
+	}
+
+	res := eng.DisplayResolver(context.Background(), doc, req, env, "", rts.Locals{})
+	if got, err := res.ExpandTemplates("{{shown}}"); err != nil || got != "visible" {
+		t.Fatalf("{{shown}} = %q, %v, want %q", got, err, "visible")
+	}
+	for _, name := range []string{"fsecret", "dsecret", "rsecret", "gsecret"} {
+		if got, err := res.ExpandTemplates("{{" + name + "}}"); err == nil {
+			t.Fatalf("{{%s}} resolved to %q, want it withheld", name, got)
+		}
+		got, err := res.ExpandTemplates(`{{= vars.get("` + name + `") ?? "withheld" }}`)
+		if err != nil {
+			t.Fatalf(`vars.get(%q) error = %v`, name, err)
+		}
+		if got != "withheld" {
+			t.Fatalf(`vars.get(%q) = %q, want it withheld`, name, got)
+		}
+	}
+}

--- a/internal/engine/request/secret_redaction_test.go
+++ b/internal/engine/request/secret_redaction_test.go
@@ -1,0 +1,269 @@
+package request
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/directive"
+	"github.com/unkn0wn-root/resterm/internal/engine"
+	xplain "github.com/unkn0wn-root/resterm/internal/explain"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+const leakedSecret = "s3cr3t-value"
+
+func secretLeakRequest(scripts ...restfile.ScriptBlock) *restfile.Request {
+	return &restfile.Request{
+		Method:   http.MethodGet,
+		URL:      "http://example.test",
+		Metadata: restfile.RequestMetadata{Scripts: scripts},
+	}
+}
+
+func assertExplainMasksSecret(t *testing.T, rep *xplain.Report) {
+	t.Helper()
+
+	if rep == nil {
+		t.Fatal("expected an explain report")
+	}
+	rendered := fmt.Sprintf("%+v", *rep)
+	if rep.Final != nil {
+		rendered += fmt.Sprintf("\n%+v", *rep.Final)
+	}
+	if strings.Contains(rendered, leakedSecret) {
+		t.Fatalf("explain report contains the plaintext secret:\n%s", rendered)
+	}
+}
+
+func assertSecretStaysRedactable(t *testing.T, res engine.RequestResult) {
+	t.Helper()
+
+	if !slices.Contains(res.RuntimeSecrets, leakedSecret) {
+		t.Fatalf("RuntimeSecrets = %#v, want the exposed secret recorded", res.RuntimeSecrets)
+	}
+	assertExplainMasksSecret(t, res.Explain)
+
+	rendered := map[string]string{
+		"Err":              errText(res.Err),
+		"Err diagnostic":   errRender(res.Err),
+		"ScriptErr":        errText(res.ScriptErr),
+		"ScriptErr report": errRender(res.ScriptErr),
+	}
+	for _, tc := range res.Tests {
+		rendered["test "+tc.Name] = tc.Name + " " + tc.Message
+	}
+	for field, text := range rendered {
+		if strings.Contains(text, leakedSecret) {
+			t.Fatalf("%s contains the plaintext secret: %s", field, text)
+		}
+	}
+}
+
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func errRender(err error) string {
+	if err == nil {
+		return ""
+	}
+	return diag.Render(err)
+}
+
+func TestExplainMasksDeletedSecretGlobal(t *testing.T) {
+	scripts := map[string]restfile.ScriptBlock{
+		"rts": rtsPre(`vars.global.set("token", "` + leakedSecret + `", true)
+request.setHeader("X-Leak", vars.global.get("token"))
+vars.global.delete("token")`),
+		"js": jsPre(`vars.global.set("token", "` + leakedSecret + `", true);
+request.setHeader("X-Leak", vars.global.get("token"));
+vars.global.delete("token");`),
+	}
+
+	for lang, script := range scripts {
+		t.Run(lang+" send", func(t *testing.T) {
+			eng, st := newStubEngine(t)
+			res, err := eng.ExecuteWith(nil, secretLeakRequest(script), testEnv(""), ExecOptions{})
+			if err != nil || res.Err != nil {
+				t.Fatalf("ExecuteWith() error = %v, result error = %v", err, res.Err)
+			}
+			if st.wire == nil {
+				t.Fatal("request was never sent")
+			}
+			if got := st.wire.Header.Get("X-Leak"); got != leakedSecret {
+				t.Fatalf("X-Leak = %q, want the secret on the wire", got)
+			}
+			assertSecretStaysRedactable(t, res)
+		})
+
+		t.Run(lang+" preview", func(t *testing.T) {
+			eng, _ := newStubEngine(t)
+			res, err := eng.ExecuteWith(nil, secretLeakRequest(script), testEnv(""), ExecOptions{
+				Mode: ExecModePreview,
+			})
+			if err != nil || res.Err != nil {
+				t.Fatalf("ExecuteWith() error = %v, result error = %v", err, res.Err)
+			}
+			assertExplainMasksSecret(t, res.Explain)
+		})
+	}
+}
+
+func TestExplainMasksSecretGlobalDeletedFromStorage(t *testing.T) {
+	scripts := map[string]restfile.ScriptBlock{
+		"rts": rtsPre(`request.setHeader("X-Leak", vars.global.get("token"))
+vars.global.delete("token")`),
+		"js": jsPre(`request.setHeader("X-Leak", vars.global.get("token"));
+vars.global.delete("token");`),
+	}
+
+	for lang, script := range scripts {
+		t.Run(lang, func(t *testing.T) {
+			eng, st := newStubEngine(t)
+			env := testEnv("")
+			eng.rt.Globals().Set(env.Scope(), "token", leakedSecret, true)
+
+			res, err := eng.ExecuteWith(nil, secretLeakRequest(script), env, ExecOptions{})
+			if err != nil || res.Err != nil {
+				t.Fatalf("ExecuteWith() error = %v, result error = %v", err, res.Err)
+			}
+			if st.wire == nil || st.wire.Header.Get("X-Leak") != leakedSecret {
+				t.Fatalf("the script never copied the secret onto the wire: %v", st.wire)
+			}
+			assertSecretStaysRedactable(t, res)
+		})
+	}
+}
+
+func TestExplainMasksSecretGlobalDeletedByLaterScript(t *testing.T) {
+	req := secretLeakRequest(
+		rtsPre(`vars.global.set("token", "`+leakedSecret+`", true)
+request.setHeader("X-Leak", vars.global.get("token"))`),
+		jsPre(`vars.global.delete("token");`),
+	)
+
+	eng, _ := newStubEngine(t)
+	res, err := eng.ExecuteWith(nil, req, testEnv(""), ExecOptions{})
+	if err != nil || res.Err != nil {
+		t.Fatalf("ExecuteWith() error = %v, result error = %v", err, res.Err)
+	}
+	assertSecretStaysRedactable(t, res)
+}
+
+func TestExplainMasksSecretGlobalOverwrittenAsPublic(t *testing.T) {
+	req := secretLeakRequest(rtsPre(`vars.global.set("token", "` + leakedSecret + `", true)
+request.setHeader("X-Leak", vars.global.get("token"))
+vars.global.set("token", "public", false)`))
+
+	eng, _ := newStubEngine(t)
+	res, err := eng.ExecuteWith(nil, req, testEnv(""), ExecOptions{})
+	if err != nil || res.Err != nil {
+		t.Fatalf("ExecuteWith() error = %v, result error = %v", err, res.Err)
+	}
+	assertSecretStaysRedactable(t, res)
+}
+
+func TestFailedProducerKeepsSecretRedactable(t *testing.T) {
+	capture := func(scope directive.Scope, name, expr string, secret bool) restfile.CaptureSpec {
+		return restfile.CaptureSpec{
+			Scope:      scope,
+			Name:       name,
+			Expression: expr,
+			Mode:       restfile.CaptureExprModeRTS,
+			Secret:     secret,
+		}
+	}
+
+	cases := map[string]*restfile.Request{
+		"rts pre-request": secretLeakRequest(rtsPre(`vars.global.set("token", "` + leakedSecret + `", true)
+fail(vars.global.get("token"))`)),
+		"js pre-request": secretLeakRequest(jsPre(`vars.global.set("token", "` + leakedSecret + `", true);
+throw new Error(vars.global.get("token"));`)),
+		"js test": secretLeakRequest(restfile.ScriptBlock{
+			Kind: "test",
+			Lang: "js",
+			Body: `vars.global.set("token", "` + leakedSecret + `", true);
+throw new Error(vars.global.get("token"));`,
+		}),
+		"capture batch": {
+			Method: http.MethodGet,
+			URL:    "http://example.test",
+			Metadata: restfile.RequestMetadata{
+				Captures: []restfile.CaptureSpec{
+					capture(directive.ScopeGlobal, "token", `"`+leakedSecret+`"`, true),
+					capture(directive.ScopeRequest, "boom", `fail(vars.get("token"))`, false),
+				},
+			},
+		},
+	}
+
+	for name, req := range cases {
+		t.Run(name, func(t *testing.T) {
+			eng, _ := newStubEngine(t)
+			res, err := eng.ExecuteWith(nil, req, testEnv(""), ExecOptions{})
+			if err != nil {
+				t.Fatalf("ExecuteWith() error = %v", err)
+			}
+			if res.Err == nil && res.ScriptErr == nil {
+				t.Fatal("expected the producer to fail")
+			}
+			assertSecretStaysRedactable(t, res)
+		})
+	}
+}
+
+func TestFailedProducerKeepsStoredSecretRedactable(t *testing.T) {
+	scripts := map[string]restfile.ScriptBlock{
+		"rts": rtsPre(`fail(vars.global.get("token"))`),
+		"js":  jsPre(`throw new Error(vars.global.get("token"));`),
+	}
+
+	for lang, script := range scripts {
+		t.Run(lang, func(t *testing.T) {
+			eng, _ := newStubEngine(t)
+			env := testEnv("")
+			eng.rt.Globals().Set(env.Scope(), "token", leakedSecret, true)
+
+			res, err := eng.ExecuteWith(nil, secretLeakRequest(script), env, ExecOptions{})
+			if err != nil {
+				t.Fatalf("ExecuteWith() error = %v", err)
+			}
+			if res.Err == nil {
+				t.Fatal("expected the script to fail")
+			}
+			assertSecretStaysRedactable(t, res)
+		})
+	}
+}
+
+func TestFailedAssertKeepsSecretRedactable(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "http://example.test",
+		Metadata: restfile.RequestMetadata{
+			Scripts: []restfile.ScriptBlock{{
+				Kind: "test",
+				Lang: "js",
+				Body: `vars.global.set("token", "` + leakedSecret + `", true);
+tests.assert(false, "leaked " + vars.global.get("token"));`,
+			}},
+		},
+	}
+
+	eng, _ := newStubEngine(t)
+	res, err := eng.ExecuteWith(nil, req, testEnv(""), ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if len(res.Tests) != 1 || res.Tests[0].Passed {
+		t.Fatalf("Tests = %#v, want one failed test", res.Tests)
+	}
+	assertSecretStaysRedactable(t, res)
+}

--- a/internal/engine/request/util.go
+++ b/internal/engine/request/util.go
@@ -17,19 +17,3 @@ func cloneStringMap(src map[string]string) map[string]string {
 	maps.Copy(dst, src)
 	return dst
 }
-
-func mergeStringMaps(xs ...map[string]string) map[string]string {
-	size := 0
-	for _, x := range xs {
-		size += len(x)
-	}
-	if size == 0 {
-		return nil
-	}
-
-	out := make(map[string]string, size)
-	for _, x := range xs {
-		maps.Copy(out, x)
-	}
-	return out
-}

--- a/internal/engine/request/varplan.go
+++ b/internal/engine/request/varplan.go
@@ -15,6 +15,7 @@ const (
 	sourceConst
 	sourceScript
 	sourceWorkflow
+	sourceRequestCapture
 	sourceRequest
 	sourceRuntimeGlobal
 	sourceDocumentGlobal
@@ -37,6 +38,7 @@ var sourceTable = [...]sourceTraits{
 	sourceConst:          {label: "const", template: true, hidden: true},
 	sourceScript:         {label: "script"},
 	sourceWorkflow:       {label: "workflow"},
+	sourceRequestCapture: {label: "request"},
 	sourceRequest:        {label: "request", template: true},
 	sourceRuntimeGlobal:  {label: "global"},
 	sourceDocumentGlobal: {label: "document-global", template: true},
@@ -74,17 +76,21 @@ type varSources struct {
 	doc     *restfile.Document
 	req     *restfile.Request
 	env     vars.Environment
-	globals map[string]vars.GlobalMutation
+	globals vars.Globals
 	sec     secrecy
 	run     runVars
 }
 
-// buildVariablePlan defines the precedence shared by template and script lookups.
+// Variable plans keep template and script lookups at the same precedence. Each
+// plan includes every source layer because resolver memoization uses provider
+// positions. Authored values may expand nested templates, while runtime values
+// such as captures remain literal.
 func (e *Engine) buildVariablePlan(src varSources) variablePlan {
 	plan := variablePlan{layers: make([]variableLayer, 0, len(sourceTable))}
 	plan.add(sourceConst, constEntries(src.doc))
 	plan.addNames(sourceScript, src.run.scripts)
 	plan.addNames(sourceWorkflow, src.run.overlay)
+	plan.add(sourceRequestCapture, nil)
 	plan.add(sourceRequest, requestEntries(src.req, src.sec))
 	plan.add(sourceRuntimeGlobal, globalEntries(src.globals))
 	plan.add(sourceDocumentGlobal, docGlobalEntries(src.doc, src.sec))
@@ -109,10 +115,16 @@ func (p *variablePlan) addNames(source variableSource, vals vars.NameMap[string]
 }
 
 func (p *variablePlan) appendLayer(source variableSource, vals vars.NameMap[string]) {
-	if vals.Len() == 0 {
-		return
-	}
 	p.layers = append(p.layers, variableLayer{source: source, vals: vals})
+}
+
+func (p *variablePlan) overlay(source variableSource, vals vars.NameMap[string]) {
+	for i := range p.layers {
+		if p.layers[i].source == source {
+			p.layers[i].vals.Merge(vals)
+			return
+		}
+	}
 }
 
 // providers exposes each layer to template resolution. Authored values use
@@ -192,14 +204,13 @@ func declaredEntries(xs []restfile.Variable, sec secrecy) []variableEntry {
 	return out
 }
 
-func globalEntries(globs map[string]vars.GlobalMutation) []variableEntry {
-	out := make([]variableEntry, 0, len(globs))
-	for _, key := range slices.Sorted(maps.Keys(globs)) {
-		g := globs[key]
+func globalEntries(globs vars.Globals) []variableEntry {
+	out := make([]variableEntry, 0, globs.Len())
+	for name, g := range globs.Sorted() {
 		if g.Delete {
 			continue
 		}
-		out = append(out, variableEntry{name: storedName(g.Name, key), value: g.Value})
+		out = append(out, variableEntry{name: name, value: g.Value})
 	}
 	return out
 }

--- a/internal/engine/request/varplan.go
+++ b/internal/engine/request/varplan.go
@@ -1,0 +1,257 @@
+package request
+
+import (
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+type variableSource uint8
+
+const (
+	sourceUnknown variableSource = iota
+	sourceConst
+	sourceScript
+	sourceWorkflow
+	sourceRequest
+	sourceRuntimeGlobal
+	sourceDocumentGlobal
+	sourceRuntimeFile
+	sourceFile
+	sourceEnvironment
+)
+
+type sourceTraits struct {
+	// label identifies the source in traces and qualified {{label.name}} lookups.
+	label string
+	// template enables nested expansion for authored values; runtime values stay literal.
+	template bool
+	// hidden excludes values from script-facing vars; constants are not overridable.
+	hidden bool
+}
+
+var sourceTable = [...]sourceTraits{
+	sourceUnknown:        {},
+	sourceConst:          {label: "const", template: true, hidden: true},
+	sourceScript:         {label: "script"},
+	sourceWorkflow:       {label: "workflow"},
+	sourceRequest:        {label: "request", template: true},
+	sourceRuntimeGlobal:  {label: "global"},
+	sourceDocumentGlobal: {label: "document-global", template: true},
+	sourceRuntimeFile:    {label: "file"},
+	sourceFile:           {label: "file", template: true},
+	sourceEnvironment:    {label: "environment"},
+}
+
+func (s variableSource) traits() sourceTraits { return sourceTable[s] }
+
+type variableEntry struct {
+	name  string
+	value string
+}
+
+type variableLayer struct {
+	source variableSource
+	// vals holds one value per name, keyed by the form the winning
+	// declaration used.
+	vals map[string]string
+}
+
+// variablePlan is the shared precedence order for template and script lookups.
+// Layers run from highest to lowest precedence. RTS locals, @use aliases, and
+// host bindings use separate lexical scoping and are not included.
+type variablePlan struct {
+	layers []variableLayer
+}
+
+type runVars struct {
+	scripts map[string]string
+	// overlay contains workflow step and @for-each bindings.
+	overlay map[string]string
+}
+
+type varSources struct {
+	doc     *restfile.Document
+	req     *restfile.Request
+	env     vars.Environment
+	globals map[string]vars.GlobalMutation
+	sec     secrecy
+	run     runVars
+}
+
+// buildVariablePlan defines the precedence shared by template and script lookups.
+func (e *Engine) buildVariablePlan(src varSources) variablePlan {
+	plan := variablePlan{layers: make([]variableLayer, 0, len(sourceTable))}
+	plan.add(sourceConst, constEntries(src.doc))
+	plan.add(sourceScript, sortedEntries(src.run.scripts))
+	plan.add(sourceWorkflow, sortedEntries(src.run.overlay))
+	plan.add(sourceRequest, requestEntries(src.req, src.sec))
+	plan.add(sourceRuntimeGlobal, globalEntries(src.globals))
+	plan.add(sourceDocumentGlobal, docGlobalEntries(src.doc, src.sec))
+	plan.add(sourceRuntimeFile, e.runtimeFileEntries(src.doc, src.env, src.sec))
+	plan.add(sourceFile, docVarEntries(src.doc, src.sec))
+	plan.add(sourceEnvironment, sortedEntries(src.env.Values()))
+	return plan
+}
+
+// add appends the layer source contributes, or nothing when the source
+// declared no variables. Every layer is built here, so one holding two forms
+// of a name or a value map the source never filled cannot reach a plan.
+func (p *variablePlan) add(source variableSource, entries []variableEntry) {
+	vals := collapseEntries(entries)
+	if len(vals) == 0 {
+		return
+	}
+	p.layers = append(p.layers, variableLayer{source: source, vals: vals})
+}
+
+// providers exposes each layer to template resolution. Authored values use
+// template providers so nested placeholders still expand.
+func (p variablePlan) providers() []vars.Provider {
+	out := make([]vars.Provider, 0, len(p.layers)+1)
+	for _, l := range p.layers {
+		t := l.source.traits()
+		if t.template {
+			out = append(out, vars.NewTemplateProvider(t.label, l.vals))
+			continue
+		}
+		out = append(out, vars.NewMapProvider(t.label, l.vals))
+	}
+	// Process environment values are not enumerable, so they remain the final
+	// fallback outside the plan.
+	return append(out, vars.EnvProvider{})
+}
+
+// values flattens the plan for RTS and JavaScript while preserving provider precedence.
+func (p variablePlan) values() map[string]string {
+	out := make(map[string]string)
+	claimed := make(map[string]struct{})
+	for _, l := range p.layers {
+		if l.source.traits().hidden {
+			continue
+		}
+		for name, value := range l.vals {
+			key := vars.NameKey(name)
+			if _, taken := claimed[key]; taken {
+				continue
+			}
+			claimed[key] = struct{}{}
+			out[name] = value
+		}
+	}
+	return out
+}
+
+// collapseEntries reduces a layer's declarations to a single value per name,
+// keyed by the form the winning declaration used. Entries are walked in order
+// and a later one replaces an earlier form of the same name, which is the rule
+// environment merging and @capture upserts already follow.
+func collapseEntries(entries []variableEntry) map[string]string {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		vars.Upsert(out, e.name, e.value)
+	}
+	return out
+}
+
+func constEntries(doc *restfile.Document) []variableEntry {
+	if doc == nil {
+		return nil
+	}
+	out := make([]variableEntry, 0, len(doc.Constants))
+	for _, c := range doc.Constants {
+		out = append(out, variableEntry{name: c.Name, value: c.Value})
+	}
+	return out
+}
+
+func requestEntries(req *restfile.Request, sec secrecy) []variableEntry {
+	if req == nil {
+		return nil
+	}
+	return declaredEntries(req.Variables, sec)
+}
+
+func docGlobalEntries(doc *restfile.Document, sec secrecy) []variableEntry {
+	if doc == nil {
+		return nil
+	}
+	return declaredEntries(doc.Globals, sec)
+}
+
+func docVarEntries(doc *restfile.Document, sec secrecy) []variableEntry {
+	if doc == nil {
+		return nil
+	}
+	return declaredEntries(doc.Variables, sec)
+}
+
+func declaredEntries(xs []restfile.Variable, sec secrecy) []variableEntry {
+	out := make([]variableEntry, 0, len(xs))
+	for _, v := range xs {
+		if sec == omitSecrets && v.Secret {
+			continue
+		}
+		out = append(out, variableEntry{name: v.Name, value: v.Value})
+	}
+	return out
+}
+
+func globalEntries(globs map[string]vars.GlobalMutation) []variableEntry {
+	out := make([]variableEntry, 0, len(globs))
+	for _, key := range slices.Sorted(maps.Keys(globs)) {
+		g := globs[key]
+		name := strings.TrimSpace(g.Name)
+		if name == "" {
+			name = strings.TrimSpace(key)
+		}
+		if name == "" || g.Delete {
+			continue
+		}
+		out = append(out, variableEntry{name: name, value: g.Value})
+	}
+	return out
+}
+
+func (e *Engine) runtimeFileEntries(
+	doc *restfile.Document,
+	env vars.Environment,
+	sec secrecy,
+) []variableEntry {
+	fs := e.rt.Files()
+	if fs == nil {
+		return nil
+	}
+	snap := fs.Snapshot(env.Scope(), e.filePath(doc))
+	out := make([]variableEntry, 0, len(snap))
+	for _, key := range slices.Sorted(maps.Keys(snap)) {
+		v := snap[key]
+		if sec == omitSecrets && v.Secret {
+			continue
+		}
+		name := strings.TrimSpace(v.Name)
+		if name == "" {
+			name = key
+		}
+		out = append(out, variableEntry{name: name, value: v.Value})
+	}
+	return out
+}
+
+// sortedEntries orders a map source by name so one set of inputs always builds
+// the same plan. A map has no declaration order, so the layers that come from
+// one hold a single form per name already: writers go through vars.Upsert and
+// the environment, global, and file stores key by name.
+func sortedEntries(src map[string]string) []variableEntry {
+	out := make([]variableEntry, 0, len(src))
+	for _, name := range slices.Sorted(maps.Keys(src)) {
+		out = append(out, variableEntry{name: name, value: src[name]})
+	}
+	return out
+}

--- a/internal/engine/request/varplan.go
+++ b/internal/engine/request/varplan.go
@@ -3,7 +3,6 @@ package request
 import (
 	"maps"
 	"slices"
-	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/vars"
@@ -55,9 +54,7 @@ type variableEntry struct {
 
 type variableLayer struct {
 	source variableSource
-	// vals holds one value per name, keyed by the form the winning
-	// declaration used.
-	vals map[string]string
+	vals   vars.NameMap[string]
 }
 
 // variablePlan is the shared precedence order for template and script lookups.
@@ -68,9 +65,9 @@ type variablePlan struct {
 }
 
 type runVars struct {
-	scripts map[string]string
+	scripts vars.NameMap[string]
 	// overlay contains workflow step and @for-each bindings.
-	overlay map[string]string
+	overlay vars.NameMap[string]
 }
 
 type varSources struct {
@@ -86,8 +83,8 @@ type varSources struct {
 func (e *Engine) buildVariablePlan(src varSources) variablePlan {
 	plan := variablePlan{layers: make([]variableLayer, 0, len(sourceTable))}
 	plan.add(sourceConst, constEntries(src.doc))
-	plan.add(sourceScript, sortedEntries(src.run.scripts))
-	plan.add(sourceWorkflow, sortedEntries(src.run.overlay))
+	plan.addNames(sourceScript, src.run.scripts)
+	plan.addNames(sourceWorkflow, src.run.overlay)
 	plan.add(sourceRequest, requestEntries(src.req, src.sec))
 	plan.add(sourceRuntimeGlobal, globalEntries(src.globals))
 	plan.add(sourceDocumentGlobal, docGlobalEntries(src.doc, src.sec))
@@ -97,12 +94,22 @@ func (e *Engine) buildVariablePlan(src varSources) variablePlan {
 	return plan
 }
 
-// add appends the layer source contributes, or nothing when the source
-// declared no variables. Every layer is built here, so one holding two forms
-// of a name or a value map the source never filled cannot reach a plan.
+// add preserves declaration order so the last form of a name wins within a source.
 func (p *variablePlan) add(source variableSource, entries []variableEntry) {
-	vals := collapseEntries(entries)
-	if len(vals) == 0 {
+	var vals vars.NameMap[string]
+	for _, e := range entries {
+		vals.Set(e.name, e.value)
+	}
+	p.appendLayer(source, vals)
+}
+
+// addNames snapshots an already-normalized source.
+func (p *variablePlan) addNames(source variableSource, vals vars.NameMap[string]) {
+	p.appendLayer(source, vals.Clone())
+}
+
+func (p *variablePlan) appendLayer(source variableSource, vals vars.NameMap[string]) {
+	if vals.Len() == 0 {
 		return
 	}
 	p.layers = append(p.layers, variableLayer{source: source, vals: vals})
@@ -115,10 +122,10 @@ func (p variablePlan) providers() []vars.Provider {
 	for _, l := range p.layers {
 		t := l.source.traits()
 		if t.template {
-			out = append(out, vars.NewTemplateProvider(t.label, l.vals))
+			out = append(out, vars.NewNameMapTemplateProvider(t.label, l.vals))
 			continue
 		}
-		out = append(out, vars.NewMapProvider(t.label, l.vals))
+		out = append(out, vars.NewNameMapProvider(t.label, l.vals))
 	}
 	// Process environment values are not enumerable, so they remain the final
 	// fallback outside the plan.
@@ -127,37 +134,19 @@ func (p variablePlan) providers() []vars.Provider {
 
 // values flattens the plan for RTS and JavaScript while preserving provider precedence.
 func (p variablePlan) values() map[string]string {
-	out := make(map[string]string)
-	claimed := make(map[string]struct{})
+	var out vars.NameMap[string]
 	for _, l := range p.layers {
 		if l.source.traits().hidden {
 			continue
 		}
-		for name, value := range l.vals {
-			key := vars.NameKey(name)
-			if _, taken := claimed[key]; taken {
+		for name, value := range l.vals.All() {
+			if out.Has(name) {
 				continue
 			}
-			claimed[key] = struct{}{}
-			out[name] = value
+			out.Set(name, value)
 		}
 	}
-	return out
-}
-
-// collapseEntries reduces a layer's declarations to a single value per name,
-// keyed by the form the winning declaration used. Entries are walked in order
-// and a later one replaces an earlier form of the same name, which is the rule
-// environment merging and @capture upserts already follow.
-func collapseEntries(entries []variableEntry) map[string]string {
-	if len(entries) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(entries))
-	for _, e := range entries {
-		vars.Upsert(out, e.name, e.value)
-	}
-	return out
+	return out.Map()
 }
 
 func constEntries(doc *restfile.Document) []variableEntry {
@@ -207,14 +196,10 @@ func globalEntries(globs map[string]vars.GlobalMutation) []variableEntry {
 	out := make([]variableEntry, 0, len(globs))
 	for _, key := range slices.Sorted(maps.Keys(globs)) {
 		g := globs[key]
-		name := strings.TrimSpace(g.Name)
-		if name == "" {
-			name = strings.TrimSpace(key)
-		}
-		if name == "" || g.Delete {
+		if g.Delete {
 			continue
 		}
-		out = append(out, variableEntry{name: name, value: g.Value})
+		out = append(out, variableEntry{name: storedName(g.Name, key), value: g.Value})
 	}
 	return out
 }
@@ -235,19 +220,11 @@ func (e *Engine) runtimeFileEntries(
 		if sec == omitSecrets && v.Secret {
 			continue
 		}
-		name := strings.TrimSpace(v.Name)
-		if name == "" {
-			name = key
-		}
-		out = append(out, variableEntry{name: name, value: v.Value})
+		out = append(out, variableEntry{name: storedName(v.Name, key), value: v.Value})
 	}
 	return out
 }
 
-// sortedEntries orders a map source by name so one set of inputs always builds
-// the same plan. A map has no declaration order, so the layers that come from
-// one hold a single form per name already: writers go through vars.Upsert and
-// the environment, global, and file stores key by name.
 func sortedEntries(src map[string]string) []variableEntry {
 	out := make([]variableEntry, 0, len(src))
 	for _, name := range slices.Sorted(maps.Keys(src)) {

--- a/internal/engine/request/varplan.go
+++ b/internal/engine/request/varplan.go
@@ -144,21 +144,40 @@ func (p variablePlan) providers() []vars.Provider {
 	return append(out, vars.EnvProvider{})
 }
 
-// values flattens the plan for RTS and JavaScript while preserving provider precedence.
+// Scripts should see ordinary nested references resolved just as templates do.
+// Dynamic helpers and expressions are left alone because they are evaluated
+// later, after pre-request scripts have run.
 func (p variablePlan) values() map[string]string {
 	var out vars.NameMap[string]
+	var res *vars.Resolver
 	for _, l := range p.layers {
-		if l.source.traits().hidden {
+		t := l.source.traits()
+		if t.hidden {
 			continue
 		}
 		for name, value := range l.vals.All() {
 			if out.Has(name) {
 				continue
 			}
+			if t.template && vars.HasPlaceholder(value) {
+				if res == nil {
+					res = p.staticResolver()
+				}
+				// Leave values that need runtime data or the expression evaluator unchanged.
+				if expanded, err := res.ExpandTemplatesStatic(value); err == nil {
+					value = expanded
+				}
+			}
 			out.Set(name, value)
 		}
 	}
 	return out.Map()
+}
+
+func (p variablePlan) staticResolver() *vars.Resolver {
+	res := vars.NewResolver(p.providers()...)
+	res.AddRefResolver(vars.EnvRefResolver)
+	return res
 }
 
 func constEntries(doc *restfile.Document) []variableEntry {

--- a/internal/engine/request/varplan_test.go
+++ b/internal/engine/request/varplan_test.go
@@ -1,0 +1,261 @@
+package request
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+type varSource int
+
+const (
+	srcConst varSource = iota
+	srcScript
+	srcWorkflow
+	srcRequest
+	srcRuntimeGlobal
+	srcDocGlobal
+	srcRuntimeFile
+	srcFileVar
+	srcEnvironment
+)
+
+var varSourceOrder = []varSource{
+	srcConst,
+	srcScript,
+	srcWorkflow,
+	srcRequest,
+	srcRuntimeGlobal,
+	srcDocGlobal,
+	srcRuntimeFile,
+	srcFileVar,
+	srcEnvironment,
+}
+
+func (s varSource) String() string {
+	switch s {
+	case srcConst:
+		return "const"
+	case srcScript:
+		return "script"
+	case srcWorkflow:
+		return "workflow"
+	case srcRequest:
+		return "request"
+	case srcRuntimeGlobal:
+		return "runtime-global"
+	case srcDocGlobal:
+		return "document-global"
+	case srcRuntimeFile:
+		return "runtime-file"
+	case srcFileVar:
+		return "file"
+	case srcEnvironment:
+		return "environment"
+	default:
+		return "unknown"
+	}
+}
+
+func (s varSource) hidden() bool { return s == srcConst }
+
+type varDecl struct {
+	src   varSource
+	name  string
+	value string
+}
+
+type planFixture struct {
+	eng   *Engine
+	doc   *restfile.Document
+	req   *restfile.Request
+	env   vars.Environment
+	globs map[string]vars.GlobalMutation
+	run   runVars
+}
+
+func newPlanFixture(t *testing.T, decls ...varDecl) planFixture {
+	t.Helper()
+
+	f := planFixture{
+		eng:   New(engcfg.Config{}, nil),
+		doc:   &restfile.Document{Path: "plan.http"},
+		req:   &restfile.Request{Method: http.MethodGet, URL: "http://example.test"},
+		globs: make(map[string]vars.GlobalMutation),
+	}
+	envValues := make(map[string]string)
+	scriptVars := make(map[string]string)
+	loopVars := make(map[string]string)
+	var runtimeFiles []varDecl
+
+	for _, d := range decls {
+		switch d.src {
+		case srcConst:
+			f.doc.Constants = append(f.doc.Constants, restfile.Constant{Name: d.name, Value: d.value})
+		case srcScript:
+			scriptVars[d.name] = d.value
+		case srcWorkflow:
+			loopVars[d.name] = d.value
+		case srcRequest:
+			f.req.Variables = append(f.req.Variables, restfile.Variable{Name: d.name, Value: d.value})
+		case srcRuntimeGlobal:
+			f.globs[vars.NameKey(d.name)] = vars.GlobalMutation{Name: d.name, Value: d.value}
+		case srcDocGlobal:
+			f.doc.Globals = append(f.doc.Globals, restfile.Variable{Name: d.name, Value: d.value})
+		case srcRuntimeFile:
+			runtimeFiles = append(runtimeFiles, d)
+		case srcFileVar:
+			f.doc.Variables = append(f.doc.Variables, restfile.Variable{Name: d.name, Value: d.value})
+		case srcEnvironment:
+			envValues[d.name] = d.value
+		default:
+			t.Fatalf("unknown variable source %d", d.src)
+		}
+	}
+
+	cat, err := vars.NewCatalog(vars.EnvironmentSet{"dev": envValues})
+	if err != nil {
+		t.Fatalf("NewCatalog() error = %v", err)
+	}
+	sel, err := cat.Select("dev", nil)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	f.env, err = cat.Resolve(sel)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	for _, d := range runtimeFiles {
+		f.eng.rt.Files().Set(f.env.Scope(), f.doc.Path, d.name, d.value, false)
+	}
+
+	f.run = runVars{scripts: scriptVars, overlay: loopVars}
+	return f
+}
+
+func (f planFixture) values() map[string]string {
+	return f.eng.buildVariablePlan(varSources{
+		doc:     f.doc,
+		req:     f.req,
+		env:     f.env,
+		globals: f.globs,
+		sec:     keepSecrets,
+		run:     f.run,
+	}).values()
+}
+
+func (f planFixture) expand(t *testing.T, input string) string {
+	t.Helper()
+
+	res := f.eng.buildResolver(
+		context.Background(),
+		f.doc,
+		f.req,
+		f.env,
+		"",
+		f.globs,
+		rts.Locals{},
+		f.run,
+	)
+	out, err := res.ExpandTemplates(input)
+	if err != nil {
+		t.Fatalf("ExpandTemplates(%q) error = %v", input, err)
+	}
+	return out
+}
+
+func TestVariablePlanPrecedenceMatrix(t *testing.T) {
+	for i, high := range varSourceOrder {
+		for _, low := range varSourceOrder[i+1:] {
+			t.Run(high.String()+"_over_"+low.String(), func(t *testing.T) {
+				f := newPlanFixture(t,
+					varDecl{src: high, name: "token", value: "high"},
+					varDecl{src: low, name: "token", value: "low"},
+				)
+
+				if got := f.expand(t, "{{token}}"); got != "high" {
+					t.Fatalf("{{token}} = %q, want %q", got, "high")
+				}
+
+				// Constants resolve in templates but are hidden from script variables.
+				want := "high"
+				if high.hidden() {
+					want = "low"
+				}
+				if got := f.values()["token"]; got != want {
+					t.Fatalf("values()[token] = %q, want %q", got, want)
+				}
+				if got := f.expand(t, `{{= vars.get("token") }}`); got != want {
+					t.Fatalf(`{{= vars.get("token") }} = %q, want %q`, got, want)
+				}
+			})
+		}
+	}
+}
+
+func TestVariablePlanCollapsesCaseVariantsAcrossLayers(t *testing.T) {
+	f := newPlanFixture(t,
+		varDecl{src: srcFileVar, name: "token", value: "file"},
+		varDecl{src: srcEnvironment, name: "TOKEN", value: "environment"},
+	)
+
+	vv := f.values()
+	if len(vv) != 1 {
+		t.Fatalf("values() = %v, want a single entry", vv)
+	}
+	if got := vv["token"]; got != "file" {
+		t.Fatalf("values()[token] = %q, want %q", got, "file")
+	}
+	if got := f.expand(t, "{{TOKEN}}"); got != "file" {
+		t.Fatalf("{{TOKEN}} = %q, want %q", got, "file")
+	}
+}
+
+func TestVariablePlanLastDeclarationWinsWithinLayer(t *testing.T) {
+	f := newPlanFixture(t,
+		varDecl{src: srcFileVar, name: "Token", value: "first"},
+		varDecl{src: srcFileVar, name: "token", value: "second"},
+	)
+
+	vv := f.values()
+	if len(vv) != 1 {
+		t.Fatalf("values() = %v, want a single entry", vv)
+	}
+	if got := vv["token"]; got != "second" {
+		t.Fatalf("values()[token] = %q, want %q", got, "second")
+	}
+	if got := f.expand(t, "{{Token}}"); got != "second" {
+		t.Fatalf("{{Token}} = %q, want %q", got, "second")
+	}
+}
+
+func TestVariablePlanReadsTheSuppliedRuntimeGlobals(t *testing.T) {
+	f := newPlanFixture(t, varDecl{src: srcRuntimeGlobal, name: "token", value: "preview"})
+
+	if got := f.values()["token"]; got != "preview" {
+		t.Fatalf("values()[token] = %q, want %q", got, "preview")
+	}
+	if got := f.expand(t, `{{= vars.get("token") }}`); got != "preview" {
+		t.Fatalf(`{{= vars.get("token") }} = %q, want %q`, got, "preview")
+	}
+}
+
+func TestVariablePlanKeepsProcessEnvironmentOutOfVars(t *testing.T) {
+	t.Setenv("RESTERM_PLAN_TOKEN", "shell")
+	f := newPlanFixture(t)
+
+	if got := f.expand(t, "{{RESTERM_PLAN_TOKEN}}"); got != "shell" {
+		t.Fatalf("{{RESTERM_PLAN_TOKEN}} = %q, want %q", got, "shell")
+	}
+	if _, ok := f.values()["RESTERM_PLAN_TOKEN"]; ok {
+		t.Fatalf("values() = %v, want no process environment entry", f.values())
+	}
+	if got := f.expand(t, `{{= vars.get("RESTERM_PLAN_TOKEN") ?? "missing" }}`); got != "missing" {
+		t.Fatalf(`{{= vars.get("RESTERM_PLAN_TOKEN") }} = %q, want %q`, got, "missing")
+	}
+}

--- a/internal/engine/request/varplan_test.go
+++ b/internal/engine/request/varplan_test.go
@@ -75,7 +75,7 @@ type planFixture struct {
 	doc   *restfile.Document
 	req   *restfile.Request
 	env   vars.Environment
-	globs map[string]vars.GlobalMutation
+	globs vars.Globals
 	run   runVars
 }
 
@@ -83,10 +83,9 @@ func newPlanFixture(t *testing.T, decls ...varDecl) planFixture {
 	t.Helper()
 
 	f := planFixture{
-		eng:   New(engcfg.Config{}, nil),
-		doc:   &restfile.Document{Path: "plan.http"},
-		req:   &restfile.Request{Method: http.MethodGet, URL: "http://example.test"},
-		globs: make(map[string]vars.GlobalMutation),
+		eng: New(engcfg.Config{}, nil),
+		doc: &restfile.Document{Path: "plan.http"},
+		req: &restfile.Request{Method: http.MethodGet, URL: "http://example.test"},
 	}
 	envValues := make(map[string]string)
 	scriptVars := make(map[string]string)
@@ -104,7 +103,7 @@ func newPlanFixture(t *testing.T, decls ...varDecl) planFixture {
 		case srcRequest:
 			f.req.Variables = append(f.req.Variables, restfile.Variable{Name: d.name, Value: d.value})
 		case srcRuntimeGlobal:
-			f.globs[vars.NameKey(d.name)] = vars.GlobalMutation{Name: d.name, Value: d.value}
+			f.globs.Set(d.name, vars.GlobalMutation{Name: d.name, Value: d.value})
 		case srcDocGlobal:
 			f.doc.Globals = append(f.doc.Globals, restfile.Variable{Name: d.name, Value: d.value})
 		case srcRuntimeFile:

--- a/internal/engine/request/varplan_test.go
+++ b/internal/engine/request/varplan_test.go
@@ -200,6 +200,42 @@ func TestVariablePlanPrecedenceMatrix(t *testing.T) {
 	}
 }
 
+func TestVariablePlanExpandsNestedAuthoredValues(t *testing.T) {
+	f := newPlanFixture(t,
+		varDecl{src: srcFileVar, name: "nested.base", value: "inner"},
+		varDecl{src: srcFileVar, name: "nested.derived", value: "{{nested.base}}"},
+	)
+
+	if got := f.expand(t, "{{nested.derived}}"); got != "inner" {
+		t.Fatalf("{{nested.derived}} = %q, want %q", got, "inner")
+	}
+	if got := f.values()["nested.derived"]; got != "inner" {
+		t.Fatalf("values()[nested.derived] = %q, want %q", got, "inner")
+	}
+	if got := f.expand(t, `{{= vars.get("nested.derived") }}`); got != "inner" {
+		t.Fatalf(`{{= vars.get("nested.derived") }} = %q, want %q`, got, "inner")
+	}
+}
+
+func TestVariablePlanKeepsRuntimeValuesLiteral(t *testing.T) {
+	f := newPlanFixture(t,
+		varDecl{src: srcFileVar, name: "nested.base", value: "inner"},
+		varDecl{src: srcScript, name: "captured", value: "{{nested.base}}"},
+	)
+
+	if got := f.values()["captured"]; got != "{{nested.base}}" {
+		t.Fatalf("values()[captured] = %q, want %q", got, "{{nested.base}}")
+	}
+}
+
+func TestVariablePlanKeepsDynamicAuthoredValuesLiteral(t *testing.T) {
+	f := newPlanFixture(t, varDecl{src: srcRequest, name: "trace.id", value: "{{$uuid}}"})
+
+	if got := f.values()["trace.id"]; got != "{{$uuid}}" {
+		t.Fatalf("values()[trace.id] = %q, want %q", got, "{{$uuid}}")
+	}
+}
+
 func TestVariablePlanCollapsesCaseVariantsAcrossLayers(t *testing.T) {
 	f := newPlanFixture(t,
 		varDecl{src: srcFileVar, name: "token", value: "file"},

--- a/internal/engine/request/varplan_test.go
+++ b/internal/engine/request/varplan_test.go
@@ -134,7 +134,10 @@ func newPlanFixture(t *testing.T, decls ...varDecl) planFixture {
 		f.eng.rt.Files().Set(f.env.Scope(), f.doc.Path, d.name, d.value, false)
 	}
 
-	f.run = runVars{scripts: scriptVars, overlay: loopVars}
+	f.run = runVars{
+		scripts: vars.CollectNames(scriptVars),
+		overlay: vars.CollectNames(loopVars),
+	}
 	return f
 }
 

--- a/internal/engine/request/vars.go
+++ b/internal/engine/request/vars.go
@@ -5,7 +5,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -174,7 +173,7 @@ func (e *Engine) buildResolver(
 	req *restfile.Request,
 	env vars.Environment,
 	base string,
-	globs map[string]vars.GlobalMutation,
+	globs vars.Globals,
 	locals rts.Locals,
 	run runVars,
 ) *vars.Resolver {
@@ -186,7 +185,14 @@ func (e *Engine) buildResolver(
 		sec:     keepSecrets,
 		run:     run,
 	})
-	in := ExprInput{Doc: doc, Req: req, Env: env, Base: base, Locals: locals}
+	in := ExprInput{
+		Doc:     doc,
+		Req:     req,
+		Env:     env,
+		Base:    base,
+		Locals:  locals,
+		globals: effectiveGlobalValues(doc, globs),
+	}
 	return e.planResolver(ctx, plan, in, ExprEvalOptions{})
 }
 
@@ -201,7 +207,7 @@ func (e *Engine) DisplayResolver(
 	locals rts.Locals,
 ) *vars.Resolver {
 	globs := e.collectStoredGlobalValues(env)
-	maps.DeleteFunc(globs, func(_ string, v vars.GlobalMutation) bool { return v.Secret })
+	globs.DeleteFunc(func(_ string, v vars.GlobalMutation) bool { return v.Secret })
 
 	plan := e.buildVariablePlan(varSources{
 		doc:     doc,
@@ -210,7 +216,14 @@ func (e *Engine) DisplayResolver(
 		globals: globs,
 		sec:     omitSecrets,
 	})
-	in := ExprInput{Doc: doc, Req: req, Env: env, Base: e.rtsBase(doc, base), Locals: locals}
+	in := ExprInput{
+		Doc:     doc,
+		Req:     req,
+		Env:     env,
+		Base:    e.rtsBase(doc, base),
+		Locals:  locals,
+		globals: effectiveGlobalValues(doc, globs),
+	}
 	return e.planResolver(ctx, plan, in, ExprEvalOptions{OmitSecretGlobals: true})
 }
 
@@ -250,7 +263,7 @@ func (e *Engine) collectVariablesWithGlobals(
 	doc *restfile.Document,
 	req *restfile.Request,
 	env vars.Environment,
-	globs map[string]vars.GlobalMutation,
+	globs vars.Globals,
 	sec secrecy,
 	run runVars,
 ) map[string]string {
@@ -264,77 +277,42 @@ func (e *Engine) collectVariablesWithGlobals(
 	}).values()
 }
 
-func (e *Engine) collectGlobalValues(
-	doc *restfile.Document,
-	env vars.Environment,
-) map[string]vars.GlobalMutation {
+func (e *Engine) collectGlobalValues(doc *restfile.Document, env vars.Environment) vars.Globals {
 	return effectiveGlobalValues(doc, e.collectStoredGlobalValues(env))
 }
 
-func (e *Engine) collectStoredGlobalValues(env vars.Environment) map[string]vars.GlobalMutation {
+func (e *Engine) collectStoredGlobalValues(env vars.Environment) vars.Globals {
+	var out vars.Globals
 	gs := e.rt.Globals()
 	if gs == nil {
-		return nil
+		return out
 	}
-	out := make(map[string]vars.GlobalMutation)
-	if snap := gs.Snapshot(env.Scope()); len(snap) > 0 {
-		for k, v := range snap {
-			name := storedName(v.Name, k)
-			out[name] = vars.GlobalMutation{Name: name, Value: v.Value, Secret: v.Secret}
-		}
-	}
-	if len(out) == 0 {
-		return nil
+	for key, v := range gs.Snapshot(env.Scope()) {
+		name := storedName(v.Name, key)
+		out.Set(name, vars.GlobalMutation{Name: name, Value: v.Value, Secret: v.Secret})
 	}
 	return out
 }
 
-func collectDocumentGlobalValues(doc *restfile.Document) map[string]vars.GlobalMutation {
-	if doc == nil || len(doc.Globals) == 0 {
-		return nil
+func collectDocumentGlobalValues(doc *restfile.Document) vars.Globals {
+	var out vars.Globals
+	if doc == nil {
+		return out
 	}
-	out := make(map[string]vars.GlobalMutation)
 	for _, v := range doc.Globals {
 		name := strings.TrimSpace(v.Name)
-		if name == "" {
-			continue
-		}
-		out[name] = vars.GlobalMutation{Name: name, Value: v.Value, Secret: v.Secret}
-	}
-	if len(out) == 0 {
-		return nil
+		out.Set(name, vars.GlobalMutation{Name: name, Value: v.Value, Secret: v.Secret})
 	}
 	return out
 }
 
-func effectiveGlobalValues(
-	doc *restfile.Document,
-	globs map[string]vars.GlobalMutation,
-) map[string]vars.GlobalMutation {
+func effectiveGlobalValues(doc *restfile.Document, globs vars.Globals) vars.Globals {
 	return mergeGlobalValues(collectDocumentGlobalValues(doc), globs)
 }
 
-func cloneGlobalValues(src map[string]vars.GlobalMutation) map[string]vars.GlobalMutation {
-	if len(src) == 0 {
-		return nil
-	}
-	dst := make(map[string]vars.GlobalMutation, len(src))
-	maps.Copy(dst, src)
-	return dst
-}
-
-// mergeGlobalValues applies changes in key order so equivalent names resolve deterministically.
-func mergeGlobalValues(
-	base map[string]vars.GlobalMutation,
-	changes map[string]vars.GlobalMutation,
-) map[string]vars.GlobalMutation {
-	if len(base) == 0 && len(changes) == 0 {
-		return nil
-	}
-	out := vars.CollectNames(base)
-	for _, key := range slices.Sorted(maps.Keys(changes)) {
-		ch := changes[key]
-		name := storedName(ch.Name, key)
+func mergeGlobalValues(base, changes vars.Globals) vars.Globals {
+	out := base.Clone()
+	for name, ch := range changes.All() {
 		if ch.Delete {
 			out.Delete(name)
 			continue
@@ -342,10 +320,7 @@ func mergeGlobalValues(
 		ch.Name = name
 		out.Set(name, ch)
 	}
-	if out.Len() == 0 {
-		return nil
-	}
-	return out.Map()
+	return out
 }
 
 // storedName prefers the recorded name and falls back to the storage key.
@@ -356,19 +331,12 @@ func storedName(name, key string) string {
 	return strings.TrimSpace(key)
 }
 
-func (e *Engine) applyGlobalMutations(
-	changes map[string]vars.GlobalMutation,
-	env vars.Environment,
-) {
+func (e *Engine) applyGlobalMutations(changes vars.Globals, env vars.Environment) {
 	gs := e.rt.Globals()
-	if len(changes) == 0 || gs == nil {
+	if gs == nil {
 		return
 	}
-	for _, ch := range changes {
-		name := strings.TrimSpace(ch.Name)
-		if name == "" {
-			continue
-		}
+	for name, ch := range changes.All() {
 		if ch.Delete {
 			gs.Delete(env.Scope(), name)
 			continue

--- a/internal/engine/request/vars.go
+++ b/internal/engine/request/vars.go
@@ -175,13 +175,18 @@ func (e *Engine) buildResolver(
 	base string,
 	globs map[string]vars.GlobalMutation,
 	locals rts.Locals,
-	extras ...map[string]string,
+	run runVars,
 ) *vars.Resolver {
-	res := vars.NewResolver(e.providers(doc, req, env, globs, keepSecrets, extras...)...)
-	res.AddRefResolver(vars.EnvRefResolver)
-	res.SetExprEval(e.rtsEval(ctx, doc, req, env, base, locals, extras...))
-	res.SetExprPos(e.rtsPos(doc, req))
-	return res
+	plan := e.buildVariablePlan(varSources{
+		doc:     doc,
+		req:     req,
+		env:     env,
+		globals: globs,
+		sec:     keepSecrets,
+		run:     run,
+	})
+	in := ExprInput{Doc: doc, Req: req, Env: env, Base: base, Locals: locals}
+	return e.planResolver(ctx, plan, in, ExprEvalOptions{})
 }
 
 // DisplayResolver uses normal variable precedence for UI text but leaves out
@@ -193,124 +198,42 @@ func (e *Engine) DisplayResolver(
 	env vars.Environment,
 	base string,
 	locals rts.Locals,
-	extras ...map[string]string,
 ) *vars.Resolver {
-	base = e.rtsBase(doc, base)
 	globs := e.collectStoredGlobalValues(env)
 	maps.DeleteFunc(globs, func(_ string, v vars.GlobalMutation) bool { return v.Secret })
 
-	res := vars.NewResolver(e.providers(doc, req, env, globs, omitSecrets, extras...)...)
+	plan := e.buildVariablePlan(varSources{
+		doc:     doc,
+		req:     req,
+		env:     env,
+		globals: globs,
+		sec:     omitSecrets,
+	})
+	in := ExprInput{Doc: doc, Req: req, Env: env, Base: e.rtsBase(doc, base), Locals: locals}
+	return e.planResolver(ctx, plan, in, ExprEvalOptions{OmitSecretGlobals: true})
+}
+
+// planResolver uses one plan for template and RTS lookups so they cannot
+// disagree on precedence.
+func (e *Engine) planResolver(
+	ctx context.Context,
+	plan variablePlan,
+	in ExprInput,
+	opt ExprEvalOptions,
+) *vars.Resolver {
+	in.Vars = plan.values()
+	res := vars.NewResolver(plan.providers()...)
 	res.AddRefResolver(vars.EnvRefResolver)
-	vv := e.collectVariablesWithGlobals(doc, req, env, globs, omitSecrets, extras...)
-	res.SetExprEval(e.ExprEvalWithOptions(
-		ctx,
-		ExprInput{Doc: doc, Req: req, Env: env, Base: base, Vars: vv, Locals: locals},
-		ExprEvalOptions{OmitSecretGlobals: true},
-	))
-	res.SetExprPos(e.rtsPos(doc, req))
+	res.SetExprEval(e.ExprEvalWithOptions(ctx, in, opt))
+	res.SetExprPos(e.rtsPos(in.Doc, in.Req))
 	return res
-}
-
-func (e *Engine) providers(
-	doc *restfile.Document,
-	req *restfile.Request,
-	env vars.Environment,
-	globs map[string]vars.GlobalMutation,
-	sec secrecy,
-	extras ...map[string]string,
-) []vars.Provider {
-	ps := make([]vars.Provider, 0, 8)
-	if doc != nil && len(doc.Constants) > 0 {
-		vals := make(map[string]string, len(doc.Constants))
-		for _, c := range doc.Constants {
-			vals[c.Name] = c.Value
-		}
-		ps = append(ps, vars.NewTemplateProvider("const", vals))
-	}
-	for _, extra := range extras {
-		if len(extra) > 0 {
-			ps = append(ps, vars.NewMapProvider("script", extra))
-		}
-	}
-	if req != nil && len(req.Variables) > 0 {
-		vals := make(map[string]string, len(req.Variables))
-		for _, v := range req.Variables {
-			if sec == omitSecrets && v.Secret {
-				continue
-			}
-			vals[v.Name] = v.Value
-		}
-		if len(vals) > 0 {
-			ps = append(ps, vars.NewTemplateProvider("request", vals))
-		}
-	}
-	if vals := globalValueMap(globs); len(vals) > 0 {
-		ps = append(ps, vars.NewMapProvider("global", vals))
-	}
-	if doc != nil && len(doc.Globals) > 0 {
-		vals := make(map[string]string, len(doc.Globals))
-		for _, v := range doc.Globals {
-			if sec == omitSecrets && v.Secret {
-				continue
-			}
-			vals[v.Name] = v.Value
-		}
-		if len(vals) > 0 {
-			ps = append(ps, vars.NewTemplateProvider("document-global", vals))
-		}
-	}
-	rv := make(map[string]string)
-	e.mergeFileRuntimeVars(rv, doc, env, sec)
-	if len(rv) > 0 {
-		ps = append(ps, vars.NewMapProvider("file", rv))
-	}
-	fv := make(map[string]string)
-	if doc != nil {
-		for _, v := range doc.Variables {
-			if sec == omitSecrets && v.Secret {
-				continue
-			}
-			fv[v.Name] = v.Value
-		}
-	}
-	if len(fv) > 0 {
-		ps = append(ps, vars.NewTemplateProvider("file", fv))
-	}
-	if values := env.Values(); len(values) > 0 {
-		ps = append(ps, vars.NewMapProvider("environment", values))
-	}
-	return append(ps, vars.EnvProvider{})
-}
-
-func (e *Engine) mergeFileRuntimeVars(
-	dst map[string]string,
-	doc *restfile.Document,
-	env vars.Environment,
-	sec secrecy,
-) {
-	fs := e.rt.Files()
-	if dst == nil || fs == nil {
-		return
-	}
-	if snap := fs.Snapshot(env.Scope(), e.filePath(doc)); len(snap) > 0 {
-		for k, v := range snap {
-			if sec == omitSecrets && v.Secret {
-				continue
-			}
-			name := strings.TrimSpace(v.Name)
-			if name == "" {
-				name = k
-			}
-			dst[name] = v.Value
-		}
-	}
 }
 
 func (e *Engine) collectVariables(
 	doc *restfile.Document,
 	req *restfile.Request,
 	env vars.Environment,
-	extras ...map[string]string,
+	run runVars,
 ) map[string]string {
 	return e.collectVariablesWithGlobals(
 		doc,
@@ -318,7 +241,7 @@ func (e *Engine) collectVariables(
 		env,
 		e.collectStoredGlobalValues(env),
 		keepSecrets,
-		extras...,
+		run,
 	)
 }
 
@@ -328,40 +251,16 @@ func (e *Engine) collectVariablesWithGlobals(
 	env vars.Environment,
 	globs map[string]vars.GlobalMutation,
 	sec secrecy,
-	extras ...map[string]string,
+	run runVars,
 ) map[string]string {
-	out := make(map[string]string)
-	if values := env.Values(); len(values) > 0 {
-		maps.Copy(out, values)
-	}
-	if doc != nil {
-		for _, v := range doc.Variables {
-			if sec == omitSecrets && v.Secret {
-				continue
-			}
-			out[v.Name] = v.Value
-		}
-		for _, v := range doc.Globals {
-			if sec == omitSecrets && v.Secret {
-				continue
-			}
-			out[v.Name] = v.Value
-		}
-	}
-	e.mergeFileRuntimeVars(out, doc, env, sec)
-	maps.Copy(out, globalValueMap(globs))
-	if req != nil {
-		for _, v := range req.Variables {
-			if sec == omitSecrets && v.Secret {
-				continue
-			}
-			out[v.Name] = v.Value
-		}
-	}
-	for _, extra := range extras {
-		maps.Copy(out, extra)
-	}
-	return out
+	return e.buildVariablePlan(varSources{
+		doc:     doc,
+		req:     req,
+		env:     env,
+		globals: globs,
+		sec:     sec,
+		run:     run,
+	}).values()
 }
 
 func (e *Engine) collectGlobalValues(
@@ -455,27 +354,6 @@ func mergeGlobalValues(
 		}
 		v.Name = name
 		out[name] = v
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func globalValueMap(globs map[string]vars.GlobalMutation) map[string]string {
-	if len(globs) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(globs))
-	for k, v := range globs {
-		name := strings.TrimSpace(v.Name)
-		if name == "" {
-			name = strings.TrimSpace(k)
-		}
-		if name == "" || v.Delete {
-			continue
-		}
-		out[name] = v.Value
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/engine/request/vars.go
+++ b/internal/engine/request/vars.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -278,10 +279,7 @@ func (e *Engine) collectStoredGlobalValues(env vars.Environment) map[string]vars
 	out := make(map[string]vars.GlobalMutation)
 	if snap := gs.Snapshot(env.Scope()); len(snap) > 0 {
 		for k, v := range snap {
-			name := strings.TrimSpace(v.Name)
-			if name == "" {
-				name = k
-			}
+			name := storedName(v.Name, k)
 			out[name] = vars.GlobalMutation{Name: name, Value: v.Value, Secret: v.Secret}
 		}
 	}
@@ -325,6 +323,7 @@ func cloneGlobalValues(src map[string]vars.GlobalMutation) map[string]vars.Globa
 	return dst
 }
 
+// mergeGlobalValues applies changes in key order so equivalent names resolve deterministically.
 func mergeGlobalValues(
 	base map[string]vars.GlobalMutation,
 	changes map[string]vars.GlobalMutation,
@@ -332,33 +331,29 @@ func mergeGlobalValues(
 	if len(base) == 0 && len(changes) == 0 {
 		return nil
 	}
-	out := cloneGlobalValues(base)
-	if out == nil {
-		out = make(map[string]vars.GlobalMutation, len(changes))
-	}
-	for k, v := range changes {
-		name := strings.TrimSpace(v.Name)
-		if name == "" {
-			name = strings.TrimSpace(k)
-		}
-		if name == "" {
+	out := vars.CollectNames(base)
+	for _, key := range slices.Sorted(maps.Keys(changes)) {
+		ch := changes[key]
+		name := storedName(ch.Name, key)
+		if ch.Delete {
+			out.Delete(name)
 			continue
 		}
-		for cur := range out {
-			if strings.EqualFold(strings.TrimSpace(cur), name) {
-				delete(out, cur)
-			}
-		}
-		if v.Delete {
-			continue
-		}
-		v.Name = name
-		out[name] = v
+		ch.Name = name
+		out.Set(name, ch)
 	}
-	if len(out) == 0 {
+	if out.Len() == 0 {
 		return nil
 	}
-	return out
+	return out.Map()
+}
+
+// storedName prefers the recorded name and falls back to the storage key.
+func storedName(name, key string) string {
+	if n := strings.TrimSpace(name); n != "" {
+		return n
+	}
+	return strings.TrimSpace(key)
 }
 
 func (e *Engine) applyGlobalMutations(

--- a/internal/engine/request/vars_test.go
+++ b/internal/engine/request/vars_test.go
@@ -137,7 +137,7 @@ func TestRunRTSApplyUsesDocumentGlobalPatchProfiles(t *testing.T) {
 		req,
 		testEnv(""),
 		"",
-		nil,
+		evalScope{},
 		rts.Locals{},
 	); err != nil {
 		t.Fatalf("runRTSApply() error = %v", err)
@@ -157,9 +157,9 @@ func TestProvidersExpandDeclaredVariableTemplates(t *testing.T) {
 	req := &restfile.Request{
 		Variables: []restfile.Variable{{Name: "trace.id", Value: "{{$uuid}}"}},
 	}
-	globs := map[string]vars.GlobalMutation{
+	globs := vars.CollectNames(map[string]vars.GlobalMutation{
 		"captured": {Name: "captured", Value: "{{file.greeting}}"},
-	}
+	})
 	plan := e.buildVariablePlan(varSources{
 		doc:     doc,
 		req:     req,

--- a/internal/engine/request/vars_test.go
+++ b/internal/engine/request/vars_test.go
@@ -166,7 +166,7 @@ func TestProvidersExpandDeclaredVariableTemplates(t *testing.T) {
 		env:     testEnv("dev"),
 		globals: globs,
 		sec:     keepSecrets,
-		run:     runVars{scripts: map[string]string{"name": "resterm"}},
+		run:     runVars{scripts: vars.CollectNames(map[string]string{"name": "resterm"})},
 	})
 	res := vars.NewResolver(plan.providers()...)
 

--- a/internal/engine/request/vars_test.go
+++ b/internal/engine/request/vars_test.go
@@ -160,9 +160,15 @@ func TestProvidersExpandDeclaredVariableTemplates(t *testing.T) {
 	globs := map[string]vars.GlobalMutation{
 		"captured": {Name: "captured", Value: "{{file.greeting}}"},
 	}
-	res := vars.NewResolver(
-		e.providers(doc, req, testEnv("dev"), globs, keepSecrets, map[string]string{"name": "resterm"})...,
-	)
+	plan := e.buildVariablePlan(varSources{
+		doc:     doc,
+		req:     req,
+		env:     testEnv("dev"),
+		globals: globs,
+		sec:     keepSecrets,
+		run:     runVars{scripts: map[string]string{"name": "resterm"}},
+	})
+	res := vars.NewResolver(plan.providers()...)
 
 	greeting, err := res.ExpandTemplates("{{file.greeting}}")
 	if err != nil {

--- a/internal/engine/runtime/runtime_test.go
+++ b/internal/engine/runtime/runtime_test.go
@@ -28,6 +28,19 @@ func (s *stubHistory) Close() error {
 	return nil
 }
 
+func TestRuntimeStoresDropBlankNames(t *testing.T) {
+	rt := New(Config{})
+	rt.Globals().Set("dev", "  ", "ghost", false)
+	rt.Files().Set("dev", "/tmp/a.http", "", "ghost", false)
+
+	if got := rt.Globals().Snapshot("dev"); len(got) != 0 {
+		t.Fatalf("Globals().Snapshot() = %#v, want no entries", got)
+	}
+	if got := rt.Files().Snapshot("dev", "/tmp/a.http"); len(got) != 0 {
+		t.Fatalf("Files().Snapshot() = %#v, want no entries", got)
+	}
+}
+
 func TestRuntimeStateRoundTrip(t *testing.T) {
 	rt := New(Config{})
 	rt.Globals().Set("dev", "token", "abc", true)

--- a/internal/engine/runtime/store.go
+++ b/internal/engine/runtime/store.go
@@ -30,7 +30,12 @@ func (s *scopedValueStore) snapshot(scope string) map[string]storedValue {
 	return cloneStoredValues(s.values[scope])
 }
 
+// Keep live state consistent with restore, which also drops blank names.
 func (s *scopedValueStore) set(scope, name, value string, secret bool) {
+	if nameKey(name) == "" {
+		return
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/exec/http.go
+++ b/internal/exec/http.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"context"
 	"fmt"
-	"maps"
 	"strings"
 	"time"
 
@@ -55,10 +54,12 @@ type HTTPHooks struct {
 	AttachSSEHandle       func(*httpx.StreamHandle, *restfile.Request)
 	AttachWebSocketHandle func(*httpx.WebSocketHandle, *restfile.Request)
 	ApplyCaptures         func(CaptureInput) error
-	CollectVariables      func(*restfile.Document, *restfile.Request) map[string]string
-	CollectGlobalValues   func(*restfile.Document) map[string]vars.GlobalMutation
-	RunAsserts            func(AssertInput) ([]scripts.TestResult, error)
-	ApplyRuntimeGlobals   func(map[string]vars.GlobalMutation)
+	// CollectVariables rebuilds variables after pre-request scripts; the third
+	// argument contains their writes at script precedence.
+	CollectVariables    func(*restfile.Document, *restfile.Request, map[string]string) map[string]string
+	CollectGlobalValues func(*restfile.Document) map[string]vars.GlobalMutation
+	RunAsserts          func(AssertInput) ([]scripts.TestResult, error)
+	ApplyRuntimeGlobals func(map[string]vars.GlobalMutation)
 }
 
 type HTTPResult struct {
@@ -178,7 +179,7 @@ func (r Runner) RunHTTP(in HTTPInput) HTTPResult {
 			Resolver: in.Resolver,
 			Response: respForScripts,
 			Stream:   streamInfo,
-			Vars:     r.captureVars(in.Doc, in.Req, in.ScriptVars),
+			Vars:     r.collectVars(in.Doc, in.Req, in.ScriptVars),
 			Locals:   in.Locals,
 		})
 		if err != nil {
@@ -189,8 +190,7 @@ func (r Runner) RunHTTP(in HTTPInput) HTTPResult {
 		}
 	}
 
-	updatedVars := r.collectVars(in.Doc, in.Req)
-	testVars := mergeStringMaps(updatedVars, in.ScriptVars)
+	testVars := r.collectVars(in.Doc, in.Req, in.ScriptVars)
 	testGlobals := r.collectGlobals(in.Doc)
 
 	var assertErr error
@@ -232,19 +232,15 @@ func (r Runner) RunHTTP(in HTTPInput) HTTPResult {
 	return res
 }
 
-func (r Runner) captureVars(
+func (r Runner) collectVars(
 	doc *restfile.Document,
 	req *restfile.Request,
 	scriptVars map[string]string,
 ) map[string]string {
-	return mergeStringMaps(r.collectVars(doc, req), scriptVars)
-}
-
-func (r Runner) collectVars(doc *restfile.Document, req *restfile.Request) map[string]string {
 	if r.Hooks.CollectVariables == nil {
 		return nil
 	}
-	return r.Hooks.CollectVariables(doc, req)
+	return r.Hooks.CollectVariables(doc, req, scriptVars)
 }
 
 func (r Runner) collectGlobals(doc *restfile.Document) map[string]vars.GlobalMutation {
@@ -378,16 +374,6 @@ func cloneHeader(src map[string][]string) map[string][]string {
 		dst[key] = append([]string(nil), values...)
 	}
 	return dst
-}
-
-func mergeStringMaps(base map[string]string, extra map[string]string) map[string]string {
-	if len(base) == 0 && len(extra) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(base)+len(extra))
-	maps.Copy(out, base)
-	maps.Copy(out, extra)
-	return out
 }
 
 func joinErr(a, b error) error {

--- a/internal/exec/http.go
+++ b/internal/exec/http.go
@@ -25,7 +25,7 @@ type HTTPInput struct {
 	Resolver         *vars.Resolver
 	Options          httpx.Options
 	EffectiveTimeout time.Duration
-	ScriptVars       map[string]string
+	ScriptVars       vars.NameMap[string]
 	Locals           rts.Locals
 }
 
@@ -56,7 +56,7 @@ type HTTPHooks struct {
 	ApplyCaptures         func(CaptureInput) error
 	// CollectVariables rebuilds variables after pre-request scripts; the third
 	// argument contains their writes at script precedence.
-	CollectVariables    func(*restfile.Document, *restfile.Request, map[string]string) map[string]string
+	CollectVariables    func(*restfile.Document, *restfile.Request, vars.NameMap[string]) map[string]string
 	CollectGlobalValues func(*restfile.Document) map[string]vars.GlobalMutation
 	RunAsserts          func(AssertInput) ([]scripts.TestResult, error)
 	ApplyRuntimeGlobals func(map[string]vars.GlobalMutation)
@@ -235,7 +235,7 @@ func (r Runner) RunHTTP(in HTTPInput) HTTPResult {
 func (r Runner) collectVars(
 	doc *restfile.Document,
 	req *restfile.Request,
-	scriptVars map[string]string,
+	scriptVars vars.NameMap[string],
 ) map[string]string {
 	if r.Hooks.CollectVariables == nil {
 		return nil

--- a/internal/exec/http.go
+++ b/internal/exec/http.go
@@ -27,6 +27,7 @@ type HTTPInput struct {
 	EffectiveTimeout time.Duration
 	ScriptVars       vars.NameMap[string]
 	Locals           rts.Locals
+	Secrets          *vars.Secrets
 }
 
 type CaptureInput struct {
@@ -57,9 +58,9 @@ type HTTPHooks struct {
 	// CollectVariables rebuilds variables after pre-request scripts; the third
 	// argument contains their writes at script precedence.
 	CollectVariables    func(*restfile.Document, *restfile.Request, vars.NameMap[string]) map[string]string
-	CollectGlobalValues func(*restfile.Document) map[string]vars.GlobalMutation
+	CollectGlobalValues func(*restfile.Document) vars.Globals
 	RunAsserts          func(AssertInput) ([]scripts.TestResult, error)
-	ApplyRuntimeGlobals func(map[string]vars.GlobalMutation)
+	ApplyRuntimeGlobals func(vars.Globals)
 }
 
 type HTTPResult struct {
@@ -221,9 +222,10 @@ func (r Runner) RunHTTP(in HTTPInput) HTTPResult {
 			BaseDir:   in.Options.BaseDir,
 			Stream:    streamInfo,
 			Trace:     traceInput,
+			Secrets:   in.Secrets,
 		},
 	)
-	if len(globalChanges) > 0 && r.Hooks.ApplyRuntimeGlobals != nil {
+	if globalChanges.Len() > 0 && r.Hooks.ApplyRuntimeGlobals != nil {
 		r.Hooks.ApplyRuntimeGlobals(globalChanges)
 	}
 
@@ -243,9 +245,9 @@ func (r Runner) collectVars(
 	return r.Hooks.CollectVariables(doc, req, scriptVars)
 }
 
-func (r Runner) collectGlobals(doc *restfile.Document) map[string]vars.GlobalMutation {
+func (r Runner) collectGlobals(doc *restfile.Document) vars.Globals {
 	if r.Hooks.CollectGlobalValues == nil {
-		return nil
+		return vars.Globals{}
 	}
 	return r.Hooks.CollectGlobalValues(doc)
 }

--- a/internal/prerequest/prerequest.go
+++ b/internal/prerequest/prerequest.go
@@ -3,7 +3,6 @@ package prerequest
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/directive"
@@ -23,12 +22,13 @@ type Input struct {
 
 // Output is the request mutation set produced by pre-request scripts.
 type Output struct {
-	Headers   http.Header
-	Query     map[string]string
-	Body      *string
-	URL       *string
-	Method    *string
-	Variables map[string]string
+	Headers http.Header
+	Query   map[string]string
+	Body    *string
+	URL     *string
+	Method  *string
+	// Variables contains script writes, normalized to one entry per name.
+	Variables vars.NameMap[string]
 	Globals   map[string]vars.GlobalMutation
 }
 
@@ -74,7 +74,6 @@ func Normalize(out *Output) {
 	}
 	out.Headers = nilIfEmpty(out.Headers)
 	out.Query = nilIfEmpty(out.Query)
-	out.Variables = nilIfEmpty(out.Variables)
 	out.Globals = nilIfEmpty(out.Globals)
 }
 
@@ -109,26 +108,24 @@ func applyQuery(req *restfile.Request, q map[string]string) error {
 
 // SetRequestVars merges script writes into request-scoped variables. Names are
 // matched case-insensitively after trimming whitespace.
-func SetRequestVars(req *restfile.Request, variables map[string]string) {
-	if req == nil || len(variables) == 0 {
+// New variables are appended in deterministic order.
+func SetRequestVars(req *restfile.Request, variables vars.NameMap[string]) {
+	if req == nil || variables.Len() == 0 {
 		return
 	}
 	idxs := make(map[string]int)
 	for i, variable := range req.Variables {
 		idxs[vars.NameKey(variable.Name)] = i
 	}
-	for name, value := range variables {
+	for name, value := range variables.Sorted() {
 		key := vars.NameKey(name)
-		if key == "" {
-			continue
-		}
 		if idx, ok := idxs[key]; ok {
 			req.Variables[idx].Value = value
 			continue
 		}
 		idxs[key] = len(req.Variables)
 		req.Variables = append(req.Variables, restfile.Variable{
-			Name:  strings.TrimSpace(name),
+			Name:  name,
 			Value: value,
 			Scope: directive.ScopeRequest,
 		})

--- a/internal/prerequest/prerequest.go
+++ b/internal/prerequest/prerequest.go
@@ -64,7 +64,7 @@ func Apply(req *restfile.Request, out Output) error {
 		req.Body.Text = *out.Body
 		req.Body.GraphQL = nil
 	}
-	setRequestVars(req, out.Variables)
+	SetRequestVars(req, out.Variables)
 	return nil
 }
 
@@ -107,22 +107,28 @@ func applyQuery(req *restfile.Request, q map[string]string) error {
 	return nil
 }
 
-func setRequestVars(req *restfile.Request, variables map[string]string) {
+// SetRequestVars merges script writes into request-scoped variables. Names are
+// matched case-insensitively after trimming whitespace.
+func SetRequestVars(req *restfile.Request, variables map[string]string) {
 	if req == nil || len(variables) == 0 {
 		return
 	}
-	existing := make(map[string]int)
+	idxs := make(map[string]int)
 	for i, variable := range req.Variables {
-		existing[strings.ToLower(variable.Name)] = i
+		idxs[vars.NameKey(variable.Name)] = i
 	}
 	for name, value := range variables {
-		key := strings.ToLower(name)
-		if idx, ok := existing[key]; ok {
+		key := vars.NameKey(name)
+		if key == "" {
+			continue
+		}
+		if idx, ok := idxs[key]; ok {
 			req.Variables[idx].Value = value
 			continue
 		}
+		idxs[key] = len(req.Variables)
 		req.Variables = append(req.Variables, restfile.Variable{
-			Name:  name,
+			Name:  strings.TrimSpace(name),
 			Value: value,
 			Scope: directive.ScopeRequest,
 		})

--- a/internal/prerequest/prerequest.go
+++ b/internal/prerequest/prerequest.go
@@ -24,13 +24,46 @@ type Input struct {
 // Output is the request mutation set produced by pre-request scripts.
 type Output struct {
 	Headers http.Header
-	Query   map[string]string
-	Body    *string
-	URL     *string
-	Method  *string
+	// Removals are tracked separately because headers declared in the file are
+	// not part of Headers and would otherwise survive the script.
+	HeaderDels map[string]struct{}
+	Query      map[string]string
+	Body       *string
+	URL        *string
+	Method     *string
 	// Variables contains script writes, normalized to one entry per name.
 	Variables vars.NameMap[string]
 	Globals   vars.Globals
+}
+
+func (o *Output) SetHeader(name, value string) {
+	o.headers().Set(name, value)
+}
+
+func (o *Output) AddHeader(name, value string) {
+	o.headers().Add(name, value)
+}
+
+func (o *Output) DelHeader(name string) {
+	o.Headers.Del(name)
+	if o.HeaderDels == nil {
+		o.HeaderDels = make(map[string]struct{})
+	}
+	o.HeaderDels[http.CanonicalHeaderKey(name)] = struct{}{}
+}
+
+func (o *Output) SetQuery(name, value string) {
+	if o.Query == nil {
+		o.Query = make(map[string]string)
+	}
+	o.Query[name] = value
+}
+
+func (o *Output) headers() http.Header {
+	if o.Headers == nil {
+		o.Headers = make(http.Header)
+	}
+	return o.Headers
 }
 
 // Apply mutates req with pre-request script output.
@@ -49,17 +82,7 @@ func Apply(req *restfile.Request, out Output) error {
 			return diag.WrapAs(diag.ClassScript, err, "invalid url after script")
 		}
 	}
-	if out.Headers != nil {
-		if req.Headers == nil {
-			req.Headers = make(http.Header)
-		}
-		for name, values := range out.Headers {
-			req.Headers.Del(name)
-			for _, value := range values {
-				req.Headers.Add(name, value)
-			}
-		}
-	}
+	applyHeaders(req, out.Headers, out.HeaderDels)
 	if out.Body != nil {
 		req.Body.FilePath = ""
 		req.Body.Text = *out.Body
@@ -74,6 +97,7 @@ func Normalize(out *Output) {
 		return
 	}
 	out.Headers = nilIfEmpty(out.Headers)
+	out.HeaderDels = nilIfEmpty(out.HeaderDels)
 	out.Query = nilIfEmpty(out.Query)
 }
 
@@ -83,6 +107,25 @@ func nilIfEmpty[M ~map[K]V, K comparable, V any](m M) M {
 	}
 	var zero M
 	return zero
+}
+
+// Apply removals first so a value set later in the same script batch is kept.
+func applyHeaders(req *restfile.Request, set http.Header, del map[string]struct{}) {
+	for name := range del {
+		req.Headers.Del(name)
+	}
+	if len(set) == 0 {
+		return
+	}
+	if req.Headers == nil {
+		req.Headers = make(http.Header)
+	}
+	for name, values := range set {
+		req.Headers.Del(name)
+		for _, value := range values {
+			req.Headers.Add(name, value)
+		}
+	}
 }
 
 func applyQuery(req *restfile.Request, q map[string]string) error {

--- a/internal/prerequest/prerequest.go
+++ b/internal/prerequest/prerequest.go
@@ -15,9 +15,10 @@ import (
 type Input struct {
 	Request   *restfile.Request
 	Variables map[string]string
-	Globals   map[string]vars.GlobalMutation
+	Globals   vars.Globals
 	BaseDir   string
 	Context   context.Context
+	Secrets   *vars.Secrets
 }
 
 // Output is the request mutation set produced by pre-request scripts.
@@ -29,7 +30,7 @@ type Output struct {
 	Method  *string
 	// Variables contains script writes, normalized to one entry per name.
 	Variables vars.NameMap[string]
-	Globals   map[string]vars.GlobalMutation
+	Globals   vars.Globals
 }
 
 // Apply mutates req with pre-request script output.
@@ -74,7 +75,6 @@ func Normalize(out *Output) {
 	}
 	out.Headers = nilIfEmpty(out.Headers)
 	out.Query = nilIfEmpty(out.Query)
-	out.Globals = nilIfEmpty(out.Globals)
 }
 
 func nilIfEmpty[M ~map[K]V, K comparable, V any](m M) M {

--- a/internal/prerequest/prerequest_test.go
+++ b/internal/prerequest/prerequest_test.go
@@ -12,15 +12,14 @@ import (
 func TestNormalize(t *testing.T) {
 	body := "body"
 	out := Output{
-		Headers:   http.Header{},
-		Query:     map[string]string{},
-		Body:      &body,
-		Variables: map[string]string{},
-		Globals:   map[string]vars.GlobalMutation{},
+		Headers: http.Header{},
+		Query:   map[string]string{},
+		Body:    &body,
+		Globals: map[string]vars.GlobalMutation{},
 	}
 
 	Normalize(&out)
-	if out.Headers != nil || out.Query != nil || out.Variables != nil || out.Globals != nil {
+	if out.Headers != nil || out.Query != nil || out.Globals != nil {
 		t.Fatalf("expected empty collections to be nil: %#v", out)
 	}
 	if out.Body == nil || *out.Body != body {

--- a/internal/prerequest/prerequest_test.go
+++ b/internal/prerequest/prerequest_test.go
@@ -25,6 +25,33 @@ func TestNormalize(t *testing.T) {
 	}
 }
 
+func TestApplyRemovesDeclaredHeaders(t *testing.T) {
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    "https://example.com",
+		Headers: http.Header{
+			"X-Declared": {"declared"},
+			"X-Replaced": {"declared"},
+		},
+	}
+
+	var out Output
+	out.DelHeader("X-Declared")
+	out.SetHeader("X-Replaced", "script")
+	out.DelHeader("X-Replaced")
+	out.SetHeader("X-Replaced", "final")
+
+	if err := Apply(req, out); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, ok := req.Headers["X-Declared"]; ok {
+		t.Fatalf("expected the removed header to be gone, got %#v", got)
+	}
+	if got := req.Headers.Get("X-Replaced"); got != "final" {
+		t.Fatalf("X-Replaced = %q, want %q", got, "final")
+	}
+}
+
 func TestApplyPreservesTemplatedURL(t *testing.T) {
 	req := &restfile.Request{
 		Method: "GET",

--- a/internal/prerequest/prerequest_test.go
+++ b/internal/prerequest/prerequest_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/unkn0wn-root/resterm/internal/restfile"
-	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 func TestNormalize(t *testing.T) {
@@ -15,11 +14,10 @@ func TestNormalize(t *testing.T) {
 		Headers: http.Header{},
 		Query:   map[string]string{},
 		Body:    &body,
-		Globals: map[string]vars.GlobalMutation{},
 	}
 
 	Normalize(&out)
-	if out.Headers != nil || out.Query != nil || out.Globals != nil {
+	if out.Headers != nil || out.Query != nil {
 		t.Fatalf("expected empty collections to be nil: %#v", out)
 	}
 	if out.Body == nil || *out.Body != body {

--- a/internal/rts/key.go
+++ b/internal/rts/key.go
@@ -34,5 +34,5 @@ func MapKey(ctx *Ctx, pos Pos, key, sig string) (string, error) {
 }
 
 func lookupKey(key string) string {
-	return strings.ToLower(key)
+	return strings.ToLower(strings.TrimSpace(key))
 }

--- a/internal/rts/key_test.go
+++ b/internal/rts/key_test.go
@@ -1,0 +1,81 @@
+package rts
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLookupIgnoresSurroundingWhitespace(t *testing.T) {
+	e := NewEng(testStdlib)
+	rt := RT{
+		Env:     map[string]string{"mode": "dev"},
+		Vars:    map[string]string{"token": "abc"},
+		Globals: map[string]string{"flag": "on"},
+	}
+	pos := Pos{Path: "test", Line: 1, Col: 1}
+
+	tests := []struct {
+		src  string
+		want string
+	}{
+		{`vars.get(" token ")`, "abc"},
+		{`vars.require(" token ")`, "abc"},
+		{`vars[" token "]`, "abc"},
+		{`vars.global.get(" flag ")`, "on"},
+		{`vars.global.require(" flag ")`, "on"},
+		{`env.get(" mode ")`, "dev"},
+	}
+	for _, tt := range tests {
+		v, err := e.Eval(context.Background(), rt, tt.src, pos)
+		if err != nil {
+			t.Errorf("%s: %v", tt.src, err)
+			continue
+		}
+		if v.K != VStr || v.S != tt.want {
+			t.Errorf("%s = %+v, want %q", tt.src, v, tt.want)
+		}
+	}
+
+	for _, src := range []string{`vars.has(" token ")`, `vars.global.has(" flag ")`} {
+		v, err := e.Eval(context.Background(), rt, src, pos)
+		if err != nil {
+			t.Errorf("%s: %v", src, err)
+			continue
+		}
+		if v.K != VBool || !v.B {
+			t.Errorf("%s = %+v, want true", src, v)
+		}
+	}
+}
+
+func TestSetTrimsNameSoLaterReadsMatch(t *testing.T) {
+	e := NewEng(testStdlib)
+	mut := &recordingVarsMut{}
+	rt := RT{Vars: map[string]string{}, VarsMut: mut}
+	pos := Pos{Path: "test", Line: 1, Col: 1}
+
+	v, err := e.Eval(
+		context.Background(),
+		rt,
+		`vars.set(" token ", "abc") ?? vars.get(" token ")`,
+		pos,
+	)
+	if err != nil {
+		t.Fatalf("set then get: %v", err)
+	}
+	if v.K != VStr || v.S != "abc" {
+		t.Fatalf("vars.get(\" token \") = %+v, want abc", v)
+	}
+	if mut.name != "token" {
+		t.Fatalf("recorded name = %q, want %q", mut.name, "token")
+	}
+}
+
+type recordingVarsMut struct {
+	name  string
+	value string
+}
+
+func (m *recordingVarsMut) SetVar(name, value string) {
+	m.name, m.value = name, value
+}

--- a/internal/rtshost/globals.go
+++ b/internal/rtshost/globals.go
@@ -15,14 +15,10 @@ const (
 )
 
 // RuntimeGlobals returns global values keyed the way RTS variable lookup expects.
-func RuntimeGlobals(globals map[string]vars.GlobalMutation, policy SecretPolicy) map[string]string {
-	out := make(map[string]string, len(globals))
-	for key, mut := range globals {
+func RuntimeGlobals(globals vars.Globals, policy SecretPolicy) map[string]string {
+	out := make(map[string]string, globals.Len())
+	for name, mut := range globals.All() {
 		if mut.Delete || (policy == OmitSecrets && mut.Secret) {
-			continue
-		}
-		name := util.FirstTrimmed(mut.Name, key)
-		if name == "" {
 			continue
 		}
 		out[util.Lower(name)] = mut.Value

--- a/internal/rtshost/globals_test.go
+++ b/internal/rtshost/globals_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestRuntimeGlobals(t *testing.T) {
-	globals := map[string]vars.GlobalMutation{
+	globals := vars.CollectNames(map[string]vars.GlobalMutation{
 		"fallback": {Value: "a"},
-		"named":    {Name: "Token", Value: "b"},
-		"secret":   {Name: "Secret", Value: "c", Secret: true},
-		"deleted":  {Name: "Deleted", Value: "d", Delete: true},
-	}
+		"Token":    {Name: "Token", Value: "b"},
+		"Secret":   {Name: "Secret", Value: "c", Secret: true},
+		"Deleted":  {Name: "Deleted", Value: "d", Delete: true},
+	})
 
 	got := RuntimeGlobals(globals, OmitSecrets)
 	if got["fallback"] != "a" || got["token"] != "b" {

--- a/internal/rtshost/mutator.go
+++ b/internal/rtshost/mutator.go
@@ -79,14 +79,12 @@ func (m *Mutator) SetBody(value string) {
 	m.out.Body = &value
 }
 
-// Both maps are keyed by the name a script wrote, so a set has to drop any
-// other form of that name. Without it two forms survive and whichever a later
-// map walk reaches last decides the value, which is not the one set last.
+// SetVar records the write and updates the host's plain-map view without
+// leaving duplicate name forms.
 func (m *Mutator) SetVar(name, value string) {
-	if m.out.Variables == nil {
-		m.out.Variables = make(map[string]string)
+	if !m.out.Variables.Set(name, value) {
+		return
 	}
-	vars.Upsert(m.out.Variables, name, value)
 	if m.vars != nil {
 		vars.Upsert(m.vars, name, value)
 	}

--- a/internal/rtshost/mutator.go
+++ b/internal/rtshost/mutator.go
@@ -24,13 +24,19 @@ type Mutator struct {
 	req  *rts.Req
 	vars map[string]string
 	glob map[string]string
+	sec  *vars.Secrets
 }
 
-func NewMutator(out *prerequest.Output, req *rts.Req, vars, globals map[string]string) *Mutator {
+func NewMutator(
+	out *prerequest.Output,
+	req *rts.Req,
+	vals, globals map[string]string,
+	sec *vars.Secrets,
+) *Mutator {
 	if req == nil {
 		req = &rts.Req{}
 	}
-	return &Mutator{out: out, req: req, vars: vars, glob: globals}
+	return &Mutator{out: out, req: req, vars: vals, glob: globals, sec: sec}
 }
 
 func (m *Mutator) Request() *rts.Req { return m.req }
@@ -91,14 +97,21 @@ func (m *Mutator) SetVar(name, value string) {
 }
 
 func (m *Mutator) SetGlobal(name, value string, secret bool) {
-	m.outGlobals()[name] = vars.GlobalMutation{Name: name, Value: value, Secret: secret}
+	if !m.out.Globals.Set(name, vars.GlobalMutation{Name: name, Value: value, Secret: secret}) {
+		return
+	}
+	if secret {
+		m.sec.Add(value)
+	}
 	if m.glob != nil {
 		m.glob[util.Lower(name)] = value
 	}
 }
 
 func (m *Mutator) DelGlobal(name string) {
-	m.outGlobals()[name] = vars.GlobalMutation{Name: name, Delete: true}
+	if !m.out.Globals.Set(name, vars.GlobalMutation{Name: name, Delete: true}) {
+		return
+	}
 	delete(m.glob, util.Lower(name))
 }
 
@@ -124,13 +137,6 @@ func (m *Mutator) outHeaders() http.Header {
 		m.out.Headers = make(http.Header)
 	}
 	return m.out.Headers
-}
-
-func (m *Mutator) outGlobals() map[string]vars.GlobalMutation {
-	if m.out.Globals == nil {
-		m.out.Globals = make(map[string]vars.GlobalMutation)
-	}
-	return m.out.Globals
 }
 
 func (m *Mutator) reqHeaders() map[string][]string {

--- a/internal/rtshost/mutator.go
+++ b/internal/rtshost/mutator.go
@@ -79,13 +79,16 @@ func (m *Mutator) SetBody(value string) {
 	m.out.Body = &value
 }
 
+// Both maps are keyed by the name a script wrote, so a set has to drop any
+// other form of that name. Without it two forms survive and whichever a later
+// map walk reaches last decides the value, which is not the one set last.
 func (m *Mutator) SetVar(name, value string) {
 	if m.out.Variables == nil {
 		m.out.Variables = make(map[string]string)
 	}
-	m.out.Variables[name] = value
+	vars.Upsert(m.out.Variables, name, value)
 	if m.vars != nil {
-		m.vars[name] = value
+		vars.Upsert(m.vars, name, value)
 	}
 }
 

--- a/internal/rtshost/mutator.go
+++ b/internal/rtshost/mutator.go
@@ -1,7 +1,6 @@
 package rtshost
 
 import (
-	"net/http"
 	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/prerequest"
@@ -56,28 +55,23 @@ func (m *Mutator) SetURL(value string) {
 }
 
 func (m *Mutator) SetHeader(name, value string) {
-	m.outHeaders().Set(name, value)
+	m.out.SetHeader(name, value)
 	m.reqHeaders()[util.Lower(name)] = []string{value}
 }
 
 func (m *Mutator) AddHeader(name, value string) {
-	m.outHeaders().Add(name, value)
+	m.out.AddHeader(name, value)
 	h, key := m.reqHeaders(), util.Lower(name)
 	h[key] = append(h[key], value)
 }
 
 func (m *Mutator) DelHeader(name string) {
-	if m.out.Headers != nil {
-		m.out.Headers.Del(name)
-	}
+	m.out.DelHeader(name)
 	delete(m.req.H, util.Lower(name))
 }
 
 func (m *Mutator) SetQuery(name, value string) {
-	if m.out.Query == nil {
-		m.out.Query = make(map[string]string)
-	}
-	m.out.Query[name] = value
+	m.out.SetQuery(name, value)
 	m.setReqQuery(name, value)
 }
 
@@ -130,13 +124,6 @@ func (m *Mutator) setReqQuery(name, value string) {
 		return
 	}
 	m.req.URL = url
-}
-
-func (m *Mutator) outHeaders() http.Header {
-	if m.out.Headers == nil {
-		m.out.Headers = make(http.Header)
-	}
-	return m.out.Headers
 }
 
 func (m *Mutator) reqHeaders() map[string][]string {

--- a/internal/rtshost/mutator_test.go
+++ b/internal/rtshost/mutator_test.go
@@ -1,17 +1,19 @@
 package rtshost
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/unkn0wn-root/resterm/internal/prerequest"
 	"github.com/unkn0wn-root/resterm/internal/rts"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 func TestMutatorNormalizesTokenMutations(t *testing.T) {
 	var out prerequest.Output
 	req := &rts.Req{}
-	mut := NewMutator(&out, req, nil, nil)
+	mut := NewMutator(&out, req, nil, nil, nil)
 
 	mut.SetMethod(" post ")
 	mut.SetURL(" https://api.example.com/users ")
@@ -28,7 +30,7 @@ func TestMutatorNormalizesTokenMutations(t *testing.T) {
 func TestMutatorMirrorsHeadersOntoRequestView(t *testing.T) {
 	var out prerequest.Output
 	req := &rts.Req{H: map[string][]string{"x-drop": {"gone"}}}
-	mut := NewMutator(&out, req, nil, nil)
+	mut := NewMutator(&out, req, nil, nil, nil)
 
 	mut.SetHeader("X-Test", "1")
 	mut.AddHeader("X-Test", "2")
@@ -48,7 +50,7 @@ func TestMutatorMirrorsHeadersOntoRequestView(t *testing.T) {
 func TestMutatorPatchesRequestURLOnQuery(t *testing.T) {
 	var out prerequest.Output
 	req := &rts.Req{URL: "https://example.com/path?seed=1"}
-	mut := NewMutator(&out, req, nil, nil)
+	mut := NewMutator(&out, req, nil, nil, nil)
 
 	mut.SetQuery("user", "alice")
 
@@ -67,7 +69,7 @@ func TestMutatorKeepsRuntimeVarsAndGlobalsInSync(t *testing.T) {
 	var out prerequest.Output
 	vv := map[string]string{}
 	gv := map[string]string{"old": "gone"}
-	mut := NewMutator(&out, nil, vv, gv)
+	mut := NewMutator(&out, nil, vv, gv, nil)
 
 	mut.SetVar("token", "abc")
 	mut.SetGlobal("NewGlobal", "ng", true)
@@ -80,13 +82,13 @@ func TestMutatorKeepsRuntimeVarsAndGlobalsInSync(t *testing.T) {
 	if gv["newglobal"] != "ng" {
 		t.Fatalf("expected runtime global newglobal=ng, got %#v", gv)
 	}
-	if got := out.Globals["NewGlobal"]; got.Value != "ng" || !got.Secret {
+	if got, _ := out.Globals.Get("NewGlobal"); got.Value != "ng" || !got.Secret {
 		t.Fatalf("expected recorded secret global, got %#v", got)
 	}
 	if _, ok := gv["old"]; ok {
 		t.Fatalf("expected deleted global to leave the runtime view: %#v", gv)
 	}
-	if got := out.Globals["Old"]; !got.Delete {
+	if got, _ := out.Globals.Get("Old"); !got.Delete {
 		t.Fatalf("expected recorded global deletion, got %#v", got)
 	}
 }
@@ -94,7 +96,7 @@ func TestMutatorKeepsRuntimeVarsAndGlobalsInSync(t *testing.T) {
 func TestMutatorDropsBlankVariableNames(t *testing.T) {
 	var out prerequest.Output
 	vv := map[string]string{}
-	mut := NewMutator(&out, nil, vv, nil)
+	mut := NewMutator(&out, nil, vv, nil, nil)
 
 	mut.SetVar("  ", "ghost")
 
@@ -106,9 +108,31 @@ func TestMutatorDropsBlankVariableNames(t *testing.T) {
 	}
 }
 
+func TestMutatorKeepsSecretValuesThroughDeleteAndOverwrite(t *testing.T) {
+	var out prerequest.Output
+	var sec vars.Secrets
+	mut := NewMutator(&out, nil, nil, map[string]string{}, &sec)
+
+	mut.SetGlobal("token", "hidden", true)
+	mut.DelGlobal("token")
+	mut.SetGlobal("other", "also-hidden", true)
+	mut.SetGlobal("other", "public", false)
+
+	if entry, _ := out.Globals.Get("token"); !entry.Delete {
+		t.Fatalf("expected the delete to win, got %#v", entry)
+	}
+	if entry, _ := out.Globals.Get("other"); entry.Secret || entry.Value != "public" {
+		t.Fatalf("expected the public overwrite to win, got %#v", entry)
+	}
+	want := []string{"hidden", "also-hidden"}
+	if got := sec.Values(); !slices.Equal(got, want) {
+		t.Fatalf("secrets = %#v, want %#v", got, want)
+	}
+}
+
 func TestMutatorWithoutRuntimeViewsOnlyRecords(t *testing.T) {
 	var out prerequest.Output
-	mut := NewMutator(&out, nil, nil, nil)
+	mut := NewMutator(&out, nil, nil, nil, nil)
 
 	mut.SetVar("token", "abc")
 	mut.SetGlobal("token", "abc", false)

--- a/internal/rtshost/mutator_test.go
+++ b/internal/rtshost/mutator_test.go
@@ -73,8 +73,9 @@ func TestMutatorKeepsRuntimeVarsAndGlobalsInSync(t *testing.T) {
 	mut.SetGlobal("NewGlobal", "ng", true)
 	mut.DelGlobal("Old")
 
-	if vv["token"] != "abc" || out.Variables["token"] != "abc" {
-		t.Fatalf("expected token variable, vars=%#v out=%#v", vv, out.Variables)
+	recorded, _ := out.Variables.Get("token")
+	if vv["token"] != "abc" || recorded != "abc" {
+		t.Fatalf("expected token variable, vars=%#v out=%#v", vv, out.Variables.Map())
 	}
 	if gv["newglobal"] != "ng" {
 		t.Fatalf("expected runtime global newglobal=ng, got %#v", gv)
@@ -103,7 +104,7 @@ func TestMutatorWithoutRuntimeViewsOnlyRecords(t *testing.T) {
 	if mut.Request() == nil {
 		t.Fatalf("expected an empty request view instead of nil")
 	}
-	if out.Variables["token"] != "abc" || out.Query["user"] != "alice" {
+	if recorded, _ := out.Variables.Get("token"); recorded != "abc" || out.Query["user"] != "alice" {
 		t.Fatalf("expected recorded mutations, out=%#v", out)
 	}
 	if out.Body == nil || *out.Body != "payload" {

--- a/internal/rtshost/mutator_test.go
+++ b/internal/rtshost/mutator_test.go
@@ -91,6 +91,21 @@ func TestMutatorKeepsRuntimeVarsAndGlobalsInSync(t *testing.T) {
 	}
 }
 
+func TestMutatorDropsBlankVariableNames(t *testing.T) {
+	var out prerequest.Output
+	vv := map[string]string{}
+	mut := NewMutator(&out, nil, vv, nil)
+
+	mut.SetVar("  ", "ghost")
+
+	if out.Variables.Len() != 0 {
+		t.Fatalf("expected no recorded variables, got %#v", out.Variables.Map())
+	}
+	if len(vv) != 0 {
+		t.Fatalf("expected the runtime view to stay empty, got %#v", vv)
+	}
+}
+
 func TestMutatorWithoutRuntimeViewsOnlyRecords(t *testing.T) {
 	var out prerequest.Output
 	mut := NewMutator(&out, nil, nil, nil)

--- a/internal/scripts/runner.go
+++ b/internal/scripts/runner.go
@@ -272,8 +272,37 @@ func (r *Runner) loadScript(block restfile.ScriptBlock, baseDir string) (string,
 	return normalizeScript(string(data)), nil
 }
 
-func normalizeGlobalKey(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
+// jsVarsAPI builds the vars object shared by pre-request and test scripts.
+// When non-nil, record receives writes that propagate beyond the script.
+func jsVarsAPI(
+	view map[string]string,
+	record func(name, value string),
+	global map[string]any,
+) map[string]any {
+	return map[string]any{
+		"get": func(name string) string {
+			return view[vars.NameKey(name)]
+		},
+		"has": func(name string) bool {
+			_, ok := view[vars.NameKey(name)]
+			return ok
+		},
+		"set": func(name, value string) {
+			view[vars.NameKey(name)] = value
+			if record != nil {
+				record(name, value)
+			}
+		},
+		"global": global,
+	}
+}
+
+func jsVarsView(src map[string]string) map[string]string {
+	out := make(map[string]string, len(src))
+	for name, value := range src {
+		out[vars.NameKey(name)] = value
+	}
+	return out
 }
 
 type preRequestAPI struct {
@@ -284,15 +313,14 @@ type preRequestAPI struct {
 }
 
 func newPreRequestAPI(output *prerequest.Output, input prerequest.Input) *preRequestAPI {
-	variables := make(map[string]string, len(input.Variables))
-	maps.Copy(variables, input.Variables)
+	variables := jsVarsView(input.Variables)
 
 	globals := make(map[string]vars.GlobalMutation, len(input.Globals))
 	for key, value := range input.Globals {
 		if strings.TrimSpace(value.Name) == "" {
 			value.Name = key
 		}
-		globals[normalizeGlobalKey(value.Name)] = value
+		globals[vars.NameKey(value.Name)] = value
 	}
 	return &preRequestAPI{
 		request:   input.Request,
@@ -361,29 +389,20 @@ func (api *preRequestAPI) requestAPI() map[string]any {
 }
 
 func (api *preRequestAPI) varsAPI() map[string]any {
-	return map[string]any{
-		"get": func(name string) string {
-			return api.variables[name]
-		},
-		"set": func(name, value string) {
-			if api.output.Variables == nil {
-				api.output.Variables = make(map[string]string)
-			}
-			api.output.Variables[name] = value
-			api.variables[name] = value
-		},
-		"has": func(name string) bool {
-			_, ok := api.variables[name]
-			return ok
-		},
-		"global": api.globalAPI(),
+	return jsVarsAPI(api.variables, api.recordVar, api.globalAPI())
+}
+
+func (api *preRequestAPI) recordVar(name, value string) {
+	if api.output.Variables == nil {
+		api.output.Variables = make(map[string]string)
 	}
+	vars.Upsert(api.output.Variables, name, value)
 }
 
 func (api *preRequestAPI) globalAPI() map[string]any {
 	return map[string]any{
 		"get": func(name string) string {
-			entry, ok := api.globals[normalizeGlobalKey(name)]
+			entry, ok := api.globals[vars.NameKey(name)]
 			if !ok {
 				return ""
 			}
@@ -403,7 +422,7 @@ func (api *preRequestAPI) globalAPI() map[string]any {
 			return goja.Undefined()
 		},
 		"has": func(name string) bool {
-			_, ok := api.globals[normalizeGlobalKey(name)]
+			_, ok := api.globals[vars.NameKey(name)]
 			return ok
 		},
 		"delete": func(name string) {
@@ -418,7 +437,7 @@ func (api *preRequestAPI) setGlobal(name, value string, secret bool) {
 		return
 	}
 
-	key := normalizeGlobalKey(name)
+	key := vars.NameKey(name)
 	entry := vars.GlobalMutation{Name: name, Value: value, Secret: secret}
 	api.globals[key] = entry
 	if api.output.Globals == nil {
@@ -433,7 +452,7 @@ func (api *preRequestAPI) deleteGlobal(name string) {
 		return
 	}
 
-	key := normalizeGlobalKey(name)
+	key := vars.NameKey(name)
 	delete(api.globals, key)
 	if api.output.Globals == nil {
 		api.output.Globals = make(map[string]vars.GlobalMutation)
@@ -471,15 +490,14 @@ func newTestAPI(
 	stream *StreamInfo,
 	trace *TraceInput,
 ) *testAPI {
-	copyVars := make(map[string]string, len(variables))
-	maps.Copy(copyVars, variables)
+	copyVars := jsVarsView(variables)
 
 	globalCopy := make(map[string]vars.GlobalMutation, len(globals))
 	for key, value := range globals {
 		if strings.TrimSpace(value.Name) == "" {
 			value.Name = key
 		}
-		globalCopy[normalizeGlobalKey(value.Name)] = value
+		globalCopy[vars.NameKey(value.Name)] = value
 	}
 	return &testAPI{
 		response:  resp,
@@ -769,26 +787,15 @@ func (api *testAPI) responseAPI() map[string]any {
 	}
 }
 
+// Test-script variable writes are local to the script.
 func (api *testAPI) varsAPI() map[string]any {
-	return map[string]any{
-		"get": func(name string) string {
-			return api.variables[name]
-		},
-		"set": func(name, value string) {
-			api.variables[name] = value
-		},
-		"has": func(name string) bool {
-			_, ok := api.variables[name]
-			return ok
-		},
-		"global": api.globalAPI(),
-	}
+	return jsVarsAPI(api.variables, nil, api.globalAPI())
 }
 
 func (api *testAPI) globalAPI() map[string]any {
 	return map[string]any{
 		"get": func(name string) string {
-			entry, ok := api.globals[normalizeGlobalKey(name)]
+			entry, ok := api.globals[vars.NameKey(name)]
 			if !ok {
 				return ""
 			}
@@ -810,7 +817,7 @@ func (api *testAPI) globalAPI() map[string]any {
 			return goja.Undefined()
 		},
 		"has": func(name string) bool {
-			_, ok := api.globals[normalizeGlobalKey(name)]
+			_, ok := api.globals[vars.NameKey(name)]
 			return ok
 		},
 		"delete": func(name string) {
@@ -825,7 +832,7 @@ func (api *testAPI) setGlobal(name, value string, secret bool) {
 		return
 	}
 
-	key := normalizeGlobalKey(name)
+	key := vars.NameKey(name)
 	entry := vars.GlobalMutation{Name: name, Value: value, Secret: secret}
 	api.globals[key] = entry
 	if api.changes == nil {
@@ -840,7 +847,7 @@ func (api *testAPI) deleteGlobal(name string) {
 		return
 	}
 
-	key := normalizeGlobalKey(name)
+	key := vars.NameKey(name)
 	delete(api.globals, key)
 	if api.changes == nil {
 		api.changes = make(map[string]vars.GlobalMutation)

--- a/internal/scripts/runner.go
+++ b/internal/scripts/runner.go
@@ -38,10 +38,11 @@ func NewRunner(fs filelookup.FileSystem) *Runner {
 type TestInput struct {
 	Response  *Response
 	Variables map[string]string
-	Globals   map[string]vars.GlobalMutation
+	Globals   vars.Globals
 	BaseDir   string
 	Stream    *StreamInfo
 	Trace     *TraceInput
+	Secrets   *vars.Secrets
 }
 
 type TestResult struct {
@@ -63,7 +64,6 @@ func (r *Runner) RunPreRequest(
 	result := prerequest.Output{
 		Headers: make(http.Header),
 		Query:   make(map[string]string),
-		Globals: make(map[string]vars.GlobalMutation),
 	}
 
 	for idx, block := range scripts {
@@ -96,9 +96,9 @@ func (r *Runner) RunPreRequest(
 func (r *Runner) RunTests(
 	scripts []restfile.ScriptBlock,
 	input TestInput,
-) ([]TestResult, map[string]vars.GlobalMutation, error) {
+) ([]TestResult, vars.Globals, error) {
 	var aggregated []TestResult
-	changes := make(map[string]vars.GlobalMutation)
+	var changes vars.Globals
 
 	for idx, block := range scripts {
 		if kind := strings.ToLower(block.Kind); kind != "test" && kind != "tests" {
@@ -122,12 +122,9 @@ func (r *Runner) RunTests(
 		}
 
 		aggregated = append(aggregated, results...)
-		maps.Copy(changes, globals)
+		changes.Merge(globals)
 	}
 
-	if len(changes) == 0 {
-		changes = nil
-	}
 	return aggregated, changes, nil
 }
 
@@ -182,52 +179,52 @@ func (r *Runner) executePreRequestScript(
 func (r *Runner) executeTestScript(
 	script string,
 	input TestInput,
-) ([]TestResult, map[string]vars.GlobalMutation, error) {
+) ([]TestResult, vars.Globals, error) {
 	vm := goja.New()
 	streamInfo := input.Stream.Clone()
-	tester := newTestAPI(input.Response, input.Variables, input.Globals, streamInfo, input.Trace)
+	tester := newTestAPI(input, streamInfo)
 	tester.vm = vm
 	streamBinding := newStreamAPI(vm, streamInfo)
 
 	if err := bindCommon(vm); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "bind console api")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind console api")
 	}
 
 	if err := vm.Set("tests", tester.testsAPI()); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "bind tests api")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind tests api")
 	}
 
 	if err := vm.Set("client", tester.clientAPI()); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "bind client api")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind client api")
 	}
 
 	if err := vm.Set("resterm", tester.clientAPI()); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "bind resterm alias")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind resterm alias")
 	}
 
 	if err := vm.Set("response", tester.responseAPI()); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "bind response api")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind response api")
 	}
 
 	if err := vm.Set("vars", tester.varsAPI()); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "bind vars api")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind vars api")
 	}
 
 	if err := vm.Set("stream", streamBinding.object()); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "bind stream api")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind stream api")
 	}
 
 	if err := vm.Set("trace", tester.traceAPI()); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "bind trace api")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind trace api")
 	}
 
 	_, err := vm.RunString(script)
 	if err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "execute test script")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "execute test script")
 	}
 
 	if err := streamBinding.replay(); err != nil {
-		return nil, nil, diag.WrapAs(diag.ClassScript, err, "execute stream callbacks")
+		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "execute stream callbacks")
 	}
 	return tester.results(), tester.globalChanges(), nil
 }
@@ -313,24 +310,17 @@ type preRequestAPI struct {
 	request   *restfile.Request
 	output    *prerequest.Output
 	variables map[string]string
-	globals   map[string]vars.GlobalMutation
+	globals   vars.Globals
+	secrets   *vars.Secrets
 }
 
 func newPreRequestAPI(output *prerequest.Output, input prerequest.Input) *preRequestAPI {
-	variables := jsVarsView(input.Variables)
-
-	globals := make(map[string]vars.GlobalMutation, len(input.Globals))
-	for key, value := range input.Globals {
-		if strings.TrimSpace(value.Name) == "" {
-			value.Name = key
-		}
-		globals[vars.NameKey(value.Name)] = value
-	}
 	return &preRequestAPI{
 		request:   input.Request,
 		output:    output,
-		variables: variables,
-		globals:   globals,
+		variables: jsVarsView(input.Variables),
+		globals:   input.Globals.Clone(),
+		secrets:   input.Secrets,
 	}
 }
 
@@ -403,10 +393,7 @@ func (api *preRequestAPI) recordVar(name, value string) {
 func (api *preRequestAPI) globalAPI() map[string]any {
 	return map[string]any{
 		"get": func(name string) string {
-			entry, ok := api.globals[vars.NameKey(name)]
-			if !ok {
-				return ""
-			}
+			entry, _ := api.globals.Get(name)
 			return entry.Value
 		},
 		"set": func(call goja.FunctionCall) goja.Value {
@@ -423,8 +410,7 @@ func (api *preRequestAPI) globalAPI() map[string]any {
 			return goja.Undefined()
 		},
 		"has": func(name string) bool {
-			_, ok := api.globals[vars.NameKey(name)]
-			return ok
+			return api.globals.Has(name)
 		},
 		"delete": func(name string) {
 			api.deleteGlobal(name)
@@ -433,32 +419,20 @@ func (api *preRequestAPI) globalAPI() map[string]any {
 }
 
 func (api *preRequestAPI) setGlobal(name, value string, secret bool) {
-	name = strings.TrimSpace(name)
-	if name == "" {
+	entry := vars.GlobalMutation{Name: name, Value: value, Secret: secret}
+	if !api.output.Globals.Set(name, entry) {
 		return
 	}
-
-	key := vars.NameKey(name)
-	entry := vars.GlobalMutation{Name: name, Value: value, Secret: secret}
-	api.globals[key] = entry
-	if api.output.Globals == nil {
-		api.output.Globals = make(map[string]vars.GlobalMutation)
+	if secret {
+		api.secrets.Add(value)
 	}
-	api.output.Globals[key] = entry
+	api.globals.Set(name, entry)
 }
 
 func (api *preRequestAPI) deleteGlobal(name string) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return
+	if api.output.Globals.Set(name, vars.GlobalMutation{Name: name, Delete: true}) {
+		api.globals.Delete(name)
 	}
-
-	key := vars.NameKey(name)
-	delete(api.globals, key)
-	if api.output.Globals == nil {
-		api.output.Globals = make(map[string]vars.GlobalMutation)
-	}
-	api.output.Globals[key] = vars.GlobalMutation{Name: name, Delete: true}
 }
 
 func parseGlobalSecret(value goja.Value) bool {
@@ -476,37 +450,23 @@ func parseGlobalSecret(value goja.Value) bool {
 type testAPI struct {
 	response  *Response
 	variables map[string]string
-	globals   map[string]vars.GlobalMutation
-	changes   map[string]vars.GlobalMutation
+	globals   vars.Globals
+	changes   vars.Globals
+	secrets   *vars.Secrets
 	cases     []TestResult
 	stream    *StreamInfo
 	trace     *traceBinding
 	vm        *goja.Runtime
 }
 
-func newTestAPI(
-	resp *Response,
-	variables map[string]string,
-	globals map[string]vars.GlobalMutation,
-	stream *StreamInfo,
-	trace *TraceInput,
-) *testAPI {
-	copyVars := jsVarsView(variables)
-
-	globalCopy := make(map[string]vars.GlobalMutation, len(globals))
-	for key, value := range globals {
-		if strings.TrimSpace(value.Name) == "" {
-			value.Name = key
-		}
-		globalCopy[vars.NameKey(value.Name)] = value
-	}
+func newTestAPI(in TestInput, stream *StreamInfo) *testAPI {
 	return &testAPI{
-		response:  resp,
-		variables: copyVars,
-		globals:   globalCopy,
-		changes:   make(map[string]vars.GlobalMutation),
+		response:  in.Response,
+		variables: jsVarsView(in.Variables),
+		globals:   in.Globals.Clone(),
+		secrets:   in.Secrets,
 		stream:    stream,
-		trace:     newTraceBinding(trace),
+		trace:     newTraceBinding(in.Trace),
 	}
 }
 
@@ -796,10 +756,7 @@ func (api *testAPI) varsAPI() map[string]any {
 func (api *testAPI) globalAPI() map[string]any {
 	return map[string]any{
 		"get": func(name string) string {
-			entry, ok := api.globals[vars.NameKey(name)]
-			if !ok {
-				return ""
-			}
+			entry, _ := api.globals.Get(name)
 			return entry.Value
 		},
 		"set": func(call goja.FunctionCall) goja.Value {
@@ -818,8 +775,7 @@ func (api *testAPI) globalAPI() map[string]any {
 			return goja.Undefined()
 		},
 		"has": func(name string) bool {
-			_, ok := api.globals[vars.NameKey(name)]
-			return ok
+			return api.globals.Has(name)
 		},
 		"delete": func(name string) {
 			api.deleteGlobal(name)
@@ -828,42 +784,24 @@ func (api *testAPI) globalAPI() map[string]any {
 }
 
 func (api *testAPI) setGlobal(name, value string, secret bool) {
-	name = strings.TrimSpace(name)
-	if name == "" {
+	entry := vars.GlobalMutation{Name: name, Value: value, Secret: secret}
+	if !api.changes.Set(name, entry) {
 		return
 	}
-
-	key := vars.NameKey(name)
-	entry := vars.GlobalMutation{Name: name, Value: value, Secret: secret}
-	api.globals[key] = entry
-	if api.changes == nil {
-		api.changes = make(map[string]vars.GlobalMutation)
+	if secret {
+		api.secrets.Add(value)
 	}
-	api.changes[key] = entry
+	api.globals.Set(name, entry)
 }
 
 func (api *testAPI) deleteGlobal(name string) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return
+	if api.changes.Set(name, vars.GlobalMutation{Name: name, Delete: true}) {
+		api.globals.Delete(name)
 	}
-
-	key := vars.NameKey(name)
-	delete(api.globals, key)
-	if api.changes == nil {
-		api.changes = make(map[string]vars.GlobalMutation)
-	}
-	api.changes[key] = vars.GlobalMutation{Name: name, Delete: true}
 }
 
-func (api *testAPI) globalChanges() map[string]vars.GlobalMutation {
-	if len(api.changes) == 0 {
-		return nil
-	}
-
-	clone := make(map[string]vars.GlobalMutation, len(api.changes))
-	maps.Copy(clone, api.changes)
-	return clone
+func (api *testAPI) globalChanges() vars.Globals {
+	return api.changes.Clone()
 }
 
 func (api *testAPI) assert(condition bool, message string) {

--- a/internal/scripts/runner.go
+++ b/internal/scripts/runner.go
@@ -286,8 +286,13 @@ func jsVarsAPI(
 			_, ok := view[vars.NameKey(name)]
 			return ok
 		},
+		// Blank writes must not appear in the script view when recorded output drops them.
 		"set": func(name, value string) {
-			view[vars.NameKey(name)] = value
+			key := vars.NameKey(name)
+			if key == "" {
+				return
+			}
+			view[key] = value
 			if record != nil {
 				record(name, value)
 			}

--- a/internal/scripts/runner.go
+++ b/internal/scripts/runner.go
@@ -65,6 +65,8 @@ func (r *Runner) RunPreRequest(
 		Headers: make(http.Header),
 		Query:   make(map[string]string),
 	}
+	// Keep one API for the whole batch so each block sees earlier changes.
+	api := newPreRequestAPI(&result, input)
 
 	for idx, block := range scripts {
 		if err := ctx.Err(); err != nil {
@@ -83,7 +85,7 @@ func (r *Runner) RunPreRequest(
 			continue
 		}
 
-		if err := r.executePreRequestScript(ctx, script, input, &result); err != nil {
+		if err := r.executePreRequestScript(ctx, script, api); err != nil {
 			return result, diag.WrapAsf(diag.ClassScript, err, "pre-request script %d", idx+1)
 		}
 	}
@@ -131,8 +133,7 @@ func (r *Runner) RunTests(
 func (r *Runner) executePreRequestScript(
 	ctx context.Context,
 	script string,
-	input prerequest.Input,
-	output *prerequest.Output,
+	api *preRequestAPI,
 ) error {
 	vm := goja.New()
 	if ctx != nil {
@@ -147,16 +148,15 @@ func (r *Runner) executePreRequestScript(
 		}
 	}
 
-	pre := newPreRequestAPI(output, input)
 	if err := bindCommon(vm); err != nil {
 		return diag.WrapAs(diag.ClassScript, err, "bind console api")
 	}
 
-	if err := vm.Set("request", pre.requestAPI()); err != nil {
+	if err := vm.Set("request", api.requestAPI()); err != nil {
 		return diag.WrapAs(diag.ClassScript, err, "bind request api")
 	}
 
-	if err := vm.Set("vars", pre.varsAPI()); err != nil {
+	if err := vm.Set("vars", api.varsAPI()); err != nil {
 		return diag.WrapAs(diag.ClassScript, err, "bind vars api")
 	}
 
@@ -307,16 +307,24 @@ func jsVarsView(src map[string]string) map[string]string {
 }
 
 type preRequestAPI struct {
-	request   *restfile.Request
+	request   requestView
 	output    *prerequest.Output
 	variables map[string]string
 	globals   vars.Globals
 	secrets   *vars.Secrets
 }
 
+// Scripts read from a copy that is updated after each mutation. Query parameters
+// are excluded because they are merged into the URL after the scripts finish.
+type requestView struct {
+	method  string
+	url     string
+	headers http.Header
+}
+
 func newPreRequestAPI(output *prerequest.Output, input prerequest.Input) *preRequestAPI {
 	return &preRequestAPI{
-		request:   input.Request,
+		request:   newRequestView(input.Request),
 		output:    output,
 		variables: jsVarsView(input.Variables),
 		globals:   input.Globals.Clone(),
@@ -324,56 +332,50 @@ func newPreRequestAPI(output *prerequest.Output, input prerequest.Input) *preReq
 	}
 }
 
+func newRequestView(req *restfile.Request) requestView {
+	if req == nil {
+		return requestView{headers: make(http.Header)}
+	}
+	headers := req.Headers.Clone()
+	if headers == nil {
+		headers = make(http.Header)
+	}
+	return requestView{method: req.Method, url: req.URL, headers: headers}
+}
+
 func (api *preRequestAPI) requestAPI() map[string]any {
 	return map[string]any{
 		"getURL": func() string {
-			if api.request == nil {
-				return ""
-			}
-			return api.request.URL
+			return api.request.url
 		},
 		"getMethod": func() string {
-			if api.request == nil {
-				return ""
-			}
-			return api.request.Method
+			return api.request.method
 		},
 		"getHeader": func(name string) string {
-			if api.request == nil || api.request.Headers == nil {
-				return ""
-			}
-			return api.request.Headers.Get(name)
+			return api.request.headers.Get(name)
 		},
 		"setHeader": func(name, value string) {
-			if api.output.Headers == nil {
-				api.output.Headers = make(http.Header)
-			}
-			api.output.Headers.Set(name, value)
+			api.output.SetHeader(name, value)
+			api.request.headers.Set(name, value)
 		},
 		"addHeader": func(name, value string) {
-			if api.output.Headers == nil {
-				api.output.Headers = make(http.Header)
-			}
-			api.output.Headers.Add(name, value)
+			api.output.AddHeader(name, value)
+			api.request.headers.Add(name, value)
 		},
 		"removeHeader": func(name string) {
-			if api.output.Headers != nil {
-				api.output.Headers.Del(name)
-			}
+			api.output.DelHeader(name)
+			api.request.headers.Del(name)
 		},
-		"setQueryParam": func(name, value string) {
-			if api.output.Query == nil {
-				api.output.Query = make(map[string]string)
-			}
-			api.output.Query[name] = value
-		},
+		"setQueryParam": api.output.SetQuery,
 		"setURL": func(url string) {
-			copied := strings.TrimSpace(url)
-			api.output.URL = &copied
+			val := strings.TrimSpace(url)
+			api.output.URL = &val
+			api.request.url = val
 		},
 		"setMethod": func(method string) {
-			copied := util.UpperTrim(method)
-			api.output.Method = &copied
+			val := util.UpperTrim(method)
+			api.output.Method = &val
+			api.request.method = val
 		},
 		"setBody": func(body string) {
 			copied := body

--- a/internal/scripts/runner.go
+++ b/internal/scripts/runner.go
@@ -61,10 +61,9 @@ func (r *Runner) RunPreRequest(
 	}
 
 	result := prerequest.Output{
-		Headers:   make(http.Header),
-		Query:     make(map[string]string),
-		Variables: make(map[string]string),
-		Globals:   make(map[string]vars.GlobalMutation),
+		Headers: make(http.Header),
+		Query:   make(map[string]string),
+		Globals: make(map[string]vars.GlobalMutation),
 	}
 
 	for idx, block := range scripts {
@@ -393,10 +392,7 @@ func (api *preRequestAPI) varsAPI() map[string]any {
 }
 
 func (api *preRequestAPI) recordVar(name, value string) {
-	if api.output.Variables == nil {
-		api.output.Variables = make(map[string]string)
-	}
-	vars.Upsert(api.output.Variables, name, value)
+	api.output.Variables.Set(name, value)
 }
 
 func (api *preRequestAPI) globalAPI() map[string]any {

--- a/internal/scripts/runner_test.go
+++ b/internal/scripts/runner_test.go
@@ -76,6 +76,29 @@ func TestRunPreRequestNormalizesTokenMutations(t *testing.T) {
 	}
 }
 
+func TestRunPreRequestDropsBlankVariableNames(t *testing.T) {
+	runner := NewRunner(nil)
+	req := &restfile.Request{Method: "GET", URL: "https://example.com/api"}
+	scripts := []restfile.ScriptBlock{{
+		Kind: "pre-request",
+		Body: `vars.set("  ", "ghost"); request.setHeader("X-Seen", String(vars.has("")));`,
+	}}
+
+	out, err := runner.RunPreRequest(
+		scripts,
+		prerequest.Input{Request: req, Variables: map[string]string{}},
+	)
+	if err != nil {
+		t.Fatalf("pre-request runner: %v", err)
+	}
+	if out.Variables.Len() != 0 {
+		t.Fatalf("expected no recorded variables, got %#v", out.Variables.Map())
+	}
+	if got := out.Headers.Get("X-Seen"); got != "false" {
+		t.Fatalf("vars.has(\"\") = %s, want false inside the script too", got)
+	}
+}
+
 func TestRunPreRequestSkipsRTS(t *testing.T) {
 	runner := NewRunner(nil)
 	req := &restfile.Request{}

--- a/internal/scripts/runner_test.go
+++ b/internal/scripts/runner_test.go
@@ -174,8 +174,8 @@ client.test("vars carried", function () {
 			t.Fatalf("expected results to pass: %+v", results)
 		}
 	}
-	if globals != nil {
-		t.Fatalf("expected no global changes, got %+v", globals)
+	if globals.Len() != 0 {
+		t.Fatalf("expected no global changes, got %+v", globals.Map())
 	}
 }
 
@@ -215,8 +215,8 @@ func TestRunTestsScripts(t *testing.T) {
 			t.Fatalf("expected all tests to pass, got %#v", results)
 		}
 	}
-	if globals != nil {
-		t.Fatalf("expected no global changes, got %+v", globals)
+	if globals.Len() != 0 {
+		t.Fatalf("expected no global changes, got %+v", globals.Map())
 	}
 }
 
@@ -301,8 +301,8 @@ client.test("response stream access", function () {
 			t.Fatalf("expected all stream tests to pass, got %+v", results)
 		}
 	}
-	if globals != nil {
-		t.Fatalf("expected no global changes, got %+v", globals)
+	if globals.Len() != 0 {
+		t.Fatalf("expected no global changes, got %+v", globals.Map())
 	}
 }
 
@@ -336,8 +336,8 @@ func TestResponseAPIUsesWireForBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run tests: %v", err)
 	}
-	if globals != nil {
-		t.Fatalf("expected no globals, got %+v", globals)
+	if globals.Len() != 0 {
+		t.Fatalf("expected no globals, got %+v", globals.Map())
 	}
 	if len(results) != 5 {
 		t.Fatalf("expected five results (four asserts + wrapper), got %d", len(results))
@@ -360,21 +360,21 @@ vars.global.delete("removeMe");`,
 	input := prerequest.Input{
 		Request:   &restfile.Request{Method: "GET", URL: "https://example.com"},
 		Variables: map[string]string{},
-		Globals: map[string]vars.GlobalMutation{
+		Globals: vars.CollectNames(map[string]vars.GlobalMutation{
 			"token":    {Name: "token", Value: "seed"},
 			"removeMe": {Name: "removeMe", Value: "gone"},
-		},
+		}),
 	}
 	out, err := runner.RunPreRequest(blocks, input)
 	if err != nil {
 		t.Fatalf("pre-request globals: %v", err)
 	}
-	if out.Globals == nil {
+	if out.Globals.Len() == 0 {
 		t.Fatalf("expected globals map to be populated")
 	}
 	assertGlobal := func(name string, expectDelete bool, expectSecret bool, expectValue string) {
 		found := false
-		for _, entry := range out.Globals {
+		for _, entry := range out.Globals.All() {
 			if entry.Name == name {
 				found = true
 				if entry.Delete != expectDelete {
@@ -394,6 +394,51 @@ vars.global.delete("removeMe");`,
 	}
 	assertGlobal("token", false, true, "updated")
 	assertGlobal("removeMe", true, false, "")
+}
+
+func TestPreRequestKeepsSecretValuesThroughDelete(t *testing.T) {
+	runner := NewRunner(nil)
+	blocks := []restfile.ScriptBlock{{
+		Kind: "pre-request",
+		Body: `vars.global.set("token", "hidden", true);
+vars.global.delete("token");`,
+	}}
+	var sec vars.Secrets
+	out, err := runner.RunPreRequest(blocks, prerequest.Input{
+		Request:   &restfile.Request{Method: "GET", URL: "https://example.com"},
+		Variables: map[string]string{},
+		Secrets:   &sec,
+	})
+	if err != nil {
+		t.Fatalf("pre-request: %v", err)
+	}
+	if entry, _ := out.Globals.Get("token"); !entry.Delete {
+		t.Fatalf("expected the delete to win, got %#v", entry)
+	}
+	if got := sec.Values(); len(got) != 1 || got[0] != "hidden" {
+		t.Fatalf("secrets = %#v, want the transient secret recorded", got)
+	}
+}
+
+func TestRunTestsKeepsSecretValuesThroughDelete(t *testing.T) {
+	runner := NewRunner(nil)
+	resp := &Response{Kind: ResponseKindHTTP, Status: "200 OK", Code: 200}
+	scripts := []restfile.ScriptBlock{{
+		Kind: "test",
+		Body: `vars.global.set("token", "hidden", true);
+vars.global.delete("token");`,
+	}}
+	var sec vars.Secrets
+	_, changes, err := runner.RunTests(scripts, TestInput{Response: resp, Secrets: &sec})
+	if err != nil {
+		t.Fatalf("run tests: %v", err)
+	}
+	if entry, _ := changes.Get("token"); !entry.Delete {
+		t.Fatalf("expected the delete to win, got %#v", entry)
+	}
+	if got := sec.Values(); len(got) != 1 || got[0] != "hidden" {
+		t.Fatalf("secrets = %#v, want the transient secret recorded", got)
+	}
 }
 
 func TestPreRequestCancellationInterruptsScript(t *testing.T) {
@@ -441,9 +486,9 @@ func TestTestScriptsGlobalMutation(t *testing.T) {
 	results, globals, err := runner.RunTests(scripts, TestInput{
 		Response:  resp,
 		Variables: map[string]string{},
-		Globals: map[string]vars.GlobalMutation{
+		Globals: vars.CollectNames(map[string]vars.GlobalMutation{
 			"token": {Name: "token", Value: "seed"},
-		},
+		}),
 	})
 	if err != nil {
 		t.Fatalf("test globals: %v", err)
@@ -451,18 +496,10 @@ func TestTestScriptsGlobalMutation(t *testing.T) {
 	if len(results) != 2 {
 		t.Fatalf("expected two results, got %d", len(results))
 	}
-	if globals == nil {
+	if globals.Len() == 0 {
 		t.Fatalf("expected globals to be returned")
 	}
-	var updated vars.GlobalMutation
-	found := false
-	for _, entry := range globals {
-		if entry.Name == "token" {
-			updated = entry
-			found = true
-			break
-		}
-	}
+	updated, found := globals.Get("token")
 	if !found {
 		t.Fatalf("expected updated token entry")
 	}
@@ -575,8 +612,8 @@ func TestTraceBindingProvidesTimeline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("trace test script: %v", err)
 	}
-	if globals != nil {
-		t.Fatalf("expected no globals, got %+v", globals)
+	if globals.Len() != 0 {
+		t.Fatalf("expected no globals, got %+v", globals.Map())
 	}
 	if len(results) == 0 {
 		t.Fatalf("expected trace script results")

--- a/internal/scripts/runner_test.go
+++ b/internal/scripts/runner_test.go
@@ -48,7 +48,7 @@ func TestRunPreRequestScripts(t *testing.T) {
 	if out.Query["user"] != "alice" {
 		t.Fatalf("expected query param to be set")
 	}
-	if out.Variables["token"] != "abc" {
+	if token, _ := out.Variables.Get("token"); token != "abc" {
 		t.Fatalf("expected script variable to be returned")
 	}
 }
@@ -125,7 +125,7 @@ client.test("vars carried", function () {
 	if preResult.Headers.Get("X-File") != "1" {
 		t.Fatalf("expected header from file script")
 	}
-	if preResult.Variables["fromFile"] != "yes" {
+	if fromFile, _ := preResult.Variables.Get("fromFile"); fromFile != "yes" {
 		t.Fatalf("expected variable from file script")
 	}
 
@@ -138,7 +138,7 @@ client.test("vars carried", function () {
 	testBlocks := []restfile.ScriptBlock{{Kind: "test", FilePath: "test.js"}}
 	results, globals, err := runner.RunTests(
 		testBlocks,
-		TestInput{Response: response, Variables: preResult.Variables, BaseDir: dir},
+		TestInput{Response: response, Variables: preResult.Variables.Map(), BaseDir: dir},
 	)
 	if err != nil {
 		t.Fatalf("test file script: %v", err)

--- a/internal/scripts/runner_test.go
+++ b/internal/scripts/runner_test.go
@@ -99,6 +99,79 @@ func TestRunPreRequestDropsBlankVariableNames(t *testing.T) {
 	}
 }
 
+func TestRunPreRequestBlocksShareWrites(t *testing.T) {
+	runner := NewRunner(nil)
+	req := &restfile.Request{
+		Method:  "GET",
+		URL:     "https://example.com/api",
+		Headers: http.Header{"X-Seed": {"seed"}},
+	}
+	blocks := []restfile.ScriptBlock{
+		{Kind: "pre-request", Body: `
+			vars.set("block.chain", "first");
+			vars.global.set("global.chain", "first");
+			request.setHeader("X-Chain", "first");
+			request.setURL("https://example.com/second");
+			request.setMethod("post");
+		`},
+		{Kind: "pre-request", Body: `
+			request.setHeader("X-Var", vars.get("block.chain"));
+			request.setHeader("X-Global", vars.global.get("global.chain"));
+			request.setHeader("X-Header", request.getHeader("X-Chain"));
+			request.setHeader("X-URL", request.getURL());
+			request.setHeader("X-Method", request.getMethod());
+			request.setHeader("X-Seen", String(vars.has("block.chain")));
+		`},
+	}
+
+	out, err := runner.RunPreRequest(blocks, prerequest.Input{
+		Request:   req,
+		Variables: map[string]string{},
+		Secrets:   &vars.Secrets{},
+	})
+	if err != nil {
+		t.Fatalf("pre-request runner: %v", err)
+	}
+	want := map[string]string{
+		"X-Var":    "first",
+		"X-Global": "first",
+		"X-Header": "first",
+		"X-URL":    "https://example.com/second",
+		"X-Method": "POST",
+		"X-Seen":   "true",
+	}
+	for name, value := range want {
+		if got := out.Headers.Get(name); got != value {
+			t.Errorf("%s = %q, want %q", name, got, value)
+		}
+	}
+}
+
+func TestRunPreRequestRecordsHeaderRemoval(t *testing.T) {
+	runner := NewRunner(nil)
+	req := &restfile.Request{
+		Method:  "GET",
+		URL:     "https://example.com/api",
+		Headers: http.Header{"X-Declared": {"declared"}},
+	}
+	blocks := []restfile.ScriptBlock{{
+		Kind: "pre-request",
+		Body: `request.removeHeader("X-Declared");
+			request.setHeader("X-Seen", request.getHeader("X-Declared") || "gone");`,
+	}}
+
+	out, err := runner.RunPreRequest(blocks, prerequest.Input{Request: req})
+	if err != nil {
+		t.Fatalf("pre-request runner: %v", err)
+	}
+	if _, ok := out.HeaderDels["X-Declared"]; !ok {
+		t.Fatalf("expected a recorded removal, got %#v", out.HeaderDels)
+	}
+	if got := out.Headers.Get("X-Seen"); got != "gone" {
+		t.Fatalf("X-Seen = %q, want %q", got, "gone")
+	}
+}
+
 func TestRunPreRequestSkipsRTS(t *testing.T) {
 	runner := NewRunner(nil)
 	req := &restfile.Request{}

--- a/internal/ui/rts_prerequest_test.go
+++ b/internal/ui/rts_prerequest_test.go
@@ -42,10 +42,10 @@ vars.global.delete("old")`,
 		},
 	}
 	variables := map[string]string{"seed": "value"}
-	globals := map[string]vars.GlobalMutation{
-		"secret": {Name: "Secret", Value: "top", Secret: true},
+	globals := vars.CollectNames(map[string]vars.GlobalMutation{
+		"Secret": {Name: "Secret", Value: "top", Secret: true},
 		"old":    {Name: "old", Value: "gone"},
-	}
+	})
 
 	out, err := model.requestSvc(httpx.Options{}).
 		RunPreRequest(context.Background(), nil, req, testEnv(""), "", variables, rts.Locals{}, globals)
@@ -71,10 +71,10 @@ vars.global.delete("old")`,
 	if got := variables["token"]; got != "abc" {
 		t.Fatalf("expected variables map token=abc, got %q", got)
 	}
-	if gv, ok := out.Globals["newglobal"]; !ok || gv.Value != "ng" || gv.Secret {
+	if gv, ok := out.Globals.Get("newglobal"); !ok || gv.Value != "ng" || gv.Secret {
 		t.Fatalf("expected newglobal=ng (non-secret), got %#v", gv)
 	}
-	if gv, ok := out.Globals["old"]; !ok || !gv.Delete {
+	if gv, ok := out.Globals.Get("old"); !ok || !gv.Delete {
 		t.Fatalf("expected old to be marked deleted, got %#v", gv)
 	}
 }
@@ -96,7 +96,7 @@ request.setQueryParam("mutated", "true")`,
 	}
 
 	out, err := model.requestSvc(httpx.Options{}).
-		RunPreRequest(context.Background(), nil, req, testEnv(""), "", nil, rts.Locals{}, nil)
+		RunPreRequest(context.Background(), nil, req, testEnv(""), "", nil, rts.Locals{}, vars.Globals{})
 	if err != nil {
 		t.Fatalf("runRTSPreRequest: %v", err)
 	}
@@ -135,7 +135,7 @@ GET https://example.com
 		"",
 		nil,
 		rts.Locals{},
-		nil,
+		vars.Globals{},
 	)
 	if err == nil {
 		t.Fatalf("expected rts error")
@@ -182,7 +182,7 @@ func TestRunRTSPreRequestErrorRendersIncludedSource(t *testing.T) {
 	}
 
 	_, err := model.requestSvc(httpx.Options{}).
-		RunPreRequest(context.Background(), nil, req, testEnv(""), dir, nil, rts.Locals{}, nil)
+		RunPreRequest(context.Background(), nil, req, testEnv(""), dir, nil, rts.Locals{}, vars.Globals{})
 	if err == nil {
 		t.Fatalf("expected rts error")
 	}

--- a/internal/ui/rts_prerequest_test.go
+++ b/internal/ui/rts_prerequest_test.go
@@ -65,7 +65,7 @@ vars.global.delete("old")`,
 	if out.Body == nil || *out.Body != "payload" {
 		t.Fatalf("expected body payload, got %#v", out.Body)
 	}
-	if got := out.Variables["token"]; got != "abc" {
+	if got, _ := out.Variables.Get("token"); got != "abc" {
 		t.Fatalf("expected output vars token=abc, got %q", got)
 	}
 	if got := variables["token"]; got != "abc" {

--- a/internal/ui/status_text.go
+++ b/internal/ui/status_text.go
@@ -25,24 +25,16 @@ func expandStatusText(r *vars.Resolver, raw string) string {
 	return strings.TrimSpace(expanded)
 }
 
-func (m *Model) statusResolver(
-	doc *restfile.Document,
-	req *restfile.Request,
-	extras ...map[string]string,
-) *vars.Resolver {
+func (m *Model) statusResolver(doc *restfile.Document, req *restfile.Request) *vars.Resolver {
 	rq := m.requestSvc(httpx.Options{})
-	return rq.DisplayResolver(context.Background(), doc, req, m.ws.active, "", rts.Locals{}, extras...)
+	return rq.DisplayResolver(context.Background(), doc, req, m.ws.active, "", rts.Locals{})
 }
 
-func (m *Model) statusRequestLabel(
-	doc *restfile.Document,
-	req *restfile.Request,
-	extras ...map[string]string,
-) string {
+func (m *Model) statusRequestLabel(doc *restfile.Document, req *restfile.Request) string {
 	if req == nil {
 		return ""
 	}
-	r := m.statusResolver(doc, req, extras...)
+	r := m.statusResolver(doc, req)
 	name := expandStatusText(r, req.Metadata.Name)
 	if name == "" {
 		name = expandStatusText(r, req.URL)
@@ -50,15 +42,11 @@ func (m *Model) statusRequestLabel(
 	return name
 }
 
-func (m *Model) statusRequestTitle(
-	doc *restfile.Document,
-	req *restfile.Request,
-	extras ...map[string]string,
-) string {
+func (m *Model) statusRequestTitle(doc *restfile.Document, req *restfile.Request) string {
 	if req == nil {
 		return ""
 	}
-	r := m.statusResolver(doc, req, extras...)
+	r := m.statusResolver(doc, req)
 
 	method := strings.ToUpper(strings.TrimSpace(req.Method))
 	if method == "" {

--- a/internal/vars/globals.go
+++ b/internal/vars/globals.go
@@ -1,9 +1,42 @@
 package vars
 
+import (
+	"slices"
+	"strings"
+)
+
 // GlobalMutation describes a script/runtime global variable set or delete.
 type GlobalMutation struct {
 	Name   string
 	Value  string
 	Secret bool
 	Delete bool
+}
+
+type Globals = NameMap[GlobalMutation]
+
+// Secrets records values that must remain masked for the lifetime of a run.
+// Values are added when exposed rather than when a change commits because
+// failed, deleted, and overwritten mutations may still appear in output.
+type Secrets struct {
+	vals []string
+}
+
+func (s *Secrets) Add(vals ...string) {
+	if s == nil {
+		return
+	}
+	for _, v := range vals {
+		if strings.TrimSpace(v) == "" || slices.Contains(s.vals, v) {
+			continue
+		}
+		s.vals = append(s.vals, v)
+	}
+}
+
+func (s *Secrets) Values() []string {
+	if s == nil {
+		return nil
+	}
+	return append([]string(nil), s.vals...)
 }

--- a/internal/vars/names.go
+++ b/internal/vars/names.go
@@ -1,0 +1,27 @@
+package vars
+
+// NameKey returns the case-insensitive, whitespace-trimmed identity of name.
+func NameKey(name string) string { return norm(name) }
+
+// Upsert writes value under name and drops any other form of that name, so a
+// map keyed by authored names never holds two forms of one variable. Callers
+// that write in order therefore get last-write-wins, which a plain map
+// assignment cannot give them.
+func Upsert(m map[string]string, name, value string) {
+	key := NameKey(name)
+	for cur := range m {
+		if cur != name && NameKey(cur) == key {
+			delete(m, cur)
+		}
+	}
+	m[name] = value
+}
+
+// Merge folds src into dst with Upsert semantics, so a later source wins even
+// when it uses a different form of a name dst already holds. src itself must
+// hold one form per name, which is what building it through Upsert guarantees.
+func Merge(dst, src map[string]string) {
+	for name, value := range src {
+		Upsert(dst, name, value)
+	}
+}

--- a/internal/vars/names.go
+++ b/internal/vars/names.go
@@ -89,6 +89,12 @@ func (m *NameMap[V]) SetMap(src map[string]V) {
 	}
 }
 
+func (m *NameMap[V]) DeleteFunc(del func(name string, value V) bool) {
+	maps.DeleteFunc(m.entries, func(_ string, e namedValue[V]) bool {
+		return del(e.name, e.value)
+	})
+}
+
 // Clone returns an independent copy of m.
 func (m NameMap[V]) Clone() NameMap[V] {
 	return NameMap[V]{entries: maps.Clone(m.entries)}

--- a/internal/vars/names.go
+++ b/internal/vars/names.go
@@ -1,12 +1,117 @@
 package vars
 
+import (
+	"iter"
+	"maps"
+	"slices"
+
+	str "github.com/unkn0wn-root/resterm/internal/util"
+)
+
 // NameKey returns the case-insensitive, whitespace-trimmed identity of name.
 func NameKey(name string) string { return norm(name) }
 
+// NameMap stores one value per case-insensitive, whitespace-trimmed name. It
+// preserves the most recently written form for display, and its zero value is
+// ready to use.
+type NameMap[V any] struct {
+	entries map[string]namedValue[V]
+}
+
+type namedValue[V any] struct {
+	name  string
+	value V
+}
+
+// Set stores value and reports whether name was non-blank.
+func (m *NameMap[V]) Set(name string, value V) bool {
+	key := NameKey(name)
+	if key == "" {
+		return false
+	}
+	if m.entries == nil {
+		m.entries = make(map[string]namedValue[V])
+	}
+	m.entries[key] = namedValue[V]{name: str.Trim(name), value: value}
+	return true
+}
+
+func (m NameMap[V]) Get(name string) (V, bool) {
+	e, ok := m.entries[NameKey(name)]
+	return e.value, ok
+}
+
+func (m NameMap[V]) Has(name string) bool {
+	_, ok := m.entries[NameKey(name)]
+	return ok
+}
+
+func (m *NameMap[V]) Delete(name string) {
+	delete(m.entries, NameKey(name))
+}
+
+func (m NameMap[V]) Len() int { return len(m.entries) }
+
+// All iterates over entries in unspecified order.
+func (m NameMap[V]) All() iter.Seq2[string, V] {
+	return func(yield func(string, V) bool) {
+		for _, e := range m.entries {
+			if !yield(e.name, e.value) {
+				return
+			}
+		}
+	}
+}
+
+// Sorted iterates over entries by normalized name.
+func (m NameMap[V]) Sorted() iter.Seq2[string, V] {
+	return func(yield func(string, V) bool) {
+		for _, key := range slices.Sorted(maps.Keys(m.entries)) {
+			e := m.entries[key]
+			if !yield(e.name, e.value) {
+				return
+			}
+		}
+	}
+}
+
+// Merge overwrites entries in m with entries from src.
+func (m *NameMap[V]) Merge(src NameMap[V]) {
+	for name, value := range src.All() {
+		m.Set(name, value)
+	}
+}
+
+// SetMap adds src in name order so equivalent keys resolve deterministically.
+func (m *NameMap[V]) SetMap(src map[string]V) {
+	for _, name := range slices.Sorted(maps.Keys(src)) {
+		m.Set(name, src[name])
+	}
+}
+
+// Clone returns an independent copy of m.
+func (m NameMap[V]) Clone() NameMap[V] {
+	return NameMap[V]{entries: maps.Clone(m.entries)}
+}
+
+// Map returns a writable plain map using each entry's preserved name.
+func (m NameMap[V]) Map() map[string]V {
+	out := make(map[string]V, len(m.entries))
+	for _, e := range m.entries {
+		out[e.name] = e.value
+	}
+	return out
+}
+
+// CollectNames builds a NameMap using SetMap's deterministic ordering.
+func CollectNames[V any](src map[string]V) NameMap[V] {
+	var out NameMap[V]
+	out.SetMap(src)
+	return out
+}
+
 // Upsert writes value under name and drops any other form of that name, so a
-// map keyed by authored names never holds two forms of one variable. Callers
-// that write in order therefore get last-write-wins, which a plain map
-// assignment cannot give them.
+// plain map contains at most one case or whitespace variant.
 func Upsert(m map[string]string, name, value string) {
 	key := NameKey(name)
 	for cur := range m {
@@ -17,11 +122,9 @@ func Upsert(m map[string]string, name, value string) {
 	m[name] = value
 }
 
-// Merge folds src into dst with Upsert semantics, so a later source wins even
-// when it uses a different form of a name dst already holds. src itself must
-// hold one form per name, which is what building it through Upsert guarantees.
-func Merge(dst, src map[string]string) {
-	for name, value := range src {
+// MergeInto copies src into dst, replacing any equivalent names already present.
+func MergeInto(dst map[string]string, src NameMap[string]) {
+	for name, value := range src.All() {
 		Upsert(dst, name, value)
 	}
 }

--- a/internal/vars/names_test.go
+++ b/internal/vars/names_test.go
@@ -1,0 +1,132 @@
+package vars
+
+import (
+	"maps"
+	"slices"
+	"testing"
+)
+
+func TestNameMapZeroValueTakesWrites(t *testing.T) {
+	var m NameMap[string]
+
+	if !m.Set("token", "abc") {
+		t.Fatalf("Set() = false, want the value stored")
+	}
+	if got, ok := m.Get("token"); !ok || got != "abc" {
+		t.Fatalf("Get(token) = %q, %v, want %q, true", got, ok, "abc")
+	}
+}
+
+func TestNameMapKeepsOneFormPerName(t *testing.T) {
+	var m NameMap[string]
+	m.Set("Token", "first")
+	m.Set(" token ", "second")
+
+	if m.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", m.Len())
+	}
+	if got, _ := m.Get("TOKEN"); got != "second" {
+		t.Fatalf("Get(TOKEN) = %q, want %q", got, "second")
+	}
+	if got := m.Map(); !maps.Equal(got, map[string]string{"token": "second"}) {
+		t.Fatalf("Map() = %v, want the last form written", got)
+	}
+}
+
+func TestNameMapDropsBlankNames(t *testing.T) {
+	var m NameMap[string]
+
+	if m.Set("   ", "value") {
+		t.Fatalf("Set() = true, want a blank name to be dropped")
+	}
+	if m.Len() != 0 {
+		t.Fatalf("Len() = %d, want 0", m.Len())
+	}
+	if _, ok := m.Get(""); ok {
+		t.Fatalf("Get() found a value under the empty name")
+	}
+}
+
+func TestNameMapDeleteMatchesAnyForm(t *testing.T) {
+	var m NameMap[string]
+	m.Set("Token", "abc")
+	m.Delete(" TOKEN ")
+
+	if m.Has("token") {
+		t.Fatalf("Has(token) = true, want the value deleted")
+	}
+}
+
+func TestNameMapSetMapFoldsFormsInOneOrder(t *testing.T) {
+	src := map[string]string{"TOKEN": "upper", "token": "lower"}
+	for range 8 {
+		if got, _ := CollectNames(src).Get("token"); got != "lower" {
+			t.Fatalf("Get(token) = %q, want %q", got, "lower")
+		}
+	}
+}
+
+func TestNameMapCloneIsolatesLaterWrites(t *testing.T) {
+	var m NameMap[string]
+	m.Set("token", "first")
+
+	cp := m.Clone()
+	m.Set("token", "second")
+	m.Set("extra", "new")
+
+	if got, _ := cp.Get("token"); got != "first" {
+		t.Fatalf("Get(token) = %q, want the value held when cloned", got)
+	}
+	if cp.Has("extra") {
+		t.Fatalf("Has(extra) = true, want a write after the clone to stay out")
+	}
+}
+
+func TestNameMapMergePrefersSource(t *testing.T) {
+	var dst NameMap[string]
+	dst.Set("token", "old")
+	dst.Set("keep", "kept")
+
+	var src NameMap[string]
+	src.Set("TOKEN", "new")
+	dst.Merge(src)
+
+	if got, _ := dst.Get("token"); got != "new" {
+		t.Fatalf("Get(token) = %q, want %q", got, "new")
+	}
+	if got, _ := dst.Get("keep"); got != "kept" {
+		t.Fatalf("Get(keep) = %q, want %q", got, "kept")
+	}
+	if dst.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2", dst.Len())
+	}
+}
+
+func TestNameMapSortedReadsByNameIdentity(t *testing.T) {
+	var m NameMap[string]
+	m.Set("Beta", "2")
+	m.Set("alpha", "1")
+	m.Set("Gamma", "3")
+
+	var names []string
+	for name := range m.Sorted() {
+		names = append(names, name)
+	}
+	if want := []string{"alpha", "Beta", "Gamma"}; !slices.Equal(names, want) {
+		t.Fatalf("Sorted() names = %v, want %v", names, want)
+	}
+}
+
+func TestNameMapHoldsGlobalMutations(t *testing.T) {
+	var m NameMap[GlobalMutation]
+	m.Set("Token", GlobalMutation{Name: "Token", Value: "first"})
+	m.Set("token", GlobalMutation{Name: "token", Value: "second", Secret: true})
+
+	got, ok := m.Get("TOKEN")
+	if !ok || got.Value != "second" || !got.Secret {
+		t.Fatalf("Get(TOKEN) = %#v, %v, want the second mutation", got, ok)
+	}
+	if m.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", m.Len())
+	}
+}

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -252,7 +252,7 @@ type lookupHit struct {
 }
 
 func (h lookupHit) key() variableKey {
-	return variableKey{provider: h.idx, name: strings.ToLower(h.subject)}
+	return variableKey{provider: h.idx, name: NameKey(h.subject)}
 }
 
 // lookupValue first tries direct lookup across all providers.
@@ -528,7 +528,9 @@ type MapProvider struct {
 	template bool
 }
 
-// Keys get lowercased so lookups are case-insensitive
+// Keys are normalized to their NameKey so lookups are case-insensitive. Two
+// forms of one name collapse to whichever the map iteration reaches last, so
+// callers that care about the winner deduplicate before constructing.
 func NewMapProvider(label string, values map[string]string) Provider {
 	return newMapProvider(label, values, false)
 }
@@ -544,7 +546,7 @@ func NewTemplateProvider(label string, values map[string]string) Provider {
 func newMapProvider(label string, values map[string]string, template bool) Provider {
 	normalized := make(map[string]string, len(values))
 	for k, v := range values {
-		normalized[strings.ToLower(k)] = v
+		normalized[NameKey(k)] = v
 	}
 	return &MapProvider{values: normalized, label: label, template: template}
 }
@@ -563,7 +565,7 @@ func expandableProvider(p Provider) bool {
 }
 
 func (p *MapProvider) Resolve(name string) (string, bool) {
-	value, ok := p.values[strings.ToLower(name)]
+	value, ok := p.values[NameKey(name)]
 	return value, ok
 }
 

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -523,16 +523,15 @@ func splitDynamicOffset(name string) (string, time.Duration, bool) {
 }
 
 type MapProvider struct {
-	values   map[string]string
+	values   NameMap[string]
 	label    string
 	template bool
 }
 
-// Keys are normalized to their NameKey so lookups are case-insensitive. Two
-// forms of one name collapse to whichever the map iteration reaches last, so
-// callers that care about the winner deduplicate before constructing.
+// NewMapProvider normalizes names case-insensitively. Equivalent keys resolve
+// in deterministic name order.
 func NewMapProvider(label string, values map[string]string) Provider {
-	return newMapProvider(label, values, false)
+	return newMapProvider(label, CollectNames(values), false)
 }
 
 // NewTemplateProvider is a MapProvider whose values are authored template
@@ -540,15 +539,21 @@ func NewMapProvider(label string, values map[string]string) Provider {
 // Use it only for values written in source files, never for runtime data such
 // as captured responses.
 func NewTemplateProvider(label string, values map[string]string) Provider {
+	return newMapProvider(label, CollectNames(values), true)
+}
+
+// NewNameMapProvider wraps an already-normalized NameMap without copying it.
+func NewNameMapProvider(label string, values NameMap[string]) Provider {
+	return newMapProvider(label, values, false)
+}
+
+// NewNameMapTemplateProvider is the template-expanding variant of NewNameMapProvider.
+func NewNameMapTemplateProvider(label string, values NameMap[string]) Provider {
 	return newMapProvider(label, values, true)
 }
 
-func newMapProvider(label string, values map[string]string, template bool) Provider {
-	normalized := make(map[string]string, len(values))
-	for k, v := range values {
-		normalized[NameKey(k)] = v
-	}
-	return &MapProvider{values: normalized, label: label, template: template}
+func newMapProvider(label string, values NameMap[string], template bool) Provider {
+	return &MapProvider{values: values, label: label, template: template}
 }
 
 type templateValueProvider interface {
@@ -565,8 +570,7 @@ func expandableProvider(p Provider) bool {
 }
 
 func (p *MapProvider) Resolve(name string) (string, bool) {
-	value, ok := p.values[NameKey(name)]
-	return value, ok
+	return p.values.Get(name)
 }
 
 func (p *MapProvider) Label() string {

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -152,7 +152,7 @@ func (r *Resolver) resolve(
 
 	var resolved string
 	var found bool
-	if expandableProvider(hit.prov) && strings.Contains(hit.raw, "{{") {
+	if expandableProvider(hit.prov) && HasPlaceholder(hit.raw) {
 		variable := hit.key()
 		if err := checkExpandState(name, variable, st); err != nil {
 			return "", false, err

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -111,6 +111,17 @@ func (r *Resolver) WithExprEval(fn ExprEval) *Resolver {
 	return &cp
 }
 
+// WithProviders reuses memoized expansions with a new provider set. Providers
+// must retain their order because memoized entries use provider positions.
+func (r *Resolver) WithProviders(providers ...Provider) *Resolver {
+	if r == nil {
+		return r
+	}
+	cp := *r
+	cp.providers = providers
+	return &cp
+}
+
 func (r *Resolver) Resolve(name string) (string, bool) {
 	value, ok, err := r.resolve(name, r.exprPos, true, true, nil)
 	if err != nil {

--- a/internal/vars/resolver_test.go
+++ b/internal/vars/resolver_test.go
@@ -573,6 +573,28 @@ func TestWithExprEvalKeepsPinnedValues(t *testing.T) {
 	}
 }
 
+func TestWithProvidersKeepsPinnedValues(t *testing.T) {
+	base := NewResolver(NewTemplateProvider("file", map[string]string{"id": "{{$uuid}}"}))
+	first, err := base.ExpandTemplates("{{id}}")
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	derived := base.WithProviders(NewTemplateProvider("file", map[string]string{
+		"id":    "{{$uuid}}",
+		"fresh": "staged",
+	}))
+	second, err := derived.ExpandTemplates("{{id}}")
+	if err != nil {
+		t.Fatalf("expand derived: %v", err)
+	}
+	if first != second {
+		t.Fatalf("re-planned resolver re-rolled the value: %q then %q", first, second)
+	}
+	if got, err := derived.ExpandTemplates("{{fresh}}"); err != nil || got != "staged" {
+		t.Fatalf("fresh = %q, %v; want the new provider visible", got, err)
+	}
+}
+
 func TestLenientResolverCycleNotMaskedByUndefined(t *testing.T) {
 	r := NewResolver(NewTemplateProvider("file", map[string]string{
 		"a": "{{b}}",

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -22,6 +22,10 @@ type tplSeg struct {
 	ph   bool
 }
 
+func HasPlaceholder(input string) bool {
+	return strings.Contains(input, "{{")
+}
+
 func CompileTemplate(input string) Template {
 	ms := templateVarPattern.FindAllStringSubmatchIndex(input, -1)
 	if len(ms) == 0 {

--- a/internal/vars/trace.go
+++ b/internal/vars/trace.go
@@ -34,7 +34,7 @@ func (t *Trace) Add(it ResolveTrace) {
 		return
 	}
 
-	key := strings.ToLower(name)
+	key := NameKey(name)
 
 	t.mu.Lock()
 	defer t.mu.Unlock()


### PR DESCRIPTION
Previously, templates and scripts resolved variables through different code paths. As a result, `{{name}}`, `{{=vars.name }}`, the RTS `vars` object, and the JavaScript `vars` API could disagree about which declaration took precedence or what value it contained.

This branch makes all four use the same precedence rules, name handling, and resolved values. It also includes several related bug fixes.

## What changed

- `variablePlan` defines the source order: `const`, scripts, workflows, requests, globals, files, and environment variables. Both template resolution and the variable map exposed to scripts now use this plan. Workflow and `@for-each` variables are handled as a separate layer.

- `vars.NameMap[V]` now handles trimmed, case-insensitive variable names while preserving the most recently written form for display. This replaces separate lowercasing logic across six packages. Names that are blank after trimming are ignored by the runtime store and JavaScript, while RTS and `@apply` continue to report an error.

- Document and runtime globals are merged per environment and resolved through the same variable plan. A policy controls whether secret values are available to scripts.

- Secrets are now masked at the engine boundary, before errors, script output, test results, workflow summaries, or history can receive them. A secret remains protected after it is deleted, overwritten, or returned by an operation that later fails.

- Captures are evaluated in declaration order and saved only if the entire batch succeeds.

## Fixes

- JavaScript pre-request blocks previously created a new API for each block. This meant one block could not read values written by an earlier block, and chained `vars.set(...)` calls could produce an incorrect outgoing request. All blocks in a batch now share one API, including the `request` getters.

- `request.removeHeader(...)` did not remove headers declared in the request file, in either JavaScript or RTS. `prerequest.Output` can now represent removals, which are applied before header updates.

- `vars.get("nested.derived")` could return the unresolved value `{{nested.base}}` even though `{{nested.derived}}` returned `inner`. Declared variable values are now expanded when the flattened variable map is built, so scripts and templates receive the same result.

- RTS trimmed variable names when writing but not when reading. A value written with `vars.set(" token ", value)` can now be read with `vars.get(" token ")`, as documented.

- When a workflow continued after a failed step, its summary could name the final step even if that step passed. The summary now names a step only when the workflow ends with that step failing, matching the UI.