### PR TITLE
RST-335: Fix HTTP version handling and body line endings

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2065,7 +2065,8 @@ Key points:
 
 - Global defaults are passed via CLI flags (`--timeout`, `--follow`, `--insecure`, `--proxy`).
 - Per-request overrides use `@setting`, `@settings`, or `@timeout`.
-- HTTP version: `@setting http-version 1.1` (accepts `1.0`, `1.1`, `2`, `HTTP/1.1`, `HTTP/2`). A trailing `HTTP/1.1` on the request line also sets the version; explicit settings win. `2` is strict and fails if the response is not HTTP/2. WebSocket requests are incompatible with `1.0` and `2`.
+- HTTP version: `@setting http-version 1.1` (accepts `1.1`, `2`, `HTTP/1.1`, `HTTP/2`). A trailing `HTTP/1.1` on the request line also sets the version; explicit settings win. `2` is strict and fails if the response is not HTTP/2. WebSocket requests are incompatible with `2`.
+- HTTP/1.0 is not supported. Resterm rejects `http-version 1.0`, trailing `HTTP/1.0`, and other unsupported version tokens such as `HTTP/3`.
 - Requests use an in-memory cookie jar per environment. Cookies are isolated between environments, and `@setting no-cookies true` disables cookies for a request without clearing the stored jar. Use `Ctrl+Shift+G` (or `g Shift+G`) to clear cookies for the current environment.
 - TLS per request: `# @settings http-root-cas=a.pem http-client-cert=cert.pem http-client-key=key.pem http-insecure=true` for a single line, or `@setting key value` per line (`http-root-cas` accepts space/comma/semicolon separated lists; paths are relative). GraphQL/REST/WebSocket/SSE all share these HTTP settings.
 - Use `@no-log` to omit sensitive bodies from history snapshots.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2067,6 +2067,7 @@ Key points:
 - Per-request overrides use `@setting`, `@settings`, or `@timeout`.
 - HTTP version: `@setting http-version 1.1` (accepts `1.1`, `2`, `HTTP/1.1`, `HTTP/2`). A trailing `HTTP/1.1` on the request line also sets the version; explicit settings win. `2` is strict and fails if the response is not HTTP/2. WebSocket requests are incompatible with `2`.
 - HTTP/1.0 is not supported. Resterm rejects `http-version 1.0`, trailing `HTTP/1.0`, and other unsupported version tokens such as `HTTP/3`.
+- Only a trailing `HTTP/<major>` or `HTTP/<major>.<minor>` is read as a version. Any other trailing text stays part of the URL, so `GET https://example.com/a http/foo` requests `/a%20http/foo`.
 - Requests use an in-memory cookie jar per environment. Cookies are isolated between environments, and `@setting no-cookies true` disables cookies for a request without clearing the stored jar. Use `Ctrl+Shift+G` (or `g Shift+G`) to clear cookies for the current environment.
 - TLS per request: `# @settings http-root-cas=a.pem http-client-cert=cert.pem http-client-key=key.pem http-insecure=true` for a single line, or `@setting key value` per line (`http-root-cas` accepts space/comma/semicolon separated lists; paths are relative). GraphQL/REST/WebSocket/SSE all share these HTTP settings.
 - Use `@no-log` to omit sensitive bodies from history snapshots.

--- a/internal/eol/eol.go
+++ b/internal/eol/eol.go
@@ -1,0 +1,57 @@
+// Package eol splits text while preserving line endings.
+package eol
+
+import (
+	"bytes"
+	"iter"
+	"strings"
+)
+
+const (
+	LF   = "\n"
+	CRLF = "\r\n"
+)
+
+// ScanLines is a bufio.SplitFunc that keeps line endings.
+func ScanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		return i + 1, data[:i+1], nil
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
+}
+
+// Cut separates a trailing LF or CRLF from s.
+func Cut(s string) (text, term string) {
+	switch {
+	case strings.HasSuffix(s, CRLF):
+		return s[:len(s)-len(CRLF)], CRLF
+	case strings.HasSuffix(s, LF):
+		return s[:len(s)-len(LF)], LF
+	default:
+		return s, ""
+	}
+}
+
+// Lines yields each line and its ending. Joining each pair reproduces s.
+func Lines(s string) iter.Seq2[string, string] {
+	return func(yield func(string, string) bool) {
+		for s != "" {
+			i := strings.IndexByte(s, '\n')
+			if i < 0 {
+				yield(s, "")
+				return
+			}
+			text, term := Cut(s[:i+1])
+			if !yield(text, term) {
+				return
+			}
+			s = s[i+1:]
+		}
+	}
+}

--- a/internal/eol/eol.go
+++ b/internal/eol/eol.go
@@ -1,4 +1,3 @@
-// Package eol splits text while preserving line endings.
 package eol
 
 import (

--- a/internal/eol/eol_test.go
+++ b/internal/eol/eol_test.go
@@ -1,0 +1,93 @@
+package eol
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestCut(t *testing.T) {
+	tests := []struct {
+		in   string
+		text string
+		term string
+	}{
+		{in: "a\r\n", text: "a", term: CRLF},
+		{in: "a\n", text: "a", term: LF},
+		{in: "a", text: "a"},
+		{in: "\r\n", term: CRLF},
+		{in: "a\r", text: "a\r"},
+		{in: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			text, term := Cut(tt.in)
+			if text != tt.text || term != tt.term {
+				t.Fatalf("Cut(%q) = (%q, %q), want (%q, %q)", tt.in, text, term, tt.text, tt.term)
+			}
+		})
+	}
+}
+
+func TestLinesRoundTrips(t *testing.T) {
+	for _, in := range []string{
+		"",
+		"a",
+		"a\n",
+		"a\r\nb",
+		"a\r\nb\r\n",
+		"a\n\r\nb",
+		"\n\n",
+	} {
+		t.Run(in, func(t *testing.T) {
+			var b strings.Builder
+			for text, term := range Lines(in) {
+				b.WriteString(text)
+				b.WriteString(term)
+			}
+			if b.String() != in {
+				t.Fatalf("rebuilt %q, want %q", b.String(), in)
+			}
+		})
+	}
+}
+
+func TestLinesReportsTerminators(t *testing.T) {
+	var got []string
+	for text, term := range Lines("a\r\nb\nc") {
+		got = append(got, text+"|"+term)
+	}
+	want := []string{"a|\r\n", "b|\n", "c|"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("Lines = %v, want %v", got, want)
+	}
+}
+
+func TestLinesStopsEarly(t *testing.T) {
+	seen := 0
+	for range Lines("a\nb\nc\n") {
+		seen++
+		break
+	}
+	if seen != 1 {
+		t.Fatalf("saw %d lines, want 1", seen)
+	}
+}
+
+func TestScanLinesKeepsTerminators(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader("a\r\nb\nc"))
+	scanner.Split(ScanLines)
+
+	var got []string
+	for scanner.Scan() {
+		got = append(got, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	want := []string{"a\r\n", "b\n", "c"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("ScanLines = %q, want %q", got, want)
+	}
+}

--- a/internal/http/version/version.go
+++ b/internal/http/version/version.go
@@ -2,12 +2,17 @@ package version
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
 const Key = "http-version"
 
 const tokenPrefix = "http/"
+
+// HTTP/2 is accepted alongside the RFC's dotted version form. Other tails are
+// URL text unless they match this numeric grammar.
+var tokenRe = regexp.MustCompile(`(?i)^http/[0-9]+(\.[0-9]+)?$`)
 
 type HTTP int
 
@@ -45,18 +50,18 @@ func SplitToken(fields []string) ([]string, HTTP, error) {
 		return fields, Unknown, nil
 	}
 	last := fields[len(fields)-1]
+	if !isTokenForm(last) {
+		return fields, Unknown, nil
+	}
 	v, ok := ParseToken(last)
 	if !ok {
-		if isTokenForm(last) {
-			return fields, Unknown, &UnsupportedError{Token: last}
-		}
-		return fields, Unknown, nil
+		return fields, Unknown, &UnsupportedError{Token: last}
 	}
 	return fields[:len(fields)-1], v, nil
 }
 
 func isTokenForm(raw string) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(raw)), tokenPrefix)
