### PR TITLE
feat(vars): read OS variables from document declarations

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -424,11 +424,26 @@ Use `env:NAME` when a value should come from an OS environment variable. This ke
 }
 ```
 
-Resterm reads the OS variable once at the start of each request and exposes it under the key from the environment file. In this example, `{{auth.token}}`, `env.get("auth.token")`, and `vars.get("auth.token")` return the same value. The name `RESTERM_TOKEN` is not added to `env` or `vars`.
+Resterm reads the OS variable once at the start of each request and exposes it under the declared name. In this example, `{{auth.token}}`, `env.get("auth.token")`, and `vars.get("auth.token")` return the same value. `RESTERM_TOKEN` itself is not added to `env` or `vars`.
 
-If the OS variable is missing, `auth.token` is omitted from `env` and `vars`. Requests that do not depend on it can still run. Values loaded through `env:NAME` are treated as secrets. Resterm hides them from display and status previews and redacts them from request results, explain output, and history.
+You can also use `env:NAME` in request files:
 
-Resterm first looks up the OS variable exactly as written, then tries the uppercase name.
+```
+# @file token env:RESTERM_TOKEN
+
+### Reports
+# @name Reports
+GET https://api.example.com/reports
+Authorization: Bearer {{token}}
+```
+
+`@const`, `@request`, `@global`, and `@file` all accept this form. The mapped value is available through templates and `vars`; constants remain template-only. File declarations do not appear in `env`, which only contains values from the selected environment.
+
+If the OS variable is missing, the declaration stays undefined and still shadows lower-precedence sources. Resterm first tries the name as written, then its uppercase form.
+
+Values loaded through `env:NAME` are secrets. Resterm hides them from previews and redacts them from results, explain output, and history. References are resolved once, so an OS value that contains `env:OTHER` stays unchanged. Only declarations are interpreted as references; values from captures, workflows, and scripts are plain data. An empty `env:` reference is reported as an error.
+
+A reference name may contain a template, as in `env:{{picked}}`. Only declarations can supply `picked`; runtime data cannot choose which OS variable Resterm reads.
 
 #### Shared variables (`$shared`)
 
@@ -564,7 +579,9 @@ When expanding `{{variable}}` templates, Resterm looks in:
 8. Selected environment JSON.
 9. OS environment variables (case-sensitive with an uppercase fallback).
 
-Templates, RestermScript expressions, the RestermScript `vars` object, and the JavaScript `vars` API all use this order. `@const` and unmapped OS environment variables are available only to templates. They are not exposed through `vars` because scripts cannot override them. A selected environment can map an OS variable with `env:NAME`. Scripts receive that value under the key from the environment file, not under the OS variable name.
+Templates, RestermScript expressions, the RestermScript `vars` object, and the JavaScript `vars` API all use this order. `@const` and unmapped OS environment variables are available only to templates. They are not exposed through `vars` because scripts cannot override them.
+
+Any declaration above, or a selected environment value, may use `env:NAME`. The value is exposed under the declared name. A missing reference stays undefined and continues to shadow lower sources, including the OS fallback in step 9. See [Values from OS environment variables](#values-from-os-environment-variables).
 
 Scripts receive declared values with ordinary variable references already expanded. For example, `vars.get("name")` returns the same value as `{{name}}`. Dynamic helpers and `{{= ... }}` expressions are left unchanged because they are evaluated later, when the request runs. Captured values and values written by scripts are treated as data and are not expanded.
 

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -663,11 +663,15 @@ env.NAME          // the same variable, since env names are case-insensitive
 
 An environment file can map an OS variable to a key, for example `"auth.token": "env:RESTERM_TOKEN"`. Resterm reads the OS value once per request, and `env.get("auth.token")`, `vars.get("auth.token")`, and `{{auth.token}}` return the same value. The name `RESTERM_TOKEN` is not added to `env` or `vars`. If the OS variable is missing, `auth.token` is absent. Resterm treats values loaded this way as secrets.
 
+`env` only contains the selected environment. A file declaration such as `# @file token env:RESTERM_TOKEN` is available through `vars.get("token")` and `{{token}}`, but not `env.get("token")`.
+
 ### vars
 
 `vars` provides request runtime variables, including globals and workflow overrides. You can access values through `vars.get("key")`, `vars.has("key")`, `vars.require("key"[, msg])`, or `vars.key`. `vars.global` provides global reads and writes in pre-request scripts through `get`, `has`, `require`, `set`, and `delete`.
 
