### PR TITLE
RST-332: env file load recovery

### DIFF
--- a/cmd/resterm/main.go
+++ b/cmd/resterm/main.go
@@ -344,7 +344,7 @@ func run(a []string) error {
 		initialContent = string(data)
 	}
 
-	cfg, err := exec.Resolve(filePath)
+	cfg, err := exec.ResolveSession(filePath)
 	if err != nil {
 		return err
 	}

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -386,7 +386,7 @@ Opening a *workspace*, or a request file that lives outside the current one, mov
 - The environment that carries across is the one you asked for, not the one you ended up with. A session started with `--env prod` looks for `prod` in the new workspace, and a later `Ctrl+E` choice becomes what gets replayed instead.
 - When the new workspace does not have it, the catalog loads but nothing is selected, since falling back to that workspace's default could put a `dev` session on `prod`. The header reads `ENV: none selected`, `Ctrl+E` offers what the workspace does have, and requests are refused until you choose.
 - The last response is forgotten. Globals, file variables, cookie jars, OAuth tokens and command auth are kept, but they stay tied to the workspace they came from. Runtime values are keyed by a scope that names both the selection and the environment file it was read from, so the new workspace cannot read them, and switching back restores the old session without logging in again. Two workspaces pointed at one `--env-file` share that scope on purpose. A workspace without an environment file has no file to key its values by, so they are forgotten when you leave. The same goes for environments built through the Go API.
-- An `--env-file` passed on the command line is a choice for the whole session, so it survives the move and Resterm warns when the new workspace has an environment file of its own. A workspace with no environment file leaves the session with none, and one whose environment file fails to load fails closed with an error and no environment.
+- A file passed with `--env-file` remains active when the workspace changes. Resterm warns if the new workspace has its own environment file. Without `--env-file`, moving to a workspace with no environment file clears the current environment. If the new workspace's environment file cannot load, the move is refused and the current workspace and environment remain active.
 - A move is refused while a request is running, because that request can still write runtime values back and undo the reset. Finish or cancel it first.
 
 Example environment (`_examples/resterm.env.json`):
@@ -441,7 +441,9 @@ Authorization: Bearer {{token}}
 
 If the OS variable is missing, the declaration stays undefined and still shadows lower-precedence sources. Resterm first tries the name as written, then its uppercase form.
 
-Values loaded through `env:NAME` are secrets. Resterm hides them from previews and redacts them from results, explain output, and history. References are resolved once, so an OS value that contains `env:OTHER` stays unchanged. Only declarations are interpreted as references; values from captures, workflows, and scripts are plain data. An empty `env:` reference is reported as an error: a request file reports it on the line where it appears, and an environment file refuses to load.
+Values loaded through `env:NAME` are secrets. Resterm hides them from previews and redacts them from results, explain output, and history. References are resolved once, so an OS value that contains `env:OTHER` stays unchanged. Only declarations are interpreted as references. Values from captures, workflows, and scripts are plain data.
+
+An empty `env:` reference is an error. In a request file, Resterm reports the line where it appears. In an environment file, it stops `resterm run`. The TUI still starts so you can fix the file, but it blocks all requests until the file loads successfully.
 
 A reference name may contain a template, as in `env:{{picked}}`. Only declarations can supply `picked`; runtime data cannot choose which OS variable Resterm reads. If a capture replaces the declaration that supplied the name, nothing declares it any more and the reference becomes undefined rather than following the captured value.
 
