### PR TITLE
RST-320: new dynamic helpers

### DIFF
--- a/_examples/basic.http
+++ b/_examples/basic.http
@@ -35,6 +35,24 @@ Accept: application/json
   "now_unix_ms": "{{$timestampMs}}"
 }
 
+### Random Data Helpers
+# @name randomHelpers
+POST {{base.url}}/anything/signup
+Content-Type: application/json
+Accept: application/json
+
+{
+  "id": "{{$uuid}}",
+  "name": "{{$randomName}}",
+  "email": "{{$randomEmail}}",
+  "employer": "{{$fake.company}}",
+  "city": "{{$fake.city}}",
+  "phone": "{{$fake.phone}}",
+  "password": "{{$randomString(24)}}",
+  "plan": "{{$randomChoice('free', 'pro', 'team')}}",
+  "seats": "{{$randomInt(1, 25)}}"
+}
+
 ### Bearer Auth Example
 # @name bearerEcho
 # @auth bearer {{auth.token}}

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -541,7 +541,33 @@ Variable names are case-insensitive and ignore surrounding whitespace. A file va
 
 Blank names are invalid. RestermScript and `@apply` report an error, while JavaScript and runtime stores ignore the write.
 
-Dynamic helpers are also available: `{{$uuid}}` (alias `{{$guid}}`), `{{$timestamp}}` (Unix seconds), `{{$timestampMs}}` (Unix milliseconds), `{{$timestampISO8601}}`, and `{{$randomInt}}`.
+### Dynamic helpers
+
+Helper names are case-insensitive and need no declaration.
+
+| Helper | Value |
+| --- | --- |
+| `{{$uuid}}` (alias `{{$guid}}`) | Random UUID v4 |
+| `{{$timestamp}}` | Unix time in seconds |
+| `{{$timestampMs}}` | Unix time in milliseconds |
+| `{{$timestampISO8601}}` | Current time, RFC3339 UTC |
+| `{{$randomInt}}` | Random integer. `{{$randomInt(100)}}` gives 0 to 100, `{{$randomInt(1, 6)}}` gives 1 to 6, both ends included |
+| `{{$randomString}}` | Random alphanumeric string of 16 characters. `{{$randomString(24)}}` sets the length, up to 4096 |
+| `{{$randomChoice("a", "b", "c")}}` | Random value from the given list |
+| `{{$randomName}}` | Random full name |
+| `{{$randomEmail}}` | Random email address |
+| `{{$fake.person}}` | Random full name |
+| `{{$fake.firstName}}`, `{{$fake.lastName}}` | Random name parts |
+| `{{$fake.email}}`, `{{$fake.username}}` | Random account details |
+| `{{$fake.company}}`, `{{$fake.domain}}` | Random company name and hostname |
+| `{{$fake.city}}`, `{{$fake.country}}`, `{{$fake.phone}}` | Random address details |
+| `{{$fake.word}}`, `{{$fake.sentence}}` | Random filler text |
+
+Every reference is resolved on its own, so two `{{$uuid}}` in one body give two values. Declare the helper as a variable when a request needs the same value twice: `# @request trace.id {{$uuid}}`.
+
+Generated addresses and hostnames stay under the reserved `example.com`, `example.net`, and `example.org` domains, and phone numbers stay in the fictional `555-01xx` range, so no helper output points at a real host or mailbox.
+
+Arguments accept either quote form and may be left unquoted when they contain no comma: `{{$randomChoice(red, green)}}`. Inside a JSON body prefer single quotes, since a backslash-escaped `\"` is part of the argument rather than a quote. A helper used the wrong way, such as `{{$randomChoice()}}`, fails the request with an error that names the helper instead of reporting a missing variable.
 
 Timestamp helpers accept optional offsets: `{{$timestamp + 6d}}`, `{{$timestampISO8601 - 90m}}`, `{{$timestampMs + 2h}}`. Supported units are the standard Go duration units plus `d` (days) and `w` (weeks).
 
@@ -866,7 +892,7 @@ Available inputs are:
 - `{{query.name}}` for a query value. Repeated values use the first value.
 - `{{headers.Name}}` for a request header, including `{{headers.Host}}`. Header names are case-insensitive and repeated values use the first value.
 - `{{body.path.to.field}}` for a JSON body field. Array indexes and quoted keys use the same forms as `items[0].id` and `$["display.name"]`.
