### PR TITLE
RST-336: base-url setting for relative request targets

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -882,7 +882,7 @@ Some directives can span multiple comment lines. Resterm keeps reading while the
 | `@trace` | `# @trace dns<=40ms total<=200ms tolerance=25ms` | Enable per-phase tracing and optional latency budgets. |
 | `@no-log` | `# @no-log` | Prevents the response body snippet from being stored in history. |
 | `@log-sensitive-headers` | `# @log-sensitive-headers [true\|false]` | Allow allowlisted sensitive headers (Authorization, Proxy-Authorization, API-token headers such as `X-API-Key`, `X-Access-Token`, `X-Auth-Key`, etc.) to appear in history; omit or set to `false` to keep them masked (default). |
-| `@setting` | `# @setting key value` | Generic settings (transport/TLS today: `timeout`, `proxy`, `followredirects`, `insecure`, `no-cookies`, `http-*`, `grpc-*`). |
+| `@setting` | `# @setting key value` | Generic settings (transport/TLS today: `base-url`, `timeout`, `proxy`, `followredirects`, `insecure`, `no-cookies`, `http-*`, `grpc-*`). |
 | `@settings` | `# @settings key1=val1 key2=val2 ...` | Batch settings on one line; supports the same keys as `@setting` and future prefixes. |
 | `@timeout` | `# @timeout 5s` | Equivalent to `@setting timeout 5s`. |
 
@@ -2063,8 +2063,60 @@ Key points:
 
 ## HTTP Transport & Settings
 
-- Global defaults are passed via CLI flags (`--timeout`, `--follow`, `--insecure`, `--proxy`).
+- CLI-wide transport defaults are available through flags (`--timeout`, `--follow`, `--insecure`, `--proxy`).
 - Per-request overrides use `@setting`, `@settings`, or `@timeout`.
+
+### Relative request URLs
+
+Set `base-url` to resolve shorter HTTP request targets without repeating a host:
+
+```http
+# File default when declared before the first request
+# @setting base-url https://api.example.com/v1/
+
+### List users
+GET users?page=2
+
+### Root-relative health check
+GET /health
+
+### One-request override
+# @setting base-url https://admin.example.com/api/
+GET status
+```
+
+The same setting can be selected globally through an environment:
+
+```json
+{
+  "dev": {
+    "settings.base-url": "https://api.dev.example.com/v1/"
+  },
+  "prod": {
+    "settings.base-url": "https://api.example.com/v1/"
+  }
+}
+```
+
+Environment, file, and request values use the normal global < file < request precedence. Setting keys are case-insensitive. A base or request target may contain templates, such as `# @setting base-url {{services.api.base}}`; the base is expanded only when the final request target is relative. An absolute request target ignores `base-url`, including an invalid or unresolved non-empty value. A skipped request and a gRPC request do not use it either.
+
+Relative targets follow standard URI-reference resolution, including path-relative, root-relative, query-only, parent-segment, and network-path references:
+
+| Base `https://api.example.com/v1/` | Effective URL |
+| --- | --- |
+| `users` | `https://api.example.com/v1/users` |
+| `/users` | `https://api.example.com/users` |
+| `../health` | `https://api.example.com/health` |
+| `?page=2` | `https://api.example.com/v1/?page=2` |
+| `//uploads.example.com/x` | `https://uploads.example.com/x` |
+| `https://other.example.com/x` | unchanged |
+
+Trailing slash semantics are significant: `https://api.example.com/v1/` plus `users` keeps `/v1/`, while `https://api.example.com/v1` plus `users` produces `https://api.example.com/users`. Resterm does not insert a scheme or slash.
+
+The configured base must be an absolute `http` or `https` URL with a host. It may include a port and path, but not userinfo, a query, or a fragment. An explicitly empty value is an error. A relative request without a usable base fails before connecting. Network-path targets (`//host/path`) deliberately may change the destination host; request headers and configured authentication apply to that effective host.
+
+REST, GraphQL, SSE, and WebSocket requests share the setting. For WebSockets, an effective `http` URL becomes `ws` and `https` becomes `wss`; WebSocket fragments are rejected. `base-url` does not change gRPC targets. A request method remains required, so `GET /users` is valid while a bare `/users` line is not a request.
+
 - HTTP version: `@setting http-version 1.1` (accepts `1.1`, `2`, `HTTP/1.1`, `HTTP/2`). A trailing `HTTP/1.1` on the request line also sets the version; explicit settings win. `2` is strict and fails if the response is not HTTP/2. WebSocket requests are incompatible with `2`.
 - HTTP/1.0 is not supported. Resterm rejects `http-version 1.0`, trailing `HTTP/1.0`, and other unsupported version tokens such as `HTTP/3`.
 - Only a trailing `HTTP/<major>` or `HTTP/<major>.<minor>` is read as a version. Any other trailing text stays part of the URL, so `GET https://example.com/a http/foo` requests `/a%20http/foo`.
@@ -2076,10 +2128,10 @@ Key points:
 - If the SQLite history file is detected as corrupted, Resterm quarantines it to `history.db.corrupt-<timestamp>` and initializes a fresh `history.db`.
 - Custom root CAs replace system roots by default (strict). Set `http-root-mode append` or `grpc-root-mode append` if you want to keep system roots in addition to your own.
 - File-level defaults: place `# @setting key value` or `# @settings key1=val1 ...` before the first request to apply to all requests in that file. Request-level overrides still win.
-- Settings are generic. Today the recognized prefixes are transport/TLS (`http-*`, `grpc-*`, `timeout`, `proxy`, `followredirects`, `insecure`, `no-cookies`). Future features can add more prefixes; unknown keys are ignored for now to stay forward-compatible.
+- Settings are generic. Today the recognized prefixes are transport/TLS (`base-url`, `http-*`, `grpc-*`, `timeout`, `proxy`, `followredirects`, `insecure`, `no-cookies`). Future features can add more prefixes; unknown keys are ignored for now to stay forward-compatible.
 - Boolean settings (`followredirects`, `insecure`, `no-cookies`, `http-insecure`, `grpc-insecure`) accept `true`/`false`, `yes`/`no`, `on`/`off`, and `1`/`0`. A key written on its own is a flag meaning `true`, so `# @setting insecure`, `# @settings insecure`, and `# @setting insecure true` are the same thing. `@setting` also accepts the `key=value` spelling, so `# @setting insecure=false` means what `# @settings insecure=false` does.