@@ -527,7 +529,11 @@ resterm \
   --env-group credentials=ci
 ```
 
-`--env` still selects named environments and cannot be combined with `--env-group`. Groups you do not pass keep their defaults. A broken environment file stops TUI and headless startup with a parse error, whether it was discovered or passed explicitly.
+`--env` still selects named environments and cannot be combined with `--env-group`. Groups you do not pass keep their defaults.
+
+`resterm run` and headless execution stop when an environment file is invalid. The TUI can recover from parse errors because the file can be fixed there. It starts without an active environment, shows the error in a modal, displays `ENV: not loaded` in the header, and blocks all requests. Saving a valid file reloads the environment and reapplies the current selection. Changes made outside Resterm are also reloaded while the environment file is open.
+
+Missing or unreadable environment files still prevent the TUI from starting.
 
 The public Go API accepts the same model:
 

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
@@ -151,47 +152,65 @@ func (f ExecFlags) TelemetryConfig(version string) telemetry.Config {
 	return cfg
 }
 
+// Resolve builds a run configuration and requires a valid environment file.
 func (f ExecFlags) Resolve(filePath string) (ExecConfig, error) {
+	cfg, err := f.ResolveSession(filePath)
+	if err != nil {
+		return ExecConfig{}, err
+	}
+	if cfg.Env.FileErr != nil {
+		return ExecConfig{}, cfg.Env.FileErr
+	}
+	return cfg, nil
+}
+
+// ResolveSession builds an editor configuration. Parse errors are returned in
+// Env.FileErr so the editor can open the file, while other load errors remain
+// fatal. Requests stay blocked until the file parses successfully.
+func (f ExecFlags) ResolveSession(filePath string) (ExecConfig, error) {
 	if err := f.ValidateEnvFlag(); err != nil {
 		return ExecConfig{}, err
 	}
 	filePath = CleanExecPath(filePath)
 	work := resolveWorkspace(filePath, f.Workspace)
 
-	cat, envFile, err := f.loadEnvironment(filePath, work)
-	if err != nil {
-		return ExecConfig{}, err
-	}
-	sel, err := cat.Select(f.EnvName, f.EnvGroups)
-	if err != nil {
-		return ExecConfig{}, err
-	}
-	envFallback := ""
-	if f.EnvName == "" && len(f.EnvGroups) == 0 && !cat.Empty() {
-		env, resolveErr := cat.Resolve(sel)
-		if resolveErr != nil {
-			return ExecConfig{}, resolveErr
-		}
-		if cat.Len() > 1 {
-			envFallback = env.Label()
-		}
+	cat, envFile, fileErr := f.loadEnvironment(filePath, work)
+	if fileErr != nil && diag.ClassOf(fileErr) != diag.ClassParse {
+		return ExecConfig{}, fileErr
 	}
 
-	targets, err := ParseCompareTargets(f.CompareTargetsRaw)
+	compare, err := f.compareConfig()
 	if err != nil {
-		return ExecConfig{}, fmt.Errorf("invalid --compare value: %w", err)
+		return ExecConfig{}, err
 	}
-	base := f.CompareBaseline
-	if err := runcheck.ValidateConcreteEnvironment(base, "--compare-base"); err != nil {
-		return ExecConfig{}, fmt.Errorf("invalid --compare-base value: %w", err)
+
+	env := vars.Config{
+		Catalog:      cat,
+		File:         envFile,
+		FileExplicit: str.Trim(f.EnvFile) != "",
+		Intent:       vars.Intent{Name: f.EnvName, Groups: maps.Clone(f.EnvGroups)},
+		FileErr:      fileErr,
 	}
-	group := str.Trim(f.CompareGroup)
-	if group != "" && len(targets) == 0 {
-		return ExecConfig{}, fmt.Errorf("--compare-group requires --compare")
-	}
-	if len(targets) > 0 {
-		if _, err := cat.CompareTargets(sel, group, base, targets); err != nil {
-			return ExecConfig{}, fmt.Errorf("invalid compare selection: %w", err)
+	// Keep selection and compare settings until a catalog is available. They
+	// cannot be checked against the empty catalog left by a parse error.
+	if fileErr == nil {
+		if env.Selection, err = cat.Select(f.EnvName, f.EnvGroups); err != nil {
+			return ExecConfig{}, err
+		}
+		if f.EnvName == "" && len(f.EnvGroups) == 0 && !cat.Empty() {
+			active, err := cat.Resolve(env.Selection)
+			if err != nil {
+				return ExecConfig{}, err
+			}
+			if cat.Len() > 1 {
+				env.Fallback = active.Label()
+			}
+		}
+		if len(compare.Targets) > 0 {
+			_, err := cat.CompareTargets(env.Selection, compare.Group, compare.Base, compare.Targets)
+			if err != nil {
+				return ExecConfig{}, fmt.Errorf("invalid compare selection: %w", err)
+			}
 		}
 	}
 
@@ -209,30 +228,36 @@ func (f ExecFlags) Resolve(filePath string) (ExecConfig, error) {
 		FilePath:  filePath,
 		Workspace: work,
 		Recursive: f.Recursive,
-		Env: vars.Config{
-			Catalog:      cat,
-			Selection:    sel,
-			File:         envFile,
-			FileExplicit: str.Trim(f.EnvFile) != "",
-			Intent:       vars.Intent{Name: f.EnvName, Groups: maps.Clone(f.EnvGroups)},
-			Fallback:     envFallback,
-		},
-		HTTPOpts: httpOpts,
-		GRPCOpts: grpcx.Options{DefaultPlaintext: restfile.OptOf(true)},
-		Compare:  engine.CompareConfig{Targets: targets, Base: base, Group: group},
+		Env:       env,
+		HTTPOpts:  httpOpts,
+		GRPCOpts:  grpcx.Options{DefaultPlaintext: restfile.OptOf(true)},
+		Compare:   compare,
 	}, nil
 }
 
+func (f ExecFlags) compareConfig() (engine.CompareConfig, error) {
+	targets, err := ParseCompareTargets(f.CompareTargetsRaw)
+	if err != nil {
+		return engine.CompareConfig{}, fmt.Errorf("invalid --compare value: %w", err)
+	}
+	base := f.CompareBaseline
+	if err := runcheck.ValidateConcreteEnvironment(base, "--compare-base"); err != nil {
+		return engine.CompareConfig{}, fmt.Errorf("invalid --compare-base value: %w", err)
+	}
+	group := str.Trim(f.CompareGroup)
+	if group != "" && len(targets) == 0 {
+		return engine.CompareConfig{}, fmt.Errorf("--compare-group requires --compare")
+	}
+	return engine.CompareConfig{Targets: targets, Base: base, Group: group}, nil
+}
+
 // loadEnvironment loads the file named with --env-file, or discovers one near
-// the launch context. The command line is the one place the ambient working
-// directory takes part in discovery.
+// the launch context. It returns the path with load errors so the editor can
+// open a file that failed to parse.
 func (f ExecFlags) loadEnvironment(filePath, work string) (vars.Catalog, string, error) {
 	if explicit := str.Trim(f.EnvFile); explicit != "" {
 		cat, err := vars.LoadEnvironmentFile(explicit)
-		if err != nil {
-			return vars.Catalog{}, "", err
-		}
-		return cat, explicit, nil
+		return cat, explicit, err
 	}
 
 	var fileDir string

--- a/internal/cli/exec_session_test.go
+++ b/internal/cli/exec_session_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const brokenEnvFile = `{"dev":{"token":"env:"},"prod":{"token":"env:PROD"}}`
+
+func TestResolveSessionOpensOnABrokenEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "resterm.env.json")
+	if err := os.WriteFile(envFile, []byte(brokenEnvFile), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	flags := NewExecFlags()
+	flags.Workspace = dir
+	cfg, err := flags.ResolveSession(filepath.Join(dir, "api.http"))
+	if err != nil {
+		t.Fatalf("ResolveSession() error = %v, want the session to open", err)
+	}
+	if cfg.Env.FileErr == nil {
+		t.Fatal("FileErr is nil, want the reason the file did not load")
+	}
+	if got := cfg.Env.FileErr.Error(); !strings.Contains(got, "env: reference with no variable name") {
+		t.Fatalf("FileErr = %q, want it to name the problem", got)
+	}
+	if cfg.Env.File != envFile {
+		t.Fatalf("File = %q, want %q so the session can name the file to fix", cfg.Env.File, envFile)
+	}
+	if !cfg.Env.Catalog.Empty() {
+		t.Fatalf("catalog = %v, want nothing loaded", cfg.Env.Catalog.Names())
+	}
+}
+
+func TestResolveStopsOnABrokenEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "resterm.env.json")
+	if err := os.WriteFile(envFile, []byte(brokenEnvFile), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	flags := NewExecFlags()
+	flags.Workspace = dir
+	if _, err := flags.Resolve(filepath.Join(dir, "api.http")); err == nil {
+		t.Fatal("Resolve() ran on an environment file that did not load")
+	}
+}
+
+func TestResolveSessionKeepsSelectionFlagsOnABrokenEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "resterm.env.json")
+	if err := os.WriteFile(envFile, []byte(`{"$groups":{"api":{"dev":{"a":"env:"}}}}`), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	flags := NewExecFlags()
+	flags.EnvFile = envFile
+	flags.EnvGroups = GroupFlags{"api": "dev"}
+	flags.CompareTargetsRaw = "dev,prod"
+	flags.CompareGroup = "api"
+	cfg, err := flags.ResolveSession(filepath.Join(dir, "api.http"))
+	if err != nil {
+		t.Fatalf("ResolveSession() error = %v, want the session to open", err)
+	}
+	if got := cfg.Env.Intent.Groups["api"]; got != "dev" {
+		t.Fatalf("intent group = %q, want the flag kept for the reload", got)
+	}
+	if cfg.Env.File != envFile {
+		t.Fatalf("File = %q, want %q", cfg.Env.File, envFile)
+	}
+	if len(cfg.Compare.Targets) != 2 {
+		t.Fatalf("compare targets = %v, want both kept", cfg.Compare.Targets)
+	}
+}
+
+func TestResolveSessionStopsOnAnUnreadableEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "resterm.env.json"), 0o755); err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		envFile string
+	}{
+		{name: "discovered", envFile: ""},
+		{name: "passed with --env-file", envFile: filepath.Join(dir, "resterm.env.json")},
+		{name: "missing", envFile: filepath.Join(dir, "typo.env.json")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := NewExecFlags()
+			flags.Workspace = dir
+			flags.EnvFile = tc.envFile
+			if _, err := flags.ResolveSession(filepath.Join(dir, "api.http")); err == nil {
+				t.Fatal("ResolveSession() opened on an environment file it could not read")
+			}
+		})
+	}
+}
+
+func TestResolveSessionStopsOnFlagErrors(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "resterm.env.json")
+	if err := os.WriteFile(envFile, []byte(brokenEnvFile), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	flags := NewExecFlags()
+	flags.Workspace = dir
+	flags.CompareGroup = "api"
+	if _, err := flags.ResolveSession(filepath.Join(dir, "api.http")); err == nil {
+		t.Fatal("ResolveSession() accepted --compare-group without --compare")
+	}
+}

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -72,11 +72,10 @@ func toEditorEventCmd(evt editorEvent) tea.Cmd {
 }
 
 func statusCmd(level statusLevel, text string) tea.Cmd {
-	status := statusMsg{
-		level: level,
-		text:  text,
-	}
+	return statusMsgCmd(statusMsg{level: level, text: text})
+}
 
+func statusMsgCmd(status statusMsg) tea.Cmd {
 	return toEditorEventCmd(editorEvent{status: &status})
 }
 

--- a/internal/ui/env_status.go
+++ b/internal/ui/env_status.go
@@ -11,6 +11,9 @@ import (
 
 // startupEnvStatus picks the first message worth showing when a session opens.
 func startupEnvStatus(entries []files.Entry, ws workspace, fallback string, wsErr error) statusMsg {
+	if s := ws.envLoadStatus(); s.text != "" {
+		return s
+	}
 	if wsErr != nil {
 		return statusMsg{text: fmt.Sprintf("workspace error: %v", wsErr), level: statusWarn}
 	}
@@ -21,6 +24,17 @@ func startupEnvStatus(entries []files.Entry, ws workspace, fallback string, wsEr
 		return statusMsg{text: fmt.Sprintf("Using environment: %s", fallback), level: statusInfo}
 	}
 	return statusMsg{}
+}
+
+func (w workspace) envLoadStatus() statusMsg {
+	if w.envErr == nil {
+		return statusMsg{}
+	}
+	return statusMsg{text: envLoadFailed(w.envErr) + ". " + envFixHint, level: statusError}
+}
+
+func envLoadFailed(err error) string {
+	return fmt.Sprintf("Environment file failed to load: %v", err)
 }
 
 // envFileWarning surfaces environment files that will not take effect. Startup

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -90,6 +90,20 @@ type statusMsg struct {
 	noModal     bool // error shown elsewhere (e.g. response pane); don't also pop the modal
 }
 
+func (s statusMsg) then(next statusMsg) statusMsg {
+	if next.text == "" {
+		return s
+	}
+	if s.text == "" {
+		return next
+	}
+	s.text += ". " + next.text
+	if next.level == statusWarn || next.level == statusError {
+		s.level = next.level
+	}
+	return s
+}
+
 type updateCheckMsg struct {
 	res *update.Result
 	err error

--- a/internal/ui/model_core.go
+++ b/internal/ui/model_core.go
@@ -736,5 +736,9 @@ func New(cfg Config) Model {
 		model.lastResponseSaveDir = model.ws.root
 	}
 	model.startLatAnim()
+	// Startup bypasses setStatusMessage, so open an error modal explicitly.
+	if initialStatus.level == statusError {
+		model.openStatusModal(initialStatus.level, initialStatus.text)
+	}
 	return model
 }

--- a/internal/ui/model_engine.go
+++ b/internal/ui/model_engine.go
@@ -209,9 +209,12 @@ func (m *Model) runMsg(fn func(context.Context) tea.Msg) tea.Cmd {
 	}
 }
 
-// runBlocked refuses to execute while no environment is selected. Every path
-// onto the wire passes this one rule.
+// runBlocked prevents requests when the environment file failed to load or the
+// requested selection is unavailable. Every path that can send calls it.
 func (m *Model) runBlocked() tea.Cmd {
+	if s := m.ws.envLoadStatus(); s.text != "" {
+		return statusMsgCmd(s)
+	}
 	if !m.ws.unselected {
 		return nil
 	}

--- a/internal/ui/model_env_reload_test.go
+++ b/internal/ui/model_env_reload_test.go
@@ -1,0 +1,461 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/unkn0wn-root/resterm/internal/bindings"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+	"github.com/unkn0wn-root/resterm/internal/watcher"
+)
+
+const (
+	brokenEnv = `{"dev":{"token":"env:"}}`
+	loadedEnv = `{"dev":{"token":"dev-token"},"prod":{"token":"prod-token"}}`
+)
+
+func brokenEnvModel(t *testing.T, root string) Model {
+	t.Helper()
+	cat, envFile, err := vars.Discover(root)
+	if err == nil {
+		t.Fatal("the environment file loaded, so there is nothing to recover from")
+	}
+	return New(Config{
+		Env:           vars.Config{Catalog: cat, File: envFile, FileErr: err},
+		WorkspaceRoot: root,
+	})
+}
+
+func brokenPinnedEnvModel(t *testing.T, root, pinned string) Model {
+	t.Helper()
+	cat, err := vars.LoadEnvironmentFile(pinned)
+	if err == nil {
+		t.Fatal("the environment file loaded, so there is nothing to recover from")
+	}
+	return New(Config{
+		Env:           vars.Config{Catalog: cat, File: pinned, FileExplicit: true, FileErr: err},
+		WorkspaceRoot: root,
+	})
+}
+
+func TestBrokenEnvironmentFileStillOpensTheSession(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{
+		"resterm.env.json": brokenEnv,
+		"api.http":         "GET http://example.test/{{token}}\n",
+	})
+	m := brokenEnvModel(t, root)
+
+	if got := m.statusMessage.level; got != statusError {
+		t.Fatalf("level = %v, want error", got)
+	}
+	for _, want := range []string{
+		"Environment file failed to load",
+		"env: reference with no variable name",
+		envFixHint,
+	} {
+		if !strings.Contains(m.statusMessage.text, want) {
+			t.Fatalf("status = %q, want it to contain %q", m.statusMessage.text, want)
+		}
+	}
+
+	if !m.showStatusModal {
+		t.Fatal("the session opened with the failure only in the status bar")
+	}
+	if m.statusModalMessage != m.statusMessage.text {
+		t.Fatalf("modal = %q, want the status text", m.statusModalMessage)
+	}
+	if got := m.headerEnvVariants()[0]; got != "not loaded" {
+		t.Fatalf("header = %q, want it to show there is no environment", got)
+	}
+}
+
+func TestBrokenEnvironmentFileRefusesToSend(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{
+		"resterm.env.json": brokenEnv,
+		"api.http":         "GET http://example.test/\n",
+	})
+	model := brokenEnvModel(t, root)
+	m := &model
+
+	refused, ok := statusMsgFromCmd(runCmd(m.startRun(runSpec{sel: m.ws.sel})))
+	if !ok {
+		t.Fatal("the run was not refused")
+	}
+	if refused.level != statusError {
+		t.Fatalf("level = %v, want error", refused.level)
+	}
+	for _, want := range []string{"Environment file failed to load", envFixHint} {
+		if !strings.Contains(refused.text, want) {
+			t.Fatalf("refusal = %q, want it to contain %q", refused.text, want)
+		}
+	}
+
+	binding := bindings.Binding{Action: bindings.ActionOpenEnvSelector}
+	opened, _ := statusMsgFromCmd(runCmd(m.runShortcutBinding(binding, tea.KeyMsg{})))
+	if !strings.Contains(opened.text, "Environment file failed to load") {
+		t.Fatalf("Ctrl+E status = %q, want the reason the list is empty", opened.text)
+	}
+	if m.showEnvSelector {
+		t.Fatal("the picker opened on a catalog that never loaded")
+	}
+}
+
+func TestStartupWarningsDoNotOpenTheStatusModal(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{
+		"resterm.env.json":   loadedEnv,
+		"a/resterm.env.json": loadedEnv,
+		"a/req.http":         "GET http://example.test/\n",
+	})
+	m := modelInWorkspace(t, root, true)
+
+	if m.statusMessage.level != statusWarn {
+		t.Fatalf("level = %v, want the nested file warning", m.statusMessage.level)
+	}
+	if m.showStatusModal {
+		t.Fatalf("a warning opened a modal: %q", m.statusModalMessage)
+	}
+}
+
+func TestSavingTheEnvironmentFileLoadsIt(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{
+		"resterm.env.json": brokenEnv,
+		"api.http":         "GET http://example.test/{{token}}\n",
+	})
+	model := brokenEnvModel(t, root)
+	m := &model
+
+	m.openFile(filepath.Join(root, "resterm.env.json"))
+	m.editor.SetValue(loadedEnv)
+	status, ok := statusMsgFromCmd(m.saveFile())
+	if !ok {
+		t.Fatal("save produced no status message")
+	}
+
+	if want := "Saved resterm.env.json. Environment dev"; status.text != want {
+		t.Fatalf("status = %q, want %q", status.text, want)
+	}
+	if status.level != statusSuccess {
+		t.Fatalf("level = %v, want success", status.level)
+	}
+	if got := m.ws.active.Values()["token"]; got != "dev-token" {
+		t.Fatalf("token = %q, want the saved file to be active", got)
+	}
+	if got := len(m.envList.Items()); got != 2 {
+		t.Fatalf("picker items = %d, want both environments", got)
+	}
+	if cmd := m.runBlocked(); cmd != nil {
+		t.Fatal("the session still refuses to send after the file loaded")
+	}
+}
+
+func TestReloadingTheEnvironmentFileFromDiskLoadsIt(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		reload func(m *Model, path string) tea.Cmd
+	}{
+		{
+			name: "an edit made outside Resterm",
+			reload: func(m *Model, path string) tea.Cmd {
+				return m.handleFileChangeEvent(
+					fileChangedMsg{path: path, kind: watcher.EventChanged},
+				)
+			},
+		},
+		{
+			name:   "a reload from disk",
+			reload: func(m *Model, _ string) tea.Cmd { return m.reloadFileFromDisk() },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeWorkspace(t, map[string]string{
+				"resterm.env.json": brokenEnv,
+				"api.http":         "GET http://example.test/{{token}}\n",
+			})
+			model := brokenEnvModel(t, root)
+			m := &model
+
+			path := filepath.Join(root, "resterm.env.json")
+			m.openFile(path)
+			if err := os.WriteFile(path, []byte(loadedEnv), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			status, ok := statusMsgFromCmd(tc.reload(m, path))
+			if !ok {
+				t.Fatal("the reload produced no status message")
+			}
+			if !strings.Contains(status.text, "Environment dev") {
+				t.Fatalf("status = %q, want it to name what the reload activated", status.text)
+			}
+			if got := m.ws.active.Values()["token"]; got != "dev-token" {
+				t.Fatalf("token = %q, want the file on disk to be active", got)
+			}
+			if cmd := m.runBlocked(); cmd != nil {
+				t.Fatal("the session still refuses to send after the file loaded")
+			}
+		})
+	}
+}
+
+func TestReloadingARequestFileLeavesTheEnvironmentAlone(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{
+		"resterm.env.json": loadedEnv,
+		"api.http":         "GET http://example.test/\n",
+	})
+	model := modelInWorkspace(t, root, false)
+	m := &model
+
+	path := filepath.Join(root, "api.http")
+	m.openFile(path)
+	if err := os.WriteFile(path, []byte("GET http://example.test/{{token}}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _ := statusMsgFromCmd(m.reloadFileFromDisk())
+	if want := "Reloaded api.http"; status.text != want {
+		t.Fatalf("status = %q, want %q", status.text, want)
+	}
+}
+
+func TestSavingTheEnvironmentFileReplaysTheIntent(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{
+		"resterm.env.json": brokenEnv,
+		"api.http":         "GET http://example.test/{{token}}\n",
+	})
+	cat, envFile, err := vars.Discover(root)
+	if err == nil {
+		t.Fatal("the environment file loaded, so there is nothing to recover from")
+	}
+	model := New(Config{
+		Env: vars.Config{
+			Catalog: cat,
+			File:    envFile,
+			FileErr: err,
+			Intent:  vars.Intent{Name: "prod"},
+		},
+		WorkspaceRoot: root,
+	})
+	m := &model
+
+	m.openFile(envFile)
+	m.editor.SetValue(loadedEnv)
+	status, _ := statusMsgFromCmd(m.saveFile())
+
+	if want := "Saved resterm.env.json. Environment prod"; status.text != want {
+		t.Fatalf("status = %q, want %q", status.text, want)
+	}
+	if got := m.ws.active.Values()["token"]; got != "prod-token" {
+		t.Fatalf("token = %q, want the environment named at launch", got)
+	}
+}
+
+func TestSavingTheEnvironmentFileWithoutTheSelectedEnvironment(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{"resterm.env.json": loadedEnv})
+	model := modelInWorkspace(t, root, false)
+	m := &model
+	if err := m.selectEnvironment("prod", nil); err != nil {
+		t.Fatalf("select prod: %v", err)
+	}
+
+	m.openFile(filepath.Join(root, "resterm.env.json"))
+	m.editor.SetValue(`{"dev":{"token":"dev-token"}}`)
+	status, _ := statusMsgFromCmd(m.saveFile())
+
+	if !strings.Contains(status.text, noEnvSelected) {
+		t.Fatalf("status = %q, want %q", status.text, noEnvSelected)
+	}
+	if status.level != statusWarn {
+		t.Fatalf("level = %v, want warn", status.level)
+	}
+	if !m.ws.unselected {
+		t.Fatal("the session kept an environment the file no longer defines")
+	}
+}
+
+func TestSavingABrokenEnvironmentFileKeepsTheLoadedOne(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{"resterm.env.json": loadedEnv})
+	model := modelInWorkspace(t, root, false)
+	m := &model
+
+	m.openFile(filepath.Join(root, "resterm.env.json"))
+	m.editor.SetValue(brokenEnv)
+	status, ok := statusMsgFromCmd(m.saveFile())
+	if !ok {
+		t.Fatal("save produced no status message")
+	}
+
+	if status.level != statusError {
+		t.Fatalf("level = %v, want error", status.level)
+	}
+	for _, want := range []string{"Saved resterm.env.json", "Environment file failed to load"} {
+		if !strings.Contains(status.text, want) {
+			t.Fatalf("status = %q, want it to contain %q", status.text, want)
+		}
+	}
+	if got := m.ws.active.Values()["token"]; got != "dev-token" {
+		t.Fatalf("token = %q, want the loaded environment to stay active", got)
+	}
+	if cmd := m.runBlocked(); cmd != nil {
+		t.Fatal("a session running on a loaded environment was stopped by a bad write")
+	}
+}
+
+func TestSavingAStillBrokenEnvironmentFileKeepsRefusingToSend(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{"resterm.env.json": brokenEnv})
+	model := brokenEnvModel(t, root)
+	m := &model
+
+	m.openFile(filepath.Join(root, "resterm.env.json"))
+	m.editor.SetValue(`{"dev":[]}`)
+	status, _ := statusMsgFromCmd(m.saveFile())
+	if !strings.Contains(status.text, "Environment file failed to load") {
+		t.Fatalf("status = %q, want the new reason", status.text)
+	}
+
+	refused, ok := statusMsgFromCmd(m.runBlocked())
+	if !ok {
+		t.Fatal("the session sends on an environment file that never loaded")
+	}
+	if !strings.Contains(refused.text, `"dev" must be an object`) {
+		t.Fatalf("refusal = %q, want the reason the last save failed with", refused.text)
+	}
+}
+
+func TestSavingARequestFileLeavesTheEnvironmentAlone(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{
+		"resterm.env.json": loadedEnv,
+		"api.http":         "GET http://example.test/\n",
+	})
+	model := modelInWorkspace(t, root, false)
+	m := &model
+
+	m.openFile(filepath.Join(root, "api.http"))
+	m.editor.SetValue("GET http://example.test/{{token}}\n")
+	status, _ := statusMsgFromCmd(m.saveFile())
+
+	if want := "Saved api.http"; status.text != want {
+		t.Fatalf("status = %q, want %q", status.text, want)
+	}
+}
+
+func TestMovingWorkspaceKeepsABrokenPinnedEnvFile(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{"api.http": "GET http://example.test/\n"})
+	pinned := filepath.Join(
+		writeWorkspace(t, map[string]string{"pinned.env.json": brokenEnv}),
+		"pinned.env.json",
+	)
+	other := writeWorkspace(t, map[string]string{"resterm.env.json": loadedEnv})
+
+	model := brokenPinnedEnvModel(t, root, pinned)
+	m := &model
+
+	m.applyOpenDirectory(other)
+
+	if m.ws.envFile != pinned {
+		t.Fatalf("envFile = %q, want the pinned %q", m.ws.envFile, pinned)
+	}
+	if cmd := m.runBlocked(); cmd == nil {
+		t.Fatal("the move let the session send on an environment file that never loaded")
+	}
+}
+
+func TestSavingAnEnvFileOutsideTheWorkspaceReloadsThatFile(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{"resterm.env.json": `{"root":{"token":"root-token"}}`})
+	pinned := filepath.Join(writeWorkspace(t, map[string]string{"pinned.env.json": brokenEnv}), "pinned.env.json")
+
+	model := brokenPinnedEnvModel(t, root, pinned)
+	m := &model
+
+	m.openFile(pinned)
+	m.editor.SetValue(loadedEnv)
+	status, _ := statusMsgFromCmd(m.saveFile())
+
+	if want := "Saved pinned.env.json. Environment dev"; status.text != want {
+		t.Fatalf("status = %q, want %q", status.text, want)
+	}
+	if m.ws.envFile != pinned {
+		t.Fatalf("envFile = %q, want %q", m.ws.envFile, pinned)
+	}
+	if got := m.ws.active.Values()["token"]; got != "dev-token" {
+		t.Fatalf("token = %q, want the file the session runs on", got)
+	}
+}
+
+func TestWorkspaceOwnsEnvFile(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{
+		"resterm.env.json": loadedEnv,
+		"pinned.env.json":  loadedEnv,
+		"api.http":         "GET http://example.test/\n",
+	})
+	discovered := filepath.Join(root, "resterm.env.json")
+	pinned := filepath.Join(root, "pinned.env.json")
+
+	for _, tc := range []struct {
+		name string
+		ws   workspace
+		path string
+		want bool
+	}{
+		{
+			name: "the discovered file",
+			ws:   workspace{root: root, envFile: discovered},
+			path: discovered,
+			want: true,
+		},
+		{
+			name: "a request file",
+			ws:   workspace{root: root, envFile: discovered},
+			path: filepath.Join(root, "api.http"),
+		},
+		{
+			name: "the file passed with --env-file",
+			ws:   workspace{root: root, envFile: pinned, envPinned: true},
+			path: pinned,
+			want: true,
+		},
+		{
+			name: "a discoverable file beside the one in use",
+			ws:   workspace{root: root, envFile: pinned, envPinned: true},
+			path: discovered,
+		},
+		{
+			name: "a file created after launch",
+			ws:   workspace{root: root},
+			path: discovered,
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ws.ownsEnvFile(tc.path); got != tc.want {
+				t.Fatalf("ownsEnvFile(%s) = %t, want %t", filepath.Base(tc.path), got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSavingANewEnvironmentFileLoadsIt(t *testing.T) {
+	root := writeWorkspace(t, map[string]string{"api.http": "GET http://example.test/\n"})
+	model := modelInWorkspace(t, root, false)
+	m := &model
+	if !m.ws.cat.Empty() {
+		t.Fatal("the workspace already has an environment file")
+	}
+
+	path := filepath.Join(root, "resterm.env.json")
+	if err := os.WriteFile(path, []byte(loadedEnv), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.openFile(path)
+	status, _ := statusMsgFromCmd(m.saveFile())
+
+	if want := "Saved resterm.env.json. Environment dev"; status.text != want {
+		t.Fatalf("status = %q, want %q", status.text, want)
+	}
+	if m.ws.envFile != path {
+		t.Fatalf("envFile = %q, want %q", m.ws.envFile, path)
+	}
+}

--- a/internal/ui/model_environment.go
+++ b/internal/ui/model_environment.go
@@ -254,6 +254,9 @@ func (m Model) envChoices(sel vars.Selection) []envChoice {
 // form keeps the profile, because a header that reads the same on dev and on
 // prod has given up the one thing worth glancing at before sending a request.
 func (m Model) headerEnvVariants() []string {
+	if m.ws.envErr != nil {
+		return []string{"not loaded", "none"}
+	}
 	if m.ws.unselected {
 		return []string{"none selected", "none"}
 	}

--- a/internal/ui/model_files.go
+++ b/internal/ui/model_files.go
@@ -113,21 +113,22 @@ func (m *Model) saveFileWithOutcome() (saveFileOutcome, tea.Cmd) {
 	}
 	m.watchFile(m.currentFile, content)
 	m.refreshCurrentDocument(content)
-	return saveFileOutcomeSaved, batchCommands(
-		m.refreshGitStatusCmd(),
-		statusCmd(savedStatus(m.currentFile, m.doc)),
-	)
+	status := savedStatus(m.currentFile, m.doc).then(m.reloadEnvFile(m.currentFile))
+	return saveFileOutcomeSaved, batchCommands(m.refreshGitStatusCmd(), statusMsgCmd(status))
 }
 
-func savedStatus(path string, doc *restfile.Document) (statusLevel, string) {
+func savedStatus(path string, doc *restfile.Document) statusMsg {
 	saved := "Saved " + filepath.Base(path)
 	if doc == nil || len(doc.Errors) == 0 {
-		return statusSuccess, saved
+		return statusMsg{text: saved, level: statusSuccess}
 	}
 	if len(doc.Errors) == 1 {
-		return statusWarn, saved + " (1 parse error)"
+		return statusMsg{text: saved + " (1 parse error)", level: statusWarn}
 	}
-	return statusWarn, fmt.Sprintf("%s (%d parse errors)", saved, len(doc.Errors))
+	return statusMsg{
+		text:  fmt.Sprintf("%s (%d parse errors)", saved, len(doc.Errors)),
+		level: statusWarn,
+	}
 }
 
 func (m *Model) reloadWorkspace() tea.Cmd {
@@ -206,27 +207,22 @@ func (m *Model) reloadFileFromDisk() tea.Cmd {
 		}
 	}
 
-	m.applyDiskContent(path, data, diskContentOptions{})
-
-	return batchCommands(
-		m.refreshGitStatusCmd(),
-		func() tea.Msg {
-			return statusMsg{
-				text:  fmt.Sprintf("Reloaded %s", filepath.Base(path)),
-				level: statusInfo,
-			}
-		},
-	)
+	reload := m.applyDiskContent(path, data, diskContentOptions{})
+	status := statusMsg{text: fmt.Sprintf("Reloaded %s", filepath.Base(path)), level: statusInfo}
+	return batchCommands(m.refreshGitStatusCmd(), statusMsgCmd(status.then(reload)))
 }
 
 func manualDirtyReloadMessage() string {
 	return "Reload from disk? Unsaved changes in Resterm will be discarded."
 }
 
-func (m *Model) applyDiskContent(path string, data []byte, opt diskContentOptions) {
+// applyDiskContent updates the editor from disk. When path is the active
+// environment file, it also reloads the catalog.
+func (m *Model) applyDiskContent(path string, data []byte, opt diskContentOptions) statusMsg {
 	m.replaceEditorContent(string(data), editorContentOptions(opt))
 	m.refreshCurrentDocument(data)
 	m.watchFile(path, data)
+	return m.reloadEnvFile(path)
 }
 
 func (m *Model) replaceEditorWithDocument(

--- a/internal/ui/model_filewatch.go
+++ b/internal/ui/model_filewatch.go
@@ -106,14 +106,12 @@ func (m *Model) autoReloadChangedFile(path string) tea.Cmd {
 		return nil
 	}
 
-	m.applyDiskContent(path, data, diskContentOptions{PreserveView: true})
-	text := fmt.Sprintf("↻ Reloaded %s (file changed outside Resterm)", fileDisplayName(path))
-	return batchCommands(
-		m.refreshGitStatusCmd(),
-		func() tea.Msg {
-			return statusMsg{text: text, level: statusWarn}
-		},
-	)
+	reload := m.applyDiskContent(path, data, diskContentOptions{PreserveView: true})
+	status := statusMsg{
+		text:  fmt.Sprintf("↻ Reloaded %s (file changed outside Resterm)", fileDisplayName(path)),
+		level: statusWarn,
+	}
+	return batchCommands(m.refreshGitStatusCmd(), statusMsgCmd(status.then(reload)))
 }
 
 func (m *Model) showFileChangeWarning(path string, kind watcher.EventKind, text string) {

--- a/internal/ui/model_newfile.go
+++ b/internal/ui/model_newfile.go
@@ -119,11 +119,11 @@ func (m *Model) submitNewFile() tea.Cmd {
 	m.closeNewFileModal()
 	focusCmd := m.setFocus(focusEditor)
 	cmd := m.openFile(finalPath)
-	level, text := statusSuccess, "Created "+filepath.Base(finalPath)
+	status := statusMsg{text: "Created " + filepath.Base(finalPath), level: statusSuccess}
 	if fromSave {
-		level, text = savedStatus(finalPath, m.doc)
+		status = savedStatus(finalPath, m.doc)
 	}
-	m.setStatusMessage(statusMsg{text: text, level: level})
+	m.setStatusMessage(status)
 	if followUp != nil {
 		return batchCommands(focusCmd, cmd, followUp)
 	}

--- a/internal/ui/model_open_workspace_test.go
+++ b/internal/ui/model_open_workspace_test.go
@@ -46,8 +46,8 @@ func TestPlanKeepsPinnedEnvFile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("plan: %v", err)
 			}
-			if mv.envFile != pinned {
-				t.Fatalf("envFile = %q, want the pinned %q", mv.envFile, pinned)
+			if mv.env.envFile != pinned {
+				t.Fatalf("envFile = %q, want the pinned %q", mv.env.envFile, pinned)
 			}
 			if mv.reset {
 				t.Fatal("a pinned environment has nothing to reset")

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -962,6 +962,9 @@ func (m *Model) runShortcutBinding(binding bindings.Binding, msg tea.KeyMsg) (te
 		}
 		return cmd, true
 	case bindings.ActionOpenEnvSelector:
+		if s := m.ws.envLoadStatus(); s.text != "" {
+			return statusMsgCmd(s), true
+		}
 		if m.ws.cat.Empty() {
 			return func() tea.Msg {
 				return statusMsg{text: "No environments configured", level: statusWarn}

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -18,6 +18,7 @@ import (
 const (
 	moveRefused   = "Workspace not changed"
 	noEnvSelected = "No environment selected"
+	envFixHint    = "Fix and save the file to load its environments"
 )
 
 // workspace is the live workspace state. A move goes through plan, which
@@ -29,9 +30,18 @@ type workspace struct {
 	cat        vars.Catalog
 	sel        vars.Selection
 	envFile    string
+	envErr     error
 	envPinned  bool
 	intent     vars.Intent
 	active     vars.Environment
+	unselected bool
+}
+
+type envState struct {
+	cat        vars.Catalog
+	sel        vars.Selection
+	envFile    string
+	envErr     error
 	unselected bool
 }
 
@@ -42,6 +52,7 @@ func newWorkspace(root string, recursive bool, env vars.Config) workspace {
 		cat:       env.Catalog,
 		sel:       env.Selection,
 		envFile:   env.File,
+		envErr:    env.FileErr,
 		envPinned: env.FileExplicit,
 		intent:    env.Intent,
 	}
@@ -59,30 +70,28 @@ func (w *workspace) use(env vars.Environment) {
 }
 
 type wsMove struct {
-	root       string
-	cat        vars.Catalog
-	sel        vars.Selection
-	envFile    string
-	unselected bool
-	reset      bool
-	status     statusMsg
+	root   string
+	env    envState
+	reset  bool
+	status statusMsg
 }
 
-// plan works out what a move to root would activate, without touching the
-// current state. Discovery searches only the new root, and a root whose
-// environment file does not load refuses the move the same way launching
-// there would.
+// plan validates a workspace move without changing the current state. A broken
+// environment file causes the move to fail.
 func (w workspace) plan(root string) (wsMove, error) {
 	text := fmt.Sprintf("Workspace set to %s", filepath.Base(root))
 
 	if w.envPinned {
 		mv := wsMove{
-			root:       root,
-			cat:        w.cat,
-			sel:        w.sel,
-			envFile:    w.envFile,
-			unselected: w.unselected,
-			status:     statusMsg{text: text, level: statusInfo},
+			root: root,
+			env: envState{
+				cat:        w.cat,
+				sel:        w.sel,
+				envFile:    w.envFile,
+				envErr:     w.envErr,
+				unselected: w.unselected,
+			},
+			status: statusMsg{text: text, level: statusInfo},
 		}
 		if own := vars.DiscoverPath(root); own != "" && !util.SameFile(own, w.envFile) {
 			mv.status = statusMsg{
@@ -99,11 +108,10 @@ func (w workspace) plan(root string) (wsMove, error) {
 	}
 
 	mv := wsMove{
-		root:    root,
-		cat:     cat,
-		envFile: envFile,
-		reset:   !w.sameEnv(root, envFile),
-		status:  statusMsg{text: text, level: statusInfo},
+		root:   root,
+		env:    envState{cat: cat, envFile: envFile},
+		reset:  !w.sameEnv(root, envFile),
+		status: statusMsg{text: text, level: statusInfo},
 	}
 	if cat.Empty() {
 		return mv, nil
@@ -113,7 +121,7 @@ func (w workspace) plan(root string) (wsMove, error) {
 	if !ok {
 		// Falling back to the new default could promote a dev session to
 		// prod, so nothing is active until someone picks.
-		mv.unselected = true
+		mv.env.unselected = true
 		mv.status = statusMsg{
 			text: fmt.Sprintf(
 				"%s. %s, %s is not available here",
@@ -126,7 +134,7 @@ func (w workspace) plan(root string) (wsMove, error) {
 		return mv, nil
 	}
 
-	mv.sel = sel
+	mv.env.sel = sel
 	if env, err := cat.Resolve(sel); err == nil {
 		mv.status = statusMsg{
 			text:  fmt.Sprintf("%s. Environment %s", text, env.Label()),
@@ -134,6 +142,51 @@ func (w workspace) plan(root string) (wsMove, error) {
 		}
 	}
 	return mv, nil
+}
+
+func (w workspace) ownsEnvFile(path string) bool {
+	if w.envFile != "" {
+		return sameEnvFile(path, w.envFile)
+	}
+	own := vars.DiscoverPath(w.root)
+	return own != "" && util.SameFile(path, own)
+}
+
+// reloadEnv reads the environment file and reapplies the current selection
+// intent. An unavailable selection never falls back to the file's default.
+func (w workspace) reloadEnv() (envState, statusMsg, error) {
+	cat, envFile, err := w.loadEnv()
+	if err != nil {
+		return envState{}, statusMsg{}, err
+	}
+
+	next := envState{cat: cat, envFile: envFile}
+	if cat.Empty() {
+		return next, statusMsg{text: "No environments loaded", level: statusWarn}, nil
+	}
+
+	sel, ok := w.intent.Resolve(cat)
+	if !ok {
+		next.unselected = true
+		return next, statusMsg{
+			text:  fmt.Sprintf("%s, %s is not available here", noEnvSelected, w.intent.Describe()),
+			level: statusWarn,
+		}, nil
+	}
+
+	next.sel = sel
+	env, _ := cat.Resolve(sel)
+	return next, statusMsg{text: "Environment " + env.Label(), level: statusInfo}, nil
+}
+
+// loadEnv reloads the active file. It uses discovery only before a file is
+// active because an explicit file may be outside the workspace.
+func (w workspace) loadEnv() (vars.Catalog, string, error) {
+	if w.envFile != "" {
+		cat, err := vars.LoadEnvironmentFile(w.envFile)
+		return cat, w.envFile, err
+	}
+	return vars.Discover(w.root)
 }
 
 // sameEnv reports whether a move to root keeps the environment the runtime
@@ -174,7 +227,7 @@ func (m *Model) prepareMove(dir, current string) (wsMove, []files.Entry, tea.Cmd
 	if err != nil {
 		return wsMove{}, nil, moveRefusedCmd(err)
 	}
-	entries, err := listWorkspaceEntries(dir, m.ws.recursive, mv.envFile, current, nil)
+	entries, err := listWorkspaceEntries(dir, m.ws.recursive, mv.env.envFile, current, nil)
 	if err != nil {
 		return wsMove{}, nil, moveRefusedCmd(err)
 	}
@@ -182,7 +235,12 @@ func (m *Model) prepareMove(dir, current string) (wsMove, []files.Entry, tea.Cmd
 	// Surface the same environment file warnings launching with -w would,
 	// unless the move already has something more specific to say.
 	if mv.status.level == statusInfo {
-		next := workspace{root: dir, recursive: m.ws.recursive, cat: mv.cat, envFile: mv.envFile}
+		next := workspace{
+			root:      dir,
+			recursive: m.ws.recursive,
+			cat:       mv.env.cat,
+			envFile:   mv.env.envFile,
+		}
 		if warn := envFileWarning(entries, next); warn.text != "" {
 			mv.status = statusMsg{text: mv.status.text + ". " + warn.text, level: statusWarn}
 		}
@@ -212,26 +270,55 @@ func (m *Model) commitMove(mv wsMove) (statusMsg, tea.Cmd) {
 	m.clearResponseState()
 
 	m.ws.root = mv.root
-	m.ws.cat = mv.cat
-	m.ws.sel = mv.sel
-	m.ws.envFile = mv.envFile
-	m.ws.unselected = mv.unselected
-	if mv.unselected {
-		m.ws.active = vars.Environment{}
-	} else {
-		m.ws.active, _ = mv.cat.Resolve(mv.sel)
-	}
+	m.applyEnv(mv.env)
 
 	// Runs re-derive their base directory from the file they execute.
 	m.cfg.HTTPOptions.BaseDir = ""
 
-	m.envDraft = vars.Selection{}
-	m.envList.ResetFilter()
-	m.envList.SetItems(makeEnvItems(mv.cat, mv.sel))
-	m.envList.SetDelegate(envDelegateForTheme(m.theme, mv.cat))
 	// Document-derived state is the caller's to rebuild. Only it knows whether
 	// the move clears the document or installs a new one.
 	return mv.status, stop
+}
+
+func (m *Model) applyEnv(next envState) {
+	m.ws.cat = next.cat
+	m.ws.sel = next.sel
+	m.ws.envFile = next.envFile
+	m.ws.envErr = next.envErr
+	m.ws.unselected = next.unselected
+	// Resolve would choose the default when the requested selection is
+	// unavailable, so leave the active environment empty in that case.
+	m.ws.active = vars.Environment{}
+	if !next.unselected {
+		m.ws.active, _ = next.cat.Resolve(next.sel)
+	}
+
+	m.envDraft = vars.Selection{}
+	m.envList.ResetFilter()
+	m.envList.SetItems(makeEnvItems(next.cat, next.sel))
+	m.envList.SetDelegate(envDelegateForTheme(m.theme, next.cat))
+}
+
+// reloadEnvFile reloads path when it is the active environment file. If the
+// reload fails after a successful load, the previous catalog stays active. If
+// no catalog has loaded yet, the error is stored and requests remain blocked.
+func (m *Model) reloadEnvFile(path string) statusMsg {
+	if !m.ws.ownsEnvFile(path) {
+		return statusMsg{}
+	}
+
+	next, status, err := m.ws.reloadEnv()
+	if err != nil {
+		if m.ws.cat.Empty() {
+			m.ws.envErr = err
+		}
+		return statusMsg{text: envLoadFailed(err), level: statusError}
+	}
+
+	m.applyEnv(next)
+	m.syncRequestList(m.doc)
+	m.syncHistory()
+	return status
 }
 
 // stopLiveStreams cancels every live session and drops their consoles, so a

--- a/internal/vars/config.go
+++ b/internal/vars/config.go
@@ -9,4 +9,6 @@ type Config struct {
 	FileExplicit bool
 	Intent       Intent
 	Fallback     string
+	// FileErr holds a parse error that an editor session can recover from.
+	FileErr error
 }


### PR DESCRIPTION
The editor is where a broken environment file gets fixed, so the TUI opens on one whose contents do not parse. Nothing is selected, the reason opens in a modal and stays in the status bar, the header reads ENV: not loaded, and
every path onto the wire is refused until the file loads. Saving it, or editing it outside Resterm while it is open, applies the environment the session launched with.

Only a parse failure is recoverable. A missing --env-file path, a directory or a file with no read permission leaves nothing to fix, so it stops the TUI the way it stops a run. resterm run and headless startup stay fatal for every failure.