### PR TITLE
RST-330: env ref declaration boundary

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -441,9 +441,9 @@ Authorization: Bearer {{token}}
 
 If the OS variable is missing, the declaration stays undefined and still shadows lower-precedence sources. Resterm first tries the name as written, then its uppercase form.
 
-Values loaded through `env:NAME` are secrets. Resterm hides them from previews and redacts them from results, explain output, and history. References are resolved once, so an OS value that contains `env:OTHER` stays unchanged. Only declarations are interpreted as references; values from captures, workflows, and scripts are plain data. An empty `env:` reference is reported as an error.
+Values loaded through `env:NAME` are secrets. Resterm hides them from previews and redacts them from results, explain output, and history. References are resolved once, so an OS value that contains `env:OTHER` stays unchanged. Only declarations are interpreted as references; values from captures, workflows, and scripts are plain data. An empty `env:` reference is reported as an error: a request file reports it on the line where it appears, and an environment file refuses to load.
 
-A reference name may contain a template, as in `env:{{picked}}`. Only declarations can supply `picked`; runtime data cannot choose which OS variable Resterm reads.
+A reference name may contain a template, as in `env:{{picked}}`. Only declarations can supply `picked`; runtime data cannot choose which OS variable Resterm reads. If a capture replaces the declaration that supplied the name, nothing declares it any more and the reference becomes undefined rather than following the captured value.
 
 #### Shared variables (`$shared`)
 

--- a/internal/engine/core/wf.go
+++ b/internal/engine/core/wf.go
@@ -624,10 +624,12 @@ func (r *wfRun) evalStepValue(
 	if expr == "" {
 		return rts.Value{}, fmt.Errorf("%s expression missing", tag)
 	}
+	// Not Environment.Resolve: a templated env: reference needs the document's
+	// declarations to expand its name.
 	return r.dep.EvalValue(ctx, request.EvalInput{
 		Doc:    r.pl.Doc,
 		Req:    req,
-		Env:    r.pl.Run.Env.Resolve(),
+		Env:    request.ResolveEnvironment(r.pl.Run.Env, r.pl.Doc, req),
 		Base:   baseDir(r.pl.Doc),
 		Expr:   expr,
 		Site:   tag + " " + str.FoldLines(expr),

--- a/internal/engine/headless/wf_env_ref_test.go
+++ b/internal/engine/headless/wf_env_ref_test.go
@@ -1,0 +1,85 @@
+package headless
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/parser"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+func TestWorkflowBranchResolvesEnvRefs(t *testing.T) {
+	t.Setenv("RESTERM_WF_REF_TARGET", "wf-value")
+
+	for _, tt := range []struct {
+		name  string
+		alias string
+	}{
+		{name: "direct name", alias: "direct"},
+		{name: "templated name", alias: "alias"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if _, err := fmt.Fprint(w, `{"ok":true}`); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			src := fmt.Sprintf(`# @file picked RESTERM_WF_REF_TARGET
+
+### flow
+# @workflow probe
+# @step First using=First
+# @if env.get(%q) == "wf-value" run=Match
+# @else run=Miss
+
+### First
+# @name First
+GET %s/first
+
+### Match
+# @name Match
+GET %s/match
+
+### Miss
+# @name Miss
+GET %s/miss
+`, tt.alias, srv.URL, srv.URL, srv.URL)
+
+			doc := parser.Parse("wf.http", []byte(src))
+			if len(doc.Errors) != 0 {
+				t.Fatalf("parse errors: %#v", doc.Errors)
+			}
+			if len(doc.Workflows) != 1 {
+				t.Fatalf("workflows = %d, want 1", len(doc.Workflows))
+			}
+
+			cat, err := vars.NewCatalog(vars.EnvironmentSet{"dev": {
+				"direct": "env:RESTERM_WF_REF_TARGET",
+				"alias":  "env:{{picked}}",
+			}})
+			if err != nil {
+				t.Fatalf("NewCatalog() error = %v", err)
+			}
+			sel, err := cat.Select("dev", nil)
+			if err != nil {
+				t.Fatalf("Select() error = %v", err)
+			}
+
+			out, err := New(engine.Config{Catalog: cat}).ExecuteWorkflow(doc, &doc.Workflows[0], sel)
+			if err != nil {
+				t.Fatalf("ExecuteWorkflow() error = %v", err)
+			}
+			if len(out.Steps) != 2 {
+				t.Fatalf("steps = %d, want 2", len(out.Steps))
+			}
+			if got := out.Steps[1].Name; got != "@if -> Match" {
+				t.Fatalf("branch = %q, want the reference to resolve in the condition", got)
+			}
+		})
+	}
+}

--- a/internal/engine/request/env_ref_malformed_test.go
+++ b/internal/engine/request/env_ref_malformed_test.go
@@ -40,36 +40,6 @@ X-Token: {{token}}
 	}
 }
 