-- Dynamic helpers such as `{{$uuid}}`, `{{$guid}}`, `{{$timestamp}}`, `{{$timestampms}}`, `{{$timestampISO8601}}`, and `{{$randomint}}`. Timestamp offsets such as `{{$timestampISO8601 - 1h}}` are supported.
+- Every [dynamic helper](#dynamic-helpers), such as `{{$uuid}}`, `{{$timestampISO8601 - 1h}}`, `{{$randomChoice("queued", "done")}}`, and `{{$fake.company}}`. A helper reference that names no helper, or one called the wrong way, fails when the mock set compiles.
 
 The placeholders above insert text as-is. Use them in response headers and in plain text or XML bodies. Strings read from a JSON request body are not quoted or escaped. Other JSON values such as numbers, booleans, `null`, arrays, and objects are written as compact JSON. Each occurrence is resolved separately.
 

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -565,7 +565,7 @@ Helper names are case-insensitive and need no declaration.
 
 Every reference is resolved on its own, so two `{{$uuid}}` in one body give two values. Declare the helper as a variable when a request needs the same value twice: `# @request trace.id {{$uuid}}`.
 
-Generated addresses and hostnames stay under the reserved `example.com`, `example.net`, and `example.org` domains, and phone numbers stay in the fictional `555-01xx` range, so no helper output points at a real host or mailbox.
+Generated addresses and hostnames stay under the reserved `example.com`, `example.net`, and `example.org` domains, and phone numbers come from a range reserved for fiction, so no helper output points at a real host, mailbox, or line.
 
 Arguments accept either quote form and may be left unquoted when they contain no comma: `{{$randomChoice(red, green)}}`. Inside a JSON body prefer single quotes, since a backslash-escaped `\"` is part of the argument rather than a quote. A helper used the wrong way, such as `{{$randomChoice()}}`, fails the request with an error that names the helper instead of reporting a missing variable.
 

--- a/internal/helpdoc/topics/variables.md
+++ b/internal/helpdoc/topics/variables.md
@@ -10,4 +10,6 @@ GET {{apiUrl}}/users/{{userId}}
 
 Declare values at `@const`, `@request`, `@file`, or `@global` scope. Append `-secret` to mask them in summaries. `@capture` stores response data for later requests. Press `Ctrl+E` to select an environment.
 
+Built-in helpers need no declaration: `{{$uuid}}`, `{{$timestamp}}`, `{{$timestampMs}}`, `{{$timestampISO8601}}`, `{{$randomInt}}`, `{{$randomString}}`, `{{$randomName}}`, `{{$randomEmail}}`, `{{$randomChoice("a", "b")}}`, and the `{{$fake.*}}` family (`person`, `firstName`, `lastName`, `email`, `username`, `company`, `domain`, `city`, `country`, `phone`, `word`, `sentence`). Timestamps accept offsets such as `{{$timestampISO8601 - 90m}}`; `{{$randomInt(1, 6)}}` and `{{$randomString(24)}}` take arguments.
+
 An undefined variable in any part of an outbound request blocks the send. Previews keep the `{{...}}` placeholder and list the missing names.

--- a/internal/intellisense/variables.go
+++ b/internal/intellisense/variables.go
@@ -1,11 +1,31 @@
 package intellisense
 
-var builtinVars = []Item{
-	{Label: "$uuid", Aliases: []string{"$guid"}, Summary: "Random UUID v4"},
-	{Label: "$timestamp", Summary: "Current Unix time in seconds"},
-	{Label: "$timestampISO8601", Summary: "Current time, RFC3339 UTC"},
-	{Label: "$timestampms", Summary: "Current Unix time in milliseconds"},
-	{Label: "$randomInt", Summary: "Random integer"},
+import "github.com/unkn0wn-root/resterm/internal/vars/dynamic"
+
+// builtinVars mirrors the helper registry, so a new helper needs no second
+// list here.
+var builtinVars = builtinItems()
+
+func builtinItems() []Item {
+	helpers := dynamic.Helpers()
+	items := make([]Item, 0, len(helpers))
+	for _, h := range helpers {
+		items = append(items, Item{
+			Label:   h.Name(),
+			Aliases: h.Aliases(),
+			Summary: helperSummary(h),
+		})
+	}
+	return items
+}
+
+// helperSummary shows the call form, since the label alone does not say a
+// helper takes arguments.
+func helperSummary(h dynamic.Descriptor) string {
+	if h.Usage() == "" {
+		return h.Summary()
+	}
+	return h.Summary() + ", e.g. " + h.Usage()
 }
 
 type variableSource struct{}

--- a/internal/mock/template.go
+++ b/internal/mock/template.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/jsonpath"
 	"github.com/unkn0wn-root/resterm/internal/vars"
+	"github.com/unkn0wn-root/resterm/internal/vars/dynamic"
 )
 
 type renderedResponse struct {
@@ -87,10 +89,15 @@ func validateTemplateName(name string, pathParams map[string]string) error {
 		return fmt.Errorf("response templates do not support expressions")
 	}
 	if strings.HasPrefix(name, "$") {
-		if vars.IsDynamic(name) {
+		err := dynamic.Validate(name)
+		switch {
+		case err == nil:
 			return nil
+		case errors.Is(err, dynamic.ErrUnknown):
+			return fmt.Errorf("unsupported dynamic response template %q", name)
+		default:
+			return fmt.Errorf("unsupported dynamic response template %q: %w", name, err)
 		}
-		return fmt.Errorf("unsupported dynamic response template %q", name)
 	}
 
 	ref, ok := parseRequestTemplate(name)

--- a/internal/mock/template_test.go
+++ b/internal/mock/template_test.go
@@ -371,6 +371,10 @@ func TestCompileRejectsInvalidResponseTemplates(t *testing.T) {
 		{name: "invalid body path", body: "{{body.items[invalid-index]}}", want: "invalid JSON body"},
 		{name: "invalid encoded body path", body: "{{json.body.items[invalid-index]}}", want: "invalid JSON body"},
 		{name: "unsupported dynamic", body: "{{$uuid + 1s}}", want: "unsupported dynamic"},
+		{name: "dynamic helper arity", body: "{{$randomChoice()}}", want: "takes at least 1 argument"},
+		{name: "dynamic helper length", body: "{{$randomString(0)}}", want: "length must be between"},
+		{name: "dynamic helper argument type", body: "{{$randomInt(soon)}}", want: "is not a whole number"},
+		{name: "dynamic helper range", body: "{{$randomInt(9, 4)}}", want: "is above maximum"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/vars/dynamic/builtins.go
+++ b/internal/vars/dynamic/builtins.go
@@ -1,0 +1,245 @@
+package dynamic
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultStringLen = 16
+	maxStringLen     = 4096
+	// randomIntMax is the range the argument-free form produced before
+	// helpers took arguments.
+	randomIntMax = 1 << 62
+)
+
+// builtins is the complete set of {{$...}} helpers, in documentation order.
+// A new helper is one entry here. eval must stay cheap and free of side
+// effects, since Validate runs it to check a reference at compile time.
+var builtins = []helper{
+	{
+		name:    "$uuid",
+		aliases: []string{"$guid"},
+		summary: "Random UUID v4",
+		eval:    evalUUID,
+	},
+	{
+		name:    "$timestamp",
+		summary: "Unix time in seconds",
+		offset:  true,
+		eval:    evalTimestamp,
+	},
+	{
+		name:    "$timestampMs",
+		summary: "Unix time in milliseconds",
+		offset:  true,
+		eval:    evalTimestampMs,
+	},
+	{
+		name:    "$timestampISO8601",
+		summary: "Current time, RFC3339 UTC",
+		offset:  true,
+		eval:    evalTimestampISO,
+	},
+	{
+		name:    "$randomInt",
+		summary: "Random integer, within min and max when given",
+		usage:   "$randomInt(1, 100)",
+		args:    arity{max: 2},
+		eval:    evalRandomInt,
+	},
+	{
+		name:    "$randomString",
+		summary: "Random alphanumeric string, 16 characters by default",
+		usage:   "$randomString(24)",
+		args:    arity{max: 1},
+		eval:    evalRandomString,
+	},
+	{
+		name:    "$randomChoice",
+		summary: "Random value from the given list",
+		usage:   `$randomChoice("a", "b", "c")`,
+		args:    arity{min: 1, max: -1},
+		eval:    evalRandomChoice,
+	},
+	{
+		name:    "$randomName",
+		summary: "Random full name",
+		eval:    gen(fakePerson),
+	},
+	{
+		name:    "$randomEmail",
+		summary: "Random email address on an example domain",
+		eval:    gen(fakeEmail),
+	},
+	{
+		name:    "$fake.person",
+		summary: "Random full name",
+		eval:    gen(fakePerson),
+	},
+	{
+		name:    "$fake.firstName",
+		summary: "Random first name",
+		eval:    gen(fakeFirstName),
+	},
+	{
+		name:    "$fake.lastName",
+		summary: "Random last name",
+		eval:    gen(fakeLastName),
+	},
+	{
+		name:    "$fake.email",
+		summary: "Random email address on an example domain",
+		eval:    gen(fakeEmail),
+	},
+	{
+		name:    "$fake.username",
+		summary: "Random username",
+		eval:    gen(fakeUsername),
+	},
+	{
+		name:    "$fake.company",
+		summary: "Random company name",
+		eval:    gen(fakeCompany),
+	},
+	{
+		name:    "$fake.domain",
+		summary: "Random hostname under example.com",
+		eval:    gen(fakeDomain),
+	},
+	{
+		name:    "$fake.city",
+		summary: "Random city",
+		eval:    gen(fakeCity),
+	},
+	{
+		name:    "$fake.country",
+		summary: "Random country",
+		eval:    gen(fakeCountry),
+	},
+	{
+		name:    "$fake.phone",
+		summary: "Random phone number in the fictional 555 range",
+		eval:    gen(fakePhone),
+	},
+	{
+		name:    "$fake.word",
+		summary: "Random single word",
+		eval:    gen(fakeWord),
+	},
+	{
+		name:    "$fake.sentence",
+		summary: "Random short sentence",
+		eval:    gen(fakeSentence),
+	},
+}
+
+var index = buildIndex()
+
+func buildIndex() map[string]helper {
+	m := make(map[string]helper, 2*len(builtins))
+	for _, h := range builtins {
+		add := func(name string) {
+			key := strings.ToLower(name)
+			if _, dup := m[key]; dup {
+				panic("dynamic: duplicate helper name " + name)
+			}
+			m[key] = h
+		}
+		add(h.name)
+		for _, alias := range h.aliases {
+			add(alias)
+		}
+	}
+	return m
+}
+
+func lookup(name string) (helper, bool) {
+	h, ok := index[strings.ToLower(strings.TrimSpace(name))]
+	return h, ok
+}
+
+// gen adapts a plain generator to a helper that takes no arguments.
+func gen(fn func() string) func(call) (string, error) {
+	return func(call) (string, error) { return fn(), nil }
+}
+
+func evalUUID(call) (string, error) {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return "", fmt.Errorf("$uuid: %w", err)
+	}
+	return id.String(), nil
+}
+
+func evalTimestamp(c call) (string, error) {
+	return strconv.FormatInt(time.Now().Add(c.offset).Unix(), 10), nil
+}
+
+func evalTimestampMs(c call) (string, error) {
+	return strconv.FormatInt(time.Now().Add(c.offset).UnixMilli(), 10), nil
+}
+
+func evalTimestampISO(c call) (string, error) {
+	return time.Now().Add(c.offset).UTC().Format(time.RFC3339), nil
+}
+
+func evalRandomInt(c call) (string, error) {
+	switch len(c.args) {
+	case 0:
+		return strconv.FormatUint(randUint64(randomIntMax), 10), nil
+	case 1:
+		hi, err := c.argInt(0)
+		if err != nil {
+			return "", err
+		}
+		return randomIntRange(c, 0, hi)
+	default:
+		lo, err := c.argInt(0)
+		if err != nil {
+			return "", err
+		}
+		hi, err := c.argInt(1)
+		if err != nil {
+			return "", err
+		}
+		return randomIntRange(c, lo, hi)
+	}
+}
+
+// randomIntRange picks from lo to hi inclusive.
+func randomIntRange(c call, lo, hi int64) (string, error) {
+	if lo > hi {
+		return "", fmt.Errorf("%s: minimum %d is above maximum %d", c.helper.name, lo, hi)
+	}
+	// Unsigned arithmetic keeps the inclusive span exact even across the full
+	// int64 range, where it wraps to zero and every value is allowed.
+	span := uint64(hi) - uint64(lo) + 1
+	if span == 0 {
+		return strconv.FormatInt(int64(randUint64Full()), 10), nil
+	}
+	return strconv.FormatInt(lo+int64(randUint64(span)), 10), nil
+}
+
+func evalRandomString(c call) (string, error) {
+	n := int64(defaultStringLen)
+	if len(c.args) == 1 {
+		size, err := c.argInt(0)
+		if err != nil {
+			return "", err
+		}
+		n = size
+	}
+	if n < 1 || n > maxStringLen {
+		return "", fmt.Errorf("%s: length must be between 1 and %d, got %d", c.helper.name, maxStringLen, n)
+	}
+	return randomString(int(n)), nil
+}
+
+func evalRandomChoice(c call) (string, error) {
+	return pick(c.args), nil
+}

--- a/internal/vars/dynamic/builtins.go
+++ b/internal/vars/dynamic/builtins.go
@@ -123,7 +123,7 @@ var builtins = []helper{
 	},
 	{
 		name:    "$fake.phone",
-		summary: "Random phone number in the fictional 555 range",
+		summary: "Random phone number from a range reserved for fiction",
 		eval:    gen(fakePhone),
 	},
 	{

--- a/internal/vars/dynamic/builtins_test.go
+++ b/internal/vars/dynamic/builtins_test.go
@@ -100,7 +100,7 @@ func TestFakeHelpersLookReal(t *testing.T) {
 		{ref: "$fake.username", pattern: `^[a-z]+[0-9]{2}$`},
 		{ref: "$fake.company", pattern: `^[A-Z][a-z]+ [A-Z][a-z]+$`},
 		{ref: "$fake.domain", pattern: `^[a-z]+\.example\.com$`},
-		{ref: "$fake.phone", pattern: `^\+1-555-01[0-9]{2}$`},
+		{ref: "$fake.phone", pattern: `^\+1-[0-9]{3}-555-01[0-9]{2}$`},
 		{ref: "$fake.word", pattern: `^[a-z]+$`},
 		{ref: "$fake.sentence", pattern: `^[A-Z][a-z]+( [a-z]+){3,7}\.$`},
 		{ref: "$fake.city", pattern: `^[A-Z][a-z]+$`},

--- a/internal/vars/dynamic/builtins_test.go
+++ b/internal/vars/dynamic/builtins_test.go
@@ -1,0 +1,160 @@
+package dynamic
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const samples = 200
+
+func TestRandomChoicePicksAnOption(t *testing.T) {
+	t.Parallel()
+
+	options := map[string]int{"alpha": 0, "beta": 0, "gamma": 0}
+	for range samples {
+		out, err := Resolve(`$randomChoice("alpha", 'beta', gamma)`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := options[out]; !ok {
+			t.Fatalf("got %q, want one of the options", out)
+		}
+		options[out]++
+	}
+	for name, hits := range options {
+		if hits == 0 {
+			t.Fatalf("option %q was never picked in %d draws", name, samples)
+		}
+	}
+}
+
+func TestRandomString(t *testing.T) {
+	t.Parallel()
+
+	out, err := Resolve("$randomString")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != defaultStringLen {
+		t.Fatalf("$randomString = %q, want %d characters", out, defaultStringLen)
+	}
+
+	sized, err := Resolve("$randomString(64)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sized) != 64 {
+		t.Fatalf("$randomString(64) = %q, want 64 characters", sized)
+	}
+	if strings.ContainsFunc(sized, func(r rune) bool { return !strings.ContainsRune(alphanum, r) }) {
+		t.Fatalf("$randomString(64) = %q, want alphanumeric characters only", sized)
+	}
+	if sized == strings.Repeat(sized[:1], len(sized)) {
+		t.Fatalf("$randomString(64) = %q, want varied characters", sized)
+	}
+}
+
+func TestRandomIntRanges(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[int64]bool)
+	for range samples {
+		n := resolveInt(t, "$randomInt(1, 6)")
+		if n < 1 || n > 6 {
+			t.Fatalf("$randomInt(1, 6) = %d, want 1 to 6", n)
+		}
+		seen[n] = true
+	}
+	if len(seen) < 2 {
+		t.Fatalf("$randomInt(1, 6) never varied across %d draws", samples)
+	}
+	if n := resolveInt(t, "$randomInt(3, 3)"); n != 3 {
+		t.Fatalf("$randomInt(3, 3) = %d, want 3", n)
+	}
+	if n := resolveInt(t, "$randomInt(-5, -5)"); n != -5 {
+		t.Fatalf("$randomInt(-5, -5) = %d, want -5", n)
+	}
+	if n := resolveInt(t, "$randomInt(0)"); n != 0 {
+		t.Fatalf("$randomInt(0) = %d, want 0", n)
+	}
+	if n := resolveInt(t, "$randomInt"); n < 0 {
+		t.Fatalf("$randomInt = %d, want a non-negative value", n)
+	}
+}
+
+func TestFakeHelpersLookReal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ref     string
+		pattern string
+	}{
+		{ref: "$randomName", pattern: `^[A-Z][a-z]+ [A-Z][a-z]+$`},
+		{ref: "$fake.person", pattern: `^[A-Z][a-z]+ [A-Z][a-z]+$`},
+		{ref: "$fake.firstName", pattern: `^[A-Z][a-z]+$`},
+		{ref: "$fake.lastName", pattern: `^[A-Z][a-z]+$`},
+		{ref: "$randomEmail", pattern: `^[a-z]+\.[a-z]+[0-9]{2}@example\.(com|net|org)$`},
+		{ref: "$fake.email", pattern: `^[a-z]+\.[a-z]+[0-9]{2}@example\.(com|net|org)$`},
+		{ref: "$fake.username", pattern: `^[a-z]+[0-9]{2}$`},
+		{ref: "$fake.company", pattern: `^[A-Z][a-z]+ [A-Z][a-z]+$`},
+		{ref: "$fake.domain", pattern: `^[a-z]+\.example\.com$`},
+		{ref: "$fake.phone", pattern: `^\+1-555-01[0-9]{2}$`},
+		{ref: "$fake.word", pattern: `^[a-z]+$`},
+		{ref: "$fake.sentence", pattern: `^[A-Z][a-z]+( [a-z]+){3,7}\.$`},
+		{ref: "$fake.city", pattern: `^[A-Z][a-z]+$`},
+		{ref: "$fake.country", pattern: `^[A-Z][a-z]+$`},
+	}
+	for _, test := range tests {
+		t.Run(test.ref, func(t *testing.T) {
+			t.Parallel()
+
+			re := regexp.MustCompile(test.pattern)
+			values := make(map[string]bool)
+			for range samples {
+				out, err := Resolve(test.ref)
+				if err != nil {
+					t.Fatalf("Resolve(%q): %v", test.ref, err)
+				}
+				if !re.MatchString(out) {
+					t.Fatalf("Resolve(%q) = %q, want it to match %s", test.ref, out, test.pattern)
+				}
+				values[out] = true
+			}
+			if len(values) < 2 {
+				t.Fatalf("Resolve(%q) returned the same value %d times", test.ref, samples)
+			}
+		})
+	}
+}
+
+func TestUUIDIsUnique(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]bool, samples)
+	for range samples {
+		out, err := Resolve("$guid")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if seen[out] {
+			t.Fatalf("$guid repeated %q", out)
+		}
+		seen[out] = true
+	}
+}
+
+func resolveInt(t *testing.T, ref string) int64 {
+	t.Helper()
+
+	out, err := Resolve(ref)
+	if err != nil {
+		t.Fatalf("Resolve(%q): %v", ref, err)
+	}
+	n, err := strconv.ParseInt(out, 10, 64)
+	if err != nil {
+		t.Fatalf("Resolve(%q) = %q, want a number", ref, out)
+	}
+	return n
+}

--- a/internal/vars/dynamic/dynamic.go
+++ b/internal/vars/dynamic/dynamic.go
@@ -1,0 +1,284 @@
+// Package dynamic implements the built-in {{$...}} template helpers.
+// A helper is one entry in the table in builtins.go. Parsing, argument
+// validation and error wording live here, so adding a helper never touches
+// the resolver.
+package dynamic
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/unkn0wn-root/resterm/internal/duration"
+)
+
+// ErrUnknown reports a reference that no helper claims. Callers use it to
+// tell a helper apart from an ordinary variable whose name starts with '$'.
+var ErrUnknown = errors.New("unknown template helper")
+
+// helper is one built-in. Names match case-insensitively. It stays private
+// so the live table cannot be reached from outside the package.
+type helper struct {
+	name    string
+	aliases []string
+	summary string
+	usage   string // example call, empty when the helper takes no arguments
+	offset  bool   // accepts a trailing "+/- duration"
+	args    arity
+	eval    func(call) (string, error)
+}
+
+// Descriptor is a helper as documentation and completions see it. Every copy
+// owns its data, so callers cannot reach the registry through one.
+type Descriptor struct {
+	name    string
+	aliases []string
+	summary string
+	usage   string
+}
+
+func (d Descriptor) Name() string {
+	return d.name
+}
+
+func (d Descriptor) Aliases() []string {
+	return slices.Clone(d.aliases)
+}
+
+func (d Descriptor) Summary() string {
+	return d.summary
+}
+
+// Usage is an example call, empty when the helper takes no arguments.
+func (d Descriptor) Usage() string {
+	return d.usage
+}
+
+// arity bounds the argument count. A zero value means "no arguments";
+// max below zero means unbounded.
+type arity struct {
+	min, max int
+}
+
+type call struct {
+	helper helper
+	args   []string
+	offset time.Duration
+}
+
+func (c call) argInt(i int) (int64, error) {
+	n, err := strconv.ParseInt(strings.TrimSpace(c.args[i]), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %q is not a whole number: %s", c.helper.name, c.args[i], c.helper.usage)
+	}
+	return n, nil
+}
+
+// Resolve renders one helper reference, without the surrounding braces.
+// ErrUnknown means no helper matches the name, which callers treat as "not a
+// helper". Any other error means the reference itself is wrong.
+func Resolve(ref string) (string, error) {
+	c, err := parse(ref)
+	if err != nil {
+		return "", err
+	}
+	return c.helper.eval(c)
+}
+
+// Validate reports whether ref is usable, for checks that run before the
+// request or mock response does. It renders and drops the value because
+// bounds and ranges are only known to the evaluator, and one shared path
+// cannot accept what rendering later rejects.
+func Validate(ref string) error {
+	_, err := Resolve(ref)
+	return err
+}
+
+// Helpers describes every built-in, in documentation order.
+func Helpers() []Descriptor {
+	out := make([]Descriptor, len(builtins))
+	for i, h := range builtins {
+		out[i] = h.describe()
+	}
+	return out
+}
+
+func (h helper) describe() Descriptor {
+	return Descriptor{
+		name:    h.name,
+		aliases: slices.Clone(h.aliases),
+		summary: h.summary,
+		usage:   h.usage,
+	}
+}
+
+func parse(ref string) (call, error) {
+	name, args, err := splitCall(ref)
+	if err != nil {
+		return call{}, err
+	}
+
+	var offset time.Duration
+	hasOffset := false
+	h, ok := lookup(name)
+	if !ok {
+		// Only a reference that matches nothing is worth splitting: no helper
+		// name carries a sign, while a variable name may ("$my-var + 1h").
+		if base, dur, split := splitOffset(name); split {
+			h, ok = lookup(base)
+			offset, hasOffset = dur, true
+		}
+		if !ok {
+			return call{}, fmt.Errorf("%w: %s", ErrUnknown, strings.TrimSpace(ref))
+		}
+	}
+
+	if hasOffset && !h.offset {
+		return call{}, fmt.Errorf("%s does not accept a time offset", h.name)
+	}
+	if n := len(args); n < h.args.min || (h.args.max >= 0 && n > h.args.max) {
+		return call{}, h.arityError(n)
+	}
+	return call{helper: h, args: args, offset: offset}, nil
+}
+
+func (h helper) arityError(n int) error {
+	var want string
+	switch {
+	case h.args.max == 0:
+		want = "no arguments"
+	case h.args.max < 0:
+		want = fmt.Sprintf("at least %s", plural(h.args.min))
+	case h.args.min == 0:
+		want = fmt.Sprintf("at most %s", plural(h.args.max))
+	case h.args.min == h.args.max:
+		want = plural(h.args.min)
+	default:
+		want = fmt.Sprintf("%d to %s", h.args.min, plural(h.args.max))
+	}
+	if h.usage != "" {
+		return fmt.Errorf("%s takes %s, got %d: %s", h.name, want, n, h.usage)
+	}
+	return fmt.Errorf("%s takes %s, got %d", h.name, want, n)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "1 argument"
+	}
+	return fmt.Sprintf("%d arguments", n)
+}
+
+// splitCall turns `$randomChoice("a", "b")` into "$randomChoice" and
+// ["a", "b"]. A reference without a trailing argument list has no arguments.
+func splitCall(ref string) (string, []string, error) {
+	ref = strings.TrimSpace(ref)
+	open := strings.Index(ref, "(")
+	if open < 0 || !strings.HasSuffix(ref, ")") {
+		return ref, nil, nil
+	}
+
+	name := strings.TrimSpace(ref[:open])
+	args, err := splitArgs(ref[open+1 : len(ref)-1])
+	if err != nil {
+		return "", nil, fmt.Errorf("%s: %w", name, err)
+	}
+	return name, args, nil
+}
+
+// splitArgs splits an argument list on commas. Arguments may use either quote
+// form, and a backslash inside quotes escapes the next character. Space around
+// an argument is dropped, space inside quotes is kept, so `"a b" , c` yields
+// "a b" and "c". Trailing space is only known to be trailing once the argument
+// ends, so it waits in space until a later rune proves it was interior.
+func splitArgs(in string) ([]string, error) {
+	var (
+		args  []string
+		arg   strings.Builder
+		space strings.Builder
+		quote rune
+		esc   bool
+	)
+	write := func(r rune, quoted bool) {
+		if !quoted && unicode.IsSpace(r) {
+			if arg.Len() > 0 {
+				space.WriteRune(r)
+			}
+			return
+		}
+		if space.Len() > 0 {
+			arg.WriteString(space.String())
+			space.Reset()
+		}
+		arg.WriteRune(r)
+	}
+	flush := func() {
+		args = append(args, arg.String())
+		arg.Reset()
+		space.Reset()
+	}
+
+	quotedArg := false
+	for _, r := range in {
+		switch {
+		case esc:
+			write(r, true)
+			esc = false
+		case quote != 0 && r == '\\':
+			esc = true
+		case quote != 0 && r == quote:
+			quote = 0
+		case quote != 0:
+			write(r, true)
+		case r == '"' || r == '\'':
+			quote, quotedArg = r, true
+		case r == ',':
+			flush()
+			quotedArg = false
+		default:
+			write(r, false)
+		}
+	}
+	if quote != 0 || esc {
+		return nil, errors.New("unterminated quoted argument")
+	}
+	// An empty list is a call without arguments, not one blank argument.
+	if len(args) == 0 && !quotedArg && arg.Len() == 0 {
+		return nil, nil
+	}
+	flush()
+	return args, nil
+}
+
+// splitOffset splits "$helper +/- duration" into the base name and a signed
+// offset. "$timestampISO8601 - 90m" becomes "$timestampISO8601" and -90m.
+func splitOffset(name string) (string, time.Duration, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", 0, false
+	}
+	for i := len(name) - 1; i > 0; i-- {
+		ch := name[i]
+		if ch != '+' && ch != '-' {
+			continue
+		}
+		base := strings.TrimSpace(name[:i])
+		raw := strings.TrimSpace(name[i+1:])
+		if base == "" || raw == "" {
+			continue
+		}
+		dur, ok := duration.Parse(raw)
+		if !ok {
+			continue
+		}
+		if ch == '-' {
+			dur = -dur
+		}
+		return base, dur, true
+	}
+	return "", 0, false
+}

