### PR TITLE
RST-323: grpc header parsing and auth spec fixes

### DIFF
--- a/internal/engine/request/auth.go
+++ b/internal/engine/request/auth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/authcmd"
 	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/oauth"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
@@ -95,8 +96,8 @@ func InjectedAuthSecrets(
 		return nil
 	}
 	hdr := injectedAuthHeader(auth)
-	beforeVal := headerValue(reqHeaders(before), hdr)
-	afterVal := headerValue(reqHeaders(after), hdr)
+	beforeVal := header.Value(reqHeaders(before), hdr)
+	afterVal := header.Value(reqHeaders(after), hdr)
 	if strings.TrimSpace(afterVal) == "" || afterVal == beforeVal {
 		return nil
 	}
@@ -145,12 +146,8 @@ func injectedAuthHeader(auth *restfile.AuthSpec) string {
 	return oauth.DefaultHeader
 }
 
-func headerPresent(h http.Header, name string) bool {
-	return h != nil && h.Get(name) != ""
-}
-
 func requestHeaderPresent(req *restfile.Request, name string) bool {
-	return headerPresent(reqHeaders(req), name) || grpcMetadataPresent(req, name)
+	return header.Present(reqHeaders(req), name) || grpcMetadataPresent(req, name)
 }
 
 // A key set via @grpc-metadata overrides auth the same way a header does.
@@ -229,13 +226,6 @@ func grpcAuthHeaders(req *restfile.Request) http.Header {
 		out.Add(pair.Key, pair.Value)
 	}
 	return out