-- Settings validate their values. A value outside a setting's vocabulary fails the request instead of falling back to a default, so a typo cannot silently leave TLS verification or redirects at the wrong setting. This covers booleans, `timeout` (a Go duration such as `30s`), `proxy` (a URL with a scheme and host, such as `http://host:8080`), `http-version`, and `http-root-mode`/`grpc-root-mode`. Writing a key with an empty value (`# @settings insecure=`, or `"settings.insecure": ""` in an environment file) is reported as a missing value rather than treated as a flag.
-- Environment defaults: `resterm.env.json` can carry global settings under the `settings.` prefix (e.g., `"settings.http-root-cas": "ca-dev.pem"`, `"settings.grpc-insecure": "false"`). Precedence is global (env) < file < request.
+- Settings validate their values. A value outside a setting's vocabulary fails the request instead of falling back to a default, so a typo cannot silently leave TLS verification or redirects at the wrong setting. This covers booleans, `timeout` (a Go duration such as `30s`), `proxy` (a URL with a scheme and host, such as `http://host:8080`), `http-version`, and `http-root-mode`/`grpc-root-mode`. A non-empty `base-url` is resolved and validated only when a relative HTTP-family target needs it. Writing a key with an empty value (`# @settings insecure=`, or `"settings.insecure": ""` in an environment file) is reported as a missing value rather than treated as a flag.
+- Environment defaults: `resterm.env.json` can carry global settings under the `settings.` prefix (e.g., `"settings.base-url": "https://api.example.com/v1/"`, `"settings.http-root-cas": "ca-dev.pem"`, `"settings.grpc-insecure": "false"`). Precedence is global (env) < file < request.
 - OAuth token exchanges reuse the same HTTP TLS settings (root CAs, client cert/key, `http-insecure`) as the main request.
 
 Body helpers:

--- a/headless/run_test.go
+++ b/headless/run_test.go
@@ -65,6 +65,46 @@ func TestRunRequestParity(t *testing.T) {
 	assertReportParity(t, reportFromRunner(want), got)
 }
 