--- a/internal/vars/dynamic/dynamic_test.go
+++ b/internal/vars/dynamic/dynamic_test.go
@@ -1,0 +1,313 @@
+package dynamic
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveUnknownHelper(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range []string{"$nope", "$my-custom-var + 1h", "$timestamp + missing", "host"} {
+		if _, err := Resolve(ref); !errors.Is(err, ErrUnknown) {
+			t.Fatalf("Resolve(%q) error = %v, want ErrUnknown", ref, err)
+		}
+	}
+}
+
+func TestResolveMatchesNamesCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range []string{"$UUID", "$Guid", "$TIMESTAMPISO8601", "$timestampms", "$FAKE.Company"} {
+		if _, err := Resolve(ref); err != nil {
+			t.Fatalf("Resolve(%q): %v", ref, err)
+		}
+	}
+}
+
+func TestResolveTimestampOffsets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ref  string
+		want time.Duration
+	}{
+		{ref: "$timestamp + 2s", want: 2 * time.Second},
+		{ref: "$timestampMs - 90m", want: -90 * time.Minute},
+		{ref: "$timestampISO8601-1h", want: -time.Hour},
+		{ref: "$timestamp + 6d", want: 6 * 24 * time.Hour},
+	}
+	for _, test := range tests {
+		t.Run(test.ref, func(t *testing.T) {
+			t.Parallel()
+
+			start := time.Now().Add(test.want)
+			out, err := Resolve(test.ref)
+			if err != nil {
+				t.Fatalf("Resolve(%q): %v", test.ref, err)
+			}
+			end := time.Now().Add(test.want)
+			got := parseStamp(t, test.ref, out)
+			if got.Before(start.Truncate(time.Second)) || got.After(end) {
+				t.Fatalf("Resolve(%q) = %q, want between %v and %v", test.ref, out, start, end)
+			}
+		})
+	}
+}
+
+func TestValidateRejectsMisuse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{ref: "$uuid + 1s", want: "$uuid does not accept a time offset"},
+		{ref: "$randomChoice()", want: "$randomChoice takes at least 1 argument, got 0"},
+		{ref: `$randomString(8, "hex")`, want: "$randomString takes at most 1 argument, got 2"},
+		{ref: "$randomInt(1, 2, 3)", want: "$randomInt takes at most 2 arguments, got 3"},
+		{ref: "$uuid(1)", want: "$uuid takes no arguments, got 1"},
+		{ref: `$randomChoice("a)`, want: "unterminated quoted argument"},
+		{ref: "$randomInt(soon)", want: `"soon" is not a whole number`},
+		{ref: "$randomString(0)", want: "length must be between 1 and 4096"},
+		{ref: "$randomInt(9, 4)", want: "minimum 9 is above maximum 4"},
+	}
+	for _, test := range tests {
+		t.Run(test.ref, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Resolve(test.ref)
+			if err == nil {
+				t.Fatalf("Resolve(%q) succeeded, want error", test.ref)
+			}
+			if errors.Is(err, ErrUnknown) {
+				t.Fatalf("Resolve(%q) reported the helper as unknown: %v", test.ref, err)
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Resolve(%q) error = %v, want it to contain %q", test.ref, err, test.want)
+			}
+		})
+	}
+}
+
+// A reference rejected only at render time reaches the user as a failed
+// request instead of a broken file, so the two must agree, bounds and ranges
+// included.
+func TestValidateAgreesWithResolve(t *testing.T) {
+	t.Parallel()
+
+	refs := []string{
+		"$uuid",
+		"$timestamp + 1h",
+		`$randomChoice("a", "b")`,
+		"$randomString(4)",
+		"$randomInt(1, 6)",
+		"$nope",
+		"$uuid + 1s",
+		"$randomChoice()",
+		"$randomString(0)",
+		"$randomString(9999)",
+		"$randomInt(soon)",
+		"$randomInt(9, 4)",
+	}
+	for _, ref := range refs {
+		t.Run(ref, func(t *testing.T) {
+			t.Parallel()
+
+			_, resolveErr := Resolve(ref)
+			validateErr := Validate(ref)
+			if (validateErr == nil) != (resolveErr == nil) {
+				t.Fatalf("Validate(%q) = %v, but Resolve = %v", ref, validateErr, resolveErr)
+			}
+			if errors.Is(validateErr, ErrUnknown) != errors.Is(resolveErr, ErrUnknown) {
+				t.Fatalf("Validate(%q) and Resolve disagree on ErrUnknown: %v, %v", ref, validateErr, resolveErr)
+			}
+		})
+	}
+}
+
+func TestSplitArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "blank", in: "   ", want: nil},
+		{name: "bare", in: "a, b ,c", want: []string{"a", "b", "c"}},
+		{name: "quoted keeps spaces", in: `" a ", "b"`, want: []string{" a ", "b"}},
+		{name: "single quotes", in: `'a', "b"`, want: []string{"a", "b"}},
+		{name: "comma inside quotes", in: `"a, b", c`, want: []string{"a, b", "c"}},
+		{name: "escaped quote", in: `"say \"hi\""`, want: []string{`say "hi"`}},
+		{name: "empty quoted", in: `""`, want: []string{""}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := splitArgs(test.in)
+			if err != nil {
+				t.Fatalf("splitArgs(%q): %v", test.in, err)
+			}
+			if len(got) != len(test.want) {
+				t.Fatalf("splitArgs(%q) = %q, want %q", test.in, got, test.want)
+			}
+			for i := range got {
+				if got[i] != test.want[i] {
+					t.Fatalf("splitArgs(%q) = %q, want %q", test.in, got, test.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSplitOffset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		in     string
+		base   string
+		offset time.Duration
+		ok     bool
+	}{
+		{name: "no space", in: "$timestampISO8601-1h", base: "$timestampISO8601", offset: -time.Hour, ok: true},
+		{name: "hyphenated base", in: "$my-custom-var + 1h", base: "$my-custom-var", offset: time.Hour, ok: true},
+		{name: "no offset", in: "$timestamp", ok: false},
+		{name: "unparsable", in: "$timestamp + soon", ok: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			base, offset, ok := splitOffset(test.in)
+			if ok != test.ok {
+				t.Fatalf("splitOffset(%q) ok = %t, want %t", test.in, ok, test.ok)
+			}
+			if !ok {
+				return
+			}
+			if base != test.base || offset != test.offset {
+				t.Fatalf("splitOffset(%q) = %q, %v, want %q, %v", test.in, base, offset, test.base, test.offset)
+			}
+		})
+	}
+}
+
+// Nothing else forces the table to stay consistent with what the parser and
+// the completion list expect of it.
+func TestRegistryIsWellFormed(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]string)
+	for _, h := range builtins {
+		for _, name := range append([]string{h.name}, h.aliases...) {
+			if !strings.HasPrefix(name, "$") {
+				t.Fatalf("helper %q must start with '$'", name)
+			}
+			if strings.ContainsAny(name, "+-() ") {
+				t.Fatalf("helper %q must not contain call or offset syntax", name)
+			}
+			key := strings.ToLower(name)
+			if prev, dup := seen[key]; dup {
+				t.Fatalf("helper %q collides with %q", name, prev)
+			}
+			seen[key] = name
+		}
+		if h.summary == "" {
+			t.Fatalf("helper %s needs a summary", h.name)
+		}
+		if (h.args.max != 0) != (h.usage != "") {
+			t.Fatalf("helper %s must document its arguments with usage", h.name)
+		}
+		if h.eval == nil {
+			t.Fatalf("helper %s has no eval", h.name)
+		}
+	}
+}
+
+// Descriptors go to other packages, so editing one must not reach the table.
+func TestDescriptorsShareNoStateWithRegistry(t *testing.T) {
+	t.Parallel()
+
+	var target Descriptor
+	for _, d := range Helpers() {
+		if len(d.Aliases()) > 0 {
+			target = d
+			break
+		}
+	}
+	if target.Name() == "" {
+		t.Fatal("no helper with aliases to check")
+	}
+
+	alias := target.Aliases()[0]
+	target.Aliases()[0] = "$mutated"
+	if got := target.Aliases()[0]; got != alias {
+		t.Fatalf("descriptor kept the edit: alias = %q, want %q", got, alias)
+	}
+
+	for _, d := range Helpers() {
+		if d.Name() != target.Name() {
+			continue
+		}
+		if got := d.Aliases()[0]; got != alias {
+			t.Fatalf("registry alias = %q, want %q", got, alias)
+		}
+	}
+	if _, err := Resolve(alias); err != nil {
+		t.Fatalf("Resolve(%q) after the edit: %v", alias, err)
+	}
+}
+
+// A new entry cannot ship broken: every helper renders from the form it
+// documents.
+func TestEveryHelperResolves(t *testing.T) {
+	t.Parallel()
+
+	for _, h := range builtins {
+		ref := h.name
+		if h.args.min > 0 {
+			ref = h.usage
+		}
+		out, err := Resolve(ref)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", ref, err)
+		}
+		if strings.TrimSpace(out) == "" {
+			t.Fatalf("Resolve(%q) returned nothing", ref)
+		}
+		if h.usage != "" {
+			if _, err := Resolve(h.usage); err != nil {
+				t.Fatalf("Resolve(%q): %v", h.usage, err)
+			}
+		}
+	}
+}
+
+func parseStamp(t *testing.T, ref, value string) time.Time {
+	t.Helper()
+
+	if strings.Contains(strings.ToLower(ref), "iso8601") {
+		stamp, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			t.Fatalf("Resolve(%q) = %q, want RFC3339", ref, value)
+		}
+		return stamp
+	}
+
+	unit := time.Second
+	if strings.Contains(strings.ToLower(ref), "ms") {
+		unit = time.Millisecond
+	}
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		t.Fatalf("Resolve(%q) = %q, want a number", ref, value)
+	}
+	return time.Unix(0, n*int64(unit))
+}

