### PR TITLE
RST-321: mock latency distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The same files that hold your requests can serve HTTP mocks.
 
 - Match incoming requests by query, headers or JSON body, then pick a named or default response.
 - Model polling and retry flows with response sequences, including independent cursors per resource or caller.
+- Delay responses by a fixed amount, or give every request a different delay with `random`, `normal`, or `jitter`.
 - Build responses from path, query, header and body values, with generators for dynamic data.
 - Verify call counts with `@expect` or inspect received traffic from RestermScript.
 - Hot reload source files and fixtures, with optional TLS.

--- a/_examples/mocks.http
+++ b/_examples/mocks.http
@@ -25,6 +25,16 @@ X-Provider: sandbox
 
 {"id":"pay_123","status":"pending"}
 
+### Slow inventory lookup
+# random gives every request its own delay between the bounds. The other forms
+# are normal(mean,stddev) and jitter(base,spread), whose second argument may
+# also be a percentage, as in jitter(200ms,20%).
+# @mock method=GET path=/inventory latency=random(100ms,500ms)
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"sku":"widget","available":12}
+
 ### User fixture
 # @mock method=GET path=/users/{id} name=user default=true
 HTTP/1.1 200 OK
@@ -182,6 +192,10 @@ Content-Type: application/json
 ### Poll payment until it completes
 # @name poll-payment
 GET {{mock.base}}/payments/pay_42
+
+### Watch the inventory latency move between runs
+# @name fetch-inventory
+GET {{mock.base}}/inventory
 
 ### Spend the quota for one API key
 # @name spend-quota

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -859,11 +859,32 @@ resterm mock --source users.http,payments.http ./workspace
 - `sequence` names a response sequence and follows the same naming rules. It cannot be combined with `name`.
 - `sequence-key` optionally gives a sequence its own cursor per `path`, `query`, `header`, or `cookie` value. It requires `sequence`.
 - `default=true` marks the fallback for a route. A route can have at most one default, and a default cannot also have `@match` conditions.
-- `latency` accepts a non-negative Go duration such as `150ms` or `2s`. Waiting stops when the client cancels the request.
+- `latency` takes a non-negative duration such as `150ms` or `2s`, or a [distribution](#response-latency) that changes the delay from request to request. Waiting stops when the client cancels the request.
 - Response interpolation is enabled by default. Set `interpolate=false` to preserve `{{...}}` as literal response text.
 - The response status must be `200` through `599`. Repeated headers are preserved. Connection/framing headers such as `Content-Length`, `Transfer-Encoding`, and `Connection` are managed by the server and rejected in source files.
 - The body is literal text through the next `###`, or a single `< ./fixtures/body.json` file reference. Relative fixtures resolve from the declaring request file and participate in hot reload, but must remain within the selected request file's directory or workspace root. Absolute paths and paths or symlinks that escape that root are rejected.
 - `HEAD` returns the selected status and headers without a body. `204`, `205`, and `304` scenarios must not declare a body.
+
+### Response latency
+
+`latency=150ms` delays every response by the same amount. Real services are less predictable than that, so `latency` also takes a distribution, which gives each request a different delay. That is what makes a mock useful for testing client timeouts, retries, and backoff:
+
+```http
+# @mock method=GET path=/slow latency=random(100ms,500ms)
+# @mock method=GET path=/steady latency=normal(250ms,50ms)
+# @mock method=GET path=/jittery latency=jitter(200ms,20%)
+```
+
+| Form | Delay |
+| --- | --- |
+| `150ms` | The same every time. |
+| `random(min,max)` | Anywhere between the two bounds, evenly spread. `max` cannot be shorter than `min`. |
+| `normal(mean,stddev)` | Around `mean`, most of the time within `stddev` of it, occasionally further out. |
+| `jitter(base,spread)` | Anywhere between `base - spread` and `base + spread`. |
+
+Durations are written as they are everywhere else in Resterm: `250ms`, `1.5s`, `2m30s`. The second argument of `normal` and `jitter` can be a percentage of the first instead of a duration, so `jitter(200ms,20%)` stays between `160ms` and `240ms`, and `normal(250ms,20%)` spreads by `50ms`. When the numbers reach below zero, the response is not delayed at all.
+
+Spaces between arguments are fine, as in `random(100ms, 500ms)`, and the name is case-insensitive. A value that is neither a duration nor a known distribution is reported with the mock's other parse errors.
 
 ### Response interpolation
 

--- a/internal/delay/delay.go
+++ b/internal/delay/delay.go
@@ -1,0 +1,206 @@
+// Package delay parses the delay expressions used by mock latency, such as
+// 150ms, random(100ms,500ms), normal(250ms,50ms) or jitter(200ms,20%), and
+// draws waits from them.
+package delay
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/unkn0wn-root/resterm/internal/duration"
+)
+
+// Spec is one parsed delay expression; the zero value waits for nothing. What
+// base and spread hold depends on the kind: the constant wait, the bounds of
+// random, or a center and the deviation around it. A deviation written as a
+// percentage stays one so the text round-trips.
+type Spec struct {
+	kind   kind
+	base   time.Duration
+	spread time.Duration
+	pct    float64
+}
+
+func Fixed(d time.Duration) Spec {
+	return Spec{base: d}
+}
+
+// Parse reads a duration such as "150ms" or a call such as "random(100ms,500ms)".
+func Parse(raw string) (Spec, error) {
+	raw = strings.TrimSpace(raw)
+	name, args, isCall, err := splitCall(raw)
+	if err != nil {
+		return Spec{}, err
+	}
+	if !isCall {
+		d, ok := duration.Parse(raw)
+		switch {
+		case !ok:
+			return Spec{}, fmt.Errorf("must be a duration such as 150ms or a distribution: %s", formsHint)
+		case d < 0:
+			return Spec{}, errors.New("cannot be negative")
+		}
+		return Fixed(d), nil
+	}
+
+	k, f, ok := lookup(name)
+	if !ok {
+		return Spec{}, fmt.Errorf("%q is not a delay distribution: use %s", name, formsHint)
+	}
+	if len(args) != len(f.params) {
+		return Spec{}, fmt.Errorf(
+			"%s takes %d arguments, got %d: %s",
+			f.name, len(f.params), len(args), f.usage,
+		)
+	}
+
+	base, err := f.duration(0, args[0])
+	if err != nil {
+		return Spec{}, err
+	}
+	s := Spec{kind: k, base: base}
+	switch pct, relative, err := f.percent(1, args[1]); {
+	case err != nil:
+		return Spec{}, err
+	case relative:
+		s.pct = pct
+	default:
+		if s.spread, err = f.duration(1, args[1]); err != nil {
+			return Spec{}, err
+		}
+	}
+	if f.check != nil {
+		if err := f.check(s); err != nil {
+			return Spec{}, err
+		}
+	}
+	return s, nil
+}
+
+// Sample draws one wait. It is never negative and is safe for concurrent use.
+func (s Spec) Sample() time.Duration {
+	return s.draw(globalSource{})
+}
+
+func (s Spec) draw(r source) time.Duration {
+	return forms[s.kind].sample(s, r)
+}
+
+func (s Spec) IsZero() bool {
+	return s.kind == fixed && s.base <= 0
+}
+
+// String is the canonical expression, empty when there is no wait.
+func (s Spec) String() string {
+	f := forms[s.kind]
+	if f.name == "" {
+		if s.IsZero() {
+			return ""
+		}
+		return s.base.String()
+	}
+	return f.name + "(" + s.base.String() + "," + s.argText() + ")"
+}
+
+func (s Spec) argText() string {
+	if s.pct > 0 {
+		return strconv.FormatFloat(s.pct, 'f', -1, 64) + "%"
+	}
+	return s.spread.String()
+}
+
+func (s Spec) deviation() time.Duration {
+	if s.pct > 0 {
+		return clamp(float64(s.base) * s.pct / 100)
+	}
+	return s.spread
+}
+
+// The mock reload digest hashes parsed specs as JSON, so a spec has to encode
+// as the text it was written with.
+func (s Spec) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s *Spec) UnmarshalText(text []byte) error {
+	if len(bytes.TrimSpace(text)) == 0 {
+		*s = Spec{}
+		return nil
+	}
+	spec, err := Parse(string(text))
+	if err != nil {
+		return err
+	}
+	*s = spec
+	return nil
+}
+
+// Descriptor is one distribution as documentation and completions see it.
+type Descriptor struct {
+	name    string
+	summary string
+	usage   string
+}
+
+func (d Descriptor) Name() string {
+	return d.name
+}
+
+func (d Descriptor) Summary() string {
+	return d.summary
+}
+
+func (d Descriptor) Usage() string {
+	return d.usage
+}
+
+// Distributions describes the call forms, in documentation order.
+func Distributions() []Descriptor {
+	out := make([]Descriptor, 0, len(forms)-1)
+	for _, f := range forms {
+		if f.name != "" {
+			out = append(out, Descriptor{name: f.name, summary: f.summary, usage: f.usage})
+		}
+	}
+	return out
+}
+
+// A value without a trailing argument list is a plain duration, not a call.
+func splitCall(raw string) (name string, args []string, isCall bool, err error) {
+	head, tail, ok := strings.Cut(raw, "(")
+	if !ok {
+		return "", nil, false, nil
+	}
+	name = strings.TrimSpace(head)
+	rest, closed := strings.CutSuffix(tail, ")")
+	if !closed {
+		return "", nil, false, fmt.Errorf("%s is missing a closing \")\"", name)
+	}
+	if strings.TrimSpace(rest) == "" {
+		return name, nil, true, nil
+	}
+	args = strings.Split(rest, ",")
+	for i, arg := range args {
+		args[i] = strings.TrimSpace(arg)
+	}
+	return name, args, true, nil
+}
+
+var formsHint = describeForms()
+
+func describeForms() string {
+	usages := make([]string, 0, len(forms))
+	for _, f := range forms {
+		if f.usage != "" {
+			usages = append(usages, f.usage)
+		}
+	}
+	if last := len(usages) - 1; last > 0 {
+		usages[last] = "or " + usages[last]
+	}
+	return strings.Join(usages, ", ")
+}