-}
-
-func headerValue(h http.Header, name string) string {
-	if h == nil {
-		return ""
-	}
-	return strings.TrimSpace(h.Get(name))
 }
 
 func (e *Engine) authCmdManager() (*authcmd.Manager, error) {

--- a/internal/engine/request/explain_build.go
+++ b/internal/engine/request/explain_build.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	xplain "github.com/unkn0wn-root/resterm/internal/explain"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/k8s"
 	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
@@ -526,7 +527,7 @@ func addExplainBodyChange(out *[]xplain.Change, a, b *restfile.Request) {
 
 func addExplainHeaderChanges(out *[]xplain.Change, a, b http.Header) {
 	for _, name := range mergedKeySet(a, b) {
-		addExplainChange(out, "header."+name, headerValue(a, name), headerValue(b, name))
+		addExplainChange(out, "header."+name, header.Value(a, name), header.Value(b, name))
 	}
 }
 
@@ -1201,7 +1202,7 @@ func (e *Engine) prepareExplainAuthPreview(
 }
 
 func authPresentNote(req *restfile.Request, hdr string) string {
-	if grpcMetadataPresent(req, hdr) && !headerPresent(reqHeaders(req), hdr) {
+	if grpcMetadataPresent(req, hdr) && !header.Present(reqHeaders(req), hdr) {
 		return hdr + " already set via @grpc-metadata"
 	}
 	return "auth header already set on request"

--- a/internal/engine/request/grpc_auth_test.go
+++ b/internal/engine/request/grpc_auth_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	xplain "github.com/unkn0wn-root/resterm/internal/explain"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
+	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
@@ -104,6 +106,46 @@ func TestApplyGRPCAuthKeepsExplicitHeader(t *testing.T) {
 	}
 	if got := req.Headers.Get("Authorization"); got != "Bearer from-user" {
 		t.Fatalf("Authorization = %q, want the user value kept", got)
+	}
+}
+
+func TestApplyGRPCAuthKeepsLowercaseExplicitHeaderWithoutExpandingAuth(t *testing.T) {
+	req := grpcAuthRequest(&restfile.AuthSpec{
+		Type:   "bearer",
+		Params: map[string]string{"token": "{{missing}}"},
+	})
+	req.Headers = map[string][]string{"authorization": {"Bearer from-user"}}
+
+	if err := applyGRPCAuth(req, vars.NewResolver()); err != nil {
+		t.Fatalf("apply grpc auth: %v", err)
+	}
+	if got := header.Value(req.Headers, "Authorization"); got != "Bearer from-user" {
+		t.Fatalf("authorization = %q, want the user value kept", got)
+	}
+	if len(req.Headers) != 1 {
+		t.Fatalf("auth added a second authorization header: %v", req.Headers)
+	}
+}
+
+func TestApplyGRPCAuthKeepsParsedExplicitHeaderWithoutExpandingAuth(t *testing.T) {
+	doc := parser.Parse("auth.http", []byte(`
+# @auth bearer {{missing}}
+# @grpc pkg.Service/Call
+# @grpc-plaintext true
+GRPC grpc://127.0.0.1:8082
+Authorization: Bearer from-user
+
+{}
+`))
+	if len(doc.Errors) != 0 || len(doc.Requests) != 1 {
+		t.Fatalf("parse errors=%v requests=%d", doc.Errors, len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if err := applyGRPCAuth(req, vars.NewResolver()); err != nil {
+		t.Fatalf("apply grpc auth with headers %v: %v", req.Headers, err)
+	}
+	if got := req.Headers.Get("Authorization"); got != "Bearer from-user" {
+		t.Fatalf("authorization = %q, want the parsed value kept: %v", got, req.Headers)
 	}
 }
 

--- a/internal/http/header/header.go
+++ b/internal/http/header/header.go
@@ -64,6 +64,39 @@ func Key(name string) (string, error) {
 	return n.Key(), nil
 }
 
+// Value returns the first non-blank value stored under name. Keys are matched
+// case-insensitively and are never canonicalized, so a block written straight
+// into the map answers the same way one built with the http.Header setters
+// does.
+func Value(src map[string][]string, name string) string {
+	if v := firstValue(src[name]); v != "" {
+		return v
+	}
+	for key, values := range src {
+		if !strings.EqualFold(key, name) {
+			continue
+		}
+		if v := firstValue(values); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// Present reports whether name carries a non-blank value in src.
+func Present(src map[string][]string, name string) bool {
+	return Value(src, name) != ""
+}
+
+func firstValue(values []string) string {
+	for _, value := range values {
+		if v := strings.TrimSpace(value); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // Named contains a header name and its case-insensitive identity.
 type Named struct {
 	Source string

--- a/internal/http/header/header_test.go
+++ b/internal/http/header/header_test.go
@@ -55,6 +55,29 @@ func TestParseReturnsCaseInsensitiveIdentityWithoutTrimming(t *testing.T) {
 	}
 }
 
+func TestValueAndPresentIgnoreKeyCaseAndBlanks(t *testing.T) {
+	src := map[string][]string{
+		"authorization": {"Bearer from-user"},
+		"X-Blank":       {"", "  "},
+		"X-Second":      {" ", "kept"},
+	}
+	if got := Value(src, "Authorization"); got != "Bearer from-user" {
+		t.Fatalf("Value(Authorization) = %q, want the lowercase entry", got)
+	}
+	if got := Value(src, "x-second"); got != "kept" {
+		t.Fatalf("Value(x-second) = %q, want kept", got)
+	}
+	if Present(src, "X-Blank") {
+		t.Fatal("a blank value counts as present")
+	}
+	if Present(nil, "Authorization") {
+		t.Fatal("a nil block reports a header")
+	}
+	if Present(src, "X-Missing") {
+		t.Fatal("an absent header reports present")
+	}
+}
+
 func TestNormalizeKeepsEveryValueAsAList(t *testing.T) {
 	src := map[string][]string{
 		"X-Test":    {"a", "b"},

--- a/internal/parser/body.go
+++ b/internal/parser/body.go
@@ -102,27 +102,42 @@ func (b *documentBuilder) handleHeaderLine(ln line) bool {
 	if !b.inRequest || !b.request.http.HasMethod() || b.request.http.HeaderDone() {
 		return false
 	}
-	// A feature collecting raw lines takes them before the header block does.
-	// Without this, a @query or @variables block written straight after the
-	// method line loses its content to a header named after whatever sits in
-	// front of the first colon.
-	if b.request.protoBodyLine(ln.raw) {
-		b.appendLine(ln.raw)
-		return true
-	}
 	if before, after, ok := strings.Cut(ln.raw, ":"); ok {
 		headerName := strings.TrimSpace(before)
 		headerValue := strings.TrimSpace(after)
+		// A valid header must win before a GraphQL or gRPC raw-block collector.
+		// Both protocols accept arbitrary body lines, so offering the line to
+		// them first used to swallow valid gRPC headers as protobuf JSON.
+		if header.Valid(headerName) {
+			b.request.http.AddHeader(headerName, headerValue)
+			b.appendLine(ln.raw)
+			return true
+		}
+		// Query/variables and protobuf JSON may contain colons. Give an invalid
+		// header-shaped line to the active protocol before diagnosing it as a
+		// request header.
+		if b.request.protoBodyLine(ln.raw) {
+			b.request.markHeadersDone()
+			b.appendLine(ln.raw)
+			return true
+		}
 		// A name that is not an HTTP field name cannot be sent, and header
 		// names are never expanded, so nothing later can rescue it. Report it
 		// here, where the line number points at the fix, and still record it so
 		// the request stays what the file says.
-		if !header.Valid(headerName) {
-			b.addError(ln.no, fmt.Sprintf("header name %q is not an HTTP field name", headerName))
-		}
+		b.addError(ln.no, fmt.Sprintf("header name %q is not an HTTP field name", headerName))
 		if headerName != "" {
 			b.request.http.AddHeader(headerName, headerValue)
 		}
+	} else if b.request.protoBodyLine(ln.raw) {
+		// A feature collecting a raw block takes non-header lines before the
+		// ordinary body builder. This supports @query/@variables immediately
+		// after the request line as well as protobuf JSON without a blank line.
+		// The block also ends the header span, so a later query line such as a
+		// GraphQL alias is never read back as a header.
+		b.request.markHeadersDone()
+		b.appendLine(ln.raw)
+		return true
 	}
 	b.appendLine(ln.raw)
 	return true

--- a/internal/parser/directive.go
+++ b/internal/parser/directive.go
@@ -253,7 +253,7 @@ var errAuthSpec = errors.New("@auth requires a valid auth spec")
 
 func parseAuthDirective(rest string) (authDirective, error) {
 	dir := authDirective{Scope: directive.ScopeRequest}
-	fields := directive.Fields(strings.TrimSpace(rest))
+	fields := directive.Fields(rest)
 	if len(fields) == 0 {
 		return dir, errAuthSpec
 	}
@@ -279,7 +279,7 @@ func parseAuthDirective(rest string) (authDirective, error) {
 		return dir, nil
 	}
 
-	spec, err := parseAuthSpec(strings.Join(fields, " "))
+	spec, err := parseAuthSpec(fields)
 	if err != nil {
 		return dir, err
 	}
@@ -293,8 +293,10 @@ func parseAuthDirective(rest string) (authDirective, error) {
 	return dir, nil
 }
 
-func parseAuthSpec(rest string) (*restfile.AuthSpec, error) {
-	fields := directive.Fields(rest)
+// Fields arrive decoded. Rejoining them loses the boundary around a quoted
+// option value, so scope="read write" would read back as scope=read plus an
+// unrelated bare word.
+func parseAuthSpec(fields []string) (*restfile.AuthSpec, error) {
 	if len(fields) == 0 {
 		return nil, nil
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -155,6 +155,47 @@ GET https://example.com
 	}
 }
 
+func TestParseOAuthPreservesQuotedScope(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		scope string
+	}{
+		{name: "implicit request"},
+		{name: "explicit request", scope: "request "},
+		{name: "file", scope: "file "},
+		{name: "global", scope: "global "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := `# @auth ` + tc.scope + `oauth2 token_url=https://auth.example/token client_id=client client_secret=secret scope="read write" cache_key=api
+GET https://example.com
+`
+
+			doc := Parse("oauth.http", []byte(src))
+			if len(doc.Errors) != 0 {
+				t.Fatalf("expected no parse errors, got %v", doc.Errors)
+			}
+			var spec *restfile.AuthSpec
+			if tc.scope == "" || tc.scope == "request " {
+				if len(doc.Requests) != 1 {
+					t.Fatalf("requests = %d, want 1", len(doc.Requests))
+				}
+				spec = doc.Requests[0].Metadata.Auth
+			} else {
+				if len(doc.Auth) != 1 {
+					t.Fatalf("auth profiles = %d, want 1", len(doc.Auth))
+				}
+				spec = &doc.Auth[0].Spec
+			}
+			if spec == nil {
+				t.Fatal("expected auth metadata")
+			}
+			if got := spec.Params["scope"]; got != "read write" {
+				t.Fatalf("scope = %q, want %q", got, "read write")
+			}
+		})
+	}
+}
+
 func TestParseMethodLineWithHTTPVersion(t *testing.T) {
 	src := `###
 
@@ -1751,9 +1792,9 @@ GET https://example.com
 }
 
 func TestParseOAuth2AuthSpec(t *testing.T) {
-	spec, _ := parseAuthSpec(
+	spec, _ := parseAuthSpec(directive.Fields(
 		`oauth2 token_url="https://auth.example.com/token" client_id=my-client client_secret="s3cr3t" scope="read write" grant=password username=jane password=pwd client_auth=body audience=https://api.example.com`,
-	)
+	))
 	if spec == nil {
 		t.Fatalf("expected oauth2 spec")
 	}
@@ -1779,7 +1820,7 @@ func TestParseOAuth2AuthSpec(t *testing.T) {
 }
 
 func TestParseOAuth2AuthSpecCacheOnly(t *testing.T) {
-	spec, _ := parseAuthSpec(`oauth2 cache_key=github`)
+	spec, _ := parseAuthSpec(directive.Fields(`oauth2 cache_key=github`))
 	if spec == nil {
 		t.Fatalf("expected oauth2 spec for cache-only directive")
 	}
@@ -1801,9 +1842,9 @@ func TestParseOAuth2AuthSpecCacheOnly(t *testing.T) {
 }
 
 func TestParseCommandAuthSpec(t *testing.T) {
-	spec, _ := parseAuthSpec(
+	spec, _ := parseAuthSpec(directive.Fields(
 		`command argv='["gh","auth","token"]' header=Authorization cache_key=github timeout=5s`,
-	)
+	))
 	if spec == nil {
 		t.Fatalf("expected command auth spec")
 	}
@@ -1824,9 +1865,9 @@ func TestParseCommandAuthSpec(t *testing.T) {
 }
 
 func TestParseCommandAuthSpecBareJSONArgv(t *testing.T) {
-	spec, _ := parseAuthSpec(
+	spec, _ := parseAuthSpec(directive.Fields(
 		`command argv=["gh", "auth", "token"] header=Authorization cache_key=github timeout=5s`,
-	)
+	))
 	if spec == nil {
 		t.Fatalf("expected command auth spec")
 	}
@@ -1847,7 +1888,7 @@ func TestParseCommandAuthSpecBareJSONArgv(t *testing.T) {
 }
 
 func TestParseCommandAuthSpecCacheOnly(t *testing.T) {
-	spec, _ := parseAuthSpec(`command cache_key=github header=X-Token`)
+	spec, _ := parseAuthSpec(directive.Fields(`command cache_key=github header=X-Token`))
 	if spec == nil {
 		t.Fatalf("expected command auth spec")
 	}
@@ -3038,6 +3079,59 @@ query FetchUser($id: ID!) {
 	}
 	if strings.Contains(gql.Query, "# @variables") {
 		t.Fatalf("expected directives stripped from query")
+	}
+}
+
+func TestParseGraphQLBodyWithoutBlankLineKeepsHeadersAndAliases(t *testing.T) {
+	src := `# @graphql
+POST https://example.com/graphql
+X-Token: abc
+{
+  hero: character(id: "1") { name }
+}
+`
+
+	doc := Parse("graphql-alias.http", []byte(src))
+	if len(doc.Errors) != 0 || len(doc.Requests) != 1 {
+		t.Fatalf("parse errors=%v requests=%d", doc.Errors, len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if got := req.Headers.Get("X-Token"); got != "abc" {
+		t.Fatalf("X-Token = %q, want abc: %v", got, req.Headers)
+	}
+	if len(req.Headers) != 1 {
+		t.Fatalf("query lines leaked into headers: %v", req.Headers)
+	}
+	if req.Body.GraphQL == nil {
+		t.Fatalf("expected GraphQL body")
+	}
+	if !strings.Contains(req.Body.GraphQL.Query, `hero: character(id: "1")`) {
+		t.Fatalf("alias line missing from query: %q", req.Body.GraphQL.Query)
+	}
+}
+
+func TestParseGRPCHeaderWithoutBlankLineStaysAHeader(t *testing.T) {
+	src := `# @grpc pkg.Service/Call
+GRPC grpc://127.0.0.1:8082
+Authorization: Bearer t
+{
+  "user": "x"
+}
+`
+
+	doc := Parse("grpc-header.http", []byte(src))
+	if len(doc.Errors) != 0 || len(doc.Requests) != 1 {
+		t.Fatalf("parse errors=%v requests=%d", doc.Errors, len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if got := req.Headers.Get("Authorization"); got != "Bearer t" {
+		t.Fatalf("Authorization = %q, want Bearer t: %v", got, req.Headers)
+	}
+	if req.GRPC == nil || !strings.Contains(req.GRPC.Message, `"user": "x"`) {
+		t.Fatalf("unexpected grpc message: %+v", req.GRPC)
+	}
+	if strings.Contains(req.GRPC.Message, "Authorization") {
+		t.Fatalf("header leaked into the message: %q", req.GRPC.Message)
 	}
 }
 

--- a/internal/protocol/httpx/auth.go
+++ b/internal/protocol/httpx/auth.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/util"
 	"github.com/unkn0wn-root/resterm/internal/vars"
@@ -63,13 +64,13 @@ func AuthValues(
 		out, err := expandResult(param)
 		return out.Value, err
 	}
-	header := func(name, value string) []AuthValue {
+	hdr := func(name, value string) []AuthValue {
 		return []AuthValue{{Placement: AuthInHeader, Name: name, Value: value}}
 	}
 
 	switch kind {
 	case restfile.AuthBasic:
-		if headerSet(existing, authorizationHeader) {
+		if header.Present(existing, authorizationHeader) {
 			return nil, nil
 		}
 		user, err := expand(authParamUsername)
@@ -81,17 +82,17 @@ func AuthValues(
 			return nil, err
 		}
 		encoded := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
-		return header(authorizationHeader, basicPrefix+encoded), nil
+		return hdr(authorizationHeader, basicPrefix+encoded), nil
 
 	case restfile.AuthBearer:
-		if headerSet(existing, authorizationHeader) {
+		if header.Present(existing, authorizationHeader) {
 			return nil, nil
 		}
 		token, err := expand(authParamToken)
 		if err != nil {
 			return nil, err
 		}
-		return header(authorizationHeader, bearerTokenPrefix+token), nil
+		return hdr(authorizationHeader, bearerTokenPrefix+token), nil
 
 	case restfile.AuthAPIKey:
 		placement, err := expandResult(authParamPlacement)
@@ -113,14 +114,14 @@ func AuthValues(
 			if name == "" {
 				name = defaultAPIKeyHeader
 			}
-			if headerSet(existing, name) {
+			if header.Present(existing, name) {
 				return nil, nil
 			}
 			value, err := expand(authParamValue)
 			if err != nil {
 				return nil, err
 			}
-			return header(name, value), nil
+			return hdr(name, value), nil
 		default:
 			if placement.HasUndefinedVariables {
 				return nil, nil
@@ -140,18 +141,14 @@ func AuthValues(
 		if err != nil {
 			return nil, err
 		}
-		if name == "" || headerSet(existing, name) {
+		if name == "" || header.Present(existing, name) {
 			return nil, nil
 		}
 		value, err := expand(authParamValue)
 		if err != nil {
 			return nil, err
 		}
-		return header(name, value), nil
+		return hdr(name, value), nil
 	}
 	return nil, nil
-}
-
-func headerSet(h http.Header, name string) bool {
-	return h != nil && h.Get(name) != ""
 }

--- a/internal/protocol/httpx/request_test.go
+++ b/internal/protocol/httpx/request_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/http/version"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/vars"
@@ -162,6 +163,31 @@ func TestApplyAuthenticationSkipsUnusedParams(t *testing.T) {
 	}
 	if got := httpReq.Header.Get("Authorization"); got != "Bearer explicit" {
 		t.Fatalf("authorization header changed: %q", got)
+	}
+}
+
+func TestApplyAuthenticationSkipsUnusedParamsForLowercaseHeader(t *testing.T) {
+	c := NewClient(nil)
+	httpReq, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// A block assigned straight into the header map keeps the case it was
+	// written with, so auth has to see the name without canonicalizing it.
+	httpReq.Header = http.Header{"authorization": {"Bearer explicit"}}
+	auth := &restfile.AuthSpec{
+		Type:   "bearer",
+		Params: map[string]string{"token": "{{missing}}"},
+	}
+
+	if err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
+		t.Fatalf("unexpected error for case-insensitive auth override: %v", err)
+	}
+	if got := header.Value(httpReq.Header, "Authorization"); got != "Bearer explicit" {
+		t.Fatalf("authorization header changed: %q", got)
+	}
+	if len(httpReq.Header) != 1 {
+		t.Fatalf("auth added a second authorization header: %v", httpReq.Header)
 	}
 }
 


### PR DESCRIPTION
fix(parser): keep grpc and graphql headers out of the body
fix(parser): keep quoted auth option values whole
ref(header): one case insensitive lookup for auth headers