--- a/internal/vars/dynamic/fake.go
+++ b/internal/vars/dynamic/fake.go
@@ -1,0 +1,104 @@
+package dynamic
+
+import "strings"
+
+// Sample data for the $fake and $random helpers. Pools are plain ASCII so
+// generated names stay usable inside emails and hostnames. Request files are
+// executed, so helper output must never point a request at a real host or
+// mailbox: addresses and hosts stay under the RFC 2606 example domains, and
+// phone numbers inside the fictional 555-01xx block.
+
+var (
+	firstNames = []string{
+		"Ada", "Amara", "Anders", "Bianca", "Camille", "Dario", "Elena", "Farid",
+		"Grace", "Hugo", "Ines", "Jonas", "Keiko", "Lucas", "Maya", "Nadia",
+		"Omar", "Priya", "Quentin", "Rafael", "Sofia", "Tomas", "Uma", "Viktor",
+		"Wren", "Yusuf", "Zara",
+	}
+	lastNames = []string{
+		"Alvarez", "Bennett", "Castillo", "Dubois", "Eriksen", "Fontaine",
+		"Gallagher", "Haddad", "Ibarra", "Jensen", "Kowalski", "Laurent",
+		"Moreau", "Novak", "Okafor", "Petrov", "Quinn", "Ramirez", "Sorensen",
+		"Tanaka", "Vargas", "Whitfield", "Yilmaz", "Zhang",
+	}
+	companyNames = []string{
+		"Anchor", "Beacon", "Brightpath", "Cascade", "Cobalt", "Fieldstone",
+		"Harbor", "Ironwood", "Lakeside", "Meridian", "Northwind", "Pioneer",
+		"Redwood", "Silverline", "Summit", "Trailhead",
+	}
+	companySuffixes = []string{
+		"Analytics", "Foods", "Holdings", "Industries", "Labs", "Logistics",
+		"Media", "Partners", "Robotics", "Supply", "Systems", "Works",
+	}
+	cities = []string{
+		"Aarhus", "Bergen", "Cordoba", "Dresden", "Fukuoka", "Galway",
+		"Helsinki", "Innsbruck", "Jaipur", "Krakow", "Lucerne", "Maribor",
+		"Nantes", "Ostrava", "Porto", "Salerno", "Tampere", "Utrecht", "Valencia",
+	}
+	countries = []string{
+		"Argentina", "Belgium", "Canada", "Denmark", "Estonia", "Finland",
+		"Hungary", "Iceland", "Japan", "Kenya", "Latvia", "Malta", "Norway",
+		"Oman", "Peru", "Romania", "Slovenia", "Thailand", "Uruguay", "Vietnam",
+	}
+	words = []string{
+		"amber", "brisk", "cedar", "delta", "ember", "fjord", "glint", "harbor",
+		"ivory", "jetty", "kelp", "lumen", "marsh", "nimbus", "onyx", "pebble",
+		"quartz", "ripple", "spruce", "tide", "umber", "vellum", "willow", "zenith",
+	}
+	emailDomains = []string{"example.com", "example.net", "example.org"}
+)
+
+func fakeFirstName() string {
+	return pick(firstNames)
+}
+
+func fakeLastName() string {
+	return pick(lastNames)
+}
+
+func fakePerson() string {
+	return fakeFirstName() + " " + fakeLastName()
+}
+
+func fakeUsername() string {
+	return strings.ToLower(fakeFirstName()+fakeLastName()) + randomDigits(2)
+}
+
+func fakeEmail() string {
+	local := strings.ToLower(fakeFirstName() + "." + fakeLastName())
+	return local + randomDigits(2) + "@" + pick(emailDomains)
+}
+
+func fakeCompany() string {
+	return pick(companyNames) + " " + pick(companySuffixes)
+}
+
+func fakeDomain() string {
+	return strings.ToLower(pick(companyNames)) + ".example.com"
+}
+
+func fakeCity() string {
+	return pick(cities)
+}
+
+func fakeCountry() string {
+	return pick(countries)
+}
+
+func fakePhone() string {
+	return "+1-555-01" + randomDigits(2)
+}
+
+func fakeWord() string {
+	return pick(words)
+}
+
+func fakeSentence() string {
+	n := 4 + int(randUint64(5))
+	out := make([]string, n)
+	for i := range out {
+		out[i] = pick(words)
+	}
+	s := strings.Join(out, " ")
+	return strings.ToUpper(s[:1]) + s[1:] + "."
+}