--- a/internal/delay/delay.go
+++ b/internal/delay/delay.go
@@ -1,6 +1,6 @@
 // Package delay parses the delay expressions used by mock latency, such as
 // 150ms, random(100ms,500ms), normal(250ms,50ms) or jitter(200ms,20%), and
-// draws waits from them.
+// turns them into one delay per request.
 package delay
 
 import (
@@ -14,8 +14,8 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/duration"
 )
 
-// Spec is one parsed delay expression; the zero value waits for nothing. What
-// base and spread hold depends on the kind: the constant wait, the bounds of
+// Spec is one parsed delay expression; the zero value never delays. What base
+// and spread hold depends on the kind: the constant delay, the bounds of
 // random, or a center and the deviation around it. A deviation written as a
 // percentage stays one so the text round-trips.
 type Spec struct {
@@ -81,7 +81,8 @@ func Parse(raw string) (Spec, error) {
 	return s, nil
 }
 
-// Sample draws one wait. It is never negative and is safe for concurrent use.
+// Sample returns the delay for one request. It is never negative and is safe
+// for concurrent use.
 func (s Spec) Sample() time.Duration {
 	return s.draw(globalSource{})
 }
@@ -94,7 +95,7 @@ func (s Spec) IsZero() bool {
 	return s.kind == fixed && s.base <= 0
 }
 
-// String is the canonical expression, empty when there is no wait.
+// String is the canonical expression, empty when there is no delay.
 func (s Spec) String() string {
 	f := forms[s.kind]
 	if f.name == "" {

--- a/internal/delay/delay_test.go
+++ b/internal/delay/delay_test.go
@@ -1,0 +1,254 @@
+package delay
+
+import (
+	"encoding/json"
+	"math/rand/v2"
+	"strings"
+	"testing"
+	"time"
+)
+
+func draws(t *testing.T, s Spec, n int) []time.Duration {
+	t.Helper()
+	r := rand.New(rand.NewPCG(1, 2))
+	out := make([]time.Duration, n)
+	for i := range out {
+		out[i] = s.draw(r)
+	}
+	return out
+}
+
+func mustParse(t *testing.T, raw string) Spec {
+	t.Helper()
+	s, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", raw, err)
+	}
+	return s
+}
+
+func TestParseText(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: "150ms", want: "150ms"},
+		{input: " 2s ", want: "2s"},
+		{input: "1h30m", want: "1h30m0s"},
+		{input: "0", want: ""},
+		{input: "random(100ms,500ms)", want: "random(100ms,500ms)"},
+		{input: "random(100ms, 500ms)", want: "random(100ms,500ms)"},
+		{input: "RANDOM(1s,1s)", want: "random(1s,1s)"},
+		{input: "normal(250ms,50ms)", want: "normal(250ms,50ms)"},
+		{input: "normal(250ms,20%)", want: "normal(250ms,20%)"},
+		{input: "jitter(200ms,20%)", want: "jitter(200ms,20%)"},
+		{input: "jitter(200ms,12.5%)", want: "jitter(200ms,12.5%)"},
+		{input: "jitter(200ms,20ms)", want: "jitter(200ms,20ms)"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			s := mustParse(t, tc.input)
+			if got := s.String(); got != tc.want {
+				t.Fatalf("String() = %q, want %q", got, tc.want)
+			}
+			if tc.want == "" {
+				return
+			}
+			if again := mustParse(t, s.String()); again != s {
+				t.Fatalf("reparsed %#v, want %#v", again, s)
+			}
+		})
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: "must be a duration"},
+		{input: "soon", want: "must be a duration"},
+		{input: "-5ms", want: "cannot be negative"},
+		{input: "gauss(1ms,2ms)", want: `"gauss" is not a delay distribution`},
+		{input: "random(100ms,500ms", want: `missing a closing ")"`},
+		{input: "random(100ms)", want: "random takes 2 arguments, got 1"},
+		{input: "random(1ms,2ms,3ms)", want: "random takes 2 arguments, got 3"},
+		{input: "random()", want: "random takes 2 arguments, got 0"},
+		{input: "random(500ms,100ms)", want: "random max cannot be shorter than min"},
+		{input: "random(100ms,20%)", want: "random max must be a duration, not a percentage"},
+		{input: "random(soon,1s)", want: `random min "soon" is not a duration`},
+		{input: "random(-1s,1s)", want: "random min cannot be negative"},
+		{input: "normal(250ms,-10ms)", want: "normal stddev cannot be negative"},
+		{input: "normal(250ms,-5%)", want: "normal stddev cannot be negative"},
+		{input: "normal(250ms,NaN%)", want: `normal stddev "NaN%" is not a percentage`},
+		{input: "jitter(200ms,soon)", want: `jitter spread "soon" is not a duration`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			s, err := Parse(tc.input)
+			if err == nil {
+				t.Fatalf("Parse(%q) = %#v, want an error", tc.input, s)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSampleBounds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input    string
+		min, max time.Duration
+	}{
+		{input: "150ms", min: 150 * time.Millisecond, max: 150 * time.Millisecond},
+		{input: "random(100ms,500ms)", min: 100 * time.Millisecond, max: 500 * time.Millisecond},
+		{input: "jitter(200ms,20%)", min: 160 * time.Millisecond, max: 240 * time.Millisecond},
+		{input: "jitter(200ms,50ms)", min: 150 * time.Millisecond, max: 250 * time.Millisecond},
+		// A spread wider than the base only reaches down to no wait at all.
+		{input: "jitter(100ms,300%)", min: 0, max: 400 * time.Millisecond},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			for _, got := range draws(t, mustParse(t, tc.input), 2000) {
+				if got < tc.min || got > tc.max {
+					t.Fatalf("sample = %s, want within [%s, %s]", got, tc.min, tc.max)
+				}
+			}
+		})
+	}
+}
+
+func TestSampleNormalSpreadsAroundMean(t *testing.T) {
+	t.Parallel()
+
+	const n = 20000
+	samples := draws(t, mustParse(t, "normal(250ms,50ms)"), n)
+	var total time.Duration
+	tail := 0
+	for _, got := range samples {
+		if got < 0 {
+			t.Fatalf("sample = %s, want a non-negative wait", got)
+		}
+		total += got
+		if got < 200*time.Millisecond || got > 300*time.Millisecond {
+			tail++
+		}
+	}
+
+	if mean := total / n; mean < 245*time.Millisecond || mean > 255*time.Millisecond {
+		t.Fatalf("mean = %s, want it near 250ms", mean)
+	}
+	// About a third of a normal distribution sits beyond one deviation.
+	if tail < n/5 || tail > n/2 {
+		t.Fatalf("%d of %d samples fell outside one deviation", tail, n)
+	}
+}
+
+func TestSampleNormalNeverNegative(t *testing.T) {
+	t.Parallel()
+
+	for _, got := range draws(t, mustParse(t, "normal(10ms,50ms)"), 5000) {
+		if got < 0 {
+			t.Fatalf("sample = %s, want a non-negative wait", got)
+		}
+	}
+}
+
+func TestRelativeDeviationResolvesAgainstBase(t *testing.T) {
+	t.Parallel()
+
+	if got := mustParse(t, "normal(250ms,20%)").deviation(); got != 50*time.Millisecond {
+		t.Fatalf("deviation() = %s, want 50ms", got)
+	}
+	if got := mustParse(t, "jitter(1s,0.5%)").deviation(); got != 5*time.Millisecond {
+		t.Fatalf("deviation() = %s, want 5ms", got)
+	}
+}
+
+func TestFixed(t *testing.T) {
+	t.Parallel()
+
+	s := Fixed(150 * time.Millisecond)
+	if got := s.Sample(); got != 150*time.Millisecond {
+		t.Fatalf("Sample() = %s, want 150ms", got)
+	}
+	if s.IsZero() || s.String() != "150ms" {
+		t.Fatalf("unexpected spec %#v", s)
+	}
+
+	var zero Spec
+	if !zero.IsZero() || zero.String() != "" || zero.Sample() != 0 {
+		t.Fatalf("unexpected zero spec %#v", zero)
+	}
+	if got := Fixed(-time.Second).Sample(); got != 0 {
+		t.Fatalf("Sample() = %s, want no wait", got)
+	}
+}
+
+func TestMarshalText(t *testing.T) {
+	t.Parallel()
+
+	type holder struct {
+		Latency Spec
+	}
+	data, err := json.Marshal(holder{Latency: mustParse(t, "jitter(200ms,20%)")})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got, want := string(data), `{"Latency":"jitter(200ms,20%)"}`; got != want {
+		t.Fatalf("marshaled %s, want %s", got, want)
+	}
+
+	var back holder
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Latency != mustParse(t, "jitter(200ms,20%)") {
+		t.Fatalf("decoded %#v", back.Latency)
+	}
+
+	var empty holder
+	if err := json.Unmarshal([]byte(`{"Latency":""}`), &empty); err != nil {
+		t.Fatalf("unmarshal empty: %v", err)
+	}
+	if !empty.Latency.IsZero() {
+		t.Fatalf("decoded %#v, want the zero spec", empty.Latency)
+	}
+	if err := json.Unmarshal([]byte(`{"Latency":"gauss(1s,1s)"}`), &empty); err == nil {
+		t.Fatal("expected an error for an unknown distribution")
+	}
+}
+
+func TestDistributions(t *testing.T) {
+	t.Parallel()
+
+	forms := Distributions()
+	if len(forms) == 0 {
+		t.Fatal("no distributions described")
+	}
+	for _, f := range forms {
+		if f.Name() == "" || f.Summary() == "" {
+			t.Fatalf("incomplete descriptor %+v", f)
+		}
+		s := mustParse(t, f.Usage())
+		if s.String() != f.Usage() {
+			t.Fatalf("usage %q parsed as %q", f.Usage(), s)
+		}
+		if !strings.Contains(formsHint, f.Usage()) {
+			t.Fatalf("hint %q omits %q", formsHint, f.Usage())
+		}
+	}
+}