-`vars` names the values a run can override, so `@const` values and unmapped OS environment variables are not in it even though `{{name}}` resolves them. An OS variable mapped by the selected environment is available under the key from the environment file. All other values use the same precedence as templates, so a name comes from the same source in both places. See [Variable resolution order](resterm.md#variable-resolution-order).
+`vars` contains values a run can override, so `@const` values and unmapped OS variables remain template-only. An `env:NAME` mapping from the selected environment, `@request`, `@global`, or `@file` appears under its declared name. Missing mappings are absent from `vars` and still shadow lower sources. Other values follow the same precedence as templates. See [Variable resolution order](resterm.md#variable-resolution-order).
+
+Values written by scripts, captures, or workflow steps are plain data. Text beginning with `env:` in a runtime value stays literal.
 
 ### request
 

--- a/internal/engine/headless/cmp.go
+++ b/internal/engine/headless/cmp.go
@@ -78,19 +78,20 @@ func (c *cmpCollector) OnEvt(_ context.Context, e core.Evt) error {
 func compareRow(meta core.RowMeta, out engine.RequestResult) engine.CompareRow {
 	canceled := out.Err != nil && errors.Is(out.Err, context.Canceled)
 	row := engine.CompareRow{
-		Environment: meta.Env,
-		Profile:     meta.Profile,
-		Selection:   out.Selection,
-		Response:    cloneHTTP(out.Response),
-		GRPC:        out.GRPC.Clone(),
-		Stream:      cloneStream(out.Stream),
-		Transcript:  copyBytes(out.Transcript),
-		Err:         out.Err,
-		Tests:       slices.Clone(out.Tests),
-		ScriptErr:   out.ScriptErr,
-		Skipped:     out.Skipped,
-		SkipReason:  strings.TrimSpace(out.SkipReason),
-		Canceled:    canceled,
+		Environment:    meta.Env,
+		Profile:        meta.Profile,
+		Selection:      out.Selection,
+		Response:       cloneHTTP(out.Response),
+		GRPC:           out.GRPC.Clone(),
+		Stream:         cloneStream(out.Stream),
+		Transcript:     copyBytes(out.Transcript),
+		Err:            out.Err,
+		Tests:          slices.Clone(out.Tests),
+		ScriptErr:      out.ScriptErr,
+		RuntimeSecrets: slices.Clone(out.RuntimeSecrets),
+		Skipped:        out.Skipped,
+		SkipReason:     strings.TrimSpace(out.SkipReason),
+		Canceled:       canceled,
 	}
 	if canceled {
 		row.Err = nil
@@ -249,7 +250,7 @@ func (e *Engine) recordCompare(
 		Duration:    compareDuration(out.Rows),
 		RequestText: redactText(
 			request.RenderRequestText(req),
-			e.secretValues(doc, req, env),
+			e.secretValues(doc, req, env, rowSecrets(out.Rows)...),
 			!req.Metadata.AllowSensitiveHeaders,
 		),
 		Description: strings.TrimSpace(req.Metadata.Description),
@@ -261,7 +262,7 @@ func (e *Engine) recordCompare(
 		},
 	}
 	for _, row := range out.Rows {
-		secs := e.secretValues(doc, req, e.rowEnvironment(row, env))
+		secs := e.secretValues(doc, req, e.rowEnvironment(row, env), row.RuntimeSecrets...)
 		item := history.CompareResult{
 			Environment: row.Environment,
 			Profile:     row.Profile,
@@ -300,6 +301,14 @@ func (e *Engine) recordCompare(
 		ent.Compare.Results = append(ent.Compare.Results, item)
 	}
 	_ = hs.Append(ent)
+}
+
+func rowSecrets(rows []engine.CompareRow) []string {
+	var out []string
+	for _, row := range rows {
+		out = append(out, row.RuntimeSecrets...)
+	}
+	return out
 }
 
 func compareDuration(rows []engine.CompareRow) time.Duration {

--- a/internal/engine/headless/cmp_secret_test.go
+++ b/internal/engine/headless/cmp_secret_test.go
@@ -1,0 +1,96 @@
+package headless
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/engine/request"
+	rtrun "github.com/unkn0wn-root/resterm/internal/engine/runtime"
+	"github.com/unkn0wn-root/resterm/internal/history"
+	"github.com/unkn0wn-root/resterm/internal/parser"
+	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+type memHistory struct{ entries []history.Entry }
+
+func (s *memHistory) Load() error                                { return nil }
+func (s *memHistory) Append(e history.Entry) error               { s.entries = append(s.entries, e); return nil }
+func (s *memHistory) Entries() ([]history.Entry, error)          { return s.entries, nil }
+func (s *memHistory) ByRequest(string) ([]history.Entry, error)  { return s.entries, nil }
+func (s *memHistory) ByWorkflow(string) ([]history.Entry, error) { return s.entries, nil }
+func (s *memHistory) ByFile(string) ([]history.Entry, error)     { return s.entries, nil }
+func (s *memHistory) Delete(string) (bool, error)                { return false, nil }
+func (s *memHistory) Close() error                               { return nil }
+
+func TestCompareHistoryMasksRuntimeSecrets(t *testing.T) {
+	const secret = "compare-runtime-secret"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprintf(w, `{"echo":%q}`, secret); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	src := fmt.Sprintf(`### probe
+# @name probe
+# @script pre-request
+> vars.global.set("token", "%s", {secret: true});
+> request.setHeader("X-Token", vars.global.get("token"));
+GET %s/probe
+`, secret, srv.URL)
+
+	doc := parser.Parse("compare.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("parsed %d requests, want 1", len(doc.Requests))
+	}
+
+	cl := newHTTPClientWithFactory(func(httpx.Options) (*http.Client, error) {
+		return srv.Client(), nil
+	})
+	store := &memHistory{}
+	rt := rtrun.New(rtrun.Config{Client: cl, History: store})
+	t.Cleanup(func() { _ = rt.Close() })
+
+	cfg := engine.Config{Client: cl, History: store}
+	eng := newWithDeps(request.New(cfg, rt), rt, cfg)
+
+	out, err := eng.ExecuteCompare(doc, doc.Requests[0], &restfile.CompareSpec{
+		Environments: []string{"one", "two"},
+		Baseline:     "one",
+	}, testSelection(""))
+	if err != nil {
+		t.Fatalf("ExecuteCompare: %v", err)
+	}
+	if len(out.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(out.Rows))
+	}
+	for _, row := range out.Rows {
+		if len(row.RuntimeSecrets) == 0 {
+			t.Fatalf("row %q carried no runtime secrets", row.Environment)
+		}
+	}
+
+	if len(store.entries) != 1 {
+		t.Fatalf("history entries = %d, want 1", len(store.entries))
+	}
+	ent := store.entries[0]
+	if ent.Compare == nil {
+		t.Fatal("history entry has no compare results")
+	}
+	texts := map[string]string{"entry request text": ent.RequestText}
+	for i, res := range ent.Compare.Results {
+		texts[fmt.Sprintf("row %d request text", i)] = res.RequestText
+		texts[fmt.Sprintf("row %d body snippet", i)] = res.BodySnippet
+	}
+	for field, text := range texts {
+		if strings.Contains(text, secret) {
+			t.Fatalf("%s contains the plaintext secret: %s", field, text)
+		}
+	}
+}

--- a/internal/engine/headless/history.go
+++ b/internal/engine/headless/history.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/unkn0wn-root/resterm/internal/engine/request"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
@@ -46,7 +47,8 @@ func (e *Engine) secretValues(
 		}
 		vals[v] = struct{}{}
 	}
-	for _, v := range env.Resolve().Secrets() {
+	snap := request.ResolveEnvironment(env, doc, req)
+	for _, v := range snap.Secrets() {
 		add(v)
 	}
 	if req != nil {

--- a/internal/engine/request/capture.go
+++ b/internal/engine/request/capture.go
@@ -175,7 +175,7 @@ func (e *Engine) refreshCaptureScope(
 	plan.overlay(sourceRequestCapture, capturedValues(work.requestVars))
 	plan.overlay(sourceRuntimeFile, capturedValues(work.fileVars))
 	sc.vars = plan.values()
-	sc.globals = effectiveGlobalValues(in.doc, runtime)
+	sc.globals = effectiveGlobalValues(in.doc, runtime, in.env.Refs())
 
 	ei := ExprInput{
 		Doc:      sc.doc,
@@ -827,7 +827,7 @@ func upsertVariable(
 	xs := *list
 	for i := range xs {
 		if strings.ToLower(xs[i].Name) == low {
-			xs[i].Value = value
+			xs[i].SetRuntimeValue(value)
 			xs[i].Scope = scope
 			xs[i].Secret = secret
 			return

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -144,11 +144,10 @@ func (e *Engine) ExecuteWith(
 	if req == nil {
 		return engine.RequestResult{}, diag.New(diag.ClassUI, "request is nil")
 	}
-	// Resolve once so templates, scripts, and redaction use the same values.
-	env := src.Resolve()
-
 	e.syncRegistry(doc)
 	req = CloneRequest(req)
+	// Snapshot references before scripts can change declarations.
+	env := ResolveEnvironment(src, doc, req)
 	opts := e.resolveHTTPOptions(doc, e.cfg.HTTPOptions)
 	if opts.CookieJar == nil {
 		if cs := e.rt.Cookies(); cs != nil {
@@ -408,7 +407,7 @@ func (x *execCtx) currentVariables() map[string]string {
 }
 
 func (x *execCtx) currentGlobals() vars.Globals {
-	return effectiveGlobalValues(x.doc, x.storeG)
+	return effectiveGlobalValues(x.doc, x.storeG, x.env.Refs())
 }
 
 func (x *execCtx) evalScope(vv map[string]string) evalScope {
@@ -434,7 +433,7 @@ func (x *execCtx) applyRuntimeGlobals(ch vars.Globals) {
 		x.storeG = x.eng.collectStoredGlobalValues(x.env)
 	}
 	if x.exp != nil {
-		x.exp.globals = effectiveGlobalValues(x.doc, x.storeG)
+		x.exp.globals = effectiveGlobalValues(x.doc, x.storeG, x.env.Refs())
 	}
 }
 
@@ -1204,7 +1203,7 @@ func (x *execCtx) httpRunner() xexec.Runner {
 				})
 			},
 			CollectGlobalValues: func(doc *restfile.Document) vars.Globals {
-				return effectiveGlobalValues(doc, x.storeG)
+				return effectiveGlobalValues(doc, x.storeG, x.env.Refs())
 			},
 			RunAsserts: func(in xexec.AssertInput) ([]scripts.TestResult, error) {
 				rr, err := rtsHTTP(in.HTTP)

--- a/internal/engine/request/env_ref_malformed_test.go
+++ b/internal/engine/request/env_ref_malformed_test.go
@@ -1,0 +1,99 @@
+package request
+
+import "testing"
+
+func TestEnvRefWithNoNameStaysUndefined(t *testing.T) {
+	for _, decl := range []string{
+		"# @file token env:",
+		"# @global token env:",
+		"# @request token env:",
+		"# @file token env:   ",
+	} {
+		t.Run(decl, func(t *testing.T) {
+			t.Setenv("TOKEN", "ambient-value")
+			doc, req := parseDoc(t, `### one
+# @name one
+`+decl+`
+GET http://example.test
+X-Token: {{token}}
+`)
+			req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(
+				`request.setHeader("X-Vars", vars.get("token") ?? "absent")`,
+			))
+
+			eng, st := newStubEngine(t)
+			res, err := eng.ExecuteWith(doc, req, envWith(t, "dev", nil), ExecOptions{})
+			if err != nil {
+				t.Fatalf("ExecuteWith() error = %v", err)
+			}
+			if res.Err == nil {
+				t.Fatal("a reference with no name produced a value")
+			}
+			if st.wire != nil {
+				t.Fatal("request with an unusable reference was sent")
+			}
+
+			if len(doc.Errors) == 0 {
+				t.Fatal("the malformed reference was not reported")
+			}
+		})
+	}
+}
+
+func TestEnvironmentEnvRefWithNoNameStaysUndefined(t *testing.T) {
+	t.Setenv("TOKEN", "ambient-value")
+	doc, req := parseDoc(t, `### one
+# @name one
+GET http://example.test
+X-Token: {{token}}
+`)
+
+	env := envWith(t, "dev", map[string]string{"token": "env:"})
+	eng, st := newStubEngine(t)
+	res, err := eng.ExecuteWith(doc, req, env, ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil {
+		t.Fatal("a catalog reference with no name produced a value")
+	}
+	if st.wire != nil {
+		t.Fatal("request with an unusable reference was sent")
+	}
+
+	snap := ResolveEnvironment(env, doc, req)
+	if _, ok := snap.Values()["token"]; ok {
+		t.Fatal("the env host exposes a reference that names nothing")
+	}
+	if len(snap.Secrets()) != 0 {
+		t.Fatalf("Secrets() = %#v, want none", snap.Secrets())
+	}
+}
+
+func TestValuesThatOnlyLookLikeReferencesStayText(t *testing.T) {
+	doc, req := parseDoc(t, `# @file a environment:X
+# @file b envs:X
+# @file c env
+
+### one
+# @name one
+GET http://example.test
+X-A: {{a}}
+X-B: {{b}}
+X-C: {{c}}
+`)
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	for name, want := range map[string]string{
+		"X-A": "environment:X",
+		"X-B": "envs:X",
+		"X-C": "env",
+	} {
+		if got := sent.wire.Header.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+	if len(doc.Errors) != 0 {
+		t.Fatalf("errors = %#v, want none", doc.Errors)
+	}
+}

--- a/internal/engine/request/env_ref_name_test.go
+++ b/internal/engine/request/env_ref_name_test.go
@@ -1,0 +1,232 @@
+package request
+
+import (
+	"context"
+	"testing"
+
+	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/rts"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+const namedRefTarget = "RESTERM_NAMED_TARGET"
+
+func TestRefNameComesFromDeclarationsOnly(t *testing.T) {
+	decl := `# @file picked ` + namedRefTarget + `
+# @file token env:{{picked}}
+`
+
+	t.Run("declaration names it", func(t *testing.T) {
+		t.Setenv(namedRefTarget, "declared-value")
+		doc, req := parseDoc(t, decl+`
+### one
+# @name one
+GET http://example.test
+X-Token: {{token}}
+`)
+		req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(
+			`request.setHeader("X-Vars", vars.get("token") ?? "absent")`,
+		))
+		sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+		for _, name := range []string{"X-Token", "X-Vars"} {
+			if got := sent.wire.Header.Get(name); got != "declared-value" {
+				t.Fatalf("%s = %q, want %q", name, got, "declared-value")
+			}
+		}
+	})
+
+	t.Run("script write cannot name it", func(t *testing.T) {
+		t.Setenv(namedRefTarget, "declared-value")
+		t.Setenv("RESTERM_NAMED_HIJACK", "hijacked-value")
+		doc, req := parseDoc(t, decl+`
+### one
+# @name one
+GET http://example.test
+X-Token: {{token}}
+`)
+		req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(
+			`vars.set("picked", "RESTERM_NAMED_HIJACK")`,
+		))
+		sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+		if got := sent.wire.Header.Get("X-Token"); got != "declared-value" {
+			t.Fatalf("X-Token = %q, want the declared name to stand", got)
+		}
+	})
+
+	t.Run("workflow value cannot name it", func(t *testing.T) {
+		t.Setenv(namedRefTarget, "declared-value")
+		t.Setenv("RESTERM_NAMED_HIJACK", "hijacked-value")
+		doc, req := parseDoc(t, decl+`
+### one
+# @name one
+GET http://example.test
+X-Token: {{token}}
+`)
+		sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{
+			Extra: map[string]string{"picked": "RESTERM_NAMED_HIJACK"},
+		})
+		if got := sent.wire.Header.Get("X-Token"); got != "declared-value" {
+			t.Fatalf("X-Token = %q, want the declared name to stand", got)
+		}
+	})
+
+	t.Run("capture cannot name it", func(t *testing.T) {
+		t.Setenv(namedRefTarget, "declared-value")
+		t.Setenv("RESTERM_NAMED_HIJACK", "hijacked-value")
+		doc, req := parseDoc(t, decl+`
+### one
+# @name one
+# @capture request picked {{response.body}}
+GET http://example.test
+`)
+		eng, st := newStubEngine(t)
+		st.body = "RESTERM_NAMED_HIJACK"
+		if _, err := eng.ExecuteWith(doc, req, envWith(t, "dev", nil), ExecOptions{}); err != nil {
+			t.Fatalf("ExecuteWith() error = %v", err)
+		}
+		vv := eng.CollectVariables(doc, req, envWith(t, "dev", nil), nil)
+		if vv["token"] != "declared-value" {
+			t.Fatalf("token = %q, want the declared name to stand", vv["token"])
+		}
+	})
+}
+
+func TestRefNameWorksInEnvironmentCatalog(t *testing.T) {
+	t.Setenv(namedRefTarget, "catalog-value")
+	doc, req := parseDoc(t, `# @file picked `+namedRefTarget+`
+
+### one
+# @name one
+GET http://example.test
+X-Env: {{alias}}
+`)
+
+	env := envWith(t, "dev", map[string]string{"alias": "env:{{picked}}"})
+	sent := sendRequest(t, doc, req, env, ExecOptions{})
+	if got := sent.wire.Header.Get("X-Env"); got != "catalog-value" {
+		t.Fatalf("X-Env = %q, want the catalog reference resolved", got)
+	}
+
+	snap := ResolveEnvironment(env, doc, req)
+	if got := snap.Values()["alias"]; got != "catalog-value" {
+		t.Fatalf("env host alias = %q, want %q", got, "catalog-value")
+	}
+	if secrets := snap.Secrets(); len(secrets) != 1 {
+		t.Fatalf("Secrets() = %#v, want one entry for one process variable", secrets)
+	}
+}
+
+func TestRefNameKeepsGlobalHostInAgreement(t *testing.T) {
+	t.Setenv(namedRefTarget, "global-value")
+	doc, req := parseDoc(t, `# @file picked `+namedRefTarget+`
+# @global token env:{{picked}}
+
+### one
+# @name one
+GET http://example.test
+`)
+	req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(
+		`request.setHeader("X-Global", vars.global.get("token") ?? "absent")
+request.setHeader("X-Vars", vars.get("token") ?? "absent")`,
+	))
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	for _, name := range []string{"X-Global", "X-Vars"} {
+		if got := sent.wire.Header.Get(name); got != "global-value" {
+			t.Fatalf("%s = %q, want %q", name, got, "global-value")
+		}
+	}
+}
+
+func TestRefNameOnUnusedConstIsStillRedactable(t *testing.T) {
+	t.Setenv(namedRefTarget, leakedSecret)
+	doc, req := parseDoc(t, `# @file picked `+namedRefTarget+`
+# @const unused env:{{picked}}
+
+### one
+# @name one
+GET http://example.test
+`)
+	req.Metadata.Scripts = append(req.Metadata.Scripts, restfileTestBlock(leakedSecret))
+
+	eng, _ := newStubEngine(t)
+	res, err := eng.ExecuteWith(doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if err != nil || res.Err != nil {
+		t.Fatalf("ExecuteWith() error = %v, result error = %v", err, res.Err)
+	}
+	assertSecretStaysRedactable(t, res)
+}
+
+func TestRefNameIsWithheldFromDisplay(t *testing.T) {
+	t.Setenv(namedRefTarget, "private")
+	t.Setenv("TOKEN", "ambient-value")
+	doc, req := parseDoc(t, `# @file picked `+namedRefTarget+`
+# @file token env:{{picked}}
+
+### one
+# @name one
+GET http://example.test
+`)
+
+	eng := New(engcfg.Config{}, nil)
+	res := eng.DisplayResolver(context.Background(), doc, req, envWith(t, "dev", nil), "", rts.Locals{})
+	for _, name := range []string{"token", "file.token"} {
+		if got, err := res.ExpandTemplates("{{" + name + "}}"); err == nil {
+			t.Fatalf("{{%s}} resolved to %q, want the reference withheld", name, got)
+		}
+	}
+}
+
+func TestRefNameWithNoDeclarationStaysUndefined(t *testing.T) {
+	doc, req := parseDoc(t, `# @file token env:{{picked}}
+
+### one
+# @name one
+GET http://example.test
+X-Token: {{token}}
+`)
+
+	eng, st := newStubEngine(t)
+	res, err := eng.ExecuteWith(doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil {
+		t.Fatal("an unresolvable reference name produced a value")
+	}
+	if st.wire != nil {
+		t.Fatal("request with an unresolved reference was sent")
+	}
+}
+
+func TestOnlyDocumentSourcesMayNameAReference(t *testing.T) {
+	runtime := []variableSource{
+		sourceScript,
+		sourceWorkflow,
+		sourceRequestCapture,
+		sourceRuntimeGlobal,
+		sourceRuntimeFile,
+	}
+	for _, s := range runtime {
+		if s.traits().declared {
+			t.Fatalf("%s is marked declared; a value produced while a request runs must not name a reference",
+				s.traits().label)
+		}
+	}
+
+	declared := []variableSource{
+		sourceConst,
+		sourceRequest,
+		sourceDocumentGlobal,
+		sourceFile,
+		sourceEnvironment,
+	}
+	for _, s := range declared {
+		if !s.traits().declared {
+			t.Fatalf("%s is not marked declared; its values would stop naming references", s.traits().label)
+		}
+		if declaredText(s, nil, nil, vars.Environment{}).Len() != 0 {
+			t.Fatalf("%s produced values from an empty document", s.traits().label)
+		}
+	}
+}

--- a/internal/engine/request/env_ref_runtime_test.go
+++ b/internal/engine/request/env_ref_runtime_test.go
@@ -1,0 +1,109 @@
+package request
+
+import (
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+	"github.com/unkn0wn-root/resterm/internal/prerequest"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+func TestRuntimeWriteClearsEnvRef(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(req *restfile.Request, value string)
+	}{
+		{
+			name: "script and @apply",
+			write: func(req *restfile.Request, value string) {
+				var set vars.NameMap[string]
+				set.Set("token", value)
+				prerequest.SetRequestVars(req, set)
+			},
+		},
+		{
+			name: "capture",
+			write: func(req *restfile.Request, value string) {
+				upsertVariable(&req.Variables, directive.ScopeRequest, "token", value, false)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, value := range []string{"patched", "env:RESTERM_RUNTIME_WRITE_OTHER"} {
+				req := &restfile.Request{Variables: []restfile.Variable{{
+					Name:     "token",
+					Value:    "env:RESTERM_RUNTIME_WRITE",
+					Scope:    directive.ScopeRequest,
+					Authored: true,
+				}}}
+				tt.write(req, value)
+
+				got := req.Variables[0]
+				if got.Value != value {
+					t.Fatalf("Value = %q, want %q", got.Value, value)
+				}
+				if got.Authored {
+					t.Fatal("the write kept the declaration flag, so it could still be read as a reference")
+				}
+			}
+		})
+	}
+}
+
+func TestApplyOverwritesEnvBackedRequestVar(t *testing.T) {
+	t.Setenv("RESTERM_APPLY_ORIGINAL", "ORIGINAL")
+	t.Setenv("RESTERM_APPLY_OTHER", "OTHER")
+
+	for _, tt := range []struct {
+		name  string
+		patch string
+		want  string
+	}{
+		{name: "ordinary value", patch: `"patched"`, want: "patched"},
+		{
+			name:  "value that looks like a reference",
+			patch: `"env:RESTERM_APPLY_OTHER"`,
+			want:  "env:RESTERM_APPLY_OTHER",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, req := parseDoc(t, `### one
+# @name one
+# @request token env:RESTERM_APPLY_ORIGINAL
+# @apply {vars: {token: `+tt.patch+`}}
+GET http://example.test
+X-Token: {{token}}
+`)
+			req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(
+				`request.setHeader("X-Vars", vars.require("token"))`,
+			))
+
+			sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+			for _, name := range []string{"X-Token", "X-Vars"} {
+				if got := sent.wire.Header.Get(name); got != tt.want {
+					t.Fatalf("%s = %q, want %q", name, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestScriptOverwritesEnvBackedRequestVar(t *testing.T) {
+	t.Setenv("RESTERM_SCRIPT_ORIGINAL", "ORIGINAL")
+
+	doc, req := parseDoc(t, `### one
+# @name one
+# @request token env:RESTERM_SCRIPT_ORIGINAL
+GET http://example.test
+X-Token: {{token}}
+`)
+	req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(`vars.set("token", "patched")`))
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if got := sent.wire.Header.Get("X-Token"); got != "patched" {
+		t.Fatalf("X-Token = %q, want the script write to win", got)
+	}
+}

--- a/internal/engine/request/env_ref_test.go
+++ b/internal/engine/request/env_ref_test.go
@@ -1,0 +1,370 @@
+package request
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/parser"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
+)
+
+func absentKey(t *testing.T, label string) string {
+	t.Helper()
+	return fmt.Sprintf("RESTERM_ABSENT_%s_%d", label, time.Now().UnixNano())
+}
+
+func parseDoc(t *testing.T, src string) (*restfile.Document, *restfile.Request) {
+	t.Helper()
+	doc := parser.Parse("env_ref.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("parsed %d requests, want 1", len(doc.Requests))
+	}
+	return doc, doc.Requests[0]
+}
+
+func echoToken(req *restfile.Request) {
+	req.Metadata.Scripts = append(req.Metadata.Scripts,
+		rtsPre(`request.setHeader("X-RTS-Vars", vars.get("token") ?? "absent")
+request.setHeader("X-RTS-Env", env.get("token") ?? "absent")`),
+		jsPre(`request.setHeader("X-JS-Vars", vars.get("token") || "absent");`),
+	)
+}
+
+func TestAuthoredEnvRefsResolveEverywhere(t *testing.T) {
+	tests := []struct {
+		name   string
+		decl   string
+		hidden bool // @const is not exposed to scripts
+	}{
+		{name: "file", decl: "# @file token env:RESTERM_AUTHORED_REF"},
+		{name: "global", decl: "# @global token env:RESTERM_AUTHORED_REF"},
+		{name: "request", decl: "# @request token env:RESTERM_AUTHORED_REF"},
+		{name: "const", decl: "# @const token env:RESTERM_AUTHORED_REF", hidden: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("RESTERM_AUTHORED_REF", "os-value")
+			doc, req := parseDoc(t, `### one
+# @name one
+`+tt.decl+`
+GET http://example.test
+X-Template: {{token}}
+`)
+			echoToken(req)
+
+			sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+			if got := sent.wire.Header.Get("X-Template"); got != "os-value" {
+				t.Fatalf("{{token}} = %q, want the process value", got)
+			}
+
+			want := "os-value"
+			if tt.hidden {
+				want = "absent"
+			}
+			for _, name := range []string{"X-RTS-Vars", "X-JS-Vars"} {
+				if got := sent.wire.Header.Get(name); got != want {
+					t.Fatalf("%s = %q, want %q", name, got, want)
+				}
+			}
+			if got := sent.wire.Header.Get("X-RTS-Env"); got != "absent" {
+				t.Fatalf(`env.get("token") = %q, want the alias absent from env`, got)
+			}
+		})
+	}
+}
+
+func TestAuthoredEnvRefResolvesUnderQualifiedName(t *testing.T) {
+	t.Setenv("RESTERM_QUALIFIED_REF", "os-value")
+	doc, req := parseDoc(t, `# @file token env:RESTERM_QUALIFIED_REF
+
+### one
+# @name one
+GET http://example.test
+X-Plain: {{token}}
+X-Qualified: {{file.token}}
+`)
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	for _, name := range []string{"X-Plain", "X-Qualified"} {
+		if got := sent.wire.Header.Get(name); got != "os-value" {
+			t.Fatalf("%s = %q, want the process value", name, got)
+		}
+	}
+}
+
+func TestMissingAuthoredEnvRefBlocksLowerSources(t *testing.T) {
+	key := absentKey(t, "PRECEDENCE")
+	t.Setenv("TOKEN", "ambient-value")
+	src := `# @file token file-value
+
+### one
+# @name one
+# @request token env:` + key + `
+GET http://example.test
+`
+	doc, req := parseDoc(t, src+"X-Used: {{token}}\n")
+
+	eng, st := newStubEngine(t)
+	res, err := eng.ExecuteWith(doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil {
+		t.Fatal("a missing reference resolved through a lower source")
+	}
+	if st.wire != nil {
+		t.Fatal("request with an unresolved reference was sent")
+	}
+
+	doc2, req2 := parseDoc(t, src+"X-Lower: {{file.token}}\n")
+	echoToken(req2)
+	sent := sendRequest(t, doc2, req2, envWith(t, "dev", nil), ExecOptions{})
+	if got := sent.wire.Header.Get("X-Lower"); got != "file-value" {
+		t.Fatalf("{{file.token}} = %q, want the file value still reachable", got)
+	}
+	for _, name := range []string{"X-RTS-Vars", "X-JS-Vars"} {
+		if got := sent.wire.Header.Get(name); got != "absent" {
+			t.Fatalf("%s = %q, want the missing reference to stay undefined", name, got)
+		}
+	}
+}
+
+func TestAuthoredEnvRefResolvesOnePass(t *testing.T) {
+	t.Setenv("RESTERM_ONE_PASS_INNER", "inner-value")
+	t.Setenv("RESTERM_ONE_PASS", "env:RESTERM_ONE_PASS_INNER")
+	doc, req := parseDoc(t, `# @file token env:RESTERM_ONE_PASS
+
+### one
+# @name one
+GET http://example.test
+X-Template: {{token}}
+`)
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if got := sent.wire.Header.Get("X-Template"); got != "env:RESTERM_ONE_PASS_INNER" {
+		t.Fatalf("{{token}} = %q, want a single resolution", got)
+	}
+}
+
+func TestRuntimeValuesNeverBecomeEnvRefs(t *testing.T) {
+	key := "RESTERM_RUNTIME_LITERAL"
+	literal := "env:" + key
+
+	t.Run("script write", func(t *testing.T) {
+		t.Setenv(key, "must-not-leak")
+		doc, req := parseDoc(t, `### one
+# @name one
+GET http://example.test
+X-Template: {{token}}
+`)
+		req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(
+			`vars.set("token", "`+literal+`")
+request.setHeader("X-Vars", vars.require("token"))`,
+		))
+
+		sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+		for _, name := range []string{"X-Template", "X-Vars"} {
+			if got := sent.wire.Header.Get(name); got != literal {
+				t.Fatalf("%s = %q, want the text unchanged", name, got)
+			}
+		}
+	})
+
+	t.Run("workflow overlay", func(t *testing.T) {
+		t.Setenv(key, "must-not-leak")
+		doc, req := parseDoc(t, `### one
+# @name one
+GET http://example.test
+X-Template: {{token}}
+`)
+		sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{
+			Extra: map[string]string{"token": literal},
+		})
+		if got := sent.wire.Header.Get("X-Template"); got != literal {
+			t.Fatalf("workflow value = %q, want the text unchanged", got)
+		}
+	})
+
+	t.Run("capture overwriting a declaration", func(t *testing.T) {
+		t.Setenv(key, "must-not-leak")
+		doc, req := parseDoc(t, `# @file token env:RESTERM_RUNTIME_LITERAL
+
+### one
+# @name one
+# @capture file token {{response.body}}
+GET http://example.test
+`)
+		eng, st := newStubEngine(t)
+		st.body = literal
+		if _, err := eng.ExecuteWith(doc, req, envWith(t, "dev", nil), ExecOptions{}); err != nil {
+			t.Fatalf("ExecuteWith() error = %v", err)
+		}
+		for _, v := range doc.Variables {
+			if v.Name == "token" && v.Authored {
+				t.Fatal("captured value kept the declaration flag")
+			}
+		}
+		vv := eng.CollectVariables(doc, req, envWith(t, "dev", nil), nil)
+		if vv["token"] != literal {
+			t.Fatalf("captured token = %q, want the response text unchanged", vv["token"])
+		}
+	})
+}
+
+func TestAuthoredEnvRefValueStaysRedactable(t *testing.T) {
+	key := "RESTERM_AUTHORED_REDACTION"
+	t.Setenv(key, leakedSecret)
+	doc, req := parseDoc(t, `# @file unused env:`+key+`
+
+### one
+# @name one
+GET http://example.test
+`)
+	req.Metadata.Scripts = append(req.Metadata.Scripts, restfileTestBlock(leakedSecret))
+
+	eng, _ := newStubEngine(t)
+	res, err := eng.ExecuteWith(doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if err != nil || res.Err != nil {
+		t.Fatalf("ExecuteWith() error = %v, result error = %v", err, res.Err)
+	}
+	assertSecretStaysRedactable(t, res)
+}
+
+func TestDisplayResolverWithholdsAuthoredEnvRefs(t *testing.T) {
+	key := "RESTERM_AUTHORED_DISPLAY"
+	t.Setenv(key, "private")
+	t.Setenv("TOKEN", "ambient-value")
+	doc, req := parseDoc(t, `# @file token env:`+key+`
+# @file shown visible
+
+### one
+# @name one
+GET http://example.test
+`)
+
+	eng := New(engcfg.Config{}, nil)
+	res := eng.DisplayResolver(context.Background(), doc, req, envWith(t, "dev", nil), "", rts.Locals{})
+
+	if got, err := res.ExpandTemplates("{{shown}}"); err != nil || got != "visible" {
+		t.Fatalf("{{shown}} = %q, %v, want %q", got, err, "visible")
+	}
+	for _, name := range []string{"token", "file.token"} {
+		if got, err := res.ExpandTemplates("{{" + name + "}}"); err == nil {
+			t.Fatalf("{{%s}} resolved to %q, want the reference withheld", name, got)
+		}
+	}
+	if got, err := res.ExpandTemplates(`{{= vars.get("token") ?? "withheld" }}`); err != nil ||
+		got != "withheld" {
+		t.Fatalf(`vars.get("token") = %q, %v, want %q`, got, err, "withheld")
+	}
+}
+
+func TestAuthoredAndEnvironmentRefsShareOneSnapshot(t *testing.T) {
+	key := "RESTERM_SHARED_REF"
+	t.Setenv(key, "shared-value")
+	doc, req := parseDoc(t, `# @file doc_token env:`+key+`
+
+### one
+# @name one
+GET http://example.test
+X-Doc: {{doc_token}}
+X-Env: {{env_token}}
+`)
+
+	env := envWith(t, "dev", map[string]string{"env_token": "env:" + key})
+	sent := sendRequest(t, doc, req, env, ExecOptions{})
+	for _, name := range []string{"X-Doc", "X-Env"} {
+		if got := sent.wire.Header.Get(name); got != "shared-value" {
+			t.Fatalf("%s = %q, want %q", name, got, "shared-value")
+		}
+	}
+
+	snap := env.Resolve()
+	_ = snap
+	if secrets := snap.Secrets(); len(secrets) != 1 {
+		t.Fatalf("Secrets() = %#v, want one entry for one process variable", secrets)
+	}
+}
+
+func TestAuthoredEnvRefIsSecretWithoutTheSecretForm(t *testing.T) {
+	key := "RESTERM_IMPLICIT_SECRET"
+	t.Setenv(key, "implicit")
+	doc, req := parseDoc(t, `# @global token env:`+key+`
+
+### one
+# @name one
+GET http://example.test
+`)
+
+	eng, _ := newStubEngine(t)
+	res, err := eng.ExecuteWith(doc, req, envWith(t, "dev", nil), ExecOptions{})
+	if err != nil || res.Err != nil {
+		t.Fatalf("ExecuteWith() error = %v, result error = %v", err, res.Err)
+	}
+	found := false
+	for _, s := range res.RuntimeSecrets {
+		if s == "implicit" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("RuntimeSecrets = %#v, want the resolved value recorded", res.RuntimeSecrets)
+	}
+}
+
+func TestGlobalHostSeesResolvedEnvRef(t *testing.T) {
+	key := "RESTERM_GLOBAL_HOST_REF"
+	t.Setenv(key, "global-value")
+	doc, req := parseDoc(t, `# @global token env:`+key+`
+
+### one
+# @name one
+GET http://example.test
+`)
+	req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(
+		`request.setHeader("X-Global", vars.global.get("token") ?? "absent")
+request.setHeader("X-Vars", vars.get("token") ?? "absent")`,
+	))
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	for _, name := range []string{"X-Global", "X-Vars"} {
+		if got := sent.wire.Header.Get(name); got != "global-value" {
+			t.Fatalf("%s = %q, want %q", name, got, "global-value")
+		}
+	}
+}
+
+func TestAuthoredEnvRefNamedByPlaceholder(t *testing.T) {
+	t.Setenv("RESTERM_DEFERRED_TARGET", "deferred-value")
+	doc, req := parseDoc(t, `# @file picked RESTERM_DEFERRED_TARGET
+# @file token env:{{picked}}
+
+### one
+# @name one
+GET http://example.test
+X-Template: {{token}}
+`)
+	req.Metadata.Scripts = append(req.Metadata.Scripts, rtsPre(
+		`request.setHeader("X-Vars", vars.get("token") ?? "absent")`,
+	))
+
+	sent := sendRequest(t, doc, req, envWith(t, "dev", nil), ExecOptions{})
+	for _, name := range []string{"X-Template", "X-Vars"} {
+		if got := sent.wire.Header.Get(name); got != "deferred-value" {
+			t.Fatalf("%s = %q, want %q", name, got, "deferred-value")
+		}
+	}
+}
+
+func restfileTestBlock(value string) restfile.ScriptBlock {
+	return restfile.ScriptBlock{
+		Kind: "test",
+		Lang: "js",
+		Body: `tests.assert(false, "leaked ` + value + `");`,
+	}
+}

--- a/internal/engine/request/explain_build.go
+++ b/internal/engine/request/explain_build.go
@@ -88,7 +88,7 @@ func newExplainBuilder(
 		secrets: sec,
 	}
 	if e != nil {
-		b.globals = effectiveGlobalValues(doc, e.collectStoredGlobalValues(env))
+		b.globals = effectiveGlobalValues(doc, e.collectStoredGlobalValues(env), env.Refs())
 	}
 	// Done here and not in the caller so that reports built on paths which fail
 	// before the request runs carry them too.

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -411,7 +411,12 @@ func (e *Engine) CollectVariables(
 	env vars.Environment,
 	overlay map[string]string,
 ) map[string]string {
-	return e.collectVariables(doc, req, env.Resolve(), runVars{overlay: vars.CollectNames(overlay)})
+	return e.collectVariables(
+		doc,
+		req,
+		ResolveEnvironment(env, doc, req),
+		runVars{overlay: vars.CollectNames(overlay)},
+	)
 }
 
 func (e *Engine) EvalValue(ctx context.Context, in EvalInput) (rts.Value, error) {
@@ -435,7 +440,7 @@ func (e *Engine) EvalCondition(
 	vv map[string]string,
 	locals rts.Locals,
 ) (bool, string, error) {
-	env := src.Resolve()
+	env := ResolveEnvironment(src, doc, req)
 	return e.evalCondition(ctx, doc, req, env, base, spec, e.storedScope(doc, env, vv), locals)
 }
 
@@ -498,7 +503,7 @@ func (e *Engine) EvalForEachItems(
 	if expr == "" {
 		return nil, fmt.Errorf("@for-each expression missing")
 	}
-	env := src.Resolve()
+	env := ResolveEnvironment(src, doc, req)
 	sc := e.storedScope(doc, env, vv)
 	val, err := e.rtsEvalValue(ctx, EvalInput{
 		Doc:     doc,
@@ -599,7 +604,7 @@ func (e *Engine) RunPreRequest(
 	globals vars.Globals,
 ) (prerequest.Output, error) {
 	sc := newEvalScope(vv, globals)
-	return e.runRTSPreRequest(ctx, doc, req, env.Resolve(), base, sc, locals, nil)
+	return e.runRTSPreRequest(ctx, doc, req, ResolveEnvironment(env, doc, req), base, sc, locals, nil)
 }
 
 func (e *Engine) runRTSPreRequest(
@@ -1212,7 +1217,7 @@ func (e *Engine) ApplyPatches(
 	vv map[string]string,
 	locals rts.Locals,
 ) error {
-	env := src.Resolve()
+	env := ResolveEnvironment(src, doc, req)
 	return e.runRTSApply(ctx, doc, req, env, base, e.storedScope(doc, env, vv), locals)
 }
 

--- a/internal/engine/request/script_vars_test.go
+++ b/internal/engine/request/script_vars_test.go
@@ -47,7 +47,10 @@ type sentRequest struct {
 	executed *restfile.Request
 }
 
-type stubTransport struct{ wire *http.Request }
+type stubTransport struct {
+	wire *http.Request
+	body string
+}
 
 func (s *stubTransport) client() *httpx.Client {
 	return httpx.NewClientWithOptions(
@@ -55,11 +58,15 @@ func (s *stubTransport) client() *httpx.Client {
 			return &http.Client{
 				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 					s.wire = r
+					body := s.body
+					if body == "" {
+						body = "ok"
+					}
 					return &http.Response{
 						Status:     "200 OK",
 						StatusCode: http.StatusOK,
 						Header:     make(http.Header),
-						Body:       io.NopCloser(strings.NewReader("ok")),
+						Body:       io.NopCloser(strings.NewReader(body)),
 						Request:    r,
 					}, nil
 				}),

--- a/internal/engine/request/varplan.go
+++ b/internal/engine/request/varplan.go
@@ -31,34 +31,34 @@ type sourceTraits struct {
 	template bool
 	// hidden excludes values from script-facing vars; constants are not overridable.
 	hidden bool
+	// declared identifies sources allowed to contain env: references.
+	declared bool
 }
 
 var sourceTable = [...]sourceTraits{
 	sourceUnknown:        {},
-	sourceConst:          {label: "const", template: true, hidden: true},
+	sourceConst:          {label: "const", template: true, hidden: true, declared: true},
 	sourceScript:         {label: "script"},
 	sourceWorkflow:       {label: "workflow"},
 	sourceRequestCapture: {label: "request"},
-	sourceRequest:        {label: "request", template: true},
+	sourceRequest:        {label: "request", template: true, declared: true},
 	sourceRuntimeGlobal:  {label: "global"},
-	sourceDocumentGlobal: {label: "document-global", template: true},
+	sourceDocumentGlobal: {label: "document-global", template: true, declared: true},
 	sourceRuntimeFile:    {label: "file"},
-	sourceFile:           {label: "file", template: true},
-	sourceEnvironment:    {label: "environment"},
+	sourceFile:           {label: "file", template: true, declared: true},
+	sourceEnvironment:    {label: "environment", declared: true},
 }
 
 func (s variableSource) traits() sourceTraits { return sourceTable[s] }
 
 type variableEntry struct {
-	name  string
-	value string
+	name string
+	val  vars.Value
 }
 
 type variableLayer struct {
 	source variableSource
-	vals   vars.NameMap[string]
-	// script holds values exposed to scripts when they differ from vals.
-	script *vars.NameMap[string]
+	vals   vars.NameMap[vars.Value]
 }
 
 // variablePlan is the shared precedence order for template and script lookups.
@@ -66,7 +66,6 @@ type variableLayer struct {
 // host bindings use separate lexical scoping and are not included.
 type variablePlan struct {
 	layers []variableLayer
-	refs   vars.RefResolver
 }
 
 type runVars struct {
@@ -86,57 +85,43 @@ type varSources struct {
 
 // Variable plans keep template and script lookups at the same precedence. Each
 // plan includes every source layer because resolver memoization uses provider
-// positions. Authored values may expand nested templates, while runtime values
-// such as captures remain literal.
+// positions.
 func (e *Engine) buildVariablePlan(src varSources) variablePlan {
 	env := src.env
 	if src.sec == omitSecrets {
 		env = env.WithoutRefValues()
 	}
-	plan := variablePlan{
-		layers: make([]variableLayer, 0, len(sourceTable)),
-		refs:   env.RefResolver(),
-	}
-	plan.add(sourceConst, constEntries(src.doc))
-	plan.addNames(sourceScript, src.run.scripts)
-	plan.addNames(sourceWorkflow, src.run.overlay)
-	plan.add(sourceRequestCapture, nil)
-	plan.add(sourceRequest, requestEntries(src.req, src.sec))
-	plan.add(sourceRuntimeGlobal, globalEntries(src.globals))
-	plan.add(sourceDocumentGlobal, docGlobalEntries(src.doc, src.sec))
-	plan.add(sourceRuntimeFile, e.runtimeFileEntries(src.doc, env, src.sec))
-	plan.add(sourceFile, docVarEntries(src.doc, src.sec))
+	refs := env.Refs()
 
-	authored := sortedEntries(env.AuthoredValues())
-	if env.HasRefs() {
-		plan.addSplit(sourceEnvironment, authored, sortedEntries(env.Values()))
-	} else {
-		plan.add(sourceEnvironment, authored)
-	}
+	plan := variablePlan{layers: make([]variableLayer, 0, len(sourceTable))}
+	plan.add(sourceConst, constEntries(src.doc, refs))
+	plan.addLiteral(sourceScript, src.run.scripts)
+	plan.addLiteral(sourceWorkflow, src.run.overlay)
+	plan.add(sourceRequestCapture, nil)
+	plan.add(sourceRequest, requestEntries(src.req, src.sec, refs))
+	plan.add(sourceRuntimeGlobal, literalEntries(globalValues(src.globals)))
+	plan.add(sourceDocumentGlobal, docGlobalEntries(src.doc, src.sec, refs))
+	plan.add(sourceRuntimeFile, literalEntries(e.runtimeFileValues(src.doc, env, src.sec)))
+	plan.add(sourceFile, docVarEntries(src.doc, src.sec, refs))
+	plan.add(sourceEnvironment, valueEntries(env.ProviderValues()))
 	return plan
 }
 
 // add preserves declaration order so the last form of a name wins within a source.
 func (p *variablePlan) add(source variableSource, entries []variableEntry) {
-	p.appendLayer(source, nameMapOf(entries))
-}
-
-func (p *variablePlan) addSplit(source variableSource, authored, script []variableEntry) {
-	sm := nameMapOf(script)
-	p.layers = append(p.layers, variableLayer{
-		source: source,
-		vals:   nameMapOf(authored),
-		script: &sm,
-	})
-}
-
-// addNames snapshots an already-normalized source.
-func (p *variablePlan) addNames(source variableSource, vals vars.NameMap[string]) {
-	p.appendLayer(source, vals.Clone())
-}
-
-func (p *variablePlan) appendLayer(source variableSource, vals vars.NameMap[string]) {
+	var vals vars.NameMap[vars.Value]
+	for _, e := range entries {
+		vals.Set(e.name, e.val)
+	}
 	p.layers = append(p.layers, variableLayer{source: source, vals: vals})
+}
+
+func (p *variablePlan) addLiteral(source variableSource, vals vars.NameMap[string]) {
+	var out vars.NameMap[vars.Value]
+	for name, v := range vals.All() {
+		out.Set(name, vars.Value{Text: v})
+	}
+	p.layers = append(p.layers, variableLayer{source: source, vals: out})
 }
 
 func (p *variablePlan) overlay(source variableSource, vals vars.NameMap[string]) {
@@ -144,20 +129,11 @@ func (p *variablePlan) overlay(source variableSource, vals vars.NameMap[string])
 		if p.layers[i].source != source {
 			continue
 		}
-		p.layers[i].vals.Merge(vals)
-		if p.layers[i].script != nil {
-			p.layers[i].script.Merge(vals)
+		for name, v := range vals.All() {
+			p.layers[i].vals.Set(name, vars.Value{Text: v})
 		}
 		return
 	}
-}
-
-func nameMapOf(entries []variableEntry) vars.NameMap[string] {
-	var out vars.NameMap[string]
-	for _, e := range entries {
-		out.Set(e.name, e.value)
-	}
-	return out
 }
 
 // providers exposes each layer to template resolution. Authored values use
@@ -167,10 +143,10 @@ func (p variablePlan) providers() []vars.Provider {
 	for _, l := range p.layers {
 		t := l.source.traits()
 		if t.template {
-			out = append(out, vars.NewNameMapTemplateProvider(t.label, l.vals))
+			out = append(out, vars.NewValueMapTemplateProvider(t.label, l.vals))
 			continue
 		}
-		out = append(out, vars.NewNameMapProvider(t.label, l.vals))
+		out = append(out, vars.NewValueMapProvider(t.label, l.vals))
 	}
 	// Process environment values are not enumerable, so they remain the final
 	// fallback outside the plan.
@@ -178,124 +154,201 @@ func (p variablePlan) providers() []vars.Provider {
 }
 
 // Scripts should see ordinary nested references resolved just as templates do.
-// Dynamic helpers and expressions are left alone because they are evaluated
-// later, after pre-request scripts have run.
+// Dynamic helpers and expressions are evaluated later, after pre-request
+// scripts have run.
 func (p variablePlan) values() map[string]string {
-	var out vars.NameMap[string]
+	var seen vars.NameMap[vars.Value]
 	var res *vars.Resolver
 	for _, l := range p.layers {
 		t := l.source.traits()
 		if t.hidden {
 			continue
 		}
-		vals := l.vals
-		if l.script != nil {
-			vals = *l.script
-		}
-		for name, value := range vals.All() {
-			if out.Has(name) {
+		for name, val := range l.vals.All() {
+			if seen.Has(name) {
 				continue
 			}
-			if t.template && vars.HasPlaceholder(value) {
+			if !val.Missing && !val.Final && t.template && vars.HasPlaceholder(val.Text) {
 				if res == nil {
-					res = p.staticResolver()
+					res = vars.NewResolver(p.providers()...)
 				}
 				// Leave values that need runtime data or the expression evaluator unchanged.
-				if expanded, err := res.ExpandTemplatesStatic(value); err == nil {
-					value = expanded
+				if expanded, err := res.ExpandTemplatesStatic(val.Text); err == nil {
+					val.Text = expanded
 				}
 			}
-			out.Set(name, value)
+			seen.Set(name, val)
 		}
 	}
-	return out.Map()
+
+	out := make(map[string]string, seen.Len())
+	for name, val := range seen.All() {
+		if val.Missing {
+			continue
+		}
+		out[name] = val.Text
+	}
+	return out
 }
 
-func (p variablePlan) staticResolver() *vars.Resolver {
-	res := vars.NewResolver(p.providers()...)
-	res.AddRefResolver(p.refs)
-	return res
+// Only declarations may choose the OS variable in a templated env: reference.
+func declaredNames(doc *restfile.Document, req *restfile.Request, env vars.Environment) *vars.Resolver {
+	out := make([]vars.Provider, 0, len(sourceTable))
+	for i, t := range sourceTable {
+		if !t.declared {
+			continue
+		}
+		out = append(
+			out,
+			vars.NewValueMapTemplateProvider(t.label, declaredText(variableSource(i), doc, req, env)),
+		)
+	}
+	return vars.NewResolver(out...)
 }
 
-func constEntries(doc *restfile.Document) []variableEntry {
+func declaredText(
+	source variableSource,
+	doc *restfile.Document,
+	req *restfile.Request,
+	env vars.Environment,
+) vars.NameMap[vars.Value] {
+	var out vars.NameMap[vars.Value]
+	set := func(name, text string) { out.Set(name, vars.Value{Text: text}) }
+	switch source {
+	case sourceConst:
+		if doc != nil {
+			for _, c := range doc.Constants {
+				set(c.Name, c.Value)
+			}
+		}
+	case sourceRequest:
+		if req != nil {
+			for _, v := range req.Variables {
+				set(v.Name, v.Value)
+			}
+		}
+	case sourceDocumentGlobal:
+		if doc != nil {
+			for _, v := range doc.Globals {
+				set(v.Name, v.Value)
+			}
+		}
+	case sourceFile:
+		if doc != nil {
+			for _, v := range doc.Variables {
+				set(v.Name, v.Value)
+			}
+		}
+	case sourceEnvironment:
+		for _, name := range slices.Sorted(maps.Keys(env.Values())) {
+			set(name, env.Values()[name])
+		}
+	}
+	return out
+}
+
+func constEntries(doc *restfile.Document, refs *vars.EnvRefs) []variableEntry {
 	if doc == nil {
 		return nil
 	}
 	out := make([]variableEntry, 0, len(doc.Constants))
 	for _, c := range doc.Constants {
-		out = append(out, variableEntry{name: c.Name, value: c.Value})
+		out = append(out, variableEntry{name: c.Name, val: declaredValue(refs, c.Authored, c.Value)})
 	}
 	return out
 }
 
-func requestEntries(req *restfile.Request, sec secrecy) []variableEntry {
+func requestEntries(req *restfile.Request, sec secrecy, refs *vars.EnvRefs) []variableEntry {
 	if req == nil {
 		return nil
 	}
-	return declaredEntries(req.Variables, sec)
+	return declaredEntries(req.Variables, sec, refs)
 }
 
-func docGlobalEntries(doc *restfile.Document, sec secrecy) []variableEntry {
+func docGlobalEntries(doc *restfile.Document, sec secrecy, refs *vars.EnvRefs) []variableEntry {
 	if doc == nil {
 		return nil
 	}
-	return declaredEntries(doc.Globals, sec)
+	return declaredEntries(doc.Globals, sec, refs)
 }
 
-func docVarEntries(doc *restfile.Document, sec secrecy) []variableEntry {
+func docVarEntries(doc *restfile.Document, sec secrecy, refs *vars.EnvRefs) []variableEntry {
 	if doc == nil {
 		return nil
 	}
-	return declaredEntries(doc.Variables, sec)
+	return declaredEntries(doc.Variables, sec, refs)
 }
 
-func declaredEntries(xs []restfile.Variable, sec secrecy) []variableEntry {
+// Unlike -secret values, withheld env: references still shadow lower sources.
+func declaredEntries(xs []restfile.Variable, sec secrecy, refs *vars.EnvRefs) []variableEntry {
 	out := make([]variableEntry, 0, len(xs))
 	for _, v := range xs {
-		if sec == omitSecrets && v.Secret {
+		if sec == omitSecrets && v.Secret && !namesProcessVar(v.Authored, v.Value) {
 			continue
 		}
-		out = append(out, variableEntry{name: v.Name, value: v.Value})
+		out = append(out, variableEntry{name: v.Name, val: declaredValue(refs, v.Authored, v.Value)})
 	}
 	return out
 }
 
-func globalEntries(globs vars.Globals) []variableEntry {
-	out := make([]variableEntry, 0, globs.Len())
+func declaredValue(refs *vars.EnvRefs, authored bool, text string) vars.Value {
+	if !authored {
+		return vars.Value{Text: text}
+	}
+	return refs.Declared(text)
+}
+
+func namesProcessVar(authored bool, text string) bool {
+	if !authored {
+		return false
+	}
+	_, ok := vars.EnvRefKey(text)
+	return ok
+}
+
+func globalValues(globs vars.Globals) map[string]string {
+	out := make(map[string]string, globs.Len())
 	for name, g := range globs.Sorted() {
 		if g.Delete {
 			continue
 		}
-		out = append(out, variableEntry{name: name, value: g.Value})
+		out[name] = g.Value
 	}
 	return out
 }
 
-func (e *Engine) runtimeFileEntries(
+func (e *Engine) runtimeFileValues(
 	doc *restfile.Document,
 	env vars.ResolvedEnv,
 	sec secrecy,
-) []variableEntry {
+) map[string]string {
 	fs := e.rt.Files()
 	if fs == nil {
 		return nil
 	}
 	snap := fs.Snapshot(env.Scope(), e.filePath(doc))
-	out := make([]variableEntry, 0, len(snap))
-	for _, key := range slices.Sorted(maps.Keys(snap)) {
-		v := snap[key]
+	out := make(map[string]string, len(snap))
+	for key, v := range snap {
 		if sec == omitSecrets && v.Secret {
 			continue
 		}
-		out = append(out, variableEntry{name: storedName(v.Name, key), value: v.Value})
+		out[storedName(v.Name, key)] = v.Value
 	}
 	return out
 }
 
-func sortedEntries(src map[string]string) []variableEntry {
+func literalEntries(src map[string]string) []variableEntry {
 	out := make([]variableEntry, 0, len(src))
 	for _, name := range slices.Sorted(maps.Keys(src)) {
-		out = append(out, variableEntry{name: name, value: src[name]})
+		out = append(out, variableEntry{name: name, val: vars.Value{Text: src[name]}})
+	}
+	return out
+}
+
+func valueEntries(src vars.NameMap[vars.Value]) []variableEntry {
+	out := make([]variableEntry, 0, src.Len())
+	for name, val := range src.Sorted() {
+		out = append(out, variableEntry{name: name, val: val})
 	}
 	return out
 }

--- a/internal/engine/request/vars.go
+++ b/internal/engine/request/vars.go
@@ -181,7 +181,7 @@ func (e *Engine) buildResolver(
 		Env:     env,
 		Base:    base,
 		Locals:  locals,
-		globals: effectiveGlobalValues(doc, globs),
+		globals: effectiveGlobalValues(doc, globs, env.Refs()),
 	}
 	return e.planResolver(ctx, plan, in, ExprEvalOptions{})
 }
@@ -196,7 +196,7 @@ func (e *Engine) DisplayResolver(
 	base string,
 	locals rts.Locals,
 ) *vars.Resolver {
-	env := src.Resolve().WithoutRefValues()
+	env := ResolveEnvironment(src, doc, req).WithoutRefValues()
 	globs := e.collectStoredGlobalValues(env)
 	globs.DeleteFunc(func(_ string, v vars.GlobalMutation) bool { return v.Secret })
 
@@ -213,7 +213,7 @@ func (e *Engine) DisplayResolver(
 		Env:     env,
 		Base:    e.rtsBase(doc, base),
 		Locals:  locals,
-		globals: effectiveGlobalValues(doc, globs),
+		globals: effectiveGlobalValues(doc, globs, env.Refs()),
 	}
 	return e.planResolver(ctx, plan, in, ExprEvalOptions{OmitSecretGlobals: true})
 }
@@ -228,7 +228,6 @@ func (e *Engine) planResolver(
 ) *vars.Resolver {
 	in.Vars = plan.values()
 	res := vars.NewResolver(plan.providers()...)
-	res.AddRefResolver(plan.refs)
 	res.SetExprEval(e.ExprEvalWithOptions(ctx, in, opt))
 	res.SetExprPos(e.rtsPos(in.Doc, in.Req))
 	return res
@@ -269,7 +268,36 @@ func (e *Engine) collectVariablesWithGlobals(
 }
 
 func (e *Engine) collectGlobalValues(doc *restfile.Document, env vars.ResolvedEnv) vars.Globals {
-	return effectiveGlobalValues(doc, e.collectStoredGlobalValues(env))
+	return effectiveGlobalValues(doc, e.collectStoredGlobalValues(env), env.Refs())
+}
+
+// ResolveEnvironment snapshots every declared env: reference for one run,
+// including unused values that may need redaction.
+func ResolveEnvironment(
+	src vars.Environment,
+	doc *restfile.Document,
+	req *restfile.Request,
+) vars.ResolvedEnv {
+	env := src.ResolveWith(vars.NewEnvRefs(declaredNames(doc, req, src)))
+	refs := env.Refs()
+	read := func(authored bool, text string) { declaredValue(refs, authored, text) }
+	if doc != nil {
+		for _, c := range doc.Constants {
+			read(c.Authored, c.Value)
+		}
+		for _, v := range doc.Variables {
+			read(v.Authored, v.Value)
+		}
+		for _, v := range doc.Globals {
+			read(v.Authored, v.Value)
+		}
+	}
+	if req != nil {
+		for _, v := range req.Variables {
+			read(v.Authored, v.Value)
+		}
+	}
+	return env
 }
 
 func (e *Engine) collectStoredGlobalValues(env vars.ResolvedEnv) vars.Globals {
@@ -285,20 +313,32 @@ func (e *Engine) collectStoredGlobalValues(env vars.ResolvedEnv) vars.Globals {
 	return out
 }
 
-func collectDocumentGlobalValues(doc *restfile.Document) vars.Globals {
+func collectDocumentGlobalValues(doc *restfile.Document, refs *vars.EnvRefs) vars.Globals {
 	var out vars.Globals
 	if doc == nil {
 		return out
 	}
 	for _, v := range doc.Globals {
+		val := declaredValue(refs, v.Authored, v.Value)
+		if val.Missing {
+			continue
+		}
 		name := strings.TrimSpace(v.Name)
-		out.Set(name, vars.GlobalMutation{Name: name, Value: v.Value, Secret: v.Secret})
+		out.Set(name, vars.GlobalMutation{
+			Name:   name,
+			Value:  val.Text,
+			Secret: v.Secret || namesProcessVar(v.Authored, v.Value),
+		})
 	}
 	return out
 }
 
-func effectiveGlobalValues(doc *restfile.Document, globs vars.Globals) vars.Globals {
-	return mergeGlobalValues(collectDocumentGlobalValues(doc), globs)
+func effectiveGlobalValues(
+	doc *restfile.Document,
+	globs vars.Globals,
+	refs *vars.EnvRefs,
+) vars.Globals {
+	return mergeGlobalValues(collectDocumentGlobalValues(doc, refs), globs)
 }
 
 func mergeGlobalValues(base, changes vars.Globals) vars.Globals {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -153,11 +153,13 @@ type CompareRow struct {
 	Err         error
 	Tests       []scripts.TestResult
 	ScriptErr   error
-	Skipped     bool
-	SkipReason  string
-	Canceled    bool
-	Success     bool
-	Duration    time.Duration
+	// RuntimeSecrets contains the values exposed while this row ran.
+	RuntimeSecrets []string
+	Skipped        bool
+	SkipReason     string
+	Canceled       bool
+	Success        bool
+	Duration       time.Duration
 }
 
 type ProfileResult struct {

--- a/internal/parser/env_ref_test.go
+++ b/internal/parser/env_ref_test.go
@@ -1,0 +1,72 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseMarksDeclarationsAuthored(t *testing.T) {
+	src := `# @const c_tok env:CONST_TOKEN
+# @global g_tok env:GLOBAL_TOKEN
+# @file f_tok env:FILE_TOKEN
+# @file-secret f_sec env:FILE_SECRET
+# @file plain literal-value
+# @file nested env:{{picked}}
+
+### one
+# @name one
+# @request r_tok env:REQUEST_TOKEN
+GET http://example.test
+`
+	doc := Parse("sample.http", []byte(src))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("errors = %#v, want none", doc.Errors)
+	}
+
+	if len(doc.Constants) != 1 || !doc.Constants[0].Authored {
+		t.Fatalf("constants = %#v, want the constant marked authored", doc.Constants)
+	}
+	if len(doc.Globals) != 1 || !doc.Globals[0].Authored {
+		t.Fatalf("globals = %#v, want the global marked authored", doc.Globals)
+	}
+	if got := len(doc.Variables); got != 4 {
+		t.Fatalf("file variables = %d, want 4", got)
+	}
+	for _, v := range doc.Variables {
+		if !v.Authored {
+			t.Fatalf("file variable %q is not marked authored", v.Name)
+		}
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(doc.Requests))
+	}
+	rv := doc.Requests[0].Variables
+	if len(rv) != 1 || !rv[0].Authored {
+		t.Fatalf("request variables = %#v, want the variable marked authored", rv)
+	}
+}
+
+func TestParseReportsEnvRefWithNoName(t *testing.T) {
+	src := `# @file f_tok env:
+# @const c_tok env:
+# @global g_tok env:
+# @file fine env:REAL_NAME
+
+### one
+# @name one
+# @request r_tok env:
+GET http://example.test
+`
+	doc := Parse("sample.http", []byte(src))
+	if len(doc.Errors) != 4 {
+		t.Fatalf("errors = %#v, want one per malformed declaration", doc.Errors)
+	}
+	for _, e := range doc.Errors {
+		if !strings.Contains(e.Message, "env: reference is missing a variable name") {
+			t.Fatalf("error %d: %q, want the malformed reference named", e.Line, e.Message)
+		}
+		if e.Line == 0 {
+			t.Fatalf("error %q has no line", e.Message)
+		}
+	}
+}

--- a/internal/parser/metadata.go
+++ b/internal/parser/metadata.go
@@ -122,11 +122,13 @@ func (b *documentBuilder) addRequestVar(no int, rest string) {
 	if name == "" {
 		return
 	}
+	b.checkEnvRef(no, value)
 	b.request.variables = append(b.request.variables, restfile.Variable{
-		Name:  name,
-		Value: value,
-		Line:  no,
-		Scope: directive.ScopeRequest,
+		Name:     name,
+		Value:    value,
+		Line:     no,
+		Scope:    directive.ScopeRequest,
+		Authored: true,
 	})
 }
 

--- a/internal/parser/variables.go
+++ b/internal/parser/variables.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 var variableLineRe = regexp.MustCompile(
@@ -46,12 +47,14 @@ func (b *documentBuilder) addScopedVariable(
 	if name == "" {
 		return
 	}
+	b.checkEnvRef(line, value)
 	variable := restfile.Variable{
-		Name:   name,
-		Value:  value,
-		Line:   line,
-		Scope:  scope,
-		Secret: secret,
+		Name:     name,
+		Value:    value,
+		Line:     line,
+		Scope:    scope,
+		Secret:   secret,
+		Authored: true,
 	}
 	switch scope {
 	case directive.ScopeGlobal:
@@ -83,12 +86,20 @@ func (b *documentBuilder) handleScopedVariableDirective(d parsedDirective) direc
 }
 
 func (b *documentBuilder) addConstant(name, value string, line int) {
+	b.checkEnvRef(line, value)
 	constant := restfile.Constant{
-		Name:  name,
-		Value: value,
-		Line:  line,
+		Name:     name,
+		Value:    value,
+		Line:     line,
+		Authored: true,
 	}
 	b.file.consts = append(b.file.consts, constant)
+}
+
+func (b *documentBuilder) checkEnvRef(line int, value string) {
+	if key, ok := vars.EnvRefKey(value); ok && key == "" {
+		b.addError(line, "env: reference is missing a variable name")
+	}
 }
 
 func (b *documentBuilder) handleConstDirective(d parsedDirective) directiveOutcome {

--- a/internal/prerequest/prerequest.go
+++ b/internal/prerequest/prerequest.go
@@ -163,7 +163,7 @@ func SetRequestVars(req *restfile.Request, variables vars.NameMap[string]) {
 	for name, value := range variables.Sorted() {
 		key := vars.NameKey(name)
 		if idx, ok := idxs[key]; ok {
-			req.Variables[idx].Value = value
+			req.Variables[idx].SetRuntimeValue(value)
 			continue
 		}
 		idxs[key] = len(req.Variables)

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -20,12 +20,21 @@ type Variable struct {
 	Scope  directive.Scope
 	Line   int
 	Secret bool
+	// Authored distinguishes declarations from values produced during a run.
+	Authored bool
+}
+
+// SetRuntimeValue replaces the declaration with runtime data.
+func (v *Variable) SetRuntimeValue(value string) {
+	v.Value = value
+	v.Authored = false
 }
 
 type Constant struct {
 	Name  string
 	Value string
 	Line  int
+	Authored bool
 }
 
 type AuthSpec struct {

--- a/internal/ui/model_compare_run.go
+++ b/internal/ui/model_compare_run.go
@@ -280,16 +280,17 @@ func (m *Model) consumeCompareRow(
 		msg.skipped = false
 	}
 	result := compareResult{
-		Environment: currentEnv,
-		Selection:   msg.selection,
-		Stream:      cloneStreamInfo(msg.stream),
-		Transcript:  append([]byte(nil), msg.transcript...),
-		Tests:       append([]scripts.TestResult(nil), msg.tests...),
-		ScriptErr:   msg.scriptErr,
-		RequestText: state.requestText,
-		Canceled:    canceled,
-		Skipped:     msg.skipped,
-		SkipReason:  msg.skipReason,
+		Environment:    currentEnv,
+		Selection:      msg.selection,
+		Stream:         cloneStreamInfo(msg.stream),
+		Transcript:     append([]byte(nil), msg.transcript...),
+		Tests:          append([]scripts.TestResult(nil), msg.tests...),
+		ScriptErr:      msg.scriptErr,
+		RuntimeSecrets: append([]string(nil), msg.runtimeSecrets...),
+		RequestText:    state.requestText,
+		Canceled:       canceled,
+		Skipped:        msg.skipped,
+		SkipReason:     msg.skipReason,
 	}
 	if state.group != "" {
 		result.Profile, _ = msg.selection.Profile(state.group)
@@ -536,7 +537,7 @@ func (m *Model) buildCompareHistoryResult(result compareResult) history.CompareR
 		entry.RequestText = rqeng.RenderRequestText(req)
 	}
 	if req != nil {
-		secrets := m.secretValuesForSelection(result.Selection, req)
+		secrets := m.secretValuesForSelection(result.Selection, req, result.RuntimeSecrets...)
 		maskHeaders := !req.Metadata.AllowSensitiveHeaders
 		entry.RequestText = redactHistoryText(entry.RequestText, secrets, maskHeaders)
 	}
@@ -556,10 +557,10 @@ func (m *Model) buildCompareHistoryResult(result compareResult) history.CompareR
 		entry.Error = result.Err.Error()
 		entry.BodySnippet = entry.Error
 	case result.Response != nil:
-		entry.BodySnippet = m.compareHTTPSnippet(result.Response, req, result.Selection)
+		entry.BodySnippet = m.compareHTTPSnippet(result.Response, req, result)
 		entry.StatusCode = result.Response.StatusCode
 	case result.GRPC != nil:
-		entry.BodySnippet = m.compareGRPCSnippet(result.GRPC, req, result.Selection)
+		entry.BodySnippet = m.compareGRPCSnippet(result.GRPC, req, result)
 		entry.StatusCode = int(result.GRPC.StatusCode)
 	case result.Stream != nil || len(result.Transcript) > 0:
 		entry.BodySnippet = streamSummaryText(result.Stream)
@@ -577,7 +578,7 @@ func (m *Model) buildCompareHistoryResult(result compareResult) history.CompareR
 func (m *Model) compareHTTPSnippet(
 	resp *httpx.Response,
 	req *restfile.Request,
-	sel vars.Selection,
+	row compareResult,
 ) string {
 	if resp == nil {
 		return ""
@@ -585,13 +586,13 @@ func (m *Model) compareHTTPSnippet(
 	if req != nil && req.Metadata.NoLog {
 		return "<body suppressed>"
 	}
-	return redactHistoryText(string(resp.Body), m.secretValuesForSelection(sel, req), false)
+	return redactHistoryText(string(resp.Body), m.compareRowSecrets(row, req), false)
 }
 
 func (m *Model) compareGRPCSnippet(
 	resp *grpcx.Response,
 	req *restfile.Request,
-	sel vars.Selection,
+	row compareResult,
 ) string {
 	if resp == nil {
 		return ""
@@ -599,7 +600,11 @@ func (m *Model) compareGRPCSnippet(
 	if req != nil && req.Metadata.NoLog {
 		return "<body suppressed>"
 	}
-	return redactHistoryText(resp.Message, m.secretValuesForSelection(sel, req), false)
+	return redactHistoryText(resp.Message, m.compareRowSecrets(row, req), false)
+}
+
+func (m *Model) compareRowSecrets(row compareResult, req *restfile.Request) []string {
+	return m.secretValuesForSelection(row.Selection, req, row.RuntimeSecrets...)
 }
 
 func (s *compareState) progressSummary() string {

--- a/internal/ui/model_compare_secret_test.go
+++ b/internal/ui/model_compare_secret_test.go
@@ -1,0 +1,40 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+func TestCompareHistoryResultMasksRuntimeSecrets(t *testing.T) {
+	const secret = "ui-compare-runtime-secret"
+
+	model := newTestModelWithDoc("### probe\n# @name probe\nGET http://example.test\n")
+	req := &restfile.Request{
+		Method:   "GET",
+		URL:      "http://example.test",
+		Metadata: restfile.RequestMetadata{Name: "probe"},
+	}
+	result := compareResult{
+		Environment:    "dev",
+		Request:        req,
+		RequestText:    "GET http://example.test\nX-Token: " + secret,
+		RuntimeSecrets: []string{secret},
+		Response: &httpx.Response{
+			StatusCode: 200,
+			Body:       []byte(`{"echo":"` + secret + `"}`),
+		},
+	}
+
+	entry := model.buildCompareHistoryResult(result)
+	for field, text := range map[string]string{
+		"request text": entry.RequestText,
+		"body snippet": entry.BodySnippet,
+	} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("%s contains the plaintext secret: %s", field, text)
+		}
+	}
+}

--- a/internal/ui/model_compare_state.go
+++ b/internal/ui/model_compare_state.go
@@ -26,11 +26,13 @@ type compareResult struct {
 	Err         error
 	Tests       []scripts.TestResult
 	ScriptErr   error
-	Request     *restfile.Request
-	RequestText string
-	Canceled    bool
-	Skipped     bool
-	SkipReason  string
+	// RuntimeSecrets contains the values exposed while this row ran.
+	RuntimeSecrets []string
+	Request        *restfile.Request
+	RequestText    string
+	Canceled       bool
+	Skipped        bool
+	SkipReason     string
 }
 
 func (m *Model) resetCompareState() {

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -933,7 +933,8 @@ func (m *Model) secretValuesForEnv(
 		}
 		values[value] = struct{}{}
 	}
-	for _, value := range env.Resolve().Secrets() {
+	snap := rqeng.ResolveEnvironment(env, m.doc, req)
+	for _, value := range snap.Secrets() {
 		add(value)
 	}
 
@@ -994,12 +995,16 @@ func (m *Model) secretValuesForEnv(
 	return secrets
 }
 
-func (m *Model) secretValuesForSelection(sel vars.Selection, req *restfile.Request) []string {
+func (m *Model) secretValuesForSelection(
+	sel vars.Selection,
+	req *restfile.Request,
+	extraSecrets ...string,
+) []string {
 	env, err := m.environment(sel)
 	if err != nil {
-		return m.secretValuesForRedaction(req)
+		return m.secretValuesForRedaction(req, extraSecrets...)
 	}
-	return m.secretValuesForEnv(env, req)
+	return m.secretValuesForEnv(env, req, extraSecrets...)
 }
 
 func redactHistoryText(text string, secrets []string, maskHeaders bool) string {

--- a/internal/vars/refs.go
+++ b/internal/vars/refs.go
@@ -5,28 +5,90 @@ import (
 	"strings"
 )
 
-type RefResolver func(raw string) (resolved string, handled bool, found bool)
-
-// EnvRefResolver resolves values with a case-insensitive "env:" prefix by
-// looking up the remainder as an OS environment variable.
-func EnvRefResolver(raw string) (string, bool, bool) {
-	key, handled := envRefKey(raw)
-	if !handled {
-		return "", false, false
-	}
-	if key == "" {
-		return "", true, false
-	}
-	value, ok := lookupEnv(key)
-	return value, true, ok
-}
-
-func envRefKey(raw string) (string, bool) {
+// EnvRefKey parses an env: reference. An empty name is still a reference.
+func EnvRefKey(raw string) (string, bool) {
 	trimmed := strings.TrimSpace(raw)
 	if len(trimmed) < 4 || !strings.EqualFold(trimmed[:4], "env:") {
 		return "", false
 	}
 	return strings.TrimSpace(trimmed[4:]), true
+}
+
+// EnvRefs caches OS environment lookups for one run and records their values
+// for redaction.
+type EnvRefs struct {
+	seen    map[string]Value
+	named   map[string]Value
+	secrets Secrets
+	// names excludes runtime data so a response cannot select an OS variable.
+	names    *Resolver
+	withheld bool
+}
+
+// NewEnvRefs starts a per-run snapshot.
+func NewEnvRefs(names *Resolver) *EnvRefs {
+	return &EnvRefs{names: names}
+}
+
+// Withheld hides referenced values while preserving their precedence.
+func (s *EnvRefs) Withheld() *EnvRefs {
+	return &EnvRefs{withheld: true}
+}
+
+// Declared resolves env: references found in configuration and request files.
+// Runtime values must bypass it so response data cannot select an OS variable.
+func (s *EnvRefs) Declared(text string) Value {
+	ref, ok := EnvRefKey(text)
+	switch {
+	case !ok:
+		return Value{Text: text}
+	case s.withheld:
+		return Value{Missing: true}
+	case ref == "":
+		return Value{Missing: true}
+	case !HasPlaceholder(ref):
+		return s.Resolve(ref)
+	}
+
+	if v, ok := s.named[ref]; ok {
+		return v
+	}
+	v := Value{Missing: true}
+	if s.names != nil {
+		if expanded, err := s.names.ExpandTemplatesStatic(ref); err == nil {
+			v = s.Resolve(expanded)
+		}
+	}
+	if s.named == nil {
+		s.named = make(map[string]Value)
+	}
+	s.named[ref] = v
+	return v
+}
+
+// Resolve reads an OS environment variable at most once.
+func (s *EnvRefs) Resolve(key string) Value {
+	if s.withheld {
+		return Value{Missing: true}
+	}
+	if v, ok := s.seen[key]; ok {
+		return v
+	}
+	v := Value{Missing: true}
+	if text, ok := lookupEnv(key); ok {
+		v = Value{Text: text, Final: true}
+		s.secrets.Add(text)
+	}
+	if s.seen == nil {
+		s.seen = make(map[string]Value)
+	}
+	s.seen[key] = v
+	return v
+}
+
+// Secrets returns every OS value read by this snapshot.
+func (s *EnvRefs) Secrets() []string {
+	return s.secrets.Values()
 }
 
 // lookupEnv tries the key as-is first, then uppercased, so lowercase variable

--- a/internal/vars/resolved_env.go
+++ b/internal/vars/resolved_env.go
@@ -5,72 +5,78 @@ import (
 	"slices"
 )
 
-// envRef records missing references so they cannot fall through to another
-// provider.
-type envRef struct {
-	value string
-	found bool
-}
-
-// ResolvedEnv holds environment values for one execution. It keeps the original
-// env: references for templates and their captured values for scripts.
+// ResolvedEnv holds environment values and the OS lookups shared by one run.
+// The zero value is not usable.
 type ResolvedEnv struct {
 	env      Environment
-	values   map[string]string
-	refs     map[string]envRef
+	refs     *EnvRefs
+	vals     NameMap[Value]
+	plain    map[string]string
 	refNames []string
-	secrets  []string
-	withheld bool
 }
 
-// Resolve reads each referenced OS environment variable once. The result does
-// not change if the OS environment changes later.
+// Resolve creates a snapshot for callers without document declarations.
 func (e Environment) Resolve() ResolvedEnv {
-	out := ResolvedEnv{env: e, values: e.values}
-	var secrets Secrets
+	return e.ResolveWith(NewEnvRefs(nil))
+}
+
+// ResolveWith creates a snapshot that shares refs with the rest of the run.
+func (e Environment) ResolveWith(refs *EnvRefs) ResolvedEnv {
+	out := ResolvedEnv{
+		env:   e,
+		refs:  refs,
+		plain: make(map[string]string, len(e.values)),
+	}
 	for _, name := range slices.Sorted(maps.Keys(e.values)) {
 		raw := e.values[name]
-		key, ok := envRefKey(raw)
-		if !ok {
-			continue
+		if _, ok := EnvRefKey(raw); ok {
+			out.refNames = append(out.refNames, name)
 		}
-		if out.refs == nil {
-			out.refs = make(map[string]envRef)
-			out.values = maps.Clone(e.values)
+		v := refs.Declared(raw)
+		out.vals.Set(name, v)
+		if !v.Missing {
+			out.plain[name] = v.Text
 		}
-		out.refNames = append(out.refNames, name)
-
-		ref, seen := out.refs[key]
-		if !seen {
-			value, _, found := EnvRefResolver(raw)
-			ref = envRef{value: value, found: found}
-			out.refs[key] = ref
-		}
-		if !ref.found {
-			delete(out.values, name)
-			continue
-		}
-		out.values[name] = ref.value
-		secrets.Add(ref.value)
 	}
-	out.secrets = secrets.Values()
 	return out
 }
 
-// Values returns the values exposed to scripts and settings. Missing env:
-// references are omitted. The caller must not modify the returned map.
+// Refs returns the snapshot shared by this environment.
+func (r ResolvedEnv) Refs() *EnvRefs {
+	return r.refs
+}
+
+// Values returns resolved environment values. Callers must not modify the map.
 func (r ResolvedEnv) Values() map[string]string {
-	return r.values
+	return r.plain
 }
 
-// AuthoredValues returns the values from the environment file, including env:
-// references. The caller must not modify the returned map.
-func (r ResolvedEnv) AuthoredValues() map[string]string {
-	return r.env.values
+// ProviderValues returns resolver inputs, including references with no value.
+func (r ResolvedEnv) ProviderValues() NameMap[Value] {
+	return r.vals
 }
 
-func (r ResolvedEnv) HasRefs() bool {
-	return len(r.refNames) > 0
+// Secrets returns every OS value read by this environment.
+func (r ResolvedEnv) Secrets() []string {
+	return r.refs.Secrets()
+}
+
+// WithoutRefValues hides referenced values while preserving their precedence.
+func (r ResolvedEnv) WithoutRefValues() ResolvedEnv {
+	if r.refs.withheld {
+		return r
+	}
+	r.refs = r.refs.Withheld()
+	if len(r.refNames) == 0 {
+		return r
+	}
+	r.vals = r.vals.Clone()
+	r.plain = maps.Clone(r.plain)
+	for _, name := range r.refNames {
+		r.vals.Set(name, Value{Missing: true})
+		delete(r.plain, name)
+	}
+	return r
 }
 
 func (r ResolvedEnv) Label() string {
@@ -83,44 +89,4 @@ func (r ResolvedEnv) Scope() string {
 
 func (r ResolvedEnv) Selection() Selection {
 	return r.env.sel
-}
-
-// Secrets returns resolved env: values for redaction. The caller must not modify
-// the returned slice.
-func (r ResolvedEnv) Secrets() []string {
-	return r.secrets
-}
-
-// RefResolver resolves declared env: references from the captured values. A
-// reference not declared by the environment uses the current OS environment.
-func (r ResolvedEnv) RefResolver() RefResolver {
-	return func(raw string) (string, bool, bool) {
-		key, ok := envRefKey(raw)
-		if !ok {
-			return "", false, false
-		}
-		ref, seen := r.refs[key]
-		switch {
-		case !seen:
-			return EnvRefResolver(raw)
-		case r.withheld:
-			return "", true, false
-		}
-		return ref.value, true, ref.found
-	}
-}
-
-// WithoutRefValues returns a copy with mapped OS values hidden. Their names
-// remain defined so lower-priority providers cannot supply another value.
-func (r ResolvedEnv) WithoutRefValues() ResolvedEnv {
-	if !r.HasRefs() || r.withheld {
-		return r
-	}
-	r.values = maps.Clone(r.values)
-	for _, name := range r.refNames {
-		delete(r.values, name)
-	}
-	r.withheld = true
-	r.secrets = nil
-	return r
 }

--- a/internal/vars/resolved_env_test.go
+++ b/internal/vars/resolved_env_test.go
@@ -2,9 +2,27 @@ package vars
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 )
+
+func authored(refs *EnvRefs, src map[string]string) NameMap[Value] {
+	var out NameMap[Value]
+	for _, name := range slices.Sorted(maps.Keys(src)) {
+		out.Set(name, refs.Declared(src[name]))
+	}
+	return out
+}
+
+func declaredNames(src map[string]string) *Resolver {
+	var out NameMap[Value]
+	for _, name := range slices.Sorted(maps.Keys(src)) {
+		out.Set(name, Value{Text: src[name]})
+	}
+	return NewResolver(NewValueMapTemplateProvider("file", out))
+}
 
 func TestResolveCapturesEachEnvRefOnce(t *testing.T) {
 	first := "RESTERM_ENV_REF_FIRST"
@@ -23,9 +41,6 @@ func TestResolveCapturesEachEnvRefOnce(t *testing.T) {
 	if got := src.Values()["auth.token"]; got != "env:"+first {
 		t.Fatalf("catalog auth.token = %q, want the authored reference unchanged", got)
 	}
-	if got := env.AuthoredValues()["auth.token"]; got != "env:"+first {
-		t.Fatalf("authored auth.token = %q, want the authored reference", got)
-	}
 	if got := env.Values()["auth.token"]; got != "env:"+second {
 		t.Fatalf("resolved auth.token = %q, want one reference resolution", got)
 	}
@@ -35,9 +50,6 @@ func TestResolveCapturesEachEnvRefOnce(t *testing.T) {
 	if got := env.Values()["plain"]; got != "visible" {
 		t.Fatalf("resolved plain = %q, want %q", got, "visible")
 	}
-	if !env.HasRefs() {
-		t.Fatal("HasRefs() = false, want the declared references reported")
-	}
 	if secrets := env.Secrets(); len(secrets) != 1 || secrets[0] != "env:"+second {
 		t.Fatalf("Secrets() = %#v, want the resolved reference value", secrets)
 	}
@@ -45,19 +57,13 @@ func TestResolveCapturesEachEnvRefOnce(t *testing.T) {
 		t.Fatalf("snapshot changed environment identity: label=%q scope=%q", env.Label(), env.Scope())
 	}
 
-	// Template resolution must use the value captured above.
-	t.Setenv(first, "changed-after-snapshot")
-	res := NewResolver(NewMapProvider("environment", env.AuthoredValues()))
-	res.AddRefResolver(env.RefResolver())
-	got, err := res.ExpandTemplates("{{auth.token}}")
-	if err != nil {
-		t.Fatalf("expand auth.token: %v", err)
+	t.Setenv(missing, "ambient-now")
+	res := NewResolver(NewValueMapProvider("environment", env.ProviderValues()), EnvProvider{})
+	if got, err := res.ExpandTemplates("{{auth.missing}}"); err == nil {
+		t.Fatalf("{{auth.missing}} resolved to %q, want it undefined", got)
 	}
-	if got != "env:"+second {
-		t.Fatalf("template auth.token = %q, want the value already in Values()", got)
-	}
-	if got := env.Values()["auth.token"]; got != "env:"+second {
-		t.Fatalf("snapshot changed to %q after the process environment moved", got)
+	if got, err := res.ExpandTemplates("{{auth.token}}"); err != nil || got != "env:"+second {
+		t.Fatalf("{{auth.token}} = %q, %v, want the value already in Values()", got, err)
 	}
 }
 
@@ -82,12 +88,7 @@ func TestWithoutRefValuesWithholdsMappedValues(t *testing.T) {
 		t.Fatalf("withheld Secrets() = %#v, want none", public.Secrets())
 	}
 
-	// Include EnvProvider to verify that AUTH.TOKEN cannot replace the hidden alias.
-	res := NewResolver(
-		NewMapProvider("environment", public.AuthoredValues()),
-		EnvProvider{},
-	)
-	res.AddRefResolver(public.RefResolver())
+	res := NewResolver(NewValueMapProvider("environment", public.ProviderValues()), EnvProvider{})
 	if got, err := res.ExpandTemplates("{{auth.token}}"); err == nil {
 		t.Fatalf("withheld auth.token resolved to %q, want it undefined", got)
 	}
@@ -97,23 +98,66 @@ func TestWithoutRefValuesWithholdsMappedValues(t *testing.T) {
 	if got := env.Values()["auth.token"]; got != "private" {
 		t.Fatalf("WithoutRefValues() mutated the snapshot it came from: %q", got)
 	}
+
+	if got := public.Refs().Declared("env:" + key); !got.Missing {
+		t.Fatalf("withheld snapshot resolved an authored reference to %#v", got)
+	}
 }
 
-func TestResolveLeavesCatalogsWithoutRefsAlone(t *testing.T) {
-	key := "RESTERM_ENV_REF_UNDECLARED"
-	t.Setenv(key, "ambient")
+func TestEnvRefsReadEachVariableOnce(t *testing.T) {
+	key := "RESTERM_ENV_REFS_ONCE"
+	t.Setenv(key, "first")
 
-	env := testEnvironment(t, "dev", map[string]string{"plain": "visible"}).Resolve()
-	if env.HasRefs() {
-		t.Fatal("HasRefs() = true for a catalog with no env: reference")
+	var refs EnvRefs
+	if got := refs.Resolve(key); got.Text != "first" || !got.Final {
+		t.Fatalf("first read = %#v, want the process value marked final", got)
 	}
-	if len(env.Secrets()) != 0 {
-		t.Fatalf("Secrets() = %#v, want none", env.Secrets())
+	t.Setenv(key, "second")
+	if got := refs.Resolve(key); got.Text != "first" {
+		t.Fatalf("second read = %q, want the captured value", got.Text)
+	}
+	if secrets := refs.Secrets(); len(secrets) != 1 || secrets[0] != "first" {
+		t.Fatalf("Secrets() = %#v, want one entry", secrets)
+	}
+}
+
+func TestEnvRefKeyReadsTheEnvForm(t *testing.T) {
+	for _, raw := range []string{"plain", "environment:X", "envs:X", ""} {
+		if key, ok := EnvRefKey(raw); ok {
+			t.Fatalf("EnvRefKey(%q) = %q, true, want it treated as text", raw, key)
+		}
+	}
+	for raw, want := range map[string]string{
+		"env:NAME":    "NAME",
+		"ENV: NAME ":  "NAME",
+		"  env:name ": "name",
+		"env:":    "",
+		"env:   ": "",
+	} {
+		if key, ok := EnvRefKey(raw); !ok || key != want {
+			t.Fatalf("EnvRefKey(%q) = %q, %t, want %q", raw, key, ok, want)
+		}
+	}
+}
+
+func TestDeclaredEnvRefWithNoNameIsUndefined(t *testing.T) {
+	t.Setenv("TOKEN", "ambient-value")
+
+	var refs EnvRefs
+	for _, raw := range []string{"env:", "env:   "} {
+		if got := refs.Declared(raw); !got.Missing {
+			t.Fatalf("Declared(%q) = %#v, want it undefined", raw, got)
+		}
+	}
+	if len(refs.Secrets()) != 0 {
+		t.Fatalf("Secrets() = %#v, want none", refs.Secrets())
 	}
 
-	value, handled, found := env.RefResolver()("env:" + key)
-	if !handled || !found || value != "ambient" {
-		t.Fatalf("undeclared reference = %q, handled = %t, found = %t", value, handled, found)
+	var vals NameMap[Value]
+	vals.Set("token", refs.Declared("env:"))
+	res := NewResolver(NewValueMapTemplateProvider("file", vals), EnvProvider{})
+	if got, err := res.ExpandTemplates("{{token}}"); err == nil {
+		t.Fatalf("{{token}} resolved to %q, want it undefined", got)
 	}
 }
 

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -14,6 +14,29 @@ type Provider interface {
 	Label() string
 }
 
+// Value is a provider result. Its zero value is ordinary empty text.
+type Value struct {
+	Text string
+	// Missing claims the name without allowing fallback to another provider.
+	Missing bool
+	// Final prevents another round of template expansion.
+	Final bool
+}
+
+// ValueProvider returns structured provider results.
+type ValueProvider interface {
+	Provider
+	ResolveValue(name string) (Value, bool)
+}
+
+func providerValue(p Provider, name string) (Value, bool) {
+	if vp, ok := p.(ValueProvider); ok {
+		return vp.ResolveValue(name)
+	}
+	text, ok := p.Resolve(name)
+	return Value{Text: text}, ok
+}
+
 type ExprPos struct {
 	Path string
 	Line int
@@ -31,7 +54,6 @@ type Expansion struct {
 
 type Resolver struct {
 	providers []Provider
-	refs      []RefResolver
 	expr      ExprEval
 	exprPos   ExprPos
 	trace     *Trace
@@ -43,15 +65,7 @@ type Resolver struct {
 // without copying the lock.
 type memoStore struct {
 	mu      sync.Mutex
-	entries map[memoKey]memoEntry
-}
-
-// memoEntry pins the first expansion of a template-valued variable so every
-// later reference in the same resolver sees the same value, which is what
-// makes a declared {{$uuid}} stable across one request execution.
-type memoEntry struct {
-	value string
-	found bool
+	entries map[memoKey]string
 }
 
 // variableKey identifies the declaration selected by provider precedence.
@@ -125,10 +139,7 @@ func (r *Resolver) Resolve(name string) (string, bool) {
 	return value, ok
 }
 
-// resolve looks the name up and, when the winning provider holds authored
-// template text, expands nested placeholders before refs apply. A non-nil
-// error means expansion failed (cycle, depth, or an unresolvable nested
-// placeholder) and the value is unusable.
+// A missing result still wins provider lookup, preventing fallthrough.
 func (r *Resolver) resolve(
 	name string,
 	pos ExprPos,
@@ -144,10 +155,13 @@ func (r *Resolver) resolve(
 	if !ok {
 		return "", false, nil
 	}
+	if hit.val.Missing {
+		r.traceHit(name, hit, "", true)
+		return "", false, nil
+	}
 
-	var resolved string
-	var found bool
-	if expandableProvider(hit.prov) && HasPlaceholder(hit.raw) {
+	resolved := hit.val.Text
+	if !hit.val.Final && expandableProvider(hit.prov) && HasPlaceholder(resolved) {
 		variable := hit.key()
 		if err := checkExpandState(name, variable, st); err != nil {
 			return "", false, err
@@ -158,31 +172,33 @@ func (r *Resolver) resolve(
 			allowDynamic: allowDynamic,
 			allowExpr:    allowExpr,
 		}
-		entry, cached := r.memoized(key)
+		value, cached := r.memoized(key)
 		if !cached {
-			expanded, err := r.expandValue(name, hit.raw, variable, pos, allowDynamic, allowExpr, st)
+			expanded, err := r.expandValue(name, resolved, variable, pos, allowDynamic, allowExpr, st)
 			if err != nil {
 				return "", false, err
 			}
-			value, valueFound := r.applyRefs(expanded)
-			entry = r.memoize(key, memoEntry{value: value, found: valueFound})
+			value = r.memoize(key, expanded)
 		}
-		resolved, found = entry.value, entry.found
-	} else {
-		resolved, found = r.applyRefs(hit.raw)
+		resolved = value
 	}
 
-	if len(hit.sources) > 0 {
-		r.traceVar(ResolveTrace{
-			Name:     name,
-			Source:   hit.sources[0],
-			Value:    resolved,
-			Shadowed: hit.sources[1:],
-			Uses:     1,
-			Missing:  !found,
-		})
+	r.traceHit(name, hit, resolved, false)
+	return resolved, true, nil
+}
+
+func (r *Resolver) traceHit(name string, hit lookupHit, value string, missing bool) {
+	if len(hit.sources) == 0 {
+		return
 	}
-	return resolved, found, nil
+	r.traceVar(ResolveTrace{
+		Name:     name,
+		Source:   hit.sources[0],
+		Value:    value,
+		Shadowed: hit.sources[1:],
+		Uses:     1,
+		Missing:  missing,
+	})
 }
 
 func (r *Resolver) expandValue(
@@ -222,25 +238,25 @@ func checkExpandState(name string, key variableKey, st *expandState) error {
 	return nil
 }
 
-func (r *Resolver) memoized(key memoKey) (memoEntry, bool) {
+func (r *Resolver) memoized(key memoKey) (string, bool) {
 	r.memo.mu.Lock()
 	defer r.memo.mu.Unlock()
-	entry, ok := r.memo.entries[key]
-	return entry, ok
+	value, ok := r.memo.entries[key]
+	return value, ok
 }
 
 // memoize returns the first value stored for key. Multiple goroutines may do
 // the expansion work concurrently, but every caller observes the same winner.
 // Avoiding a wait on another variable's expansion also keeps concurrent roots
 // of a cyclic graph from deadlocking each other.
-func (r *Resolver) memoize(key memoKey, candidate memoEntry) memoEntry {
+func (r *Resolver) memoize(key memoKey, candidate string) string {
 	r.memo.mu.Lock()
 	defer r.memo.mu.Unlock()
 	if r.memo.entries == nil {
-		r.memo.entries = make(map[memoKey]memoEntry)
+		r.memo.entries = make(map[memoKey]string)
 	}
-	if entry, ok := r.memo.entries[key]; ok {
-		return entry
+	if value, ok := r.memo.entries[key]; ok {
+		return value
 	}
 	r.memo.entries[key] = candidate
 	return candidate
@@ -250,7 +266,7 @@ func (r *Resolver) memoize(key memoKey, candidate memoEntry) memoEntry {
 // winning provider actually resolved, which differs from the requested name
 // for prefixed lookups.
 type lookupHit struct {
-	raw     string
+	val     Value
 	prov    Provider
 	idx     int
 	subject string
@@ -265,12 +281,12 @@ func (h lookupHit) key() variableKey {
 // If that fails and the name has a dot, tries to match a provider prefix -
 // so "production.api_key" looks for a provider labeled "production" then asks for "api_key".
 func (r *Resolver) lookupValue(name string) (lookupHit, bool) {
-	hit, ok := r.lookup(func(p Provider) (string, string, bool) {
-		value, found := p.Resolve(name)
+	hit, ok := r.lookup(func(p Provider) (Value, string, bool) {
+		value, found := providerValue(p, name)
 		return value, name, found
 	})
 	if !ok && strings.Contains(name, ".") {
-		hit, ok = r.lookup(func(p Provider) (string, string, bool) {
+		hit, ok = r.lookup(func(p Provider) (Value, string, bool) {
 			return lookupPrefixed(p, name)
 		})
 	}
@@ -280,7 +296,7 @@ func (r *Resolver) lookupValue(name string) (lookupHit, bool) {
 // lookup returns the first value find yields across providers. Without tracing
 // it stops at the first hit. With tracing it keeps scanning and collects every
 // matching provider label so shadowed sources can be reported.
-func (r *Resolver) lookup(find func(Provider) (string, string, bool)) (lookupHit, bool) {
+func (r *Resolver) lookup(find func(Provider) (Value, string, bool)) (lookupHit, bool) {
 	var hit lookupHit
 	matched := false
 	for idx, p := range r.providers {
@@ -289,7 +305,7 @@ func (r *Resolver) lookup(find func(Provider) (string, string, bool)) (lookupHit
 			continue
 		}
 		if !matched {
-			hit = lookupHit{raw: value, prov: p, idx: idx, subject: subject}
+			hit = lookupHit{val: value, prov: p, idx: idx, subject: subject}
 			matched = true
 			if r.trace == nil {
 				return hit, true
@@ -302,33 +318,20 @@ func (r *Resolver) lookup(find func(Provider) (string, string, bool)) (lookupHit
 
 // lookupPrefixed matches "label.name" against the provider label, with any
 // ":detail" suffix stripped, and resolves the remainder against that provider.
-func lookupPrefixed(p Provider, name string) (string, string, bool) {
+func lookupPrefixed(p Provider, name string) (Value, string, bool) {
 	label := strings.TrimSpace(strings.ToLower(p.Label()))
 	if before, _, ok := strings.Cut(label, ":"); ok {
 		label = strings.TrimSpace(before)
 	}
 	if label == "" || !strings.HasPrefix(strings.ToLower(name), label+".") {
-		return "", "", false
+		return Value{}, "", false
 	}
 	subject := strings.TrimSpace(name[len(label)+1:])
 	if subject == "" {
-		return "", "", false
+		return Value{}, "", false
 	}
-	value, ok := p.Resolve(subject)
+	value, ok := providerValue(p, subject)
 	return value, subject, ok
-}
-
-// applyRefs runs the value through registered ref resolvers. The first
-// resolver that claims the value (handled==true) wins. If no resolver
-// handles the value it is returned as-is.
-func (r *Resolver) applyRefs(value string) (string, bool) {
-	for _, ref := range r.refs {
-		resolved, handled, found := ref(value)
-		if handled {
-			return resolved, found
-		}
-	}
-	return value, true
 }
 
 func providerLabel(p Provider) string {
@@ -358,10 +361,6 @@ func (r *Resolver) ExpandTemplatesAt(input string, pos ExprPos) (string, error) 
 
 func (r *Resolver) ExpandTemplatesStatic(input string) (string, error) {
 	return CompileTemplate(input).render(r, r.exprPos, false, false, nil)
-}
-
-func (r *Resolver) AddRefResolver(fn RefResolver) {
-	r.refs = append(r.refs, fn)
 }
 
 func (r *Resolver) SetTrace(tr *Trace) {
@@ -476,18 +475,42 @@ func NewTemplateProvider(label string, values map[string]string) Provider {
 	return newMapProvider(label, CollectNames(values), true)
 }
 
-// NewNameMapProvider wraps an already-normalized NameMap without copying it.
-func NewNameMapProvider(label string, values NameMap[string]) Provider {
-	return newMapProvider(label, values, false)
-}
-
-// NewNameMapTemplateProvider is the template-expanding variant of NewNameMapProvider.
-func NewNameMapTemplateProvider(label string, values NameMap[string]) Provider {
-	return newMapProvider(label, values, true)
-}
-
 func newMapProvider(label string, values NameMap[string], template bool) Provider {
 	return &MapProvider{values: values, label: label, template: template}
+}
+
+// ValueMapProvider is a provider backed by a NameMap of Values.
+type ValueMapProvider struct {
+	values   NameMap[Value]
+	label    string
+	template bool
+}
+
+// NewValueMapProvider wraps a NameMap without copying it.
+func NewValueMapProvider(label string, values NameMap[Value]) Provider {
+	return &ValueMapProvider{values: values, label: label}
+}
+
+// NewValueMapTemplateProvider enables template expansion for non-final values.
+func NewValueMapTemplateProvider(label string, values NameMap[Value]) Provider {
+	return &ValueMapProvider{values: values, label: label, template: true}
+}
+
+func (p *ValueMapProvider) ResolveValue(name string) (Value, bool) {
+	return p.values.Get(name)
+}
+
+func (p *ValueMapProvider) Resolve(name string) (string, bool) {
+	v, ok := p.values.Get(name)
+	return v.Text, ok
+}
+
+func (p *ValueMapProvider) Label() string {
+	return p.label
+}
+
+func (p *ValueMapProvider) templateValues() bool {
+	return p.template
 }
 
 type templateValueProvider interface {

--- a/internal/vars/resolver_nested_test.go
+++ b/internal/vars/resolver_nested_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
@@ -243,11 +244,10 @@ func TestNestedExpansionUndefinedFails(t *testing.T) {
 
 func TestNestedExpansionComposesWithEnvRef(t *testing.T) {
 	t.Setenv("RESTERM_TEST_NESTED", "from-os")
-	r := NewResolver(NewTemplateProvider("request", map[string]string{
+	r, refs := envRefResolver(map[string]string{
 		"a":   "env:{{key}}",
 		"key": "RESTERM_TEST_NESTED",
-	}))
-	r.AddRefResolver(EnvRefResolver)
+	})
 
 	out, err := r.ExpandTemplates("{{a}}")
 	if err != nil {
@@ -256,15 +256,28 @@ func TestNestedExpansionComposesWithEnvRef(t *testing.T) {
 	if out != "from-os" {
 		t.Fatalf("expected env ref to resolve after expansion, got %q", out)
 	}
+	if secrets := refs.Secrets(); len(secrets) != 1 || secrets[0] != "from-os" {
+		t.Fatalf("Secrets() = %#v, want the deferred value recorded", secrets)
+	}
+}
+
+func TestNestedEnvRefMissingReturnsUndefined(t *testing.T) {
+	r, _ := envRefResolver(map[string]string{
+		"a":   "env:{{key}}",
+		"key": fmt.Sprintf("RESTERM_TEST_NESTED_MISSING_%d", time.Now().UnixNano()),
+	})
+
+	if out, err := r.ExpandTemplates("{{a}}"); err == nil {
+		t.Fatalf("expected undefined variable error, got %q", out)
+	}
 }
 
 func TestEnvRefResultNotExpanded(t *testing.T) {
 	t.Setenv("RESTERM_TEST_NESTED", "{{secret}}")
-	r := NewResolver(NewTemplateProvider("request", map[string]string{
+	r, _ := envRefResolver(map[string]string{
 		"a":      "env:RESTERM_TEST_NESTED",
 		"secret": "hunter2",
-	}))
-	r.AddRefResolver(EnvRefResolver)
+	})
 
 	out, err := r.ExpandTemplates("{{a}}")
 	if err != nil {

--- a/internal/vars/resolver_test.go
+++ b/internal/vars/resolver_test.go
@@ -322,14 +322,16 @@ func TestExpandTemplatesExprMissing(t *testing.T) {
 	}
 }
 
-func TestEnvRefResolver(t *testing.T) {
+func envRefResolver(values map[string]string) (*Resolver, *EnvRefs) {
+	refs := NewEnvRefs(declaredNames(values))
+	return NewResolver(NewValueMapTemplateProvider("envfile", authored(refs, values))), refs
+}
+
+func TestEnvRefResolves(t *testing.T) {
 	key := "RESTERM_TEST_ENV_REF"
 	t.Setenv(key, "super-secret")
 
-	resolver := NewResolver(NewMapProvider("envfile", map[string]string{
-		"auth.password": "env:" + key,
-	}))
-	resolver.AddRefResolver(EnvRefResolver)
+	resolver, _ := envRefResolver(map[string]string{"auth.password": "env:" + key})
 
 	out, err := resolver.ExpandTemplates("{{auth.password}}")
 	if err != nil {
@@ -340,14 +342,13 @@ func TestEnvRefResolver(t *testing.T) {
 	}
 }
 
-func TestEnvRefResolverUppercaseFallback(t *testing.T) {
+func TestEnvRefUppercaseFallback(t *testing.T) {
 	key := "RESTERM_TEST_ENV_REF_UPPER"
 	t.Setenv(key, "works")
 
-	resolver := NewResolver(NewMapProvider("envfile", map[string]string{
+	resolver, _ := envRefResolver(map[string]string{
 		"auth.password": "env:" + strings.ToLower(key),
-	}))
-	resolver.AddRefResolver(EnvRefResolver)
+	})
 
 	out, err := resolver.ExpandTemplates("{{auth.password}}")
 	if err != nil {
@@ -358,12 +359,9 @@ func TestEnvRefResolverUppercaseFallback(t *testing.T) {
 	}
 }
 
-func TestEnvRefResolverMissingReturnsUndefined(t *testing.T) {
+func TestEnvRefMissingReturnsUndefined(t *testing.T) {
 	key := fmt.Sprintf("RESTERM_TEST_MISSING_ENV_REF_%d", time.Now().UnixNano())
-	resolver := NewResolver(NewMapProvider("envfile", map[string]string{
-		"auth.password": "env:" + key,
-	}))
-	resolver.AddRefResolver(EnvRefResolver)
+	resolver, _ := envRefResolver(map[string]string{"auth.password": "env:" + key})
 
 	out, err := resolver.ExpandTemplates("{{auth.password}}")
 	if err == nil {
@@ -371,6 +369,23 @@ func TestEnvRefResolverMissingReturnsUndefined(t *testing.T) {
 	}
 	if out != "{{auth.password}}" {
 		t.Fatalf("expected unresolved template placeholder, got %q", out)
+	}
+}
+
+func TestEnvRefInRuntimeValueStaysLiteral(t *testing.T) {
+	key := "RESTERM_TEST_RUNTIME_LITERAL"
+	t.Setenv(key, "leaked")
+
+	var captured NameMap[Value]
+	captured.Set("auth.password", Value{Text: "env:" + key})
+	resolver := NewResolver(NewValueMapProvider("request", captured))
+
+	out, err := resolver.ExpandTemplates("{{auth.password}}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "env:"+key {
+		t.Fatalf("runtime value resolved to %q, want the text unchanged", out)
 	}
 }
 


### PR DESCRIPTION
`@const`, `@request`, `@global` and `@file` accept env:NAME, so a value can come from the process environment without an environment file, under a shorter name, or scoped to one request file. Templates and the script vars object
read the resolved value under the declared name. env keeps describing only the selected environment. Resolved values are always secret and are redacted from results, explain output and history.

A missing OS variable leaves the name undefined and keeps a lower-precedence source from answering for it. The shadowed value stays reachable by its qualified name.

Only a value written in a file is a reference. Captures, script writes and workflow values stay literal. A reference name may itself be a template, as in env:{{picked}}, and that name expands against declarations alone, so a response cannot choose which OS variable a request reads.