--- a/internal/vars/dynamic/fake.go
+++ b/internal/vars/dynamic/fake.go
@@ -4,9 +4,9 @@ import "strings"
 
 // Sample data for the $fake and $random helpers. Pools are plain ASCII so
 // generated names stay usable inside emails and hostnames. Request files are
-// executed, so helper output must never point a request at a real host or
-// mailbox: addresses and hosts stay under the RFC 2606 example domains, and
-// phone numbers inside the fictional 555-01xx block.
+// executed, so helper output must never point a request at a real host,
+// mailbox or line: addresses and hosts stay under the RFC 2606 example
+// domains, and phone numbers inside the 555-01xx range reserved for fiction.
 
 var (
 	firstNames = []string{
@@ -46,6 +46,7 @@ var (
 		"quartz", "ripple", "spruce", "tide", "umber", "vellum", "willow", "zenith",
 	}
 	emailDomains = []string{"example.com", "example.net", "example.org"}
+	areaCodes    = []string{"202", "212", "213", "312", "415", "503", "617", "718"}
 )
 
 func fakeFirstName() string {
@@ -86,7 +87,7 @@ func fakeCountry() string {
 }
 
 func fakePhone() string {
-	return "+1-555-01" + randomDigits(2)
+	return "+1-" + pick(areaCodes) + "-555-01" + randomDigits(2)
 }
 
 func fakeWord() string {

--- a/internal/vars/dynamic/random.go
+++ b/internal/vars/dynamic/random.go
@@ -1,0 +1,69 @@
+package dynamic
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+)
+
+const alphanum = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// Helper output routinely ends up in signup payloads, tokens and idempotency
+// keys, so every value here comes from the system CSPRNG. crypto/rand.Read
+// cannot fail on a supported platform, so these primitives report no errors.
+
+func randUint64Full() uint64 {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return binary.BigEndian.Uint64(b[:])
+}
+
+// randUint64 returns a uniform value below n, which must be positive. Draws
+// that 2^64 does not divide evenly into n are redrawn, so a range as wide as
+// $randomInt(0, 9007199254740993) stays unbiased. Under half of draws are ever
+// rejected.
+func randUint64(n uint64) uint64 {
+	// -n is 2^64-n unsigned, so this is 2^64 mod n: the leading block of
+	// values one extra wrap of the modulo would favour.
+	reject := -n % n
+	for {
+		v := randUint64Full()
+		if v >= reject {
+			return v % n
+		}
+	}
+}
+
+// pick returns a random element of items, which must not be empty.
+func pick[T any](items []T) T {
+	return items[randUint64(uint64(len(items)))]
+}
+
+// randomString returns n characters from alphanum, dropping the bytes that
+// would skew the modulo.
+func randomString(n int) string {
+	const limit = 256 - 256%len(alphanum)
+
+	out := make([]byte, 0, n)
+	buf := make([]byte, n)
+	for len(out) < n {
+		_, _ = rand.Read(buf)
+		for _, b := range buf {
+			if int(b) >= limit {
+				continue
+			}
+			out = append(out, alphanum[int(b)%len(alphanum)])
+			if len(out) == n {
+				break
+			}
+		}
+	}
+	return string(out)
+}
+
+func randomDigits(n int) string {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte('0' + randUint64(10))
+	}
+	return string(out)
+}

--- a/internal/vars/dynamic/random_test.go
+++ b/internal/vars/dynamic/random_test.go
@@ -1,0 +1,57 @@
+package dynamic
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRandUint64StaysBelowN(t *testing.T) {
+	t.Parallel()
+
+	sizes := []uint64{1, 2, 6, 62, 1 << 32, 1<<62 + 1, math.MaxUint64/3 + 1, math.MaxUint64}
+	for _, n := range sizes {
+		for range 100 {
+			if got := randUint64(n); got >= n {
+				t.Fatalf("randUint64(%d) = %d, want below %d", n, got, got)
+			}
+		}
+	}
+}
+
+// A range 2^64 does not divide evenly is where plain modulo skews low.
+func TestRandUint64IsUnbiasedOnWideRanges(t *testing.T) {
+	t.Parallel()
+
+	const (
+		n     = math.MaxUint64/3*2 + 1 // one wrap covers this range once and a bit
+		draws = 4000
+	)
+	low := 0
+	for range draws {
+		if randUint64(n) < n/2 {
+			low++
+		}
+	}
+	// Plain modulo puts two thirds of the draws in the low half. Sampling
+	// noise is about 0.8%, so a 5% band cannot flake.
+	if low < draws*45/100 || low > draws*55/100 {
+		t.Fatalf("%d of %d draws landed in the low half, want about half", low, draws)
+	}
+}
+
+func TestRandomDigitsUsesEveryDigit(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[rune]bool, 10)
+	for range 500 {
+		for _, r := range randomDigits(4) {
+			if r < '0' || r > '9' {
+				t.Fatalf("randomDigits returned %q", r)
+			}
+			seen[r] = true
+		}
+	}
+	if len(seen) != 10 {
+		t.Fatalf("randomDigits produced %d distinct digits, want 10", len(seen))
+	}
+}

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -1,17 +1,12 @@
 package vars
 
 import (
-	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/big"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
-	"github.com/google/uuid"
-	"github.com/unkn0wn-root/resterm/internal/duration"
+	"github.com/unkn0wn-root/resterm/internal/vars/dynamic"
 )
 
 type Provider interface {
@@ -426,15 +421,21 @@ func (r *Resolver) resolveName(
 		if ok {
 			return value, nil
 		}
-		if dynamic, ok := resolveDynamic(name); ok {
+		// A name no helper claims falls through and is reported as undefined.
+		// Anything else is a misused helper, worth saying so.
+		built, err := dynamic.Resolve(name)
+		if err == nil {
 			r.traceVar(ResolveTrace{
 				Name:    name,
 				Source:  "dynamic",
-				Value:   dynamic,
+				Value:   built,
 				Dynamic: true,
 				Uses:    1,
 			})
-			return dynamic, nil
+			return built, nil
+		}
+		if !errors.Is(err, dynamic.ErrUnknown) {
+			return "", err
 		}
 	}
 	value, ok, err := r.resolve(name, pos, allowDynamic, allowExpr, st)
@@ -448,89 +449,11 @@ func (r *Resolver) resolveName(
 	return "", fmt.Errorf("%w: %s", ErrUndefinedVariable, name)
 }
 
-func resolveDynamic(name string) (string, bool) {
-	if base, offset, ok := splitDynamicOffset(name); ok {
-		return resolveDynamicBase(base, offset)
-	}
-	return resolveDynamicBase(name, 0)
-}
-
-// IsDynamic reports whether name identifies a supported dynamic template helper.
-// It defers to resolveDynamic so support and validation share one definition; the
-// generated value is discarded, which is why callers use it only at compile time.
-func IsDynamic(name string) bool {
-	_, ok := resolveDynamic(name)
-	return ok
-}
-
 func (r *Resolver) traceVar(it ResolveTrace) {
 	if r.trace == nil {
 		return
 	}
 	r.trace.Add(it)
-}
-
-func resolveDynamicBase(name string, offset time.Duration) (string, bool) {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "$timestamp":
-		return strconv.FormatInt(time.Now().Add(offset).Unix(), 10), true
-	case "$timestampms":
-		return strconv.FormatInt(time.Now().Add(offset).UnixMilli(), 10), true
-	case "$timestampiso8601":
-		return time.Now().Add(offset).UTC().Format(time.RFC3339), true
-	case "$randomint":
-		if offset != 0 {
-			return "", false
-		}
-		n, err := rand.Int(rand.Reader, big.NewInt(1<<62))
-		if err != nil {
-			return "", false
-		}
-		return n.String(), true
-	case "$uuid", "$guid":
-		if offset != 0 {
-			return "", false
-		}
-		id, err := uuid.NewRandom()
-		if err != nil {
-			return "", false
-		}
-		return id.String(), true
-	default:
-		return "", false
-	}
-}
-
-// splits "$helper +/- duration" into base name and signed offset.
-// "$timestampISO8601 - 90m" -> base "$timestampISO8601", offset -90m.
-func splitDynamicOffset(name string) (string, time.Duration, bool) {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
-		return "", 0, false
-	}
-	for opIdx := len(trimmed) - 1; opIdx > 0; opIdx-- {
-		ch := trimmed[opIdx]
-		if ch != '+' && ch != '-' {
-			continue
-		}
-		base := strings.TrimSpace(trimmed[:opIdx])
-		if base == "" {
-			continue
-		}
-		raw := strings.TrimSpace(trimmed[opIdx+1:])
-		if raw == "" {
-			continue
-		}
-		dur, ok := duration.Parse(raw)
-		if !ok {
-			continue
-		}
-		if ch == '-' {
-			dur = -dur
-		}
-		return base, dur, true
-	}
-	return "", 0, false
 }
 
 type MapProvider struct {

--- a/internal/vars/resolver_test.go
+++ b/internal/vars/resolver_test.go
@@ -180,27 +180,52 @@ func TestDynamicHelpersCaseInsensitive(t *testing.T) {
 	}
 }
 