--- a/internal/delay/delay_test.go
+++ b/internal/delay/delay_test.go
@@ -115,7 +115,7 @@ func TestSampleBounds(t *testing.T) {
 		{input: "random(100ms,500ms)", min: 100 * time.Millisecond, max: 500 * time.Millisecond},
 		{input: "jitter(200ms,20%)", min: 160 * time.Millisecond, max: 240 * time.Millisecond},
 		{input: "jitter(200ms,50ms)", min: 150 * time.Millisecond, max: 250 * time.Millisecond},
-		// A spread wider than the base only reaches down to no wait at all.
+		// A spread wider than the base only reaches down to no delay at all.
 		{input: "jitter(100ms,300%)", min: 0, max: 400 * time.Millisecond},
 	}
 

--- a/internal/delay/forms.go
+++ b/internal/delay/forms.go
@@ -144,7 +144,7 @@ func (globalSource) NormFloat64() float64 { return rand.NormFloat64() }
 
 const maxDurationFloat = float64(math.MaxInt64)
 
-// clamp keeps a draw inside the duration range; below zero nothing is left to wait for.
+// clamp keeps a sampled value inside the duration range; below zero there is no delay.
 func clamp(v float64) time.Duration {
 	switch {
 	case v <= 0:

--- a/internal/delay/forms.go
+++ b/internal/delay/forms.go
@@ -1,0 +1,156 @@
+package delay
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/unkn0wn-root/resterm/internal/duration"
+)
+
+type kind uint8
+
+const (
+	fixed kind = iota
+	random
+	normal
+	jitter
+)
+
+type form struct {
+	name     string // empty for a bare duration, which is not a call
+	params   [2]string
+	summary  string
+	usage    string
+	relative bool // the deviation may be a percentage of base
+	check    func(Spec) error
+	sample   func(Spec, source) time.Duration
+}
+
+// Every call form takes a base value and a deviation from it. The table is
+// indexed by kind, so a new distribution is one constant above, one entry
+// here, and a sampler.
+var forms = [...]form{
+	fixed: {sample: sampleFixed},
+	random: {
+		name:    "random",
+		params:  [2]string{"min", "max"},
+		summary: "Uniform wait between two bounds",
+		usage:   "random(100ms,500ms)",
+		check:   checkRandom,
+		sample:  sampleRandom,
+	},
+	normal: {
+		name:     "normal",
+		params:   [2]string{"mean", "stddev"},
+		summary:  "Normally distributed wait around a mean",
+		usage:    "normal(250ms,50ms)",
+		relative: true,
+		sample:   sampleNormal,
+	},
+	jitter: {
+		name:     "jitter",
+		params:   [2]string{"base", "spread"},
+		summary:  "Uniform wait within a spread of a base value",
+		usage:    "jitter(200ms,20%)",
+		relative: true,
+		sample:   sampleJitter,
+	},
+}
+
+func lookup(name string) (kind, form, bool) {
+	for i, f := range forms {
+		if f.name != "" && strings.EqualFold(f.name, name) {
+			return kind(i), f, true
+		}
+	}
+	return fixed, form{}, false
+}
+
+func (f form) duration(i int, raw string) (time.Duration, error) {
+	d, ok := duration.Parse(raw)
+	switch {
+	case !ok:
+		return 0, fmt.Errorf("%s %s %q is not a duration", f.name, f.params[i], raw)
+	case d < 0:
+		return 0, fmt.Errorf("%s %s cannot be negative", f.name, f.params[i])
+	}
+	return d, nil
+}
+
+// A value without the percent sign belongs to duration, so the only failure
+// here is a percentage written where the form does not take one.
+func (f form) percent(i int, raw string) (float64, bool, error) {
+	text, ok := strings.CutSuffix(raw, "%")
+	if !ok {
+		return 0, false, nil
+	}
+	if !f.relative {
+		return 0, false, fmt.Errorf("%s %s must be a duration, not a percentage", f.name, f.params[i])
+	}
+	pct, err := strconv.ParseFloat(strings.TrimSpace(text), 64)
+	switch {
+	case err != nil || math.IsNaN(pct) || math.IsInf(pct, 0):
+		return 0, false, fmt.Errorf("%s %s %q is not a percentage", f.name, f.params[i], raw)
+	case pct < 0:
+		return 0, false, fmt.Errorf("%s %s cannot be negative", f.name, f.params[i])
+	}
+	return pct, true, nil
+}
+
+func checkRandom(s Spec) error {
+	if s.spread < s.base {
+		return errors.New("random max cannot be shorter than min")
+	}
+	return nil
+}
+
+func sampleFixed(s Spec, _ source) time.Duration {
+	return max(s.base, 0)
+}
+
+func sampleRandom(s Spec, r source) time.Duration {
+	lo, hi := s.base, s.spread
+	return clamp(float64(lo) + float64(hi-lo)*r.Float64())
+}
+
+func sampleNormal(s Spec, r source) time.Duration {
+	mean, stddev := s.base, s.deviation()
+	return clamp(float64(mean) + float64(stddev)*r.NormFloat64())
+}
+
+func sampleJitter(s Spec, r source) time.Duration {
+	center, spread := s.base, s.deviation()
+	return clamp(float64(center) + float64(spread)*(2*r.Float64()-1))
+}
+
+// Tests seed their own source instead of the global one below.
+type source interface {
+	Float64() float64
+	NormFloat64() float64
+}
+
+// The top level math/rand/v2 functions are safe for concurrent use, which the
+// mock server needs. A wait is not security sensitive.
+type globalSource struct{}
+
+func (globalSource) Float64() float64 { return rand.Float64() }
+
+func (globalSource) NormFloat64() float64 { return rand.NormFloat64() }
+
+const maxDurationFloat = float64(math.MaxInt64)
+
+// clamp keeps a draw inside the duration range; below zero nothing is left to wait for.
+func clamp(v float64) time.Duration {
+	switch {
+	case v <= 0:
+		return 0
+	case v >= maxDurationFloat:
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(v)
+}

--- a/internal/directive/lexer.go
+++ b/internal/directive/lexer.go
@@ -6,7 +6,8 @@ import (
 	"unicode/utf8"
 )
 
-// Fields keeps quoted values and bracketed JSON after an equals sign together.
+// Fields keeps quoted values together, as well as the bracketed JSON and the
+// call arguments that follow an equals sign.
 // Quotes used to group a value are not included in the returned field.
 func Fields(input string) []string {
 	return (&lexer{src: input}).collect()
@@ -34,7 +35,18 @@ type lexer struct {
 	closers  []rune
 	inString bool
 	strEsc   bool
+	state    nameState
 }
+
+// nameState tracks how much of the token still reads as a name, which is what
+// tells an argument list from a value that merely holds a parenthesis.
+type nameState uint8
+
+const (
+	inKey  nameState = iota // before the equals sign
+	inName                  // every rune of the value so far is a name rune
+	inText                  // the value holds something a name cannot
+)
 
 // A token carries the span it came from because meaning depends on the source.
 // "a=b" and a=b decode to the same text and only one of them is an option.
@@ -63,7 +75,7 @@ func (l *lexer) next() (token, bool) {
 		}
 		switch {
 		case len(l.closers) > 0:
-			l.json(r)
+			l.group(r)
 		case l.escaped:
 			l.escaped = false
 			// Anything else inside quotes keeps the backslash it was typed with,
@@ -80,7 +92,7 @@ func (l *lexer) next() (token, bool) {
 				break
 			}
 			l.write(r)
-		case (r == '[' || r == '{') && l.last == '=':
+		case l.opens(r):
 			l.write(r)
 			l.push(r)
 		case (r == '"' || r == '\'') && l.startsValue():
@@ -91,6 +103,7 @@ func (l *lexer) next() (token, bool) {
 				return token{val: l.tok.String(), start: l.start, end: base + i}, true
 			}
 		default:
+			l.name(r)
 			l.write(r)
 		}
 	}
@@ -114,6 +127,7 @@ func (l *lexer) reset() {
 	l.closers = l.closers[:0]
 	l.inString = false
 	l.strEsc = false
+	l.state = inKey
 }
 
 func (l *lexer) write(r rune) {
@@ -121,14 +135,37 @@ func (l *lexer) write(r rune) {
 	l.last = r
 }
 
+// A value opens a group when a bracket follows the equals sign, or when an
+// argument list follows a name: headers={"a":"b"} and latency=random(1s,2s).
+func (l *lexer) opens(r rune) bool {
+	switch r {
+	case '[', '{':
+		return l.last == '='
+	case '(':
+		return l.state == inName && l.last != '='
+	}
+	return false
+}
+
+func (l *lexer) name(r rune) {
+	switch {
+	case l.state == inKey:
+		if r == '=' && l.tok.Len() > 0 {
+			l.state = inName
+		}
+	case l.state == inName && !IsKeyRune(r):
+		l.state = inText
+	}
+}
+
 // A quote groups a value when it opens the token or follows the equals sign.
 func (l *lexer) startsValue() bool {
 	return l.tok.Len() == 0 || l.last == '='
 }
 
-// Brackets inside JSON strings are ordinary characters. Outside strings we
-// track nesting, but leave mismatched brackets for the value parser to reject.
-func (l *lexer) json(r rune) {
+// Delimiters inside JSON strings are ordinary characters. Outside strings we
+// track nesting, but leave mismatched ones for the value parser to reject.
+func (l *lexer) group(r rune) {
 	l.write(r)
 	switch {
 	case l.inString:
@@ -142,11 +179,15 @@ func (l *lexer) json(r rune) {
 		}
 	case r == '"':
 		l.inString = true
-	case r == '[' || r == '{':
+	case isOpener(r):
 		l.push(r)
 	default:
 		l.pop(r)
 	}
+}
+
+func isOpener(r rune) bool {
+	return r == '[' || r == '{' || r == '('
 }
 
 func (l *lexer) push(r rune) {
@@ -155,6 +196,8 @@ func (l *lexer) push(r rune) {
 		l.closers = append(l.closers, ']')
 	case '{':
 		l.closers = append(l.closers, '}')
+	case '(':
+		l.closers = append(l.closers, ')')
 	}
 }
 

--- a/internal/directive/lexer_test.go
+++ b/internal/directive/lexer_test.go
@@ -53,6 +53,31 @@ func TestFields(t *testing.T) {
 			input: "  a \t b  ",
 			want:  []string{"a", "b"},
 		},
+		{
+			name:  "argument list keeps its spaces",
+			input: "latency=random(100ms, 500ms) name=slow",
+			want:  []string{"latency=random(100ms, 500ms)", "name=slow"},
+		},
+		{
+			name:  "nested argument list",
+			input: "a=f(g(1, 2), 3) b",
+			want:  []string{"a=f(g(1, 2), 3)", "b"},
+		},
+		{
+			name:  "parenthesis in a plain value is ordinary text",
+			input: "path=/x(y z=1",
+			want:  []string{"path=/x(y", "z=1"},
+		},
+		{
+			name:  "parenthesis without a name is ordinary text",
+			input: "a=(x y)",
+			want:  []string{"a=(x", "y)"},
+		},
+		{
+			name:  "unclosed argument list runs to the end",
+			input: "latency=random(100ms name=slow",
+			want:  []string{"latency=random(100ms name=slow"},
+		},
 		{name: "empty"},
 	}
 

--- a/internal/helpdoc/topics/mocks.md
+++ b/internal/helpdoc/topics/mocks.md
@@ -12,4 +12,6 @@ Content-Type: application/json
 
 Select responses conditionally with `@match`, chain them with `sequence=`, and assert call counts with `@expect`. Useful commands are `:mock start`, `:mock logs`, `:mock reset`, and `:mock verify`.
 
+`latency=250ms` delays every response by the same amount. To test timeouts and retries against something less even, draw a new wait per request with `latency=random(100ms,500ms)`, `latency=normal(250ms,50ms)`, or `latency=jitter(200ms,20%)`.
+
 `:mock start` serves the whole workspace. Narrow it to named files with `:mock start --source users.http,payments.http`, widen it again with `:mock restart --all`, and check the active scope with `:mock status`. The scope is remembered like the address, so a restart or a later start keeps serving the same files with the same recursion.

--- a/internal/helpdoc/topics/mocks.md
+++ b/internal/helpdoc/topics/mocks.md
@@ -12,6 +12,6 @@ Content-Type: application/json
 
 Select responses conditionally with `@match`, chain them with `sequence=`, and assert call counts with `@expect`. Useful commands are `:mock start`, `:mock logs`, `:mock reset`, and `:mock verify`.
 
-`latency=250ms` delays every response by the same amount. To test timeouts and retries against something less even, draw a new wait per request with `latency=random(100ms,500ms)`, `latency=normal(250ms,50ms)`, or `latency=jitter(200ms,20%)`.
+`latency=250ms` delays every response by the same amount. To test timeouts and retries against something less even, give each request its own delay with `latency=random(100ms,500ms)`, `latency=normal(250ms,50ms)`, or `latency=jitter(200ms,20%)`.
 
 `:mock start` serves the whole workspace. Narrow it to named files with `:mock start --source users.http,payments.http`, widen it again with `:mock restart --all`, and check the active scope with `:mock status`. The scope is remembered like the address, so a restart or a later start keeps serving the same files with the same recursion.

--- a/internal/intellisense/directives.go
+++ b/internal/intellisense/directives.go
@@ -53,13 +53,14 @@ func mockItems() []Item {
 			CursorBack: len("250ms"),
 		},
 	}
-	// No placeholder: one always runs to the end of the inserted text, so
-	// typing over the arguments would take the closing parenthesis with them.
 	for _, d := range delay.Distributions() {
+		usage := d.Usage()
+		args := usage[strings.Index(usage, "(")+1:]
 		items = append(items, Item{
-			Label:   "latency=" + d.Name(),
-			Summary: d.Summary(),
-			Insert:  "latency=" + d.Usage(),
+			Label:      "latency=" + d.Name(),
+			Summary:    d.Summary(),
+			Insert:     "latency=" + usage,
+			CursorBack: len(args),
 		})
 	}
 	return append(items, Item{

--- a/internal/intellisense/directives.go
+++ b/internal/intellisense/directives.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/unkn0wn-root/resterm/internal/delay"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 )
 
@@ -27,6 +28,44 @@ func directiveItems() []Item {
 		}
 	}
 	return items
+}
+
+var mockArgs = mockItems()
+
+// The latency suggestions mirror the delay registry, so a new distribution
+// needs no second list here.
+func mockItems() []Item {
+	items := []Item{
+		{Label: "method=", Summary: "HTTP method to match", Insert: "method=GET"},
+		{Label: "path=", Summary: "Origin-form route path", Insert: "path=/resource"},
+		{Label: "name=", Summary: "Scenario selector name", Insert: "name=success"},
+		{Label: "sequence=", Summary: "Response sequence name", Insert: "sequence=polling"},
+		{
+			Label:   "sequence-key=",
+			Summary: "Per-key cursor source (path, query, header, or cookie)",
+			Insert:  "sequence-key=path.id",
+		},
+		{Label: "default=true", Summary: "Use as the route fallback"},
+		{
+			Label:      "latency=",
+			Summary:    "Constant response latency",
+			Insert:     "latency=250ms",
+			CursorBack: len("250ms"),
+		},
+	}
+	// No placeholder: one always runs to the end of the inserted text, so
+	// typing over the arguments would take the closing parenthesis with them.
+	for _, d := range delay.Distributions() {
+		items = append(items, Item{
+			Label:   "latency=" + d.Name(),
+			Summary: d.Summary(),
+			Insert:  "latency=" + d.Usage(),
+		})
+	}
+	return append(items, Item{
+		Label:   "interpolate=false",
+		Summary: "Preserve response template syntax literally",
+	})
 }
 
 var scriptArgs = []Item{
@@ -174,20 +213,7 @@ var settingArgs = []Item{
 
 // directiveArgs maps a directive base key to its option/sub-token suggestions.
 var directiveArgs = map[directive.Name][]Item{
-	directive.Mock: {
-		{Label: "method=", Summary: "HTTP method to match", Insert: "method=GET"},
-		{Label: "path=", Summary: "Origin-form route path", Insert: "path=/resource"},
-		{Label: "name=", Summary: "Scenario selector name", Insert: "name=success"},
-		{Label: "sequence=", Summary: "Response sequence name", Insert: "sequence=polling"},
-		{
-			Label:   "sequence-key=",
-			Summary: "Per-key cursor source (path, query, header, or cookie)",
-			Insert:  "sequence-key=path.id",
-		},
-		{Label: "default=true", Summary: "Use as the route fallback"},
-		{Label: "latency=", Summary: "Fixed response latency", Insert: "latency=250ms"},
-		{Label: "interpolate=false", Summary: "Preserve response template syntax literally"},
-	},
+	directive.Mock: mockArgs,
 	directive.Match: {
 		{Label: "query=", Summary: "Query matcher rules as JSON", Insert: `query={"key":"value"}`},
 		{Label: "headers=", Summary: "Header matcher rules as JSON", Insert: `headers={"X-Key":"value"}`},

--- a/internal/intellisense/directives_test.go
+++ b/internal/intellisense/directives_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/unkn0wn-root/resterm/internal/delay"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 )
 
@@ -107,6 +108,32 @@ func TestDirectiveArgsFilterByPrefix(t *testing.T) {
 
 	if opts := argOptions("unknown", ""); opts != nil {
 		t.Fatalf("expected nil for unknown directive, got %v", opts)
+	}
+}
+
+func TestMockLatencyArgsCoverEveryDistribution(t *testing.T) {
+	mock := argOptions("mock", "latency")
+	if !contains(mock, "latency=") {
+		t.Fatalf("mock args missing the constant latency: %v", mock)
+	}
+	for _, d := range delay.Distributions() {
+		label := "latency=" + d.Name()
+		found := false
+		for _, it := range mock {
+			if it.Label != label {
+				continue
+			}
+			found = true
+			if it.Insert != "latency="+d.Usage() {
+				t.Fatalf("%s inserts %q, want the %q example", label, it.Insert, d.Usage())
+			}
+			if it.CursorBack != 0 {
+				t.Fatalf("%s selects its last %d runes, want no placeholder", label, it.CursorBack)
+			}
+		}
+		if !found {
+			t.Fatalf("mock args missing %q: %v", label, mock)
+		}
 	}
 }
 

--- a/internal/intellisense/directives_test.go
+++ b/internal/intellisense/directives_test.go
@@ -127,8 +127,9 @@ func TestMockLatencyArgsCoverEveryDistribution(t *testing.T) {
 			if it.Insert != "latency="+d.Usage() {
 				t.Fatalf("%s inserts %q, want the %q example", label, it.Insert, d.Usage())
 			}
-			if it.CursorBack != 0 {
-				t.Fatalf("%s selects its last %d runes, want no placeholder", label, it.CursorBack)
+			args, _ := strings.CutPrefix(d.Usage(), d.Name()+"(")
+			if it.CursorBack != len(args) {
+				t.Fatalf("%s selects %d runes, want the %q arguments", label, it.CursorBack, args)
 			}
 		}
 		if !found {

--- a/internal/mock/compile.go
+++ b/internal/mock/compile.go
@@ -107,8 +107,6 @@ func (c *compiler) newVariant(
 		return nil, err
 	}
 	switch {
-	case spec.Latency < 0:
-		return nil, errors.New("mock latency cannot be negative")
 	case spec.Name != "" && !restfile.ValidMockName(spec.Name):
 		return nil, errors.New("invalid mock scenario name")
 	case spec.Sequence != "" && !restfile.ValidMockName(spec.Sequence):

--- a/internal/mock/mock_test.go
+++ b/internal/mock/mock_test.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -69,6 +70,32 @@ user`)
 		http.StatusNotFound,
 		"not found",
 	)
+}
+
+func TestLatencyDistributionDelaysTheResponse(t *testing.T) {
+	handler := compileSource(t, `# @mock method=GET path=/x latency=random(20ms, 30ms)
+HTTP/1.1 200 OK
+
+slow`)
+
+	// Only the lower bound is asserted. A busy machine can take longer than the
+	// draw, but it cannot answer before the mock waited.
+	start := time.Now()
+	assertResponse(t, handler, httptest.NewRequest(http.MethodGet, "/x", nil), http.StatusOK, "slow")
+	if elapsed := time.Since(start); elapsed < 20*time.Millisecond {
+		t.Fatalf("served after %s, want at least the 20ms lower bound", elapsed)
+	}
+}
+
+func TestDigestFollowsLatency(t *testing.T) {
+	source := "# @mock method=GET path=/x latency=%s\nHTTP/1.1 200 OK\n\nok"
+	fixed := compileSource(t, fmt.Sprintf(source, "100ms"))
+	spread := compileSource(t, fmt.Sprintf(source, "random(100ms,500ms)"))
+	wider := compileSource(t, fmt.Sprintf(source, "random(100ms,900ms)"))
+
+	if fixed.Digest() == spread.Digest() || spread.Digest() == wider.Digest() {
+		t.Fatalf("digests match: %s %s %s", fixed.Digest(), spread.Digest(), wider.Digest())
+	}
 }
 
 func TestCompileRejectsInvalidMocks(t *testing.T) {

--- a/internal/mock/mock_test.go
+++ b/internal/mock/mock_test.go
@@ -79,7 +79,7 @@ HTTP/1.1 200 OK
 slow`)
 
 	// Only the lower bound is asserted. A busy machine can take longer than the
-	// draw, but it cannot answer before the mock waited.
+	// delay, but it cannot answer before the mock waited.
 	start := time.Now()
 	assertResponse(t, handler, httptest.NewRequest(http.MethodGet, "/x", nil), http.StatusOK, "slow")
 	if elapsed := time.Since(start); elapsed < 20*time.Millisecond {

--- a/internal/mock/route.go
+++ b/internal/mock/route.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/delay"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
@@ -30,7 +31,7 @@ type variant struct {
 	name            string
 	sequence        string
 	def             bool
-	latency         time.Duration
+	latency         delay.Spec
 	matchers        []matcher
 	responses       []response
 	pathParams      map[string]string
@@ -82,8 +83,8 @@ func (rt *route) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		event.SequenceTotal = total
 	}
 
-	if v.latency > 0 {
-		timer := time.NewTimer(v.latency)
+	if wait := v.latency.Sample(); wait > 0 {
+		timer := time.NewTimer(wait)
 		defer timer.Stop()
 		select {
 		case <-timer.C:

--- a/internal/parser/mock.go
+++ b/internal/parser/mock.go
@@ -7,10 +7,10 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"golang.org/x/net/http/httpguts"
 
+	"github.com/unkn0wn-root/resterm/internal/delay"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/util"
@@ -43,7 +43,7 @@ type mockBuilder struct {
 	name                 string
 	sequence             string
 	sequenceKey          restfile.MockSequenceKey
-	latency              time.Duration
+	latency              delay.Spec
 	isDefault            bool
 	disableInterpolation bool
 	match                restfile.MockMatch
@@ -120,11 +120,11 @@ func (b *documentBuilder) startMock(line int, raw string) {
 		m.isDefault = v
 	}
 	if raw, ok := vals.Lookup("latency"); ok {
-		v, err := time.ParseDuration(strings.TrimSpace(raw))
-		if err != nil || v < 0 {
-			b.addMockError(line, "@mock latency must be a non-negative Go duration")
+		spec, err := delay.Parse(raw)
+		if err != nil {
+			b.addMockError(line, "@mock latency "+err.Error())
 		} else {
-			m.latency = v
+			m.latency = spec
 		}
 	}
 	if v, ok := b.mockBool(line, vals, "interpolate"); ok {

--- a/internal/parser/mock_test.go
+++ b/internal/parser/mock_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/delay"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -38,7 +39,7 @@ GET https://example.com
 	if m.Title != "Payment accepted" || m.Method != "POST" || m.Path != "/payments" {
 		t.Fatalf("unexpected mock route: %+v", m)
 	}
-	if m.Name != "accepted" || !m.Default || m.Latency != 250*time.Millisecond {
+	if m.Name != "accepted" || !m.Default || m.Latency != delay.Fixed(250*time.Millisecond) {
 		t.Fatalf("unexpected mock options: %+v", m)
 	}
 	if len(m.Responses) != 1 {
@@ -64,6 +65,99 @@ GET https://example.com
 	}
 	if string(m.Match.JSONRules) != `{"score":{"gte":10}}` {
 		t.Fatalf("json-rules matcher = %s", m.Match.JSONRules)
+	}
+}
+
+func TestParseMockLatency(t *testing.T) {
+	tests := []struct {
+		name   string
+		option string
+		want   string
+	}{
+		{name: "fixed", option: "latency=150ms", want: "150ms"},
+		{name: "random", option: "latency=random(100ms,500ms)", want: "random(100ms,500ms)"},
+		{name: "normal", option: "latency=normal(250ms,50ms)", want: "normal(250ms,50ms)"},
+		{name: "jitter", option: "latency=jitter(200ms,20%)", want: "jitter(200ms,20%)"},
+		// The lexer keeps an argument list together, so the space neither splits
+		// the value nor swallows the option after it.
+		{name: "spaced arguments", option: "latency=random(100ms, 500ms)", want: "random(100ms,500ms)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := "# @mock method=GET path=/x " + tt.option + " name=slow\nHTTP/1.1 200 OK\n"
+			doc := Parse("mocks.http", []byte(src))
+			if len(doc.Errors) != 0 {
+				t.Fatalf("parse errors: %+v", doc.Errors)
+			}
+			if len(doc.Mocks) != 1 {
+				t.Fatalf("mocks = %d, want 1", len(doc.Mocks))
+			}
+			m := doc.Mocks[0]
+			if got := m.Latency.String(); got != tt.want {
+				t.Fatalf("latency = %q, want %q", got, tt.want)
+			}
+			if m.Name != "slow" {
+				t.Fatalf("name = %q, want the option after the latency", m.Name)
+			}
+		})
+	}
+}
+
+func TestParseMockLatencyDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		option string
+		want   string
+	}{
+		{
+			name:   "not a duration",
+			option: "latency=soon",
+			want:   "@mock latency must be a duration such as 150ms",
+		},
+		{
+			name:   "negative",
+			option: "latency=-5ms",
+			want:   "@mock latency cannot be negative",
+		},
+		{
+			name:   "unknown distribution",
+			option: "latency=gauss(1s,2s)",
+			want:   `@mock latency "gauss" is not a delay distribution`,
+		},
+		{
+			name:   "inverted bounds",
+			option: "latency=random(500ms,100ms)",
+			want:   "@mock latency random max cannot be shorter than min",
+		},
+		{
+			name:   "percentage bound",
+			option: "latency=random(100ms,20%)",
+			want:   "@mock latency random max must be a duration, not a percentage",
+		},
+		{
+			name:   "unclosed call",
+			option: "latency=jitter(200ms,20%",
+			want:   `@mock latency jitter is missing a closing ")"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := "# @mock method=GET path=/x " + tt.option + "\nHTTP/1.1 200 OK\n"
+			doc := Parse("bad.http", []byte(src))
+			found := false
+			for _, err := range doc.Errors {
+				if strings.Contains(err.Message, tt.want) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("errors=%+v, want %q", doc.Errors, tt.want)
+			}
+			if !doc.Mocks[0].Latency.IsZero() {
+				t.Fatalf("latency = %q, want none", doc.Mocks[0].Latency)
+			}
+		})
 	}
 }
 

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/delay"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 )
 
@@ -96,7 +97,7 @@ type Mock struct {
 	SequenceKey MockSequenceKey
 	Method      string
 	Path        string
-	Latency     time.Duration
+	Latency     delay.Spec
 	Default     bool
 	Match       MockMatch
 	Expectation *MockExpectation

--- a/internal/restwriter/mock.go
+++ b/internal/restwriter/mock.go
@@ -70,8 +70,8 @@ func (w mockWriter) writeDeclaration(m *restfile.Mock) {
 	if m.Default {
 		w.option("default", "true")
 	}
-	if m.Latency > 0 {
-		w.option("latency", m.Latency.String())
+	if latency := m.Latency.String(); latency != "" {
+		w.option("latency", latency)
 	}
 	if m.DisableInterpolation {
 		w.option("interpolate", "false")

--- a/internal/restwriter/mock_test.go
+++ b/internal/restwriter/mock_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/delay"
 	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
@@ -18,7 +19,7 @@ func TestRenderMocksRoundTrip(t *testing.T) {
 			Method:  http.MethodPost,
 			Path:    "/payments",
 			Default: true,
-			Latency: 250 * time.Millisecond,
+			Latency: delay.Fixed(250 * time.Millisecond),
 			Match: restfile.MockMatch{
 				Query: map[string]restfile.MockQueryRule{
 					"mode": {Op: restfile.MockOpExact, Values: []string{"test"}},
@@ -71,6 +72,35 @@ func TestRenderMocksRoundTrip(t *testing.T) {
 	}
 	if got := parsed.Mocks[1].Responses[0].Body.FilePath; got != "./fixtures/data.json" {
 		t.Fatalf("fixture path = %q", got)
+	}
+}
+
+func TestRenderMockLatencyRoundTrip(t *testing.T) {
+	for _, latency := range []string{
+		"150ms",
+		"random(100ms,500ms)",
+		"normal(250ms,50ms)",
+		"jitter(200ms,20%)",
+	} {
+		t.Run(latency, func(t *testing.T) {
+			source := "# @mock method=GET path=/x latency=" + latency + "\nHTTP/1.1 200 OK\n\nok\n"
+			parsed := parser.Parse("mocks.http", []byte(source))
+			if len(parsed.Errors) != 0 {
+				t.Fatalf("parse errors: %+v", parsed.Errors)
+			}
+
+			rendered := mustRender(t, parsed)
+			if !strings.Contains(rendered, "latency="+latency) {
+				t.Fatalf("rendered latency is not %q:\n%s", latency, rendered)
+			}
+			again := parser.Parse("generated.http", []byte(rendered))
+			if len(again.Errors) != 0 {
+				t.Fatalf("round-trip errors: %+v\n%s", again.Errors, rendered)
+			}
+			if got := again.Mocks[0].Latency; got != parsed.Mocks[0].Latency {
+				t.Fatalf("round-trip latency = %q, want %q", got, parsed.Mocks[0].Latency)
+			}
+		})
 	}
 }
 

--- a/internal/ui/editor_state_test.go
+++ b/internal/ui/editor_state_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/unkn0wn-root/resterm/internal/intellisense"
+	"github.com/unkn0wn-root/resterm/internal/parser"
 )
 
 func newTestEditor(content string) requestEditor {
@@ -2043,5 +2044,44 @@ func TestRequestEditorExitSearchMode(t *testing.T) {
 	}
 	if editor.search.index != 0 {
 		t.Fatalf("expected search index 0 after resuming, got %d", editor.search.index)
+	}
+}
+
+// A placeholder covering the arguments of a call would take the closing
+// parenthesis with it on the next keystroke.
+func TestRequestEditorCompletionsInsertWholeLatencyCall(t *testing.T) {
+	editor := newTestEditor("# ")
+	editorPtr := &editor
+	editorPtr.moveCursorTo(0, 2)
+	editorPtr.SetCompletionEnabled(true)
+
+	editor = typeRunes(editor, "@mock lat")
+	if !editor.completion.active {
+		t.Fatalf("expected latency suggestions, got %q", editor.Value())
+	}
+	for editor.completion.filtered[editor.completion.selection].Label != "latency=random" {
+		editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	const want = "# @mock latency=random(100ms,500ms)"
+	if got := editor.Value(); !strings.HasPrefix(got, want) {
+		t.Fatalf("accepted completion = %q, want it to start with %q", got, want)
+	}
+	editor = typeRunes(editor, "method=GET")
+	if got := editor.Value(); !strings.HasPrefix(got, want) {
+		t.Fatalf("typing after the completion left %q, want %q intact", got, want)
+	}
+	assertMockLatencyParses(t, editor.Value())
+}
+
+func assertMockLatencyParses(t *testing.T, line string) {
+	t.Helper()
+	doc := parser.Parse("completion.http", []byte(line+" path=/x\nHTTP/1.1 200 OK\n"))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("parse errors for %q: %+v", line, doc.Errors)
+	}
+	if got := doc.Mocks[0].Latency.String(); got != "random(100ms,500ms)" {
+		t.Fatalf("parsed latency = %q", got)
 	}
 }

--- a/internal/ui/editor_state_test.go
+++ b/internal/ui/editor_state_test.go
@@ -2047,9 +2047,7 @@ func TestRequestEditorExitSearchMode(t *testing.T) {
 	}
 }
 
-// A placeholder covering the arguments of a call would take the closing
-// parenthesis with it on the next keystroke.
-func TestRequestEditorCompletionsInsertWholeLatencyCall(t *testing.T) {
+func TestRequestEditorCompletionsInsertLatencyCall(t *testing.T) {
 	editor := newTestEditor("# ")
 	editorPtr := &editor
 	editorPtr.moveCursorTo(0, 2)
@@ -2068,16 +2066,15 @@ func TestRequestEditorCompletionsInsertWholeLatencyCall(t *testing.T) {
 	if got := editor.Value(); !strings.HasPrefix(got, want) {
 		t.Fatalf("accepted completion = %q, want it to start with %q", got, want)
 	}
-	editor = typeRunes(editor, "method=GET")
-	if got := editor.Value(); !strings.HasPrefix(got, want) {
-		t.Fatalf("typing after the completion left %q, want %q intact", got, want)
+	if got := editor.selectedText(); got != "100ms,500ms)" {
+		t.Fatalf("selected %q, want the arguments left ready to type over", got)
 	}
 	assertMockLatencyParses(t, editor.Value())
 }
 
 func assertMockLatencyParses(t *testing.T, line string) {
 	t.Helper()
-	doc := parser.Parse("completion.http", []byte(line+" path=/x\nHTTP/1.1 200 OK\n"))
+	doc := parser.Parse("completion.http", []byte(line+" method=GET path=/x\nHTTP/1.1 200 OK\n"))
 	if len(doc.Errors) != 0 {
 		t.Fatalf("parse errors for %q: %+v", line, doc.Errors)
 	}


### PR DESCRIPTION
Adds jitter, random and normal latency distribution.

```http
# @mock method=GET path=/slow    latency=random(100ms,500ms)
# @mock method=GET path=/steady  latency=normal(250ms,50ms)
# @mock method=GET path=/jittery latency=jitter(200ms,20%)
```