+func TestRunUsesBaseURLFromInjectedEnvironment(t *testing.T) {
+	seen := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.URL.RequestURI()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	file := filepath.Join(t.TempDir(), "relative.http")
+	got, err := Run(t.Context(), Options{
+		Source: Source{
+			Path:    file,
+			Content: []byte("# @name users\nGET users?page=2\n"),
+		},
+		Environment: EnvironmentOptions{
+			Set: EnvironmentSet{
+				"dev": {"settings.base-url": srv.URL + "/v1/"},
+			},
+			Name: "dev",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got.Passed != 1 || got.Failed != 0 || len(got.Results) != 1 {
+		t.Fatalf("report = %+v, want one passing request", got)
+	}
+	if want := "users?page=2"; got.Results[0].Target != want {
+		t.Fatalf("source target = %q, want %q", got.Results[0].Target, want)
+	}
+	select {
+	case requestURI := <-seen:
+		if requestURI != "/v1/users?page=2" {
+			t.Fatalf("server request URI = %q, want %q", requestURI, "/v1/users?page=2")
+		}
+	default:
+		t.Fatal("server did not receive the request")
+	}
+}
+
 func TestRunCompareParityWithEnvResolve(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/engine/request/engine_test.go
+++ b/internal/engine/request/engine_test.go
@@ -198,6 +198,67 @@ func TestPreviewWithUnresolvedVariablesDoesNotExecute(t *testing.T) {
 	}
 }
 
+func TestPreviewResolvesScopedBaseURLWithoutMutatingSourceTarget(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	doc := &restfile.Document{
+		Settings: map[string]string{"Base-Url": "https://file.example/v1/"},
+	}
+	req := &restfile.Request{
+		Method:   http.MethodGet,
+		URL:      "users",
+		Settings: map[string]string{"BASE-URL": "https://request.example/v2/"},
+	}
+	env := testEnvValues(t, "dev", map[string]string{
+		"settings.base-url": "https://global.example/v0/",
+	})
+
+	res, err := e.ExecuteWith(doc, req, env, ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if !res.Preview || res.Err != nil {
+		t.Fatalf("expected clean preview, got preview=%v err=%v", res.Preview, res.Err)
+	}
+	if res.Explain == nil || res.Explain.Final == nil {
+		t.Fatalf("expected prepared explain report, got %#v", res.Explain)
+	}
+	if got, want := res.Explain.Final.URL, "https://request.example/v2/users"; got != want {
+		t.Fatalf("explain URL = %q, want %q", got, want)
+	}
+	if res.Executed == nil || res.Executed.URL != "users" {
+		t.Fatalf("executed source target = %#v, want relative target", res.Executed)
+	}
+	if got := res.Executed.Settings["base-url"]; got != "https://request.example/v2/" {
+		t.Fatalf("merged base-url = %q, want request override", got)
+	}
+	if transportCalled() {
+		t.Fatal("preview must not construct a transport")
+	}
+}
+
+func TestPreviewAbsoluteURLDoesNotResolveConfiguredBaseURL(t *testing.T) {
+	e, transportCalled := newPreviewTestEngine(t)
+	req := &restfile.Request{
+		Method:   http.MethodGet,
+		URL:      "https://absolute.example/status",
+		Settings: map[string]string{"base-url": "{{missing}}"},
+	}
+
+	res, err := e.ExecuteWith(nil, req, testEnv(""), ExecOptions{Mode: ExecModePreview})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if !res.Preview || res.Err != nil {
+		t.Fatalf("expected clean preview, got preview=%v err=%v", res.Preview, res.Err)
+	}
+	if got := res.Explain.Final.URL; got != "https://absolute.example/status" {
+		t.Fatalf("explain URL = %q, want absolute target unchanged", got)
+	}
+	if transportCalled() {
+		t.Fatal("preview must not construct a transport")
+	}
+}
+
 func TestPreviewBuildFailureStillShortCircuits(t *testing.T) {
 	e, transportCalled := newPreviewTestEngine(t)
 	req := &restfile.Request{
@@ -344,8 +405,9 @@ func TestPreviewCommandAuthStructuralErrorStaysFatal(t *testing.T) {
 func TestPreviewGRPCUnresolvedVariablesStillPreviews(t *testing.T) {
 	e, transportCalled := newPreviewTestEngine(t)
 	req := &restfile.Request{
-		Method: "GRPC",
-		URL:    "{{host}}:50051",
+		Method:   "GRPC",
+		URL:      "{{host}}:50051",
+		Settings: map[string]string{"base-url": "{{missingBase}}"},
 		GRPC: &restfile.GRPCRequest{
 			Target:     "{{host}}:50051",
 			FullMethod: "/pkg.Service/GetUser",

--- a/internal/helpdoc/topics/transport.md
+++ b/internal/helpdoc/topics/transport.md
@@ -4,9 +4,14 @@ Use `@timeout`, `@setting`, and `@settings` to control transport behavior for a 
 
 ```http
 # @timeout 5s
+# @setting base-url https://api.example.com/v1/
 # @setting followredirects false
 # @settings http-insecure=true no-cookies
-GET https://example.com/slow
+GET slow
 ```
 
-Settings cover TLS, proxies, redirects, cookies, HTTP versions, and certificate roots. Place them before the first request to apply to the whole file. Request settings win over file and environment defaults.
+Settings cover base URLs, TLS, proxies, redirects, cookies, HTTP versions, and certificate roots. Place them before the first request to apply to the whole file. Request settings win over file and environment defaults.
+
+`base-url` accepts an absolute `http` or `https` URL with an optional port and path. Relative targets use standard URL rules: `users` joins the base path, `/users` replaces it, and `//other.example/users` may change the host. Keep a trailing slash when the last base path segment is a directory. Absolute request URLs ignore the setting.
+
+REST, GraphQL, SSE, and WebSocket share `base-url`; WebSockets map `http`/`https` to `ws`/`wss`. gRPC targets are unchanged. A request method is still required, for example `GET /health`.

--- a/internal/intellisense/directives.go
+++ b/internal/intellisense/directives.go
@@ -116,6 +116,12 @@ var workflowRunArgs = []Item{
 
 var settingArgs = []Item{
 	{
+		Label:       "base-url=",
+		Summary:     "Base URL for relative HTTP requests",
+		Insert:      "base-url=https://api.example.com/v1/",
+		Placeholder: "https://api.example.com/v1/",
+	},
+	{
 		Label:       "timeout=",
 		Summary:     "Request timeout (e.g. 5s)",
 		Insert:      "timeout=5s",

--- a/internal/intellisense/directives_test.go
+++ b/internal/intellisense/directives_test.go
@@ -106,6 +106,12 @@ func TestDirectiveArgsFilterByPrefix(t *testing.T) {
 		t.Fatal("expect args missing calls=")
 	}
 
+	for _, directive := range []string{"setting", "settings"} {
+		if !contains(argOptions(directive, "base"), "base-url=") {
+			t.Fatalf("%s args missing base-url=", directive)
+		}
+	}
+
 	if opts := argOptions("unknown", ""); opts != nil {
 		t.Fatalf("expected nil for unknown directive, got %v", opts)
 	}

--- a/internal/parser/builder/http/builder_test.go
+++ b/internal/parser/builder/http/builder_test.go
@@ -15,6 +15,12 @@ func TestParseRequestLine(t *testing.T) {
 		ver    version.HTTP
 	}{
 		{line: "GET http://example.com", method: "GET", url: "http://example.com"},
+		{line: "GET /users", method: "GET", url: "/users"},
+		{line: "POST users", method: "POST", url: "users"},
+		{line: "GET ../health", method: "GET", url: "../health"},
+		{line: "GET ?page=2", method: "GET", url: "?page=2"},
+		{line: "GET //uploads.example.com/x", method: "GET", url: "//uploads.example.com/x"},
+		{line: "GET /users HTTP/1.1", method: "GET", url: "/users", ver: version.V11},
 		{line: "CONNECT proxy.example.com:443", method: "CONNECT", url: "proxy.example.com:443"},
 		{line: "WS ws://example.com/s", method: "GET", url: "ws://example.com/s"},
 		{line: "GET {{base}}/two", method: "GET", url: "{{base}}/two"},

--- a/internal/protocol/grpcx/options_apply.go
+++ b/internal/protocol/grpcx/options_apply.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/bytesize"
 	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/util"
 
 	// Register gzip support. Requests use it only when grpc-compression is set.
 	_ "google.golang.org/grpc/encoding/gzip"
@@ -56,7 +57,7 @@ func applyOptionSettings(opts *Options, settings map[string]string, strict bool)
 
 	norm := make(map[string]string, len(settings))
 	for k, v := range settings {
-		norm[strings.ToLower(strings.TrimSpace(k))] = v
+		norm[util.LowerTrim(k)] = v
 	}
 
 	for _, s := range sizeSettings {
@@ -73,7 +74,7 @@ func applyOptionSettings(opts *Options, settings map[string]string, strict bool)
 	}
 
 	if val, ok := norm[string(optionSettingCompression)]; ok {
-		name, valid := compressors[strings.ToLower(strings.TrimSpace(val))]
+		name, valid := compressors[util.LowerTrim(val)]
 		switch {
 		case valid:
 			opts.Compression = name

--- a/internal/protocol/httpx/client.go
+++ b/internal/protocol/httpx/client.go
@@ -21,6 +21,7 @@ import (
 
 type Options struct {
 	Timeout            time.Duration
+	BaseURL            string
 	FollowRedirects    bool
 	InsecureSkipVerify bool
 	ProxyURL           string

--- a/internal/protocol/httpx/options_apply.go
+++ b/internal/protocol/httpx/options_apply.go
@@ -14,6 +14,7 @@ import (
 type optionSettingKey string
 
 const (
+	optionSettingBaseURL         optionSettingKey = "base-url"
 	optionSettingTimeout         optionSettingKey = "timeout"
 	optionSettingProxy           optionSettingKey = "proxy"
 	optionSettingFollowRedirects optionSettingKey = "followredirects"
@@ -70,6 +71,22 @@ func applyOptionSettings(opts *Options, settings map[string]string, strict bool)
 			opts.Timeout = dur
 		case strict:
 			return invalidSetting(optionSettingTimeout, val, "a duration such as 30s")
+		}
+	}
+
+	// A base URL may hold templates and an absolute request target ignores it
+	// entirely, so the raw value is kept here and only the request builder
+	// expands and validates it, once a relative target needs it.
+	if val, ok := settingValue(norm, optionSettingBaseURL); ok {
+		switch base := strings.TrimSpace(val); {
+		case base != "":
+			opts.BaseURL = base
+		case strict:
+			return invalidSetting(
+				optionSettingBaseURL,
+				val,
+				"an absolute HTTP URL such as https://api.example.com/v1/",
+			)
 		}
 	}
 

--- a/internal/protocol/httpx/options_apply_test.go
+++ b/internal/protocol/httpx/options_apply_test.go
@@ -35,6 +35,12 @@ func TestApplyOptionSettingsRejectsInvalidValues(t *testing.T) {
 			val:  "",
 			want: "missing timeout value (use a duration such as 30s)",
 		},
+		{
+			name: "empty base url",
+			key:  "base-url",
+			val:  "",
+			want: "missing base-url value",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := Options{Timeout: time.Second}
@@ -49,6 +55,20 @@ func TestApplyOptionSettingsRejectsInvalidValues(t *testing.T) {
 				t.Fatalf("expected the rejected value to leave options untouched, got %v", opts.Timeout)
 			}
 		})
+	}
+}
+
+func TestApplyOptionSettingsKeepsBaseURLRawForRequestResolution(t *testing.T) {
+	opts := Options{}
+
+	err := ApplyOptionSettings(&opts, map[string]string{
+		"base-url": "  {{api.base}}  ",
+	})
+	if err != nil {
+		t.Fatalf("ApplyOptionSettings returned error: %v", err)
+	}
+	if opts.BaseURL != "{{api.base}}" {
+		t.Fatalf("BaseURL = %q, want raw template", opts.BaseURL)
 	}
 }
 
@@ -125,7 +145,12 @@ func TestApplyOptionSettingsAcceptsBooleanSpellings(t *testing.T) {
 // value must not stop the readable ones behind it from being applied.
 func TestApplyRequestSettingsSkipsUnreadableValues(t *testing.T) {
 	jar, _ := cookiejar.New(nil)
-	opts := Options{Timeout: time.Second, HTTPVersion: version.V11, CookieJar: jar}
+	opts := Options{
+		Timeout:     time.Second,
+		BaseURL:     "https://default.example/",
+		HTTPVersion: version.V11,
+		CookieJar:   jar,
+	}
 
 	got := applyRequestSettings(opts, map[string]string{
 		"http-version":    "unsupported",
@@ -133,6 +158,7 @@ func TestApplyRequestSettingsSkipsUnreadableValues(t *testing.T) {
 		"followredirects": "maybe",
 		"insecure":        "true",
 		"no-cookies":      "true",
+		"base-url":        "{{api.base}}",
 	})
 
 	if got.HTTPVersion != version.V11 {
@@ -149,5 +175,8 @@ func TestApplyRequestSettingsSkipsUnreadableValues(t *testing.T) {
 	}
 	if got.CookieJar != nil {
 		t.Fatal("no-cookies=true follows an unreadable value and still has to apply")
+	}
+	if got.BaseURL != "{{api.base}}" {
+		t.Fatalf("BaseURL = %q, want raw request setting", got.BaseURL)
 	}
 }

--- a/internal/protocol/httpx/request.go
+++ b/internal/protocol/httpx/request.go
@@ -3,10 +3,10 @@ package httpx
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/util"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -148,11 +148,9 @@ func normalizeSettings(settings map[string]string) map[string]string {
 	}
 	norm := make(map[string]string, len(settings))
 	for k, v := range settings {
-		key := strings.ToLower(strings.TrimSpace(k))
-		if key == "" {
-			continue
+		if key := util.LowerTrim(k); key != "" {
+			norm[key] = v
 		}
-		norm[key] = v
 	}
 	return norm
 }

--- a/internal/protocol/httpx/request_build.go
+++ b/internal/protocol/httpx/request_build.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"io"
 	"net/http"
@@ -129,31 +130,17 @@ func (c *Client) buildHTTPRequest(
 		)
 	}
 
-	expandedURL := urlOverride
-	if expandedURL == "" {
-		expandedURL = req.URL
-	}
-	if expandedURL == "" {
-		return nil, opts, diag.New(
-			diag.ClassProtocol,
-			"request url is empty",
-			diag.WithComponent(diag.ComponentHTTP),
-		)
-	}
-	if resolver != nil {
-		var err error
-		expandedURL, err = resolver.ExpandTemplates(expandedURL)
-		if err != nil {
-			return nil, opts, diag.WrapAs(
-				diag.ClassProtocol,
-				err,
-				"expand url",
-				diag.WithComponent(diag.ComponentHTTP),
-			)
-		}
+	target, err := resolveRequestTarget(
+		cmp.Or(urlOverride, req.URL),
+		opts.BaseURL,
+		resolver,
+		requestSchemeOf(req),
+	)
+	if err != nil {
+		return nil, opts, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, req.Method, expandedURL, body)
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, target, body)
 	if err != nil {
 		return nil, opts, diag.WrapAs(
 			diag.ClassProtocol,

--- a/internal/protocol/httpx/request_test.go
+++ b/internal/protocol/httpx/request_test.go
@@ -221,6 +221,103 @@ func TestBuildHTTPRequestExpandsHeaderAndAuth(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPRequestResolvesBaseURLFromRequestSettings(t *testing.T) {
+	c := NewClient(nil)
+	resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{
+		"api.base": "https://api.example.com/v1/",
+	}))
+	req := &restfile.Request{
+		Method:   http.MethodGet,
+		URL:      "users/42?view=full",
+		Settings: map[string]string{"base-url": "{{api.base}}"},
+	}
+
+	httpReq, effective, _, err := c.BuildHTTPRequest(t.Context(), req, resolver, Options{})
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest() error = %v", err)
+	}
+	if got, want := httpReq.URL.String(), "https://api.example.com/v1/users/42?view=full"; got != want {
+		t.Fatalf("request URL = %q, want %q", got, want)
+	}
+	if effective.BaseURL != "{{api.base}}" {
+		t.Fatalf("effective BaseURL = %q, want raw request setting", effective.BaseURL)
+	}
+	if req.URL != "users/42?view=full" {
+		t.Fatalf("source request URL was mutated to %q", req.URL)
+	}
+}
+
+func TestBuildHTTPRequestResolvesGraphQLGETAgainstBaseURL(t *testing.T) {
+	c := NewClient(nil)
+	req := &restfile.Request{
+		Method:   http.MethodGet,
+		URL:      "graphql?existing=1",
+		Settings: map[string]string{"base-url": "https://api.example.com/v1/"},
+		Body: restfile.BodySource{GraphQL: &restfile.GraphQLBody{
+			Query:         "query { ping }",
+			OperationName: "Ping",
+		}},
+	}
+
+	httpReq, _, _, err := c.BuildHTTPRequest(t.Context(), req, vars.NewResolver(), Options{})
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest() error = %v", err)
+	}
+	if got, want := httpReq.URL.Path, "/v1/graphql"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	query := httpReq.URL.Query()
+	if query.Get("existing") != "1" || query.Get("operationName") != "Ping" ||
+		query.Get("query") == "" {
+		t.Fatalf("request query = %#v, want existing GraphQL parameters", query)
+	}
+}
+
+func TestBuildHTTPRequestUsesBaseURLForHTTPFamilyMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(*restfile.Request)
+		want string
+	}{
+		{name: "REST", want: "https://api.example.com/events"},
+		{
+			name: "SSE",
+			set: func(req *restfile.Request) {
+				req.SSE = &restfile.SSERequest{}
+			},
+			want: "https://api.example.com/events",
+		},
+		{
+			name: "WebSocket",
+			set: func(req *restfile.Request) {
+				req.WebSocket = &restfile.WebSocketRequest{}
+			},
+			want: "wss://api.example.com/events",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &restfile.Request{Method: http.MethodGet, URL: "/events"}
+			if tt.set != nil {
+				tt.set(req)
+			}
+			httpReq, _, _, err := NewClient(nil).BuildHTTPRequest(
+				t.Context(),
+				req,
+				nil,
+				Options{BaseURL: "https://api.example.com/v1/"},
+			)
+			if err != nil {
+				t.Fatalf("BuildHTTPRequest() error = %v", err)
+			}
+			if got := httpReq.URL.String(); got != tt.want {
+				t.Fatalf("request URL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildHTTPRequestLenientResolverKeepsPlaceholders(t *testing.T) {
 	c := NewClient(nil)
 	req := &restfile.Request{

--- a/internal/protocol/httpx/target.go
+++ b/internal/protocol/httpx/target.go
@@ -1,0 +1,145 @@
+package httpx
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+// requestScheme is the scheme family a resolved request URL must use. WebSocket
+// requests resolve against the same http base-url as every other request, so ws
+// and wss are applied after resolution rather than before it.
+type requestScheme int
+
+const (
+	schemeHTTP requestScheme = iota
+	schemeWebSocket
+)
+
+func requestSchemeOf(req *restfile.Request) requestScheme {
+	if req.WebSocket != nil {
+		return schemeWebSocket
+	}
+	return schemeHTTP
+}
+
+// resolveRequestTarget turns the request line URL into the absolute URL to send.
+// A relative target resolves against base-url the way RFC 3986 resolves a URI
+// reference; an absolute target ignores base-url even when it is unusable.
+func resolveRequestTarget(
+	rawTarget, rawBase string,
+	resolver *vars.Resolver,
+	scheme requestScheme,
+) (string, error) {
+	target, err := expandURL(rawTarget, resolver, "url")
+	if err != nil {
+		return "", err
+	}
+	if target == "" {
+		return "", targetError("request url is empty")
+	}
+
+	ref, err := url.Parse(target)
+	if err != nil {
+		return "", wrapTargetError(err, "parse request url")
+	}
+
+	// url.URL cannot tell an empty fragment from an absent one, so a trailing
+	// "#" has to be caught in the text before parsing drops it.
+	if scheme == schemeWebSocket && strings.Contains(target, "#") {
+		return "", targetError("websocket request url must not contain a fragment")
+	}
+
+	if !ref.IsAbs() {
+		base, err := resolveBaseURL(rawBase, resolver)
+		if err != nil {
+			return "", err
+		}
+		ref = base.ResolveReference(ref)
+	}
+
+	if err := scheme.apply(ref); err != nil {
+		return "", err
+	}
+	return ref.String(), nil
+}
+
+// apply rejects a scheme the request cannot use and maps http and https onto ws
+// and wss, so a single http base-url serves REST and WebSocket requests alike.
+func (s requestScheme) apply(u *url.URL) error {
+	if u.Hostname() == "" {
+		return targetError("request url host is empty")
+	}
+
+	if s == schemeHTTP {
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return targetError("request url scheme must be http or https")
+		}
+		return nil
+	}
+
+	switch u.Scheme {
+	case "ws", "wss":
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	default:
+		return targetError("websocket request url scheme must be ws, wss, http or https")
+	}
+	return nil
+}
+
+// The base is read only once a target actually needs it, so an unset, unresolved
+// or invalid base-url never fails a request that already carries a full URL.
+func resolveBaseURL(raw string, resolver *vars.Resolver) (*url.URL, error) {
+	expanded, err := expandURL(raw, resolver, "base-url")
+	if err != nil {
+		return nil, err
+	}
+
+	expanded = strings.TrimSpace(expanded)
+	if expanded == "" {
+		return nil, targetError("relative request url requires a base-url setting")
+	}
+
+	base, err := url.Parse(expanded)
+	if err != nil {
+		return nil, wrapTargetError(err, "parse base-url")
+	}
+	switch {
+	case base.Scheme != "http" && base.Scheme != "https":
+		return nil, targetError("invalid base-url: scheme must be http or https")
+	case base.Hostname() == "":
+		return nil, targetError("invalid base-url: host is required")
+	case base.User != nil:
+		return nil, targetError("invalid base-url: userinfo is not allowed")
+	case base.RawQuery != "" || base.ForceQuery:
+		return nil, targetError("invalid base-url: query is not allowed")
+	case strings.Contains(expanded, "#"):
+		return nil, targetError("invalid base-url: fragment is not allowed")
+	}
+	return base, nil
+}
+
+func expandURL(raw string, resolver *vars.Resolver, label string) (string, error) {
+	if resolver == nil {
+		return raw, nil
+	}
+	expanded, err := resolver.ExpandTemplates(raw)
+	if err != nil {
+		return "", wrapTargetError(err, "expand "+label)
+	}
+	return expanded, nil
+}
+
+func targetError(msg string) error {
+	return diag.New(diag.ClassProtocol, msg, diag.WithComponent(diag.ComponentHTTP))
+}
+
+func wrapTargetError(err error, op string) error {
+	return diag.WrapAs(diag.ClassProtocol, err, op, diag.WithComponent(diag.ComponentHTTP))
+}

--- a/internal/protocol/httpx/target_test.go
+++ b/internal/protocol/httpx/target_test.go
@@ -1,0 +1,129 @@
+package httpx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+func TestResolveRequestTargetRFCReferences(t *testing.T) {
+	const base = "https://api.example.com/v1/"
+	tests := []struct {
+		name   string
+		target string
+		base   string
+		scheme requestScheme
+		want   string
+	}{
+		{name: "path relative", target: "users", base: base, want: "https://api.example.com/v1/users"},
+		{name: "root relative", target: "/users", base: base, want: "https://api.example.com/users"},
+		{name: "parent segment", target: "../health", base: base, want: "https://api.example.com/health"},
+		{name: "query only", target: "?page=2", base: base, want: "https://api.example.com/v1/?page=2"},
+		{name: "network path", target: "//uploads.example.com/x", base: base, want: "https://uploads.example.com/x"},
+		{name: "base without trailing slash", target: "users", base: "https://api.example.com/v1", want: "https://api.example.com/users"},
+		{name: "encoded path", target: "files/a%2Fb", base: base, want: "https://api.example.com/v1/files/a%2Fb"},
+		{name: "uppercase base scheme", target: "users", base: "HTTPS://api.example.com/v1/", want: "https://api.example.com/v1/users"},
+		{name: "absolute ignores invalid base", target: "https://other.example/x%2Fy?z=%2F", base: "://invalid", want: "https://other.example/x%2Fy?z=%2F"},
+		{name: "uppercase absolute scheme", target: "HTTPS://other.example/x", want: "https://other.example/x"},
+		{name: "websocket relative", target: "socket", base: base, scheme: schemeWebSocket, want: "wss://api.example.com/v1/socket"},
+		{name: "websocket explicit HTTP", target: "http://socket.example/x", base: "://invalid", scheme: schemeWebSocket, want: "ws://socket.example/x"},
+		{name: "websocket explicit WSS", target: "wss://socket.example/x", scheme: schemeWebSocket, want: "wss://socket.example/x"},
+		{name: "websocket uppercase WSS", target: "WSS://socket.example/x", scheme: schemeWebSocket, want: "wss://socket.example/x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRequestTarget(tt.target, tt.base, nil, tt.scheme)
+			if err != nil {
+				t.Fatalf("resolveRequestTarget() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveRequestTarget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveRequestTargetExpandsTargetAndBase(t *testing.T) {
+	resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{
+		"api":      "https://api.example.com/v2/",
+		"resource": "users/42",
+	}))
+
+	got, err := resolveRequestTarget("{{resource}}", "{{api}}", resolver, schemeHTTP)
+	if err != nil {
+		t.Fatalf("resolveRequestTarget() error = %v", err)
+	}
+	if want := "https://api.example.com/v2/users/42"; got != want {
+		t.Fatalf("resolveRequestTarget() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRequestTargetValidatesBaseWhenNeeded(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		want string
+	}{
+		{name: "missing", want: "requires a base-url setting"},
+		{name: "relative base", base: "api.example.com/v1/", want: "scheme must be http or https"},
+		{name: "websocket scheme", base: "wss://api.example.com/", want: "scheme must be http or https"},
+		{name: "missing host", base: "https:///v1/", want: "host is required"},
+		{name: "userinfo", base: "https://user:pass@api.example.com/", want: "userinfo is not allowed"},
+		{name: "query", base: "https://api.example.com/v1/?tenant=one", want: "query is not allowed"},
+		{name: "empty query", base: "https://api.example.com/v1/?", want: "query is not allowed"},
+		{name: "fragment", base: "https://api.example.com/v1/#section", want: "fragment is not allowed"},
+		{name: "empty fragment", base: "https://api.example.com/v1/#", want: "fragment is not allowed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveRequestTarget("users", tt.base, nil, schemeHTTP)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveRequestTargetReportsExpansionAndProtocolErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		base     string
+		resolver *vars.Resolver
+		scheme   requestScheme
+		want     string
+	}{
+		{name: "missing target variable", target: "{{path}}", base: "https://api.example.com/", resolver: vars.NewResolver(), want: "expand url"},
+		{name: "empty expanded target", target: "{{path}}", base: "https://api.example.com/", resolver: vars.NewResolver(vars.NewMapProvider("env", map[string]string{"path": ""})), want: "request url is empty"},
+		{name: "missing base variable", target: "users", base: "{{api}}", resolver: vars.NewResolver(), want: "expand base-url"},
+		{name: "unsupported HTTP scheme", target: "ftp://api.example.com/x", want: "scheme must be http or https"},
+		{name: "missing target host", target: "https:///x", want: "request url host is empty"},
+		{name: "base expands to empty", target: "users", base: "{{api}}", resolver: vars.NewResolver(vars.NewMapProvider("env", map[string]string{"api": ""})), want: "requires a base-url setting"},
+		{name: "websocket fragment", target: "socket#section", base: "https://api.example.com/", scheme: schemeWebSocket, want: "must not contain a fragment"},
+		{name: "websocket empty fragment", target: "socket#", base: "https://api.example.com/", scheme: schemeWebSocket, want: "must not contain a fragment"},
+		{name: "unsupported websocket scheme", target: "ftp://api.example.com/socket", scheme: schemeWebSocket, want: "scheme must be ws, wss, http or https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveRequestTarget(
+				tt.target,
+				tt.base,
+				tt.resolver,
+				tt.scheme,
+			)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/settings/apply.go
+++ b/internal/settings/apply.go
@@ -9,6 +9,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/tlsconfig"
+	"github.com/unkn0wn-root/resterm/internal/util"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -27,7 +28,7 @@ func ApplyGRPCSettings(
 		Insecure:   opts.Insecure,
 		RootMode:   opts.RootMode,
 	}
-	if err := applyTLSSettings(&tlsCfg, settings, resolver, "grpc"); err != nil {
+	if err := applyTLSSettings(&tlsCfg, settings, resolver, tlsPrefixGRPC); err != nil {
 		return err
 	}
 	opts.RootCAs = tlsCfg.RootCAs
@@ -56,7 +57,7 @@ func ApplyHTTPSettings(
 		Insecure:   opts.InsecureSkipVerify,
 		RootMode:   opts.RootMode,
 	}
-	if err := applyTLSSettings(&tlsCfg, settings, resolver, "http"); err != nil {
+	if err := applyTLSSettings(&tlsCfg, settings, resolver, tlsPrefixHTTP); err != nil {
 		return err
 	}
 	opts.RootCAs = tlsCfg.RootCAs
@@ -70,17 +71,37 @@ func ApplyHTTPSettings(
 	return httpx.ApplyOptionSettings(opts, settings)
 }
 
+// tlsPrefix is the setting family a TLS block belongs to. Both families spell
+// their keys the same way, so the prefix picks both the keys and the component
+// that errors are reported under.
+type tlsPrefix string
+
+const (
+	tlsPrefixHTTP tlsPrefix = "http"
+	tlsPrefixGRPC tlsPrefix = "grpc"
+)
+
+func (p tlsPrefix) key(name string) string { return string(p) + "-" + name }
+
+func (p tlsPrefix) label(name string) string { return string(p) + " " + name }
+
+func (p tlsPrefix) component() diag.Component {
+	if p == tlsPrefixGRPC {
+		return diag.ComponentGRPC
+	}
+	return diag.ComponentHTTP
+}
+
 func applyTLSSettings(
 	cfg *tlsconfig.Files,
 	settings map[string]string,
 	resolver *vars.Resolver,
-	prefix string,
+	prefix tlsPrefix,
 ) error {
 	if cfg == nil || len(settings) == 0 {
 		return nil
 	}
-	prefixLower := strings.ToLower(strings.TrimSpace(prefix))
-	component := settingsComponent(prefixLower)
+	component := prefix.component()
 	resolve := func(val string, label string) (string, error) {
 		trimmed := strings.TrimSpace(val)
 		if trimmed == "" {
@@ -100,13 +121,14 @@ func applyTLSSettings(
 		}
 		return strings.TrimSpace(expanded), nil
 	}
-	norm := normalize(settings)
+	// A single scope, so this only canonicalizes the keys.
+	norm := Merge(settings)
 
 	// Read straight from the map. firstSetting skips written-empty values, and
 	// those have to reach the missing-value error like every other setting.
-	mode := prefixLower + "-root-mode"
+	mode := prefix.key("root-mode")
 	if raw, ok := norm[mode]; ok {
-		switch strings.ToLower(strings.TrimSpace(raw)) {
+		switch util.LowerTrim(raw) {
 		case string(tlsconfig.RootModeAppend):
 			cfg.RootMode = tlsconfig.RootModeAppend
 		case string(tlsconfig.RootModeReplace):
@@ -116,7 +138,7 @@ func applyTLSSettings(
 		}
 	}
 
-	key := prefixLower + "-insecure"
+	key := prefix.key("insecure")
 	if raw, ok := norm[key]; ok {
 		b, valid := directive.ParseBool(raw)
 		if !valid {
@@ -124,19 +146,14 @@ func applyTLSSettings(
 		}
 		cfg.Insecure = b
 	}
-	val, err := resolveSetting(
-		norm,
-		prefixLower+"-client-cert",
-		prefixLower+" client cert",
-		resolve,
-	)
+	val, err := resolveSetting(norm, prefix.key("client-cert"), prefix.label("client cert"), resolve)
 	if err != nil {
 		return err
 	}
 	if val != "" {
 		cfg.ClientCert = val
 	}
-	val, err = resolveSetting(norm, prefixLower+"-client-key", prefixLower+" client key", resolve)
+	val, err = resolveSetting(norm, prefix.key("client-key"), prefix.label("client key"), resolve)
 	if err != nil {
 		return err
 	}
@@ -144,14 +161,14 @@ func applyTLSSettings(
 		cfg.ClientKey = val
 	}
 
-	if raw := firstSetting(norm, prefixLower+"-root-cas", prefixLower+"-root-ca"); raw != "" {
+	if raw := firstSetting(norm, prefix.key("root-cas"), prefix.key("root-ca")); raw != "" {
 		paths := splitList(raw)
 		resolved := make([]string, 0, len(paths))
 		for _, p := range paths {
 			if p == "" {
 				continue
 			}
-			val, err := resolve(p, prefixLower+" root ca")
+			val, err := resolve(p, prefix.label("root ca"))
 			if err != nil {
 				return err
 			}
@@ -166,15 +183,6 @@ func applyTLSSettings(
 	return nil
 }
 
-func settingsComponent(prefix string) diag.Component {
-	switch prefix {
-	case "grpc":
-		return diag.ComponentGRPC
-	default:
-		return diag.ComponentHTTP
-	}
-}
-
 // Settings come from a file the user edits, so name the key and what it takes.
 // The wording matches the generic HTTP settings in protocol/httpx.
 func invalidSetting(c diag.Component, key, val, want string) error {
@@ -185,14 +193,6 @@ func invalidSetting(c diag.Component, key, val, want string) error {
 		msg = fmt.Sprintf("missing %s value (use %s)", key, want)
 	}
 	return diag.New(diag.ClassProtocol, msg, diag.WithComponent(c))
-}
-
-func normalize(settings map[string]string) map[string]string {
-	norm := make(map[string]string, len(settings))
-	for k, v := range settings {
-		norm[strings.ToLower(strings.TrimSpace(k))] = v
-	}
-	return norm
 }
 
 func firstSetting(m map[string]string, keys ...string) string {

--- a/internal/settings/env.go
+++ b/internal/settings/env.go
@@ -1,35 +1,39 @@
 package settings
 
 import (
-	"maps"
 	"strings"
+
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
+
+const envSettingPrefix = "settings."
 
 func FromValues(values map[string]string) map[string]string {
 	if len(values) == 0 {
 		return nil
 	}
 	out := make(map[string]string)
-	for key, val := range values {
-		if key == "" {
-			continue
-		}
-		lower := strings.ToLower(strings.TrimSpace(key))
-		const prefix = "settings."
-		if strings.HasPrefix(lower, prefix) {
-			name := strings.TrimSpace(key[len(prefix):])
-			if name != "" {
-				out[name] = val
-			}
+	for _, key := range util.SortedKeys(values) {
+		name, ok := strings.CutPrefix(util.LowerTrim(key), envSettingPrefix)
+		if ok && name != "" {
+			out[name] = values[key]
 		}
 	}
 	return out
 }
 
+// Merge folds scopes together in precedence order and returns canonical keys, so
+// later scopes override earlier ones regardless of how each one wrote the key.
+// Keys are visited in sorted order to keep two forms of the same key in one
+// scope from resolving differently between runs.
 func Merge(scopes ...map[string]string) map[string]string {
 	out := make(map[string]string)
 	for _, scope := range scopes {
-		maps.Copy(out, scope)
+		for _, key := range util.SortedKeys(scope) {
+			if name := util.LowerTrim(key); name != "" {
+				out[name] = scope[key]
+			}
+		}
 	}
 	return out
 }

--- a/internal/settings/keys.go
+++ b/internal/settings/keys.go
@@ -1,8 +1,13 @@
 package settings
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/unkn0wn-root/resterm/internal/util"
+)
 
 var httpSettingKeys = map[string]struct{}{
+	"base-url":        {},
 	"timeout":         {},
 	"proxy":           {},
 	"followredirects": {},
@@ -12,7 +17,7 @@ var httpSettingKeys = map[string]struct{}{
 
 // IsHTTPKey reports whether key is a supported HTTP setting key.
 func IsHTTPKey(key string) bool {
-	k := strings.ToLower(strings.TrimSpace(key))
+	k := util.LowerTrim(key)
 
 	if _, ok := httpSettingKeys[k]; ok {
 		return true

--- a/internal/settings/keys_test.go
+++ b/internal/settings/keys_test.go
@@ -4,6 +4,7 @@ import "testing"
 
 func TestIsHTTPKey(t *testing.T) {
 	ok := []string{
+		"base-url",
 		"timeout",
 		"proxy",
 		"followredirects",
@@ -24,5 +25,26 @@ func TestIsHTTPKey(t *testing.T) {
 		if IsHTTPKey(k) {
 			t.Fatalf("expected http key %q to be unsupported", k)
 		}
+	}
+}
+
+func TestMergeNormalizesKeysBeforeApplyingScopePrecedence(t *testing.T) {
+	global := map[string]string{" BASE-URL ": "https://global.example/"}
+	file := map[string]string{"Base-Url": "https://file.example/"}
+	request := map[string]string{"base-url": "https://request.example/"}
+
+	got := Merge(global, file, request)
+	if len(got) != 1 || got["base-url"] != "https://request.example/" {
+		t.Fatalf("Merge() = %#v, want canonical request override", got)
+	}
+}
+
+func TestFromValuesReturnsCanonicalSettingKeys(t *testing.T) {
+	got := FromValues(map[string]string{
+		" SETTINGS.Base-URL ": "https://api.example/",
+		"ordinary":            "value",
+	})
+	if len(got) != 1 || got["base-url"] != "https://api.example/" {
+		t.Fatalf("FromValues() = %#v, want canonical base-url", got)
 	}
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"strings"
 
+	"github.com/unkn0wn-root/resterm/internal/util"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -28,7 +29,7 @@ func (a Applier) ApplyAll(settings map[string]string) (map[string]string, error)
 	}
 	left := make(map[string]string)
 	for k, v := range settings {
-		key := strings.ToLower(strings.TrimSpace(k))
+		key := util.LowerTrim(k)
 		if key == "" {
 			continue
 		}
@@ -53,9 +54,9 @@ func (a Applier) ApplyAll(settings map[string]string) (map[string]string, error)
 
 func PrefixMatcher(prefixes ...string) Matcher {
 	return func(key string) bool {
-		lower := strings.ToLower(strings.TrimSpace(key))
+		lower := util.LowerTrim(key)
 		for _, p := range prefixes {
-			if strings.HasPrefix(lower, strings.ToLower(strings.TrimSpace(p))) {
+			if strings.HasPrefix(lower, util.LowerTrim(p)) {
 				return true
 			}
 		}


### PR DESCRIPTION
* feat(http): resolve relative request targets against a base-url setting
* fix(settings): merge scopes on canonical keys so precedence ignores key case
* fix(settings): strip the settings. env prefix from the normalized key
* refactor(http): type the request scheme instead of passing a websocket bool
* refactor(settings): normalize keys through util.LowerTrim in one place
* refactor(settings): type the TLS setting prefix