-func TestIsDynamic(t *testing.T) {
+// A name that no helper claims stays an ordinary variable, so it is reported
+// as undefined instead of as a broken helper call.
+func TestUnknownDollarNameIsUndefined(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		want bool
-	}{
-		{name: "$uuid", want: true},
-		{name: "$TIMESTAMPISO8601 - 1h", want: true},
-		{name: "$guid + 0s", want: true},
-		{name: "$uuid + 1s", want: false},
-		{name: "$unknown", want: false},
-		{name: "$timestamp + missing", want: false},
+	resolver := NewResolver()
+	for _, input := range []string{"{{$unknown}}", "{{$my-custom-var + 1h}}", "{{$timestamp + missing}}"} {
+		out, err := resolver.ExpandTemplates(input)
+		if !errors.Is(err, ErrUndefinedVariable) {
+			t.Fatalf("%s: expected undefined variable, got %v", input, err)
+		}
+		if out != input {
+			t.Fatalf("%s: expected placeholder to stay literal, got %q", input, out)
+		}
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			if got := IsDynamic(test.name); got != test.want {
-				t.Fatalf("IsDynamic(%q) = %t, want %t", test.name, got, test.want)
-			}
-		})
+}
+
+// A recognised helper used the wrong way is a file error, not a missing
+// variable, so the message names the helper.
+func TestMisusedHelperReportsHelperError(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewResolver()
+	_, err := resolver.ExpandTemplates("{{$uuid + 1s}}")
+	if err == nil || errors.Is(err, ErrUndefinedVariable) {
+		t.Fatalf("expected a helper error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "$uuid") {
+		t.Fatalf("expected error to name the helper, got %v", err)
+	}
+}
+
+func TestDynamicHelperArguments(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewResolver()
+	out, err := resolver.ExpandTemplates(`{{$randomChoice("only")}}-{{$randomString(8)}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	choice, random, _ := strings.Cut(out, "-")
+	if choice != "only" {
+		t.Fatalf("expected the single option, got %q", choice)
+	}
+	if len(random) != 8 {
+		t.Fatalf("expected 8 random characters, got %q", random)
 	}
 }
 
@@ -243,36 +268,6 @@ func TestDynamicTimestampISOOffset(t *testing.T) {
 	max := end.Add(-1 * time.Hour).Unix()
 	if parsed.Unix() < min || parsed.Unix() > max {
 		t.Fatalf("expected %v to be between %d and %d", parsed, min, max)
-	}
-}
-
-func TestSplitDynamicOffsetNoSpace(t *testing.T) {
-	t.Parallel()
-
-	base, offset, ok := splitDynamicOffset("$timestampISO8601-1h")
-	if !ok {
-		t.Fatalf("expected offset parse to succeed")
-	}
-	if base != "$timestampISO8601" {
-		t.Fatalf("expected base to be $timestampISO8601, got %q", base)
-	}
-	if offset != -1*time.Hour {
-		t.Fatalf("expected -1h offset, got %v", offset)
-	}
-}
-
-func TestSplitDynamicOffsetHyphenatedBase(t *testing.T) {
-	t.Parallel()
-
-	base, offset, ok := splitDynamicOffset("$my-custom-var + 1h")
-	if !ok {
-		t.Fatalf("expected offset parse to succeed")
-	}
-	if base != "$my-custom-var" {
-		t.Fatalf("expected base to be $my-custom-var, got %q", base)
-	}
-	if offset != time.Hour {
-		t.Fatalf("expected 1h offset, got %v", offset)
 	}
 }
 


### PR DESCRIPTION
Adds the requested interpolation helpers and moves the built-ins off the hardcoded switch.

### What

New package `internal/vars/dynamic`. A helper is one entry declaring how it is called and what it returns:

```go
{
    name:    "$randomChoice",
    summary: "Random value from the given list",
    usage:   `$randomChoice("a", "b", "c")`,
    args:    arity{min: 1, max: -1},
    eval:    evalRandomChoice,
}
```

Parsing, arity checking, offset handling, error wording, completions and the docs list all follow from that entry. dynamic.go holds the types and the parser, builtins.go the table and evaluators, random.go and fake.go the primitives and sample data.

## New helpers

$randomString(n), $randomEmail, $randomName, $randomChoice(...), and the $fake.* family: person, firstName, lastName, email, username, company, domain, city, country, phone, word, sentence. $randomInt gained optional ranges $randomInt(100) and $randomInt(1, 6). Existing helpers are unchanged.