### PR TITLE
feat(vars): support http-client.env.json and http-client.private.env.json

### DIFF
--- a/cmd/resterm/load_env_test.go
+++ b/cmd/resterm/load_env_test.go
@@ -109,3 +109,34 @@ func TestRunInitListArgs(t *testing.T) {
 		t.Fatalf("expected error for extra args")
 	}
 }
+
+func TestLoadEnvironmentDiscoverHTTPClientMergesPrivate(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "http-client.env.json"),
+		[]byte(`{"dev":{"host":"localhost","username":"public"}}`), 0o644); err != nil {
+		t.Fatalf("write public env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "http-client.private.env.json"),
+		[]byte(`{"dev":{"username":"private","password":"secret"}}`), 0o644); err != nil {
+		t.Fatalf("write private env: %v", err)
+	}
+
+	cat, resolved, err := vars.Discover(dir)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if filepath.Base(resolved) != "http-client.env.json" {
+		t.Fatalf("resolved = %q, want http-client.env.json", resolved)
+	}
+	env, err := cat.Resolve(cat.DefaultSelection())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	vals := env.Values()
+	if vals["username"] != "private" {
+		t.Fatalf("username = %q, want private", vals["username"])
+	}
+	if vals["password"] != "secret" {
+		t.Fatalf("password = %q, want secret", vals["password"])
+	}
+}

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -332,7 +332,7 @@ Binary responses show size and type hints alongside quick previews. For large bi
 
 - The history pane persists responses along with their request and environment metadata. Entries survive restarts (stored under the config directory; see [Configuration](#configuration)).
 - `Ctrl+G` shows current globals (request/file/runtime) with secrets masked. `Ctrl+Shift+G` (or `g Shift+G`) clears globals and cookies for the active environment.
-- `Ctrl+E` opens the environment picker to switch between `resterm.env.json` (or `rest-client.env.json`) entries.
+- `Ctrl+E` opens the environment picker to switch between `http-client.env.json`, `resterm.env.json` (or `rest-client.env.json`) entries.
 
 ---
 
@@ -377,7 +377,9 @@ Resterm automatically searches, in order:
 2. The workspace root.
 3. The current working directory.
 
-It loads the first `resterm.env.json` or `rest-client.env.json` it finds. Each named environment must be an object. Values inside it can contain nested objects and arrays, which are flattened using dot and bracket notation (`services.api.base`, `plans.addons[0]`).
+It loads the first `http-client.env.json`, `resterm.env.json` or `rest-client.env.json` it finds. Each named environment must be an object. Values inside it can contain nested objects and arrays, which are flattened using dot and bracket notation (`services.api.base`, `plans.addons[0]`).
+
+When the resolved file is `http-client.env.json`, Resterm also looks for a sibling `http-client.private.env.json` and overlays it, so private values win over public ones for the same environment. This matches the JetBrains convention: keep shared values in the public file and passwords, tokens and other secrets in the private one, which is meant to stay out of source control. The private file is never loaded on its own.
 
 One environment file is resolved per workspace. Opening a request *file* from another directory does not reload it, because the active selection also keys globals, file variables, cookie jars and history scopes. So `resterm requests/api.http` picks up `requests/resterm.env.json`, while opening that same file from a workspace root with its own environment file keeps the root one. In a recursive workspace Resterm warns at startup about environment files it will not load. To use one of them, start Resterm in that directory or pass `--env-file`.
 

--- a/headless/build.go
+++ b/headless/build.go
@@ -261,7 +261,7 @@ func environmentOptions(
 		cat, err = groupedCatalog(opt.Environment.Grouped)
 		envFile = ""
 	case envFile != "":
-		cat, err = vars.LoadEnvironmentFile(envFile)
+		cat, err = vars.LoadEnvironmentPath(envFile)
 	default:
 		cat, envFile, err = vars.Discover(envPaths(path, work)...)
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -228,7 +228,7 @@ func (f ExecFlags) Resolve(filePath string) (ExecConfig, error) {
 // directory takes part in discovery.
 func (f ExecFlags) loadEnvironment(filePath, work string) (vars.Catalog, string, error) {
 	if explicit := str.Trim(f.EnvFile); explicit != "" {
-		cat, err := vars.LoadEnvironmentFile(explicit)
+		cat, err := vars.LoadEnvironmentPath(explicit)
 		if err != nil {
 			return vars.Catalog{}, "", err
 		}

--- a/internal/collection/env.go
+++ b/internal/collection/env.go
@@ -19,7 +19,7 @@ func buildEnvTemplate(rootAbs, rootReal string) ([]byte, error) {
 		return data, nil
 	}
 
-	srcs := []string{defaultEnvSourceFile, altEnvSourceFile}
+	srcs := []string{defaultEnvSourceFile, altEnvSourceFile, "http-client.env.json"}
 	for _, src := range srcs {
 		raw, ok, err := readWorkspaceFileIfExists(rootAbs, rootReal, src)
 		if err != nil {

--- a/internal/collection/env_test.go
+++ b/internal/collection/env_test.go
@@ -2,6 +2,8 @@ package collection
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -47,5 +49,27 @@ func TestRedactGroupedEnvironmentPreservesSchema(t *testing.T) {
 	flags := dev["flags"].([]any)
 	if flags[0] != envPlaceholder || flags[1] != envPlaceholder {
 		t.Fatalf("profile flags = %#v, want placeholders", flags)
+	}
+}
+
+func TestBuildEnvTemplatePrefersHTTPClient(t *testing.T) {
+	root := t.TempDir()
+	// http-client.env.json, when present, feeds the exported template.
+	if err := os.WriteFile(filepath.Join(root, "http-client.env.json"),
+		[]byte(`{"dev":{"url":"https://api","token":"supersecret"}}`), 0o644); err != nil {
+		t.Fatalf("write http-client env: %v", err)
+	}
+
+	data, err := buildEnvTemplate(root, root)
+	if err != nil {
+		t.Fatalf("build env template: %v", err)
+	}
+	var v map[string]any
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("decode template: %v", err)
+	}
+	dev := v["dev"].(map[string]any)
+	if dev["url"] != envPlaceholder || dev["token"] != envPlaceholder {
+		t.Fatalf("values not redacted: %#v", dev)
 	}
 }

--- a/internal/files/kind.go
+++ b/internal/files/kind.go
@@ -113,7 +113,7 @@ func ClassifyWorkspace(path string) (Kind, bool) {
 	if kind, ok := requestExt[ext]; ok {
 		return kind, true
 	}
-	if vars.IsEnvFileName(path) {
+	if vars.IsEnvFileName(path) || vars.IsPrivateEnvFileName(path) {
 		return KindEnv, true
 	}
 	kind, ok := dataExt[ext]

--- a/internal/files/kind_test.go
+++ b/internal/files/kind_test.go
@@ -95,6 +95,8 @@ func TestClassifyWorkspacePrecedence(t *testing.T) {
 		{path: "helpers.rts", want: KindScript, ok: true},
 		{path: "resterm.env.json", want: KindEnv, ok: true},
 		{path: "rest-client.env.json", want: KindEnv, ok: true},
+		{path: "http-client.env.json", want: KindEnv, ok: true},
+		{path: "http-client.private.env.json", want: KindEnv, ok: true},
 		{path: "payload.json", want: KindJSON, ok: true},
 		{path: "query.graphql", want: KindGraphQL, ok: true},
 		{path: "query.gql", want: KindGraphQL, ok: true},

--- a/internal/ui/env_status.go
+++ b/internal/ui/env_status.go
@@ -41,9 +41,16 @@ func inactiveEnvStatus(entries []files.Entry, active string, recursive bool) sta
 
 	var names []string
 	for _, entry := range entries {
-		if entry.Kind == files.KindEnv && !util.SameFile(entry.Path, active) {
-			names = append(names, entry.Name)
+		if entry.Kind != files.KindEnv || util.SameFile(entry.Path, active) {
+			continue
 		}
+		// The private companion of the active public file is loaded as part of
+		// that file, so it is not a separate inactive environment file.
+		if active != "" && vars.IsPrivateEnvFileName(entry.Path) &&
+			sameDir(entry.Path, active) {
+			continue
+		}
+		names = append(names, entry.Name)
 	}
 	if len(names) == 0 {
 		return statusMsg{}
@@ -95,4 +102,9 @@ func envLookalikes(root string, recursive bool) []string {
 		}
 	}
 	return names
+}
+
+// sameDir reports whether a and b live in the same directory.
+func sameDir(a, b string) bool {
+	return filepath.Dir(a) == filepath.Dir(b)
 }

--- a/internal/ui/model_environment_warning_test.go
+++ b/internal/ui/model_environment_warning_test.go
@@ -220,3 +220,21 @@ func TestNestedEnvironmentFileWarnsAtStartup(t *testing.T) {
 		t.Fatalf("who = %q, want the root environment to stay active", got)
 	}
 }
+
+func TestInactiveEnvStatusIgnoresActivePrivateSibling(t *testing.T) {
+	active := filepath.Join("/ws", "http-client.env.json")
+	priv := filepath.Join("/ws", "http-client.private.env.json")
+	other := filepath.Join("/ws", "a", "resterm.env.json")
+	entries := []files.Entry{
+		envEntry("http-client.env.json", active),
+		envEntry("http-client.private.env.json", priv),
+		envEntry(filepath.Join("a", "resterm.env.json"), other),
+	}
+
+	got := inactiveEnvStatus(entries, active, true)
+	// The private sibling of the active file is not inactive, but the nested
+	// resterm.env.json still is.
+	if got.text != filepath.Join("a", "resterm.env.json")+" is inactive. This workspace uses http-client.env.json" {
+		t.Fatalf("text = %q, want only the nested file flagged", got.text)
+	}
+}

--- a/internal/vars/catalog.go
+++ b/internal/vars/catalog.go
@@ -190,6 +190,52 @@ func (c Catalog) findGroup(name string) (Group, bool) {
 	return c.groups[i], true
 }
 
+// mergePrivate overlays the private catalog's values onto c. Private values
+// win per environment (and per profile for grouped catalogs). The source is
+// kept from c so the merged catalog shares the public file's runtime scope.
+// When the two catalogs have different shapes (one flat, one grouped) the
+// merge is ambiguous, so the public catalog is returned unchanged.
+func (c Catalog) mergePrivate(priv Catalog) Catalog {
+	if priv.Empty() {
+		return c
+	}
+	if c.Grouped() != priv.Grouped() {
+		return c
+	}
+	if c.Grouped() {
+		return c.mergePrivateGrouped(priv)
+	}
+	out := c
+	for i := range out.envs {
+		if pv, ok := priv.findEnv(out.envs[i].name); ok {
+			out.envs[i].values = mergeValues(out.envs[i].values, pv.values)
+		}
+	}
+	return out
+}
+
+// mergePrivateGrouped overlays private profiles onto matching public groups.
+// A private profile only refines what the public file declares; groups or
+// profiles that exist only in the private file are ignored.
+func (c Catalog) mergePrivateGrouped(priv Catalog) Catalog {
+	out := c
+	for gi := range out.groups {
+		pg, ok := priv.findGroup(out.groups[gi].Name)
+		if !ok {
+			continue
+		}
+		profiles := make(EnvironmentSet, len(out.groups[gi].Profiles))
+		for name, values := range out.groups[gi].Profiles {
+			profiles[name] = values
+			if pv, ok := pg.Profiles[name]; ok {
+				profiles[name] = mergeValues(values, pv)
+			}
+		}
+		out.groups[gi].Profiles = profiles
+	}
+	return out
+}
+
 func parseCatalog(data []byte) (Catalog, error) {
 	var root object
 	if err := json.Unmarshal(data, &root); err != nil {

--- a/internal/vars/catalog_test.go
+++ b/internal/vars/catalog_test.go
@@ -471,3 +471,72 @@ func TestMergeValuesIsDeterministic(t *testing.T) {
 		}
 	}
 }
+
+func TestMergePrivateGrouped(t *testing.T) {
+	pub, err := NewGroupedCatalog(nil, []Group{{
+		Name:    "api",
+		Default: "dev",
+		Profiles: EnvironmentSet{
+			"dev":  {"host": "localhost", "key": "public"},
+			"prod": {"host": "example.com", "key": "public"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("public grouped catalog: %v", err)
+	}
+	priv, err := NewGroupedCatalog(nil, []Group{{
+		Name:    "api",
+		Default: "dev",
+		Profiles: EnvironmentSet{
+			"dev": {"key": "private"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("private grouped catalog: %v", err)
+	}
+
+	merged := pub.mergePrivate(priv)
+	if merged.Empty() {
+		t.Fatal("merge should not empty the catalog")
+	}
+	g, ok := merged.findGroup("api")
+	if !ok {
+		t.Fatal("group api missing")
+	}
+	if got := g.Profiles["dev"]["key"]; got != "private" {
+		t.Fatalf("dev key = %q, want private", got)
+	}
+	if got := g.Profiles["dev"]["host"]; got != "localhost" {
+		t.Fatalf("dev host = %q, want localhost", got)
+	}
+	if got := g.Profiles["prod"]["key"]; got != "public" {
+		t.Fatalf("prod key = %q, want public", got)
+	}
+}
+
+func TestMergePrivateShapeMismatchKeepsPublic(t *testing.T) {
+	pub, err := NewCatalog(EnvironmentSet{"dev": {"host": "a"}})
+	if err != nil {
+		t.Fatalf("flat catalog: %v", err)
+	}
+	priv, err := NewGroupedCatalog(nil, []Group{{
+		Name:     "api",
+		Default:  "dev",
+		Profiles: EnvironmentSet{"dev": {"key": "p"}},
+	}})
+	if err != nil {
+		t.Fatalf("grouped catalog: %v", err)
+	}
+
+	merged := pub.mergePrivate(priv)
+	if merged.Grouped() {
+		t.Fatal("shape mismatch should not turn a flat catalog grouped")
+	}
+	dev, ok := merged.findEnv("dev")
+	if !ok || dev.values["host"] != "a" {
+		t.Fatalf("flat values not preserved: %+v", dev)
+	}
+	if _, ok := dev.values["key"]; ok {
+		t.Fatal("private flat overlay should not apply to a grouped mismatch")
+	}
+}

--- a/internal/vars/environment.go
+++ b/internal/vars/environment.go
@@ -21,6 +21,7 @@ const (
 type EnvironmentSet map[string]map[string]string
 
 var environmentFileCandidates = [...]string{
+	"http-client.env.json",
 	"rest-client.env.json",
 	"resterm.env.json",
 }
@@ -34,6 +35,16 @@ func IsEnvFileName(path string) bool {
 		}
 	}
 	return false
+}
+
+// PrivateEnvFileName is the JetBrains convention user-specific companion file.
+// It holds passwords, tokens and other values meant to stay out of source
+// control, and is only ever loaded as an overlay over its public sibling.
+const PrivateEnvFileName = "http-client.private.env.json"
+
+// IsPrivateEnvFileName reports whether path names the private companion file.
+func IsPrivateEnvFileName(path string) bool {
+	return strings.EqualFold(filepath.Base(str.Trim(path)), PrivateEnvFileName)
 }
 
 // LooksLikeEnvFile reports whether a name reads as an environment file without
@@ -78,14 +89,62 @@ func LoadEnvironmentFile(path string) (Catalog, error) {
 
 // Discover loads the first environment file found directly under roots, tried
 // in order. Nothing is added implicitly, so the caller decides whether ambient
-// directories such as the working directory take part.
+// directories such as the working directory take part. When the resolved file
+// is the JetBrains public file, its private companion is merged in.
 func Discover(roots ...string) (Catalog, string, error) {
 	path := DiscoverPath(roots...)
 	if path == "" {
 		return Catalog{}, "", nil
 	}
+	if strings.EqualFold(filepath.Base(str.Trim(path)), "http-client.env.json") {
+		cat, err := LoadEnvironmentPair(path)
+		return cat, path, err
+	}
 	cat, err := LoadEnvironmentFile(path)
 	return cat, path, err
+}
+
+// LoadEnvironmentPath loads the environment file at path, merging the private
+// companion when path names the JetBrains public file. It is the entry point
+// for explicit --env-file handling.
+func LoadEnvironmentPath(path string) (Catalog, error) {
+	if strings.EqualFold(filepath.Base(str.Trim(path)), "http-client.env.json") {
+		return LoadEnvironmentPair(path)
+	}
+	return LoadEnvironmentFile(path)
+}
+
+// LoadEnvironmentPair loads the public env file and overlays the private
+// companion file (if present) so private values win. Both files must parse.
+func LoadEnvironmentPair(publicPath string) (Catalog, error) {
+	cat, err := LoadEnvironmentFile(publicPath)
+	if err != nil {
+		return Catalog{}, err
+	}
+	priv := privateSibling(publicPath)
+	if priv == "" {
+		return cat, nil
+	}
+	privCat, err := LoadEnvironmentFile(priv)
+	if err != nil {
+		return Catalog{}, diag.WrapAsf(diag.ClassParse, err, "parse private env file %s", priv)
+	}
+	return cat.mergePrivate(privCat), nil
+}
+
+// privateSibling returns the private companion path for publicPath, empty when
+// the file does not exist. Only the exact basename http-client.env.json is
+// paired, so resterm.env.json / rest-client.env.json never pick up a private
+// overlay.
+func privateSibling(publicPath string) string {
+	if !strings.EqualFold(filepath.Base(str.Trim(publicPath)), "http-client.env.json") {
+		return ""
+	}
+	priv := filepath.Join(filepath.Dir(str.Trim(publicPath)), PrivateEnvFileName)
+	if _, err := os.Stat(priv); err != nil {
+		return ""
+	}
+	return priv
 }
 
 // DiscoverPath reports the file Discover would load, without loading it.

--- a/internal/vars/environment_test.go
+++ b/internal/vars/environment_test.go
@@ -302,3 +302,183 @@ func resolveValues(t *testing.T, cat Catalog, name string) map[string]string {
 	}
 	return env.Values()
 }
+
+func TestIsEnvFileNameRecognizesHTTPClient(t *testing.T) {
+	for _, name := range []string{"http-client.env.json", "rest-client.env.json", "resterm.env.json"} {
+		if !IsEnvFileName(name) {
+			t.Fatalf("IsEnvFileName(%q) = false, want true", name)
+		}
+	}
+	if IsEnvFileName("http-client.private.env.json") {
+		t.Fatal("IsEnvFileName(http-client.private.env.json) = true, want false")
+	}
+}
+
+func TestIsPrivateEnvFileName(t *testing.T) {
+	if !IsPrivateEnvFileName("http-client.private.env.json") {
+		t.Fatal("expected private env file to be recognized")
+	}
+	if IsPrivateEnvFileName("http-client.env.json") {
+		t.Fatal("public env file should not read as private")
+	}
+	if IsPrivateEnvFileName("resterm.env.json") {
+		t.Fatal("resterm.env.json should not read as private")
+	}
+}
+
+func TestLoadEnvironmentPairOverlaysPrivate(t *testing.T) {
+	dir := t.TempDir()
+	pub := filepath.Join(dir, "http-client.env.json")
+	priv := filepath.Join(dir, "http-client.private.env.json")
+	writeTestFile(t, pub, `{
+  "dev": {
+    "host": "localhost",
+    "username": "public-user",
+    "port": 8080
+  },
+  "prod": {
+    "host": "example.com",
+    "username": "public-user"
+  }
+}`)
+	writeTestFile(t, priv, `{
+  "dev": {
+    "username": "private-user",
+    "password": "secret"
+  }
+}`)
+
+	cat, err := LoadEnvironmentPair(pub)
+	if err != nil {
+		t.Fatalf("load pair: %v", err)
+	}
+
+	dev := resolveValues(t, cat, "dev")
+	if dev["host"] != "localhost" {
+		t.Fatalf("host = %q, want localhost", dev["host"])
+	}
+	if dev["username"] != "private-user" {
+		t.Fatalf("username = %q, want private-user (private wins)", dev["username"])
+	}
+	if dev["password"] != "secret" {
+		t.Fatalf("password = %q, want secret", dev["password"])
+	}
+	if dev["port"] != "8080" {
+		t.Fatalf("port = %q, want 8080", dev["port"])
+	}
+
+	// prod has no private overlay, so public values survive.
+	prod := resolveValues(t, cat, "prod")
+	if prod["username"] != "public-user" {
+		t.Fatalf("prod username = %q, want public-user", prod["username"])
+	}
+}
+
+func TestLoadEnvironmentPairWithoutPrivateIsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	pub := filepath.Join(dir, "http-client.env.json")
+	writeTestFile(t, pub, `{"dev": {"host": "localhost"}}`)
+
+	cat, err := LoadEnvironmentPair(pub)
+	if err != nil {
+		t.Fatalf("load pair: %v", err)
+	}
+	dev := resolveValues(t, cat, "dev")
+	if dev["host"] != "localhost" {
+		t.Fatalf("host = %q, want localhost", dev["host"])
+	}
+}
+
+func TestLoadEnvironmentPairKeepsPublicSource(t *testing.T) {
+	dir := t.TempDir()
+	pub := filepath.Join(dir, "http-client.env.json")
+	priv := filepath.Join(dir, "http-client.private.env.json")
+	writeTestFile(t, pub, `{"dev": {"host": "localhost"}}`)
+	writeTestFile(t, priv, `{"dev": {"password": "secret"}}`)
+
+	cat, err := LoadEnvironmentPair(pub)
+	if err != nil {
+		t.Fatalf("load pair: %v", err)
+	}
+	absPub, _ := filepath.Abs(pub)
+	if cat.source != filepath.Clean(absPub) {
+		t.Fatalf("source = %q, want public path %q", cat.source, filepath.Clean(absPub))
+	}
+}
+
+func TestLoadEnvironmentPathDispatchesPair(t *testing.T) {
+	dir := t.TempDir()
+	pub := filepath.Join(dir, "http-client.env.json")
+	priv := filepath.Join(dir, "http-client.private.env.json")
+	writeTestFile(t, pub, `{"dev": {"host": "localhost"}}`)
+	writeTestFile(t, priv, `{"dev": {"token": "secret"}}`)
+
+	cat, err := LoadEnvironmentPath(pub)
+	if err != nil {
+		t.Fatalf("load path: %v", err)
+	}
+	dev := resolveValues(t, cat, "dev")
+	if dev["token"] != "secret" {
+		t.Fatalf("token = %q, want secret from private overlay", dev["token"])
+	}
+
+	// A non-public file is loaded without any private overlay.
+	other := filepath.Join(dir, "resterm.env.json")
+	writeTestFile(t, other, `{"dev": {"host": "localhost"}}`)
+	cat, err = LoadEnvironmentPath(other)
+	if err != nil {
+		t.Fatalf("load path: %v", err)
+	}
+	dev = resolveValues(t, cat, "dev")
+	if _, ok := dev["token"]; ok {
+		t.Fatal("resterm.env.json should not pick up the private overlay")
+	}
+}
+
+func TestDiscoverHTTPClientMergesPrivate(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "http-client.env.json"),
+		`{"dev": {"host": "localhost", "username": "public"}}`)
+	writeTestFile(t, filepath.Join(dir, "http-client.private.env.json"),
+		`{"dev": {"username": "private", "password": "secret"}}`)
+
+	cat, resolved, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if filepath.Base(resolved) != "http-client.env.json" {
+		t.Fatalf("resolved = %q, want http-client.env.json", resolved)
+	}
+	dev := resolveValues(t, cat, "dev")
+	if dev["username"] != "private" {
+		t.Fatalf("username = %q, want private", dev["username"])
+	}
+	if dev["password"] != "secret" {
+		t.Fatalf("password = %q, want secret", dev["password"])
+	}
+}
+
+func TestDiscoverPrefersHTTPClientOverResterm(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "http-client.env.json"), `{"dev": {"host": "hc"}}`)
+	writeTestFile(t, filepath.Join(dir, "resterm.env.json"), `{"dev": {"host": "re"}}`)
+
+	cat, resolved, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if filepath.Base(resolved) != "http-client.env.json" {
+		t.Fatalf("resolved = %q, want http-client.env.json", resolved)
+	}
+	dev := resolveValues(t, cat, "dev")
+	if dev["host"] != "hc" {
+		t.Fatalf("host = %q, want hc", dev["host"])
+	}
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for the JetBrains/VS Code convention environment files — `http-client.env.json` (public) and `http-client.private.env.json` (private) — alongside resterm's existing `resterm.env.json` / `rest-client.env.json`.

References:
- [ASP.NET Core `.http` files — Environment files](https://learn.microsoft.com/en-us/aspnet/core/test/http-files?view=aspnetcore-10.0#environment-files)
- [IntelliJ IDEA — HTTP Client variables / environment files](https://www.jetbrains.com/help/idea/http-client-variables.html#example-working-with-environment-files)

## Behavior

- `http-client.env.json` is now a discovery candidate (listed first, so it wins when both JetBrains and resterm files exist in the same directory).
- When the resolved file is `http-client.env.json`, Resterm also loads its sibling `http-client.private.env.json` and overlays it, so **private values win** per environment (and per profile for grouped catalogs) — matching JetBrains semantics.
- The private file is never loaded on its own and never becomes the ACTIVE file; it only refines the public file.
- Explicit `--env-file http-client.env.json` gets the same private overlay via `LoadEnvironmentPath`.
- The private file is classified as an environment in the workspace navigator (ENV badge) but excluded from the "inactive environment files" warning when it is the active file's companion.
- `http-client.env.json` is redacted when exporting collection templates (private files are never exported).

## Files changed

- `internal/vars/environment.go` — candidate list, `PrivateEnvFileName`, `IsPrivateEnvFileName`, `LoadEnvironmentPair`, `privateSibling`, `LoadEnvironmentPath`, `Discover` branch.
- `internal/vars/catalog.go` — `mergePrivate` (+ grouped variant).
- `internal/cli/exec.go`, `headless/build.go` — explicit `--env-file` pair loading.
- `internal/files/kind.go` — classify private file as `KindEnv`.
- `internal/ui/env_status.go` — exclude active file's private sibling from inactive warning.
- `internal/collection/env.go` — export template redacts `http-client.env.json`.
- `docs/resterm.md` — documentation.
- Tests across `vars`, `files`, `ui`, `collection`, `cmd/resterm`.

## Notes

- Grouped + private shape mismatch (one flat, one grouped) is ambiguous, so the merge falls back to the public catalog unchanged.
- The pre-existing `TestRenderTimelineDetails` failure in `internal/ui` is unrelated (date-dependent) and reproduces on clean `main`.