-func TestEnvironmentEnvRefWithNoNameStaysUndefined(t *testing.T) {
-	t.Setenv("TOKEN", "ambient-value")
-	doc, req := parseDoc(t, `### one
-# @name one
-GET http://example.test
-X-Token: {{token}}
-`)
-
-	env := envWith(t, "dev", map[string]string{"token": "env:"})
-	eng, st := newStubEngine(t)
-	res, err := eng.ExecuteWith(doc, req, env, ExecOptions{})
-	if err != nil {
-		t.Fatalf("ExecuteWith() error = %v", err)
-	}
-	if res.Err == nil {
-		t.Fatal("a catalog reference with no name produced a value")
-	}
-	if st.wire != nil {
-		t.Fatal("request with an unusable reference was sent")
-	}
-
-	snap := ResolveEnvironment(env, doc, req)
-	if _, ok := snap.Values()["token"]; ok {
-		t.Fatal("the env host exposes a reference that names nothing")
-	}
-	if len(snap.Secrets()) != 0 {
-		t.Fatalf("Secrets() = %#v, want none", snap.Secrets())
-	}
-}
-
 func TestValuesThatOnlyLookLikeReferencesStayText(t *testing.T) {
 	doc, req := parseDoc(t, `# @file a environment:X
 # @file b envs:X

--- a/internal/engine/request/env_ref_name_test.go
+++ b/internal/engine/request/env_ref_name_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/rts"
-	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 const namedRefTarget = "RESTERM_NAMED_TARGET"
@@ -225,8 +225,55 @@ func TestOnlyDocumentSourcesMayNameAReference(t *testing.T) {
 		if !s.traits().declared {
 			t.Fatalf("%s is not marked declared; its values would stop naming references", s.traits().label)
 		}
-		if declaredText(s, nil, nil, vars.Environment{}).Len() != 0 {
-			t.Fatalf("%s produced values from an empty document", s.traits().label)
+		if len(declarations(s, nil, nil)) != 0 {
+			t.Fatalf("%s produced declarations from an empty document", s.traits().label)
 		}
+	}
+}
+
+func TestCapturedNameCannotBeUsedByALaterRequest(t *testing.T) {
+	t.Setenv(namedRefTarget, "declared-value")
+	t.Setenv("RESTERM_NAMED_HIJACK", "hijacked-value")
+
+	doc := parser.Parse("two.http", []byte(`# @file picked `+namedRefTarget+`
+# @file token env:{{picked}}
+
+### grab
+# @name grab
+# @capture file picked {{response.body}}
+GET http://example.test/grab
+
+### use
+# @name use
+GET http://example.test/use
+X-Token: {{token}}
+`))
+	if len(doc.Requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(doc.Requests))
+	}
+
+	eng, st := newStubEngine(t)
+	st.body = "RESTERM_NAMED_HIJACK"
+	if _, err := eng.ExecuteWith(doc, doc.Requests[0], envWith(t, "dev", nil), ExecOptions{}); err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	for _, v := range doc.Variables {
+		if v.Name == "picked" && v.Authored {
+			t.Fatal("the capture left the declaration flag set")
+		}
+	}
+
+	// The capture removed the only declaration, so the name is undefined.
+	st.body = "ok"
+	st.wire = nil
+	res, err := eng.ExecuteWith(doc, doc.Requests[1], envWith(t, "dev", nil), ExecOptions{})
+	if err != nil {
+		t.Fatalf("second request: %v", err)
+	}
+	if res.Err == nil {
+		t.Fatalf("the reference resolved to %q", st.wire.Header.Get("X-Token"))
+	}
+	if st.wire != nil {
+		t.Fatalf("request was sent with X-Token = %q", st.wire.Header.Get("X-Token"))
 	}
 }

--- a/internal/engine/request/varplan.go
+++ b/internal/engine/request/varplan.go
@@ -94,15 +94,15 @@ func (e *Engine) buildVariablePlan(src varSources) variablePlan {
 	refs := env.Refs()
 
 	plan := variablePlan{layers: make([]variableLayer, 0, len(sourceTable))}
-	plan.add(sourceConst, constEntries(src.doc, refs))
+	plan.add(sourceConst, entries(sourceConst, src, refs))
 	plan.addLiteral(sourceScript, src.run.scripts)
 	plan.addLiteral(sourceWorkflow, src.run.overlay)
 	plan.add(sourceRequestCapture, nil)
-	plan.add(sourceRequest, requestEntries(src.req, src.sec, refs))
+	plan.add(sourceRequest, entries(sourceRequest, src, refs))
 	plan.add(sourceRuntimeGlobal, literalEntries(globalValues(src.globals)))
-	plan.add(sourceDocumentGlobal, docGlobalEntries(src.doc, src.sec, refs))
+	plan.add(sourceDocumentGlobal, entries(sourceDocumentGlobal, src, refs))
 	plan.add(sourceRuntimeFile, literalEntries(e.runtimeFileValues(src.doc, env, src.sec)))
-	plan.add(sourceFile, docVarEntries(src.doc, src.sec, refs))
+	plan.add(sourceFile, entries(sourceFile, src, refs))
 	plan.add(sourceEnvironment, valueEntries(env.ProviderValues()))
 	return plan
 }
@@ -192,101 +192,98 @@ func (p variablePlan) values() map[string]string {
 }
 
 // Only declarations may choose the OS variable in a templated env: reference.
+// A name from response data would let a server pick what a request sends.
 func declaredNames(doc *restfile.Document, req *restfile.Request, env vars.Environment) *vars.Resolver {
 	out := make([]vars.Provider, 0, len(sourceTable))
 	for i, t := range sourceTable {
 		if !t.declared {
 			continue
 		}
-		out = append(
-			out,
-			vars.NewValueMapTemplateProvider(t.label, declaredText(variableSource(i), doc, req, env)),
-		)
+		var vals vars.NameMap[vars.Value]
+		if variableSource(i) == sourceEnvironment {
+			// An environment file has no runtime writer.
+			for name, text := range env.Values() {
+				vals.Set(name, vars.Value{Text: text})
+			}
+		}
+		for _, d := range declarations(variableSource(i), doc, req) {
+			if d.authored {
+				vals.Set(d.name, vars.Value{Text: d.text})
+			}
+		}
+		out = append(out, vars.NewValueMapTemplateProvider(t.label, vals))
 	}
 	return vars.NewResolver(out...)
 }
 
-func declaredText(
+type declaration struct {
+	name string
+	text string
+	// authored is false once a capture or a script replaces what the document
+	// wrote. Such a value is data: it never reads as a reference nor names one.
+	authored bool
+	secret   bool
+}
+
+// declarations is the one reading of a source, so the variable plan and the
+// reference-name lookup cannot disagree about which values a run produced.
+func declarations(
 	source variableSource,
 	doc *restfile.Document,
 	req *restfile.Request,
-	env vars.Environment,
-) vars.NameMap[vars.Value] {
-	var out vars.NameMap[vars.Value]
-	set := func(name, text string) { out.Set(name, vars.Value{Text: text}) }
+) []declaration {
+	var xs []restfile.Variable
 	switch source {
 	case sourceConst:
-		if doc != nil {
-			for _, c := range doc.Constants {
-				set(c.Name, c.Value)
-			}
+		if doc == nil {
+			return nil
 		}
+		out := make([]declaration, 0, len(doc.Constants))
+		for _, c := range doc.Constants {
+			out = append(out, declaration{name: c.Name, text: c.Value, authored: c.Authored})
+		}
+		return out
 	case sourceRequest:
-		if req != nil {
-			for _, v := range req.Variables {
-				set(v.Name, v.Value)
-			}
+		if req == nil {
+			return nil
 		}
+		xs = req.Variables
 	case sourceDocumentGlobal:
-		if doc != nil {
-			for _, v := range doc.Globals {
-				set(v.Name, v.Value)
-			}
+		if doc == nil {
+			return nil
 		}
+		xs = doc.Globals
 	case sourceFile:
-		if doc != nil {
-			for _, v := range doc.Variables {
-				set(v.Name, v.Value)
-			}
+		if doc == nil {
+			return nil
 		}
-	case sourceEnvironment:
-		for _, name := range slices.Sorted(maps.Keys(env.Values())) {
-			set(name, env.Values()[name])
-		}
-	}
-	return out
-}
-
-func constEntries(doc *restfile.Document, refs *vars.EnvRefs) []variableEntry {
-	if doc == nil {
+		xs = doc.Variables
+	default:
 		return nil
 	}
-	out := make([]variableEntry, 0, len(doc.Constants))
-	for _, c := range doc.Constants {
-		out = append(out, variableEntry{name: c.Name, val: declaredValue(refs, c.Authored, c.Value)})
-	}
-	return out
-}
 
-func requestEntries(req *restfile.Request, sec secrecy, refs *vars.EnvRefs) []variableEntry {
-	if req == nil {
-		return nil
-	}
-	return declaredEntries(req.Variables, sec, refs)
-}
-
-func docGlobalEntries(doc *restfile.Document, sec secrecy, refs *vars.EnvRefs) []variableEntry {
-	if doc == nil {
-		return nil
-	}
-	return declaredEntries(doc.Globals, sec, refs)
-}
-
-func docVarEntries(doc *restfile.Document, sec secrecy, refs *vars.EnvRefs) []variableEntry {
-	if doc == nil {
-		return nil
-	}
-	return declaredEntries(doc.Variables, sec, refs)
-}
-
-// Unlike -secret values, withheld env: references still shadow lower sources.
-func declaredEntries(xs []restfile.Variable, sec secrecy, refs *vars.EnvRefs) []variableEntry {
-	out := make([]variableEntry, 0, len(xs))
+	out := make([]declaration, 0, len(xs))
 	for _, v := range xs {
-		if sec == omitSecrets && v.Secret && !namesProcessVar(v.Authored, v.Value) {
+		out = append(out, declaration{
+			name:     v.Name,
+			text:     v.Value,
+			authored: v.Authored,
+			secret:   v.Secret,
+		})
+	}
+	return out
+}
+
+// Unlike a -secret value, a withheld env: reference keeps shadowing lower
+// sources, so it stays in the layer.
+func entries(source variableSource, src varSources, refs *vars.EnvRefs) []variableEntry {
+	ds := declarations(source, src.doc, src.req)
+	out := make([]variableEntry, 0, len(ds))
+	for _, d := range ds {
+		if src.sec == omitSecrets && d.secret && !namesProcessVar(d.authored, d.text) {
 			continue
 		}
-		out = append(out, variableEntry{name: v.Name, val: declaredValue(refs, v.Authored, v.Value)})
+		out = append(out, variableEntry{name: d.name, val: declaredValue(refs, d.authored, d.text)})
 	}
 	return out
 }

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -31,9 +31,9 @@ func (v *Variable) SetRuntimeValue(value string) {
 }
 
 type Constant struct {
-	Name  string
-	Value string
-	Line  int
+	Name     string
+	Value    string
+	Line     int
 	Authored bool
 }
 

--- a/internal/vars/catalog.go
+++ b/internal/vars/catalog.go
@@ -64,10 +64,32 @@ func NewCatalog(set EnvironmentSet) (Catalog, error) {
 		)
 	}
 	slices.SortFunc(envs, func(a, b entry) int { return cmpFold(a.name, b.name) })
+	if err := checkEnvRefs(SharedEnvKey, shared); err != nil {
+		return Catalog{}, err
+	}
 	for i := range envs {
+		if err := checkEnvRefs(envs[i].name, envs[i].values); err != nil {
+			return Catalog{}, err
+		}
 		envs[i].values = mergeValues(shared, envs[i].values)
 	}
 	return Catalog{envs: envs}, nil
+}
+
+// checkEnvRefs rejects an env: reference with no variable name. A JSON file has
+// no line to report against, so the catalog refuses to load instead.
+func checkEnvRefs(scope string, values map[string]string) error {
+	for _, name := range slices.Sorted(maps.Keys(values)) {
+		if key, ok := EnvRefKey(values[name]); ok && key == "" {
+			return diag.Newf(
+				diag.ClassParse,
+				"%s: %q has an env: reference with no variable name",
+				scope,
+				name,
+			)
+		}
+	}
+	return nil
 }
 
 func NewGroupedCatalog(shared map[string]string, groups []Group) (Catalog, error) {
@@ -87,6 +109,16 @@ func NewGroupedCatalog(shared map[string]string, groups []Group) (Catalog, error
 	slices.SortFunc(out, func(a, b Group) int { return cmpFold(a.Name, b.Name) })
 	if err := checkCollisions(out); err != nil {
 		return Catalog{}, err
+	}
+	if err := checkEnvRefs(SharedEnvKey, shared); err != nil {
+		return Catalog{}, err
+	}
+	for _, g := range out {
+		for _, p := range slices.Sorted(maps.Keys(g.Profiles)) {
+			if err := checkEnvRefs(g.Name+"."+p, g.Profiles[p]); err != nil {
+				return Catalog{}, err
+			}
+		}
 	}
 	return Catalog{groups: out, shared: maps.Clone(shared)}, nil
 }

--- a/internal/vars/catalog_env_ref_test.go
+++ b/internal/vars/catalog_env_ref_test.go
@@ -1,0 +1,53 @@
+package vars
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCatalogRejectsEnvRefWithNoName(t *testing.T) {
+	t.Run("environment", func(t *testing.T) {
+		_, err := NewCatalog(EnvironmentSet{"dev": {"token": "env:"}})
+		assertEnvRefError(t, err, `dev: "token"`)
+	})
+
+	t.Run("shared", func(t *testing.T) {
+		_, err := NewCatalog(EnvironmentSet{
+			"dev":        {"ok": "value"},
+			SharedEnvKey: {"token": "env:   "},
+		})
+		assertEnvRefError(t, err, `$shared: "token"`)
+	})
+
+	t.Run("grouped profile", func(t *testing.T) {
+		_, err := NewGroupedCatalog(nil, []Group{{
+			Name:     "region",
+			Default:  "eu",
+			Profiles: EnvironmentSet{"eu": {"token": "env:"}},
+		}})
+		assertEnvRefError(t, err, `region.eu: "token"`)
+	})
+
+	t.Run("valid references load", func(t *testing.T) {
+		if _, err := NewCatalog(EnvironmentSet{"dev": {
+			"a": "env:NAME",
+			"b": "env:{{picked}}",
+			"c": "plain",
+		}}); err != nil {
+			t.Fatalf("NewCatalog() error = %v, want the catalog to load", err)
+		}
+	})
+}
+
+func assertEnvRefError(t *testing.T, err error, scope string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("the catalog loaded a reference with no variable name")
+	}
+	if !strings.Contains(err.Error(), scope) {
+		t.Fatalf("error = %q, want it to name %s", err, scope)
+	}
+	if !strings.Contains(err.Error(), "env: reference with no variable name") {
+		t.Fatalf("error = %q, want it to name the problem", err)
+	}
+}

--- a/internal/vars/resolved_env_test.go
+++ b/internal/vars/resolved_env_test.go
@@ -131,8 +131,8 @@ func TestEnvRefKeyReadsTheEnvForm(t *testing.T) {
 		"env:NAME":    "NAME",
 		"ENV: NAME ":  "NAME",
 		"  env:name ": "name",
-		"env:":    "",
-		"env:   ": "",
+		"env:":        "",
+		"env:   ":     "",
 	} {
 		if key, ok := EnvRefKey(raw); !ok || key != want {
 			t.Fatalf("EnvRefKey(%q) = %q, %t, want %q", raw, key, ok, want)


### PR DESCRIPTION
A capture commits into the parsed document, so a name a response supplied survived into the next request in the same file. The declaration only lookup read the document's variables without checking whether a run had replaced them, which let a response choose the OS variable a later request sends.

The variable plan and that lookup now share one declarations() walk, so they cannot disagree about which values a run produced. Where a capture replaces the declaration that supplied a name, nothing declares it any more and the reference is undefined rather than following the captured value.