+	return tokenRe.MatchString(raw)
 }
 
 func Format(v HTTP) string {

--- a/internal/http/version/version.go
+++ b/internal/http/version/version.go
@@ -1,14 +1,19 @@
 package version
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 const Key = "http-version"
 
+const tokenPrefix = "http/"
+
 type HTTP int
 
+// HTTP/1.0 is omitted because net/http cannot send HTTP/1.0 requests.
 const (
 	Unknown HTTP = iota
-	V10
 	V11
 	V2
 )
@@ -21,21 +26,41 @@ func ParseValue(raw string) (HTTP, bool) {
 	return parse(raw, true)
 }
 
-func SplitToken(fields []string) ([]string, HTTP) {
+// UnsupportedError reports an unsupported HTTP version token.
+type UnsupportedError struct {
+	Token string
+}
+
+func (e *UnsupportedError) Error() string {
+	return fmt.Sprintf(
+		"unsupported HTTP version %q (use HTTP/1.1 or HTTP/2)",
+		e.Token,
+	)
+}
+
+// SplitToken removes a supported trailing HTTP version.
+// Unsupported version tokens return an error.
+func SplitToken(fields []string) ([]string, HTTP, error) {
 	if len(fields) == 0 {
-		return fields, Unknown
+		return fields, Unknown, nil
 	}
-	v, ok := ParseToken(fields[len(fields)-1])
+	last := fields[len(fields)-1]
+	v, ok := ParseToken(last)
 	if !ok {
-		return fields, Unknown
+		if isTokenForm(last) {
+			return fields, Unknown, &UnsupportedError{Token: last}
+		}
+		return fields, Unknown, nil
 	}
-	return fields[:len(fields)-1], v
+	return fields[:len(fields)-1], v, nil
+}
+
+func isTokenForm(raw string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(raw)), tokenPrefix)
 }
 
 func Format(v HTTP) string {
 	switch v {
-	case V10:
-		return "1.0"
 	case V11:
 		return "1.1"
 	case V2:
@@ -67,14 +92,12 @@ func parse(raw string, allowBare bool) (HTTP, bool) {
 		return Unknown, false
 	}
 	s = strings.ToLower(s)
-	if after, ok := strings.CutPrefix(s, "http/"); ok {
+	if after, ok := strings.CutPrefix(s, tokenPrefix); ok {
 		s = after
 	} else if !allowBare {
 		return Unknown, false
 	}
 	switch s {
-	case "1.0":
-		return V10, true
 	case "1.1":
 		return V11, true
 	case "2", "2.0":

--- a/internal/http/version/version_test.go
+++ b/internal/http/version/version_test.go
@@ -46,21 +46,23 @@ func TestParseValue(t *testing.T) {
 }
 
 func TestSplitToken(t *testing.T) {
-	fields := []string{"http://example.com", "HTTP/1.1"}
-	out, v, err := SplitToken(fields)
-	if err != nil {
-		t.Fatalf("SplitToken: %v", err)
-	}
-	if v != V11 {
-		t.Fatalf("expected V11, got %v", v)
-	}
-	if len(out) != 1 || out[0] != "http://example.com" {
-		t.Fatalf("unexpected fields: %#v", out)
+	for token, want := range map[string]HTTP{
+		"HTTP/1.1": V11,
+		"http/2":   V2,
+		"HTTP/2.0": V2,
+	} {
+		out, got, err := SplitToken([]string{"http://example.com", token})
+		if err != nil {
+			t.Fatalf("SplitToken(%q): %v", token, err)
+		}
+		if got != want || len(out) != 1 || out[0] != "http://example.com" {
+			t.Fatalf("SplitToken(%q) = %#v, %v", token, out, got)
+		}
 	}
 }
 
 func TestSplitTokenRejectsUnsupportedVersion(t *testing.T) {
-	for _, token := range []string{"HTTP/9.9", "HTTP/3", "http/0.9", "HTTP/1.0"} {
+	for _, token := range []string{"HTTP/3", "HTTP/1.0", "HTTP/11"} {
 		out, v, err := SplitToken([]string{"http://example.com/bad", token})
 		var unsupported *UnsupportedError
 		if !errors.As(err, &unsupported) {
@@ -76,13 +78,17 @@ func TestSplitTokenRejectsUnsupportedVersion(t *testing.T) {
 }
 
 func TestSplitTokenKeepsNonVersionTail(t *testing.T) {
-	fields := []string{"http://example.com/a", "b"}
-	out, v, err := SplitToken(fields)
-	if err != nil {
-		t.Fatalf("SplitToken: %v", err)
+	tails := []string{
+		"b", "http/foo", "HTTP/", "HTTP/2/x", "http/2?a=b", "http/1.1.1",
 	}
-	if v != Unknown || len(out) != 2 {
-		t.Fatalf("unexpected split: %#v %v", out, v)
+	for _, tail := range tails {
+		out, v, err := SplitToken([]string{"http://example.com/a", tail})
+		if err != nil {
+			t.Fatalf("SplitToken(%q): %v", tail, err)
+		}
+		if v != Unknown || len(out) != 2 {
+			t.Fatalf("SplitToken(%q) split the tail off: %#v %v", tail, out, v)
+		}
 	}
 }
 

--- a/internal/http/version/version_test.go
+++ b/internal/http/version/version_test.go
@@ -1,10 +1,12 @@
 package version
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestParseToken(t *testing.T) {
 	cases := map[string]HTTP{
-		"HTTP/1.0": V10,
 		"HTTP/1.1": V11,
 		"http/2":   V2,
 		"http/2.0": V2,
@@ -23,7 +25,6 @@ func TestParseToken(t *testing.T) {
 
 func TestParseValue(t *testing.T) {
 	cases := map[string]HTTP{
-		"1.0":      V10,
 		"1.1":      V11,
 		"2":        V2,
 		"2.0":      V2,
@@ -37,19 +38,51 @@ func TestParseValue(t *testing.T) {
 		}
 	}
 
-	if _, ok := ParseValue("HTTP/3"); ok {
-		t.Fatalf("expected unknown version to be rejected")
+	for _, raw := range []string{"HTTP/3", "1.0", "HTTP/1.0"} {
+		if _, ok := ParseValue(raw); ok {
+			t.Fatalf("expected %q to be rejected", raw)
+		}
 	}
 }
 
 func TestSplitToken(t *testing.T) {
 	fields := []string{"http://example.com", "HTTP/1.1"}
-	out, v := SplitToken(fields)
+	out, v, err := SplitToken(fields)
+	if err != nil {
+		t.Fatalf("SplitToken: %v", err)
+	}
 	if v != V11 {
 		t.Fatalf("expected V11, got %v", v)
 	}
 	if len(out) != 1 || out[0] != "http://example.com" {
 		t.Fatalf("unexpected fields: %#v", out)
+	}
+}
+
+func TestSplitTokenRejectsUnsupportedVersion(t *testing.T) {
+	for _, token := range []string{"HTTP/9.9", "HTTP/3", "http/0.9", "HTTP/1.0"} {
+		out, v, err := SplitToken([]string{"http://example.com/bad", token})
+		var unsupported *UnsupportedError
+		if !errors.As(err, &unsupported) {
+			t.Fatalf("SplitToken(%q) error = %v, want *UnsupportedError", token, err)
+		}
+		if unsupported.Token != token {
+			t.Fatalf("token = %q, want %q", unsupported.Token, token)
+		}
+		if v != Unknown || len(out) != 2 {
+			t.Fatalf("expected the fields to be left alone, got %#v %v", out, v)
+		}
+	}
+}
+
+func TestSplitTokenKeepsNonVersionTail(t *testing.T) {
+	fields := []string{"http://example.com/a", "b"}
+	out, v, err := SplitToken(fields)
+	if err != nil {
+		t.Fatalf("SplitToken: %v", err)
+	}
+	if v != Unknown || len(out) != 2 {
+		t.Fatalf("unexpected split: %#v %v", out, v)
 	}
 }
 

--- a/internal/intellisense/directives.go
+++ b/internal/intellisense/directives.go
@@ -147,7 +147,7 @@ var settingArgs = []Item{
 	},
 	{
 		Label:       "http-version=",
-		Summary:     "HTTP protocol version (1.0|1.1|2)",
+		Summary:     "HTTP protocol version (1.1|2)",
 		Insert:      "http-version=1.1",
 		Placeholder: "1.1",
 	},

--- a/internal/parser/body.go
+++ b/internal/parser/body.go
@@ -78,11 +78,18 @@ func (b *documentBuilder) handleMethodLine(ln line) bool {
 		return true
 	}
 
-	if method, url, ver, ok := httpbuilder.ParseMethodLine(ln.raw); ok {
+	// Keep unsupported versions from being parsed as part of the URL.
+	ml, ok, err := httpbuilder.ParseMethodLine(ln.raw)
+	switch {
+	case err != nil:
+		b.addError(ln.no, err.Error())
+		b.appendLine(ln.raw)
+		return true
+	case ok:
 		b.ensureRequest(ln.no)
 
-		b.request.http.SetMethodAndURL(method, url)
-		b.request.settings = version.SetIfMissing(b.request.settings, ver)
+		b.request.http.SetMethodAndURL(ml.Method, ml.URL)
+		b.request.settings = version.SetIfMissing(b.request.settings, ml.Version)
 		b.appendLine(ln.raw)
 		return true
 	}

--- a/internal/parser/body.go
+++ b/internal/parser/body.go
@@ -37,14 +37,14 @@ func (b *documentBuilder) handleBlankLine(ln line) bool {
 		return true
 	}
 
-	b.request.http.AppendBodyLine("")
+	b.request.http.AppendBodyLine("", ln.eol)
 	b.appendLine(ln.raw)
 	return true
 }
 
 func (b *documentBuilder) handleBodyContinuation(ln line) bool {
 	if b.inRequest && b.request.http.HasMethod() && b.request.http.HeaderDone() {
-		b.handleBodyLine(ln.raw)
+		b.handleBodyLine(ln)
 		b.appendLine(ln.raw)
 		return true
 	}
@@ -58,7 +58,7 @@ func (b *documentBuilder) handleMultipartBodyLine(ln line) bool {
 		!b.request.multipart.bodyLine(ln.text) {
 		return false
 	}
-	b.request.http.AppendBodyLine(ln.raw)
+	b.request.http.AppendBodyLine(ln.raw, ln.eol)
 	b.appendLine(ln.raw)
 	return true
 }
@@ -143,16 +143,16 @@ func (b *documentBuilder) handleHeaderLine(ln line) bool {
 	return true
 }
 
-func (b *documentBuilder) handleBodyLine(raw string) {
-	if b.request.protoBodyLine(raw) {
+func (b *documentBuilder) handleBodyLine(ln line) {
+	if b.request.protoBodyLine(ln.raw) {
 		return
 	}
 
-	if file, ok := parseHTTPBodyFile(raw, b.request.bodyOptions.ForceInline); ok {
+	if file, ok := parseHTTPBodyFile(ln.raw, b.request.bodyOptions.ForceInline); ok {
 		b.request.http.SetBodyFromFile(file)
 		return
 	}
-	b.request.http.AppendBodyLine(raw)
+	b.request.http.AppendBodyLine(ln.raw, ln.eol)
 }
 
 func parseHTTPBodyFile(line string, forceInline bool) (string, bool) {

--- a/internal/parser/body.go
+++ b/internal/parser/body.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/directive"
@@ -78,8 +77,10 @@ func (b *documentBuilder) handleMethodLine(ln line) bool {
 		return true
 	}
 
-	// Keep unsupported versions from being parsed as part of the URL.
 	ml, ok, err := httpbuilder.ParseMethodLine(ln.raw)
+	if !ok && err == nil {
+		ml, ok, err = httpbuilder.ParseWebSocketURLLine(ln.raw)
+	}
 	switch {
 	case err != nil:
 		b.addError(ln.no, err.Error())
@@ -90,14 +91,6 @@ func (b *documentBuilder) handleMethodLine(ln line) bool {
 
 		b.request.http.SetMethodAndURL(ml.Method, ml.URL)
 		b.request.settings = version.SetIfMissing(b.request.settings, ml.Version)
-		b.appendLine(ln.raw)
-		return true
-	}
-
-	if url, ok := httpbuilder.ParseWebSocketURLLine(ln.raw); ok {
-		b.ensureRequest(ln.no)
-
-		b.request.http.SetMethodAndURL(http.MethodGet, url)
 		b.appendLine(ln.raw)
 		return true
 	}

--- a/internal/parser/builder/http/builder.go
+++ b/internal/parser/builder/http/builder.go
@@ -52,12 +52,17 @@ func ParseWebSocketURLLine(line string) (url string, ok bool) {
 	return "", false
 }
 
+type bodyLine struct {
+	text string
+	term string
+}
+
 type Builder struct {
 	method       string
 	url          string
 	headers      stdhttp.Header
 	headerDone   bool
-	bodyLines    []string
+	bodyLines    []bodyLine
 	bodyFromFile string
 	mimeType     string
 }
@@ -114,8 +119,8 @@ func (b *Builder) MarkHeadersDone() {
 	b.headerDone = true
 }
 
-func (b *Builder) AppendBodyLine(line string) {
-	b.bodyLines = append(b.bodyLines, line)
+func (b *Builder) AppendBodyLine(text, term string) {
+	b.bodyLines = append(b.bodyLines, bodyLine{text: text, term: term})
 }
 
 func (b *Builder) SetBodyFromFile(path string) {
@@ -127,11 +132,17 @@ func (b *Builder) BodyFromFile() string {
 	return b.bodyFromFile
 }
 
+// BodyText rebuilds the body with its original line endings.
+// The final line ending is not part of the body.
 func (b *Builder) BodyText() string {
-	if len(b.bodyLines) == 0 {
-		return ""
+	var sb strings.Builder
+	for i, ln := range b.bodyLines {
+		sb.WriteString(ln.text)
+		if i < len(b.bodyLines)-1 {
+			sb.WriteString(ln.term)
+		}
 	}
-	return strings.Join(b.bodyLines, "\n")
+	return sb.String()
 }
 
 func (b *Builder) MimeType() string {

--- a/internal/parser/builder/http/builder.go
+++ b/internal/parser/builder/http/builder.go
@@ -17,27 +17,41 @@ func isMethodLine(line string) bool {
 	return methodRe.MatchString(line)
 }
 
-func ParseMethodLine(line string) (method string, url string, ver version.HTTP, ok bool) {
+// MethodLine contains the parsed parts of a request line.
+type MethodLine struct {
+	Method  string
+	URL     string
+	Version version.HTTP
+}
+
+// ParseMethodLine parses an HTTP request line.
+func ParseMethodLine(line string) (ml MethodLine, ok bool, err error) {
 	if !isMethodLine(line) {
-		return "", "", version.Unknown, false
+		return MethodLine{}, false, nil
 	}
 
 	fields := strings.Fields(line)
 	if len(fields) < 2 {
-		return "", "", version.Unknown, false
+		return MethodLine{}, false, nil
 	}
 
-	method = str.UpperTrim(fields[0])
+	urlFields, ver, err := version.SplitToken(fields[1:])
+	if err != nil {
+		return MethodLine{}, false, err
+	}
+	if len(urlFields) == 0 {
+		return MethodLine{}, false, nil
+	}
+
+	method := str.UpperTrim(fields[0])
 	if method == "WS" || method == "WSS" {
 		method = stdhttp.MethodGet
 	}
-
-	urlFields, ver := version.SplitToken(fields[1:])
-	if len(urlFields) == 0 {
-		return "", "", version.Unknown, false
-	}
-	url = strings.Join(urlFields, " ")
-	return method, url, ver, true
+	return MethodLine{
+		Method:  method,
+		URL:     strings.Join(urlFields, " "),
+		Version: ver,
+	}, true, nil
 }
 
 func ParseWebSocketURLLine(line string) (url string, ok bool) {

--- a/internal/parser/builder/http/builder.go
+++ b/internal/parser/builder/http/builder.go
@@ -83,7 +83,7 @@ func parseURLLine(line string, schemes []string) (MethodLine, bool, error) {
 	urlFields, ver, err := version.SplitToken(fields)
 	// Check the scheme before reporting a version error so prose ending in
 	// HTTP/<number> is not mistaken for a request.
-	url := strings.Trim(strings.Join(urlFields, " "), `"'`)
+	url := unwrapMatchingQuotes(strings.Join(urlFields, " "))
 	if !hasScheme(url, schemes) {
 		return MethodLine{}, false, nil
 	}
@@ -91,6 +91,17 @@ func parseURLLine(line string, schemes []string) (MethodLine, bool, error) {
 		return MethodLine{}, false, err
 	}
 	return MethodLine{Method: stdhttp.MethodGet, URL: url, Version: ver}, true, nil
+}
+
+func unwrapMatchingQuotes(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	first, last := s[0], s[len(s)-1]
+	if first == last && (first == '"' || first == '\'') {
+		return s[1 : len(s)-1]
+	}
+	return s
 }
 
 func hasScheme(url string, schemes []string) bool {

--- a/internal/parser/builder/http/builder.go
+++ b/internal/parser/builder/http/builder.go
@@ -9,8 +9,10 @@ import (
 	str "github.com/unkn0wn-root/resterm/internal/util"
 )
 
+// A method has to be followed by whitespace. A word boundary would also match
+// the colon in "ws://host", which reads that scheme as the WS method.
 var methodRe = regexp.MustCompile(
-	`^(?i)(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT|WS|WSS)\b`,
+	`^(?i)(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT|WS|WSS)(\s|$)`,
 )
 
 func isMethodLine(line string) bool {
@@ -54,16 +56,51 @@ func ParseMethodLine(line string) (ml MethodLine, ok bool, err error) {
 	}, true, nil
 }
 
-func ParseWebSocketURLLine(line string) (url string, ok bool) {
-	s := str.Trim(line)
-	if s == "" {
-		return "", false
+// ParseRequestLine parses a method request or a bare HTTP/WebSocket URL.
+func ParseRequestLine(line string) (MethodLine, bool, error) {
+	if ml, ok, err := ParseMethodLine(line); ok || err != nil {
+		return ml, ok, err
 	}
-	lower := str.Lower(s)
-	if strings.HasPrefix(lower, "ws://") || strings.HasPrefix(lower, "wss://") {
-		return s, true
+	return parseURLLine(line, requestSchemes)
+}
+
+// ParseWebSocketURLLine parses a bare WebSocket request line.
+func ParseWebSocketURLLine(line string) (MethodLine, bool, error) {
+	return parseURLLine(line, webSocketSchemes)
+}
+
+var (
+	requestSchemes   = []string{"http://", "https://", "ws://", "wss://"}
+	webSocketSchemes = []string{"ws://", "wss://"}
+)
+
+func parseURLLine(line string, schemes []string) (MethodLine, bool, error) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return MethodLine{}, false, nil
 	}
-	return "", false
+
+	urlFields, ver, err := version.SplitToken(fields)
+	// Check the scheme before reporting a version error so prose ending in
+	// HTTP/<number> is not mistaken for a request.
+	url := strings.Trim(strings.Join(urlFields, " "), `"'`)
+	if !hasScheme(url, schemes) {
+		return MethodLine{}, false, nil
+	}
+	if err != nil {
+		return MethodLine{}, false, err
+	}
+	return MethodLine{Method: stdhttp.MethodGet, URL: url, Version: ver}, true, nil
+}
+
+func hasScheme(url string, schemes []string) bool {
+	lower := str.Lower(url)
+	for _, scheme := range schemes {
+		if strings.HasPrefix(lower, scheme) {
+			return true
+		}
+	}
+	return false
 }
 
 type bodyLine struct {

--- a/internal/parser/builder/http/builder_test.go
+++ b/internal/parser/builder/http/builder_test.go
@@ -19,6 +19,10 @@ func TestParseRequestLine(t *testing.T) {
 		{line: "WS ws://example.com/s", method: "GET", url: "ws://example.com/s"},
 		{line: "GET {{base}}/two", method: "GET", url: "{{base}}/two"},
 		{line: `"https://example.com/q"`, method: "GET", url: "https://example.com/q"},
+		{line: `'https://example.com/q'`, method: "GET", url: "https://example.com/q"},
+		{line: `https://example.com/q'`, method: "GET", url: `https://example.com/q'`},
+		{line: `https://example.com/q"`, method: "GET", url: `https://example.com/q"`},
+		{line: `"https://example.com/q" HTTP/1.1`, method: "GET", url: "https://example.com/q", ver: version.V11},
 		{line: "ws://example.com/s b", method: "GET", url: "ws://example.com/s b"},
 		{line: "http://example.com/a http/foo", method: "GET", url: "http://example.com/a http/foo"},
 		{line: "http://example.com HTTP/1.1", method: "GET", url: "http://example.com", ver: version.V11},
@@ -68,9 +72,19 @@ func TestParseRequestLineRejectsUnsupportedVersion(t *testing.T) {
 }
 
 func TestParseWebSocketURLLine(t *testing.T) {
-	ml, ok, err := ParseWebSocketURLLine("wss://example.com/chat HTTP/2")
-	if err != nil || !ok || ml.URL != "wss://example.com/chat" || ml.Version != version.V2 {
-		t.Fatalf("ParseWebSocketURLLine() = %+v, %v, %v", ml, ok, err)
+	for _, tc := range []struct {
+		line string
+		url  string
+		ver  version.HTTP
+	}{
+		{line: "wss://example.com/chat HTTP/2", url: "wss://example.com/chat", ver: version.V2},
+		{line: `"wss://example.com/chat"`, url: "wss://example.com/chat"},
+		{line: `wss://example.com/chat'`, url: `wss://example.com/chat'`},
+	} {
+		ml, ok, err := ParseWebSocketURLLine(tc.line)
+		if err != nil || !ok || ml.URL != tc.url || ml.Version != tc.ver {
+			t.Fatalf("ParseWebSocketURLLine(%q) = %+v, %v, %v", tc.line, ml, ok, err)
+		}
 	}
 	if _, ok, err := ParseWebSocketURLLine("http://example.com"); ok || err != nil {
 		t.Fatalf("ParseWebSocketURLLine(http) = ok %v, err %v", ok, err)

--- a/internal/parser/builder/http/builder_test.go
+++ b/internal/parser/builder/http/builder_test.go
@@ -1,0 +1,78 @@
+package http
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/http/version"
+)
+
+func TestParseRequestLine(t *testing.T) {
+	cases := []struct {
+		line   string
+		method string
+		url    string
+		ver    version.HTTP
+	}{
+		{line: "GET http://example.com", method: "GET", url: "http://example.com"},
+		{line: "CONNECT proxy.example.com:443", method: "CONNECT", url: "proxy.example.com:443"},
+		{line: "WS ws://example.com/s", method: "GET", url: "ws://example.com/s"},
+		{line: "GET {{base}}/two", method: "GET", url: "{{base}}/two"},
+		{line: `"https://example.com/q"`, method: "GET", url: "https://example.com/q"},
+		{line: "ws://example.com/s b", method: "GET", url: "ws://example.com/s b"},
+		{line: "http://example.com/a http/foo", method: "GET", url: "http://example.com/a http/foo"},
+		{line: "http://example.com HTTP/1.1", method: "GET", url: "http://example.com", ver: version.V11},
+		{line: "GET http://example.com HTTP/2", method: "GET", url: "http://example.com", ver: version.V2},
+	}
+	for _, tc := range cases {
+		ml, ok, err := ParseRequestLine(tc.line)
+		if err != nil {
+			t.Fatalf("ParseRequestLine(%q): %v", tc.line, err)
+		}
+		if !ok {
+			t.Fatalf("ParseRequestLine(%q) recognized no request", tc.line)
+		}
+		if ml.Method != tc.method || ml.URL != tc.url || ml.Version != tc.ver {
+			t.Fatalf("ParseRequestLine(%q) = %s %q %v, want %s %q %v",
+				tc.line, ml.Method, ml.URL, ml.Version, tc.method, tc.url, tc.ver)
+		}
+	}
+}
+
+func TestParseRequestLineIgnoresNonRequests(t *testing.T) {
+	for _, line := range []string{"example.com", "we dropped HTTP/1.0", "{{base}}/two"} {
+		ml, ok, err := ParseRequestLine(line)
+		if err != nil {
+			t.Fatalf("ParseRequestLine(%q): %v", line, err)
+		}
+		if ok {
+			t.Fatalf("ParseRequestLine(%q) built %s %q", line, ml.Method, ml.URL)
+		}
+	}
+}
+
+func TestParseRequestLineRejectsUnsupportedVersion(t *testing.T) {
+	for _, line := range []string{
+		"GET {{base}}/two HTTP/1.0",
+		"http://example.com HTTP/3",
+	} {
+		_, ok, err := ParseRequestLine(line)
+		var unsupported *version.UnsupportedError
+		if !errors.As(err, &unsupported) {
+			t.Fatalf("ParseRequestLine(%q) error = %v, want *version.UnsupportedError", line, err)
+		}
+		if ok {
+			t.Fatalf("ParseRequestLine(%q) recognized a request", line)
+		}
+	}
+}
+
+func TestParseWebSocketURLLine(t *testing.T) {
+	ml, ok, err := ParseWebSocketURLLine("wss://example.com/chat HTTP/2")
+	if err != nil || !ok || ml.URL != "wss://example.com/chat" || ml.Version != version.V2 {
+		t.Fatalf("ParseWebSocketURLLine() = %+v, %v, %v", ml, ok, err)
+	}
+	if _, ok, err := ParseWebSocketURLLine("http://example.com"); ok || err != nil {
+		t.Fatalf("ParseWebSocketURLLine(http) = ok %v, err %v", ok, err)
+	}
+}

--- a/internal/parser/document.go
+++ b/internal/parser/document.go
@@ -124,8 +124,8 @@ func (b *documentBuilder) addWarning(line int, message string) {
 	})
 }
 
-func (b *documentBuilder) processLine(no int, raw string) {
-	ln := makeLine(no, raw)
+func (b *documentBuilder) processLine(no int, raw, term string) {
+	ln := makeLine(no, raw, term)
 	b.closeOpenDirective(ln)
 
 	if b.mock != nil {

--- a/internal/parser/eol_test.go
+++ b/internal/parser/eol_test.go
@@ -1,0 +1,113 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInlineBodyKeepsSourceLineEndings(t *testing.T) {
+	tests := []struct {
+		name string
+		term string
+	}{
+		{name: "lf", term: "\n"},
+		{name: "crlf", term: "\r\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := strings.Join([]string{
+				"POST http://example.com/ HTTP/1.1",
+				"Content-Type: text/plain",
+				"",
+				"line1",
+				"line2",
+				"",
+			}, tt.term)
+
+			doc := Parse("body."+tt.name+".http", []byte(src))
+			if len(doc.Requests) != 1 {
+				t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+			}
+			want := "line1" + tt.term + "line2"
+			if got := doc.Requests[0].Body.Text; got != want {
+				t.Fatalf("body = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// The newline before a separator ends the body. An extra blank line stays in it.
+func TestInlineBodyDropsItsTrailingTerminator(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "separator follows the body",
+			src:  "POST http://example.com/ HTTP/1.1\r\n\r\nonly\r\n### next\r\nGET http://example.com/x\r\n",
+			want: "only",
+		},
+		{
+			name: "blank line follows the body",
+			src:  "POST http://example.com/ HTTP/1.1\r\n\r\nonly\r\n\r\n### next\r\nGET http://example.com/x\r\n",
+			want: "only\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := Parse("trailing.http", []byte(tt.src))
+			if len(doc.Requests) != 2 {
+				t.Fatalf("expected 2 requests, got %d", len(doc.Requests))
+			}
+			if got := doc.Requests[0].Body.Text; got != tt.want {
+				t.Fatalf("body = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInlineBodyKeepsMixedLineEndings(t *testing.T) {
+	src := "POST http://example.com/ HTTP/1.1\n\nlf\ncrlf\r\nlast\n"
+
+	doc := Parse("mixed.http", []byte(src))
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	if got := doc.Requests[0].Body.Text; got != "lf\ncrlf\r\nlast" {
+		t.Fatalf("body = %q, want %q", got, "lf\ncrlf\r\nlast")
+	}
+}
+
+func TestCRLFSourceParsesLikeLF(t *testing.T) {
+	src := "# @name crlf\r\n" +
+		"GET http://example.com/games HTTP/1.1\r\n" +
+		"Accept: application/json\r\n"
+
+	doc := Parse("headers.http", []byte(src))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("unexpected parse errors: %#v", doc.Errors)
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+
+	req := doc.Requests[0]
+	if req.Metadata.Name != "crlf" {
+		t.Fatalf("name = %q, want %q", req.Metadata.Name, "crlf")
+	}
+	if req.URL != "http://example.com/games" {
+		t.Fatalf("url = %q", req.URL)
+	}
+	if got := req.Headers.Get("Accept"); got != "application/json" {
+		t.Fatalf("accept = %q", got)
+	}
+	if req.Settings["http-version"] != "1.1" {
+		t.Fatalf("http-version = %q", req.Settings["http-version"])
+	}
+	if strings.Contains(req.OriginalText, "\r") {
+		t.Fatalf("original text should stay normalized, got %q", req.OriginalText)
+	}
+}

--- a/internal/parser/line.go
+++ b/internal/parser/line.go
@@ -6,16 +6,16 @@ import (
 	str "github.com/unkn0wn-root/resterm/internal/util"
 )
 
-// line is one source line. Handlers read text, which is raw with the
-// surrounding whitespace already trimmed off.
+// line stores the raw text, a trimmed form for matching, and its line ending.
 type line struct {
 	no   int // 1-based
 	raw  string
 	text string
+	eol  string
 }
 
-func makeLine(no int, raw string) line {
-	return line{no: no, raw: raw, text: strings.TrimSpace(raw)}
+func makeLine(no int, raw, term string) line {
+	return line{no: no, raw: raw, text: strings.TrimSpace(raw), eol: term}
 }
 
 func (ln line) isSeparator() bool {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -7,15 +7,16 @@ import (
 	"fmt"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/eol"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
 const maxScanToken = 1024 * 1024
 
 func Parse(path string, data []byte) *restfile.Document {
-	src := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
-	scanner := bufio.NewScanner(bytes.NewReader(src))
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	scanner.Buffer(make([]byte, 0, 1024), maxScanToken)
+	scanner.Split(eol.ScanLines)
 
 	doc := &restfile.Document{Path: path, Raw: data}
 	builder := &documentBuilder{doc: doc}
@@ -23,8 +24,8 @@ func Parse(path string, data []byte) *restfile.Document {
 	lineNumber := 0
 	for scanner.Scan() {
 		lineNumber++
-		line := scanner.Text()
-		builder.processLine(lineNumber, line)
+		text, term := eol.Cut(scanner.Text())
+		builder.processLine(lineNumber, text, term)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -11,7 +11,12 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
-const maxScanToken = 1024 * 1024
+// eol.ScanLines retains line endings, so reserve CRLF separately from the
+// one-megabyte content limit.
+const (
+	maxLine      = 1024 * 1024
+	maxScanToken = maxLine + len(eol.CRLF)
+)
 
 func Parse(path string, data []byte) *restfile.Document {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
@@ -34,7 +39,7 @@ func Parse(path string, data []byte) *restfile.Document {
 		}
 		msg := fmt.Sprintf("parse error: %v", err)
 		if errors.Is(err, bufio.ErrTooLong) {
-			msg = fmt.Sprintf("parse error: line exceeds %d bytes", maxScanToken)
+			msg = fmt.Sprintf("parse error: line exceeds %d bytes", maxLine)
 		}
 		builder.addError(lineNumber+1, msg)
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -225,6 +225,36 @@ GET http://127.0.0.1:5001/games/1 HTTP/1.1
 	}
 }
 
+func TestParseMethodLineRejectsUnsupportedHTTPVersion(t *testing.T) {
+	for _, token := range []string{"HTTP/9.9", "HTTP/3", "http/0.9", "HTTP/1.0"} {
+		t.Run(token, func(t *testing.T) {
+			doc := Parse("bad.http", []byte("GET http://example.com/bad "+token+"\n"))
+			if len(doc.Requests) != 0 {
+				t.Fatalf("expected no request, got %q", doc.Requests[0].URL)
+			}
+			if len(doc.Errors) != 1 {
+				t.Fatalf("expected 1 parse error, got %#v", doc.Errors)
+			}
+			if err := doc.Errors[0]; err.Line != 1 || !strings.Contains(err.Message, token) {
+				t.Fatalf("unexpected error: %#v", err)
+			}
+		})
+	}
+}
+
+func TestParseMethodLineKeepsNonVersionTail(t *testing.T) {
+	doc := Parse("tail.http", []byte("GET http://example.com/a b\n"))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("unexpected parse errors: %#v", doc.Errors)
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	if got := doc.Requests[0].URL; got != "http://example.com/a b" {
+		t.Fatalf("url = %q", got)
+	}
+}
+
 func TestHTTPVersionSettingOverridesRequestLine(t *testing.T) {
 	src := `GET https://example.com HTTP/1.1
 # @setting http-version 2

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -864,6 +864,53 @@ GET https://example.com
 	}
 }
 
+func TestParseShorthandEmptyValue(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "spaced equals", src: "@x ="},
+		{name: "tight equals", src: "@x="},
+		{name: "colon", src: "@x:"},
+		{name: "trailing space", src: "@x = "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := Parse("empty.http", []byte(tt.src+"\nGET http://example.com/\n"))
+			if len(doc.Errors) != 0 {
+				t.Fatalf("unexpected parse errors: %#v", doc.Errors)
+			}
+			if len(doc.Variables) != 1 {
+				t.Fatalf("expected 1 file variable, got %#v", doc.Variables)
+			}
+			if v := doc.Variables[0]; v.Name != "x" || v.Value != "" {
+				t.Fatalf("variable = %#v, want x with an empty value", v)
+			}
+		})
+	}
+}
+
+func TestParseShorthandKeepsValuesWithSeparators(t *testing.T) {
+	src := `@a = 1
+@b=2
+@c: three
+@d = = four
+@e five
+`
+
+	doc := Parse("values.http", []byte(src+"GET http://example.com/\n"))
+	want := map[string]string{"a": "1", "b": "2", "c": "three", "d": "= four", "e": "five"}
+	if len(doc.Variables) != len(want) {
+		t.Fatalf("expected %d file variables, got %#v", len(want), doc.Variables)
+	}
+	for _, v := range doc.Variables {
+		if got, ok := want[v.Name]; !ok || got != v.Value {
+			t.Fatalf("variable %q = %q, want %q", v.Name, v.Value, got)
+		}
+	}
+}
+
 func TestParseConstDirectives(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -2,12 +2,15 @@ package parser
 
 import (
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/directive"
+	"github.com/unkn0wn-root/resterm/internal/eol"
+	"github.com/unkn0wn-root/resterm/internal/http/version"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -242,16 +245,63 @@ func TestParseMethodLineRejectsUnsupportedHTTPVersion(t *testing.T) {
 	}
 }
 
-func TestParseMethodLineKeepsNonVersionTail(t *testing.T) {
-	doc := Parse("tail.http", []byte("GET http://example.com/a b\n"))
+func TestParseWebSocketURLLineKeepsURLWhole(t *testing.T) {
+	doc := Parse("ws.http", []byte("ws://example.com/s b\n"))
 	if len(doc.Errors) != 0 {
 		t.Fatalf("unexpected parse errors: %#v", doc.Errors)
 	}
 	if len(doc.Requests) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
 	}
-	if got := doc.Requests[0].URL; got != "http://example.com/a b" {
-		t.Fatalf("url = %q", got)
+	if req := doc.Requests[0]; req.Method != http.MethodGet || req.URL != "ws://example.com/s b" {
+		t.Fatalf("request = %s %q", req.Method, req.URL)
+	}
+}
+
+func TestParseWebSocketURLLineReadsHTTPVersion(t *testing.T) {
+	doc := Parse("ws.http", []byte("### Socket\nws://example.com/chat HTTP/1.1\n"))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("unexpected parse errors: %#v", doc.Errors)
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	req := doc.Requests[0]
+	if req.Method != http.MethodGet || req.URL != "ws://example.com/chat" {
+		t.Fatalf("request = %s %q", req.Method, req.URL)
+	}
+	if req.Settings[version.Key] != "1.1" {
+		t.Fatalf("settings = %v, want %s=1.1", req.Settings, version.Key)
+	}
+}
+
+func TestParseWebSocketURLLineRejectsUnsupportedHTTPVersion(t *testing.T) {
+	for _, token := range []string{"HTTP/1.0", "HTTP/3"} {
+		t.Run(token, func(t *testing.T) {
+			doc := Parse("ws.http", []byte("### Socket\nws://example.com/chat "+token+"\n"))
+			if len(doc.Requests) != 0 {
+				t.Fatalf("expected no request, got %q", doc.Requests[0].URL)
+			}
+			if len(doc.Errors) != 1 {
+				t.Fatalf("expected 1 parse error, got %#v", doc.Errors)
+			}
+			if err := doc.Errors[0]; err.Line != 2 || !strings.Contains(err.Message, token) {
+				t.Fatalf("unexpected error: %#v", err)
+			}
+		})
+	}
+}
+
+func TestParseMethodLineKeepsNonVersionTail(t *testing.T) {
+	doc := Parse("tail.http", []byte("GET http://example.com/a http/foo\n"))
+	if len(doc.Errors) != 0 {
+		t.Fatalf("unexpected parse errors: %#v", doc.Errors)
+	}
+	if len(doc.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(doc.Requests))
+	}
+	if got, want := doc.Requests[0].URL, "http://example.com/a http/foo"; got != want {
+		t.Fatalf("url = %q, want %q", got, want)
 	}
 }
 
@@ -3105,6 +3155,27 @@ GET https://example.org
 	}
 	if req.Metadata.Tags[0] != "smoke" || req.Metadata.Tags[1] != "regression" {
 		t.Fatalf("unexpected tags: %v", req.Metadata.Tags)
+	}
+}
+
+func TestParseAllowsMaxLineWithEitherLineEnding(t *testing.T) {
+	url := "http://example.com/" + strings.Repeat("a", maxLine-len("GET http://example.com/"))
+	line := "GET " + url
+	if len(line) != maxLine {
+		t.Fatalf("setup: line is %d bytes, want %d", len(line), maxLine)
+	}
+
+	for _, term := range []string{eol.LF, eol.CRLF} {
+		doc := Parse("long.http", []byte(line+term))
+		if len(doc.Errors) != 0 {
+			t.Fatalf("ending %q: unexpected parse errors: %#v", term, doc.Errors)
+		}
+		if len(doc.Requests) != 1 {
+			t.Fatalf("ending %q: expected 1 request, got %d", term, len(doc.Requests))
+		}
+		if doc.Requests[0].URL != url {
+			t.Fatalf("ending %q: url was truncated to %d bytes", term, len(doc.Requests[0].URL))
+		}
 	}
 }
 

--- a/internal/parser/variables.go
+++ b/internal/parser/variables.go
@@ -9,8 +9,9 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
+// Allow empty values in assignments such as "@x =".
 var variableLineRe = regexp.MustCompile(
-	`^@(?:(global(?:-secret)?|file(?:-secret)?|request(?:-secret)?)\s+)?([A-Za-z0-9_.-]+)(?:\s*(?::|=)\s*(.+?)|\s+(\S.*))$`,
+	`^@(?:(global(?:-secret)?|file(?:-secret)?|request(?:-secret)?)\s+)?([A-Za-z0-9_.-]+)(?:\s*(?::|=)\s*(.*?)|\s+(\S.*))$`,
 )
 
 func (b *documentBuilder) handleVariableLine(ln line) bool {

--- a/internal/protocol/httpx/body_eol_test.go
+++ b/internal/protocol/httpx/body_eol_test.go
@@ -1,0 +1,84 @@
+package httpx
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+func TestBuildHTTPRequestKeepsBodyLineEndings(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "lf", body: "line1\nline2"},
+		{name: "crlf", body: "line1\r\nline2"},
+		{name: "mixed", body: "line1\ncrlf\r\nlast"},
+		{name: "trailing", body: "line1\r\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &restfile.Request{
+				Method: http.MethodPost,
+				URL:    "http://example.com/",
+				Body:   restfile.BodySource{Text: tt.body},
+			}
+
+			_, _, body, err := NewClient(nil).BuildHTTPRequest(
+				context.Background(),
+				req,
+				nil,
+				Options{},
+			)
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			if string(body) != tt.body {
+				t.Fatalf("body = %q, want %q", body, tt.body)
+			}
+		})
+	}
+}
+
+func TestBuildHTTPRequestKeepsCRLFAroundExpansionsAndIncludes(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodPost,
+		URL:    "http://example.com/",
+		Body:   restfile.BodySource{Text: "head {{env.num}}\r\n@part.txt\r\ntail"},
+	}
+	resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{"num": "500"}))
+	client := NewClient(mapFS{"part.txt": []byte("included")})
+
+	_, _, body, err := client.BuildHTTPRequest(context.Background(), req, resolver, Options{})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if want := "head 500\r\nincluded\r\ntail"; string(body) != want {
+		t.Fatalf("body = %q, want %q", body, want)
+	}
+}
+
+func TestBuildHTTPRequestKeepsBodyFileLineEndingsWhileExpanding(t *testing.T) {
+	req := &restfile.Request{
+		Method: http.MethodPost,
+		URL:    "http://example.com/",
+		Body: restfile.BodySource{
+			FilePath: "payload.txt",
+			Options:  restfile.BodyOptions{ExpandTemplates: true},
+		},
+	}
+	resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{"num": "7"}))
+	client := NewClient(mapFS{"payload.txt": []byte("a {{env.num}}\r\nb\r\n")})
+
+	_, _, body, err := client.BuildHTTPRequest(context.Background(), req, resolver, Options{})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if want := "a 7\r\nb\r\n"; string(body) != want {
+		t.Fatalf("body = %q, want %q", body, want)
+	}
+}

--- a/internal/protocol/httpx/executor_test.go
+++ b/internal/protocol/httpx/executor_test.go
@@ -384,8 +384,8 @@ func TestBuildHTTPRequestMultipartUsesCRLFFramingAfterParse(t *testing.T) {
 		t.Fatalf("expected one request, got %d", len(doc.Requests))
 	}
 	req := doc.Requests[0]
-	if strings.Contains(req.Body.Text, "\r") {
-		t.Fatalf("parser should expose normalized body text before send, got %q", req.Body.Text)
+	if !strings.Contains(req.Body.Text, "\r\n") {
+		t.Fatalf("parser should keep the source CRLF framing, got %q", req.Body.Text)
 	}
 
 	client := NewClient(mapFS{"testfile.txt": []byte("hello\n")})

--- a/internal/protocol/httpx/fs.go
+++ b/internal/protocol/httpx/fs.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/eol"
 	"github.com/unkn0wn-root/resterm/internal/filelookup"
 	"github.com/unkn0wn-root/resterm/internal/parser/bodyref"
 )
@@ -49,35 +50,29 @@ func (c *Client) readFile(lookup filelookup.Lookup, path, label string) ([]byte,
 	)
 }
 
-// injectBodyIncludes replaces each "@path" line with the referenced file's
-// bytes. "@{...}" template lines are left alone. crlf rejoins lines with CRLF
-// and always terminates the body with CRLF, like curl -F: readline-based
-// multipart parsers (e.g. Python's cgi) block without it.
+// injectBodyIncludes replaces "@path" lines with file contents and leaves
+// "@{...}" templates unchanged. Other bodies keep their original line endings.
+// Multipart bodies use CRLF throughout and end with CRLF.
 func (c *Client) injectBodyIncludes(body string, lookup filelookup.Lookup, crlf bool) ([]byte, error) {
-	eol := "\n"
-	if crlf {
-		eol = "\r\n"
-	}
-
 	var b bytes.Buffer
 	b.Grow(len(body))
-	for i, line := range strings.Split(strings.TrimSuffix(body, "\n"), "\n") {
-		if i > 0 {
-			b.WriteString(eol)
-		}
-		line = strings.TrimSuffix(line, "\r")
+	for line, term := range eol.Lines(body) {
 		if path, ok := bodyref.IncludeLine(line); ok {
 			data, _, err := c.readFile(lookup, path, "include body file")
 			if err != nil {
 				return nil, err
 			}
 			b.Write(data)
-			continue
+		} else {
+			b.WriteString(line)
 		}
-		b.WriteString(line)
+		if crlf {
+			term = eol.CRLF
+		}
+		b.WriteString(term)
 	}
-	if crlf {
-		b.WriteString(eol)
+	if crlf && !bytes.HasSuffix(b.Bytes(), []byte(eol.CRLF)) {
+		b.WriteString(eol.CRLF)
 	}
 	return b.Bytes(), nil
 }

--- a/internal/protocol/httpx/options_apply.go
+++ b/internal/protocol/httpx/options_apply.go
@@ -60,7 +60,7 @@ func applyOptionSettings(opts *Options, settings map[string]string, strict bool)
 		case valid:
 			opts.HTTPVersion = v
 		case strict:
-			return invalidSetting(version.Key, val, "1.0, 1.1, 2 or HTTP/1.1, HTTP/2")
+			return invalidSetting(version.Key, val, "1.1, 2 or HTTP/1.1, HTTP/2")
 		}
 	}
 

--- a/internal/protocol/httpx/options_apply_test.go
+++ b/internal/protocol/httpx/options_apply_test.go
@@ -21,6 +21,12 @@ func TestApplyOptionSettingsRejectsInvalidValues(t *testing.T) {
 		{name: "insecure", key: "insecure", val: "maybe", want: `invalid insecure "maybe" (use true or false)`},
 		{name: "no-cookies", key: "no-cookies", val: "maybe", want: `invalid no-cookies "maybe" (use true or false)`},
 		{name: "http-version", key: "http-version", val: "unsupported", want: `invalid http-version "unsupported"`},
+		{
+			name: "http-version 1.0",
+			key:  "http-version",
+			val:  "1.0",
+			want: `invalid http-version "1.0" (use 1.1, 2 or HTTP/1.1, HTTP/2)`,
+		},
 		// A bare "@setting insecure" writes no value at all, so say it is missing.
 		{name: "bare bool", key: "insecure", val: "", want: "missing insecure value (use true or false)"},
 		{

--- a/internal/protocol/httpx/request.go
+++ b/internal/protocol/httpx/request.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
-	"github.com/unkn0wn-root/resterm/internal/http/version"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
@@ -156,22 +155,4 @@ func normalizeSettings(settings map[string]string) map[string]string {
 		norm[key] = v
 	}
 	return norm
-}
-
-func applyHTTPVersion(req *http.Request, v version.HTTP) {
-	if req == nil {
-		return
-	}
-	switch v {
-	case version.V10:
-		req.Proto = "HTTP/1.0"
-		req.ProtoMajor = 1
-		req.ProtoMinor = 0
-	case version.V11:
-		req.Proto = "HTTP/1.1"
-		req.ProtoMajor = 1
-		req.ProtoMinor = 1
-	case version.V2:
-		// HTTP/2 is negotiated by the transport; net/http ignores req.Proto for h2.
-	}
 }

--- a/internal/protocol/httpx/request_build.go
+++ b/internal/protocol/httpx/request_build.go
@@ -162,7 +162,6 @@ func (c *Client) buildHTTPRequest(
 			diag.WithComponent(diag.ComponentHTTP),
 		)
 	}
-	applyHTTPVersion(httpReq, opts.HTTPVersion)
 	if verErr := checkHTTPVersionRequest(httpReq, opts.HTTPVersion); verErr != nil {
 		return nil, opts, verErr
 	}

--- a/internal/protocol/httpx/transport.go
+++ b/internal/protocol/httpx/transport.go
@@ -58,7 +58,7 @@ func applyTransportHTTPVersion(transport *http.Transport, v version.HTTP) {
 	if transport == nil {
 		return
 	}
-	if v == version.V10 || v == version.V11 {
+	if v == version.V11 {
 		transport.ForceAttemptHTTP2 = false
 		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 	}

--- a/internal/protocol/httpx/version.go
+++ b/internal/protocol/httpx/version.go
@@ -42,18 +42,11 @@ func checkHTTPVersionRequest(req *http.Request, v version.HTTP) error {
 }
 
 func checkWebSocketHTTPVersion(v version.HTTP) error {
-	switch v {
-	case version.V10:
-		return diag.Newf(
-			diag.ClassProtocol,
-			"http-version=1.0 is not supported for WebSocket requests",
-		)
-	case version.V2:
-		return diag.Newf(
-			diag.ClassProtocol,
-			"http-version=2 is not supported for WebSocket requests",
-		)
-	default:
+	if v != version.V2 {
 		return nil
 	}
+	return diag.Newf(
+		diag.ClassProtocol,
+		"http-version=2 is not supported for WebSocket requests",
+	)
 }

--- a/internal/tunnel/transport.go
+++ b/internal/tunnel/transport.go
@@ -49,7 +49,7 @@ func ApplyHTTPTransport(
 	}
 	transport.Proxy = nil
 	transport.DialContext = dialer
-	if v == version.V10 || v == version.V11 {
+	if v == version.V11 {
 		return nil
 	}
 	return http2.ConfigureTransport(transport)

--- a/internal/ui/model_exec.go
+++ b/internal/ui/model_exec.go
@@ -229,7 +229,12 @@ func (m *Model) prepareActiveRequestExec() (*activeReqExec, tea.Cmd) {
 	}
 
 	cursorLine := currentCursorLine(m.editor)
-	req, _ := m.requestAtCursor(doc, content, cursorLine)
+	req, _, err := m.requestAtCursor(doc, content, cursorLine)
+	if err != nil {
+		return nil, func() tea.Msg {
+			return statusMsg{text: err.Error(), level: statusWarn}
+		}
+	}
 	if req == nil {
 		return nil, func() tea.Msg {
 			return statusMsg{text: "No request at cursor", level: statusWarn}
@@ -371,7 +376,11 @@ func (m *Model) startConfigCompareFromEditor() tea.Cmd {
 	}
 
 	cursorLine := currentCursorLine(m.editor)
-	req, _ := m.requestAtCursor(doc, content, cursorLine)
+	req, _, err := m.requestAtCursor(doc, content, cursorLine)
+	if err != nil {
+		m.setStatusMessage(statusMsg{level: statusWarn, text: err.Error()})
+		return nil
+	}
 	if req == nil {
 		m.setStatusMessage(statusMsg{level: statusWarn, text: "No request at cursor"})
 		return nil

--- a/internal/ui/model_exec_request.go
+++ b/internal/ui/model_exec_request.go
@@ -74,7 +74,10 @@ func inlineRequestFromLine(raw string, lineNumber int) *restfile.Request {
 	url := ""
 
 	fields := strings.Fields(trimmed)
-	fields, ver := version.SplitToken(fields)
+	fields, ver, err := version.SplitToken(fields)
+	if err != nil {
+		return nil
+	}
 	if len(fields) == 1 {
 		url = fields[0]
 	} else if len(fields) >= 2 {

--- a/internal/ui/model_exec_request.go
+++ b/internal/ui/model_exec_request.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/curl"
 	"github.com/unkn0wn-root/resterm/internal/http/version"
+	httpbuilder "github.com/unkn0wn-root/resterm/internal/parser/builder/http"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -12,34 +13,40 @@ func (m *Model) requestAtCursor(
 	doc *restfile.Document,
 	content string,
 	cursorLine int,
-) (*restfile.Request, bool) {
+) (*restfile.Request, bool, error) {
 	if req, _ := requestAtLine(doc, cursorLine); req != nil {
-		return req, false
+		return req, false, nil
 	}
-	if inline := buildInlineRequest(content, cursorLine); inline != nil {
-		return inline, true
+	// A line the parser refused is still the line the user is on, so report why
+	// instead of falling back to the last request and running something else.
+	inline, err := buildInlineRequest(content, cursorLine)
+	if err != nil {
+		return nil, false, err
+	}
+	if inline != nil {
+		return inline, true, nil
 	}
 	if doc != nil && len(doc.Requests) > 0 {
 		last := doc.Requests[len(doc.Requests)-1]
 		if last != nil && cursorLine > last.LineRange.End {
-			return last, false
+			return last, false, nil
 		}
 	}
-	return nil, false
+	return nil, false, nil
 }
 
-func buildInlineRequest(content string, lineNumber int) *restfile.Request {
+func buildInlineRequest(content string, lineNumber int) (*restfile.Request, error) {
 	if lineNumber < 1 {
-		return nil
+		return nil, nil
 	}
 
 	lines := strings.Split(content, "\n")
 	if req := inlineCurlRequest(lines, lineNumber); req != nil {
-		return req
+		return req, nil
 	}
 
 	if lineNumber > len(lines) {
-		return nil
+		return nil, nil
 	}
 	return inlineRequestFromLine(lines[lineNumber-1], lineNumber)
 }
@@ -64,67 +71,24 @@ func inlineCurlRequest(lines []string, lineNumber int) *restfile.Request {
 	return parsed
 }
 
-func inlineRequestFromLine(raw string, lineNumber int) *restfile.Request {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return nil
-	}
-
-	method := "GET"
-	url := ""
-
-	fields := strings.Fields(trimmed)
-	fields, ver, err := version.SplitToken(fields)
+// Use the parser grammar so unsupported versions cannot look like non-requests.
+func inlineRequestFromLine(raw string, lineNumber int) (*restfile.Request, error) {
+	ml, ok, err := httpbuilder.ParseRequestLine(raw)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	if len(fields) == 1 {
-		url = fields[0]
-	} else if len(fields) >= 2 {
-		candidate := strings.ToUpper(fields[0])
-		if isInlineHTTPMethod(candidate) {
-			method = candidate
-			url = fields[1]
-		}
-	}
-
-	if url == "" {
-		url = strings.Join(fields, " ")
-	}
-
-	url = strings.Trim(url, "\"'")
-	if !looksLikeHTTPRequestURL(url) {
-		return nil
+	if !ok {
+		return nil, nil
 	}
 
 	return &restfile.Request{
-		Method: method,
-		URL:    url,
+		Method: ml.Method,
+		URL:    ml.URL,
 		LineRange: restfile.LineRange{
 			Start: lineNumber,
 			End:   lineNumber,
 		},
 		OriginalText: raw,
-		Settings:     version.SetIfMissing(nil, ver),
-	}
-}
-
-func isInlineHTTPMethod(method string) bool {
-	switch method {
-	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS":
-		return true
-	default:
-		return false
-	}
-}
-
-func looksLikeHTTPRequestURL(url string) bool {
-	if url == "" {
-		return false
-	}
-	lower := strings.ToLower(url)
-	return strings.HasPrefix(lower, "http://") ||
-		strings.HasPrefix(lower, "https://") ||
-		strings.HasPrefix(lower, "ws://") ||
-		strings.HasPrefix(lower, "wss://")
+		Settings:     version.SetIfMissing(nil, ml.Version),
+	}, nil
 }

--- a/internal/ui/model_exec_test.go
+++ b/internal/ui/model_exec_test.go
@@ -81,7 +81,10 @@ func startUIWebSocketServer(t *testing.T) (*httptest.Server, func()) {
 }
 
 func TestInlineRequestFromLineURL(t *testing.T) {
-	req := inlineRequestFromLine(" https://example.com/v1/users ", 3)
+	req, err := inlineRequestFromLine(" https://example.com/v1/users ", 3)
+	if err != nil {
+		t.Fatalf("inlineRequestFromLine: %v", err)
+	}
 	if req == nil {
 		t.Fatalf("expected inline request to be created")
 	}
@@ -97,7 +100,10 @@ func TestInlineRequestFromLineURL(t *testing.T) {
 }
 
 func TestInlineRequestFromLineWithMethod(t *testing.T) {
-	req := inlineRequestFromLine("POST https://api.example.com/data", 5)
+	req, err := inlineRequestFromLine("POST https://api.example.com/data", 5)
+	if err != nil {
+		t.Fatalf("inlineRequestFromLine: %v", err)
+	}
 	if req == nil {
 		t.Fatalf("expected inline request to be created")
 	}
@@ -110,7 +116,10 @@ func TestInlineRequestFromLineWithMethod(t *testing.T) {
 }
 
 func TestInlineRequestFromLineRejectsInvalid(t *testing.T) {
-	req := inlineRequestFromLine("example.com", 2)
+	req, err := inlineRequestFromLine("example.com", 2)
+	if err != nil {
+		t.Fatalf("inlineRequestFromLine: %v", err)
+	}
 	if req != nil {
 		t.Fatalf("expected non-http line to be ignored")
 	}
@@ -121,7 +130,10 @@ func TestRequestAtCursorBeforeRequestsReturnsNil(t *testing.T) {
 	doc := parser.Parse("sample.http", []byte(content))
 	var model Model
 
-	req, inline := model.requestAtCursor(doc, content, 1)
+	req, inline, err := model.requestAtCursor(doc, content, 1)
+	if err != nil {
+		t.Fatalf("requestAtCursor: %v", err)
+	}
 	if req != nil || inline {
 		t.Fatalf(
 			"expected no request at cursor before first request, got req=%v inline=%v",
@@ -136,7 +148,10 @@ func TestRequestAtCursorFallsBackToLastRequest(t *testing.T) {
 	doc := parser.Parse("sample.http", []byte(content))
 	var model Model
 
-	req, inline := model.requestAtCursor(doc, content, 6)
+	req, inline, err := model.requestAtCursor(doc, content, 6)
+	if err != nil {
+		t.Fatalf("requestAtCursor: %v", err)
+	}
 	if inline {
 		t.Fatalf("expected document request, not inline")
 	}
@@ -147,7 +162,10 @@ func TestRequestAtCursorFallsBackToLastRequest(t *testing.T) {
 
 func TestInlineRequestStripsHTTPVersionToken(t *testing.T) {
 	content := "http://example.com HTTP/1.1"
-	req := buildInlineRequest(content, 1)
+	req, err := buildInlineRequest(content, 1)
+	if err != nil {
+		t.Fatalf("buildInlineRequest: %v", err)
+	}
 	if req == nil {
 		t.Fatalf("expected inline request to be parsed")
 	}
@@ -159,9 +177,29 @@ func TestInlineRequestStripsHTTPVersionToken(t *testing.T) {
 	}
 }
 
+func TestRequestAtCursorReportsUnsupportedVersion(t *testing.T) {
+	content := "### first\nGET https://example.com/one\n\n### second\nGET {{base}}/two HTTP/1.0\n"
+	doc := parser.Parse("sample.http", []byte(content))
+	var model Model
+
+	req, inline, err := model.requestAtCursor(doc, content, 5)
+	if err == nil {
+		t.Fatalf("expected an error, got req=%+v inline=%v", req, inline)
+	}
+	if !strings.Contains(err.Error(), "HTTP/1.0") {
+		t.Fatalf("error = %v, want it to name the token", err)
+	}
+	if req != nil {
+		t.Fatalf("expected no fallback request, got %+v", req)
+	}
+}
+
 func TestInlineCurlRequestSingleLine(t *testing.T) {
 	content := "curl https://example.com"
-	req := buildInlineRequest(content, 1)
+	req, err := buildInlineRequest(content, 1)
+	if err != nil {
+		t.Fatalf("buildInlineRequest: %v", err)
+	}
 	if req == nil {
 		t.Fatalf("expected curl request to be parsed")
 	}
@@ -177,7 +215,10 @@ func TestInlineCurlRequestMultiline(t *testing.T) {
 	content := `curl https://api.example.com/users \
 -H 'Content-Type: application/json' \
 --data '{"name":"Sam"}'`
-	req := buildInlineRequest(content, 2)
+	req, err := buildInlineRequest(content, 2)
+	if err != nil {
+		t.Fatalf("buildInlineRequest: %v", err)
+	}
 	if req == nil {
 		t.Fatalf("expected curl request to be parsed")
 	}


### PR DESCRIPTION
- Reject HTTP/1.0 instead of accepting it and sending HTTP/1.1. Go's standard HTTP client cannot send HTTP/1.0 requests, so Resterm no longer lists it as supported.
- Treat unsupported version tokens such as HTTP/3 and HTTP/9.9 as parse errors instead of including them in the URL.
- Parse `@x =` as a variable with an empty value.
- Preserve source line endings in inline request bodies, including CRLF and mixed endings.