### PR TITLE
RST-337: schemeless targets

### DIFF
--- a/_examples/basic.http
+++ b/_examples/basic.http
@@ -1,14 +1,21 @@
 ### Status Check
 # @name getStatus
-GET {{base.url}}/status/204
+// base-url can be set for one request. The relative URL below is resolved
+// against that base.
+# @setting base-url {{base.url}}
+GET /status/204
 User-Agent: resterm/0.1
 Accept: application/json
 
 ### Download binary file
 # @name downloadBinary
-// github returns 404 for an invalid Authorization header and _examples defines a global auth profile
+// GitHub returns 404 when an invalid Authorization header is sent. The example
+// environment defines global auth, so disable it for this request.
+// A base URL can include a path. Keep the trailing slash when the path is a
+// directory; otherwise, the relative URL replaces its final segment.
 # @auth none
-GET https://raw.githubusercontent.com/unkn0wn-root/resterm/main/_media/resterm_base.png
+# @setting base-url https://raw.githubusercontent.com/unkn0wn-root/resterm/main/
+GET _media/resterm_base.png
 
 ### Create Post
 # @name createPost

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2111,11 +2111,43 @@ Relative targets follow standard URI-reference resolution, including path-relati
 | `//uploads.example.com/x` | `https://uploads.example.com/x` |
 | `https://other.example.com/x` | unchanged |
 
-Trailing slash semantics are significant: `https://api.example.com/v1/` plus `users` keeps `/v1/`, while `https://api.example.com/v1` plus `users` produces `https://api.example.com/users`. Resterm does not insert a scheme or slash.
+Trailing slash semantics are significant: `https://api.example.com/v1/` plus `users` keeps `/v1/`, while `https://api.example.com/v1` plus `users` produces `https://api.example.com/users`. Resterm does not insert a slash.
 
 The configured base must be an absolute `http` or `https` URL with a host. It may include a port and path, but not userinfo, a query, or a fragment. An explicitly empty value is an error. A relative request without a usable base fails before connecting. Network-path targets (`//host/path`) deliberately may change the destination host; request headers and configured authentication apply to that effective host.
 
 REST, GraphQL, SSE, and WebSocket requests share the setting. For WebSockets, an effective `http` URL becomes `ws` and `https` becomes `wss`; WebSocket fragments are rejected. `base-url` does not change gRPC targets. A request method remains required, so `GET /users` is valid while a bare `/users` line is not a request.
+
+### URLs without a scheme
+
+You can omit `http://` when a request URL starts with a host and port. Resterm uses plain HTTP:
+
+| Request line | Effective URL |
+| --- | --- |
+| `GET localhost:8080/users` | `http://localhost:8080/users` |
+| `GET 127.0.0.1:8080/users` | `http://127.0.0.1:8080/users` |
+| `GET [::1]:8080/users` | `http://[::1]:8080/users` |
+| `GET [::1]/users` | `http://[::1]/users` |
+
+The port distinguishes these URLs from relative paths. Bracketed IPv6 addresses are also clear without a port, so `[::1]/users` works. These URLs are absolute and ignore `base-url`. Resterm always adds `http://`; write `https://` when you want TLS.
+
+Only the start of the request URL is checked. A URL in a query value does not affect the destination: `GET localhost:8080/p?next=http://example.com` still connects to `localhost:8080`. A known scheme without `//`, such as `https:443/path`, is rejected instead of being treated as a host named `https`.
+
+For a request with `# @websocket`, Resterm changes the added scheme to `ws://`. For example, `GET localhost:8080/socket` connects to `ws://localhost:8080/socket`. The `@websocket` directive starts the session; using `WS` as the method does not.
+
+A hostname without a port remains a relative URL. With `base-url` set to `https://api.example.com/v1/`, `GET example.com/users` resolves to `https://api.example.com/v1/example.com/users`. Write `http://example.com/users` when `example.com` is the destination host.
+
+Templates are expanded before these rules are applied. When a variable represents a server, include either a port or a scheme:
+
+| Value of `{{host}}` | Result of `GET {{host}}/users` |
+| --- | --- |
+| `localhost:8080` | `http://localhost:8080/users` |
+| `127.0.0.1:9000` | `http://127.0.0.1:9000/users` |
+| `http://example.com` | `http://example.com/users` |
+| `example.com` | A relative URL; requires `base-url` |
+
+A template can also provide part of the URL. Both `GET http://{{host}}/users` and `GET localhost:{{port}}/users` work.
+
+### Other HTTP settings
 
 - HTTP version: `@setting http-version 1.1` (accepts `1.1`, `2`, `HTTP/1.1`, `HTTP/2`). A trailing `HTTP/1.1` on the request line also sets the version; explicit settings win. `2` is strict and fails if the response is not HTTP/2. WebSocket requests are incompatible with `2`.
 - HTTP/1.0 is not supported. Resterm rejects `http-version 1.0`, trailing `HTTP/1.0`, and other unsupported version tokens such as `HTTP/3`.

--- a/headless/run_test.go
+++ b/headless/run_test.go
@@ -105,6 +105,53 @@ func TestRunUsesBaseURLFromInjectedEnvironment(t *testing.T) {
 	}
 }
 
+func TestRunSendsSchemelessTargetThroughTheParser(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{name: "host and port", line: "%s/users?page=2", want: "/users?page=2"},
+		{name: "url valued query", line: "%s/p?next=http://example.com&a=1", want: "/p?next=http://example.com&a=1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seen := make(chan string, 1)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seen <- r.URL.RequestURI()
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer srv.Close()
+
+			target := fmt.Sprintf(tt.line, strings.TrimPrefix(srv.URL, "http://"))
+			got, err := Run(t.Context(), Options{
+				Source: Source{
+					Path:    filepath.Join(t.TempDir(), "schemeless.http"),
+					Content: []byte("# @name probe" + "\n" + "GET " + target + "\n"),
+				},
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if got.Passed != 1 || got.Failed != 0 {
+				t.Fatalf("report = %+v, want one passing request", got)
+			}
+			if got.Results[0].Target != target {
+				t.Fatalf("source target = %q, want it unmodified", got.Results[0].Target)
+			}
+			select {
+			case uri := <-seen:
+				if uri != tt.want {
+					t.Fatalf("server request URI = %q, want %q", uri, tt.want)
+				}
+			default:
+				t.Fatal("server did not receive the request")
+			}
+		})
+	}
+}
+
 func TestRunCompareParityWithEnvResolve(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/helpdoc/topics/transport.md
+++ b/internal/helpdoc/topics/transport.md
@@ -14,4 +14,8 @@ Settings cover base URLs, TLS, proxies, redirects, cookies, HTTP versions, and c
 
 `base-url` accepts an absolute `http` or `https` URL with an optional port and path. Relative targets use standard URL rules: `users` joins the base path, `/users` replaces it, and `//other.example/users` may change the host. Keep a trailing slash when the last base path segment is a directory. Absolute request URLs ignore the setting.
 
+You can omit the scheme when a URL starts with a host and port. Resterm adds `http://`, so `GET localhost:8080/users` works. With `@websocket`, the same URL uses `ws://`. Bracketed IPv6 addresses, such as `[::1]`, also work without a port.
+
+A hostname without a port remains a relative URL, so write `http://example.com/users` when `example.com` is the destination. Templates are expanded before the same rules are applied: `localhost:8080` and `http://example.com` work as host values, while a bare `example.com` needs `base-url`.
+
 REST, GraphQL, SSE, and WebSocket share `base-url`; WebSockets map `http`/`https` to `ws`/`wss`. gRPC targets are unchanged. A request method is still required, for example `GET /health`.

--- a/internal/protocol/httpx/request_test.go
+++ b/internal/protocol/httpx/request_test.go
@@ -346,7 +346,7 @@ func TestBuildHTTPRequestSendsSchemelessLocalTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Do() error = %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("status = %s, want 204", resp.Status)
 	}

--- a/internal/protocol/httpx/request_test.go
+++ b/internal/protocol/httpx/request_test.go
@@ -3,6 +3,7 @@ package httpx
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -308,6 +309,65 @@ func TestBuildHTTPRequestUsesBaseURLForHTTPFamilyMetadata(t *testing.T) {
 				nil,
 				Options{BaseURL: "https://api.example.com/v1/"},
 			)
+			if err != nil {
+				t.Fatalf("BuildHTTPRequest() error = %v", err)
+			}
+			if got := httpReq.URL.String(); got != tt.want {
+				t.Fatalf("request URL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildHTTPRequestSendsSchemelessLocalTarget(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RequestURI() != "/users?page=2" {
+			t.Errorf("server request URI = %q", r.URL.RequestURI())
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	target := strings.TrimPrefix(srv.URL, "http://") + "/users?page=2"
+	req := &restfile.Request{Method: http.MethodGet, URL: target}
+
+	httpReq, _, _, err := NewClient(nil).BuildHTTPRequest(t.Context(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest() error = %v", err)
+	}
+	if got, want := httpReq.URL.String(), srv.URL+"/users?page=2"; got != want {
+		t.Fatalf("request URL = %q, want %q", got, want)
+	}
+	if req.URL != target {
+		t.Fatalf("source request URL was mutated to %q", req.URL)
+	}
+
+	resp, err := srv.Client().Do(httpReq)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %s, want 204", resp.Status)
+	}
+}
+
+func TestBuildHTTPRequestSchemelessWebSocketNeedsMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		ws   *restfile.WebSocketRequest
+		want string
+	}{
+		{name: "with @websocket", ws: &restfile.WebSocketRequest{}, want: "ws://localhost:8080/socket"},
+		{name: "without @websocket", want: "http://localhost:8080/socket"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &restfile.Request{
+				Method:    http.MethodGet,
+				URL:       "localhost:8080/socket",
+				WebSocket: tt.ws,
+			}
+			httpReq, _, _, err := NewClient(nil).BuildHTTPRequest(t.Context(), req, nil, Options{})
 			if err != nil {
 				t.Fatalf("BuildHTTPRequest() error = %v", err)
 			}

--- a/internal/protocol/httpx/target.go
+++ b/internal/protocol/httpx/target.go
@@ -42,7 +42,12 @@ func resolveRequestTarget(
 		return "", targetError("request url is empty")
 	}
 
-	ref, err := url.Parse(target)
+	form := classifyTarget(target)
+	if form == formCredentials {
+		return "", targetError("request url must not carry credentials, use @auth basic instead")
+	}
+
+	ref, err := form.parse(target)
 	if err != nil {
 		return "", wrapTargetError(err, "parse request url")
 	}
@@ -61,24 +66,111 @@ func resolveRequestTarget(
 		ref = base.ResolveReference(ref)
 	}
 
+	if ref.Hostname() == "" {
+		return "", targetError("request url host is empty")
+	}
 	if err := scheme.apply(ref); err != nil {
 		return "", err
 	}
 	return ref.String(), nil
 }
 
+// targetForm separates relative references, explicit schemes, and hosts that
+// need an http:// prefix.
+type targetForm int
+
+const (
+	formReference targetForm = iota
+	formAbsolute
+	// formAuthority is a host without a scheme, such as localhost:8080/users.
+	formAuthority
+	// formCredentials prevents net/http from turning URL userinfo into an
+	// Authorization header. For example: user@example.com:8080/path.
+	formCredentials
+)
+
+// classifyTarget examines only the first path segment. A colon there separates
+// either a scheme or a port; RFC relative paths cannot contain one there.
+func classifyTarget(raw string) targetForm {
+	front := raw
+	if end := strings.IndexAny(raw, "/?#"); end >= 0 {
+		front = raw[:end]
+	}
+
+	// An "@" can be part of a relative path. Treat it as userinfo only when a
+	// host and port follow it: user@example.com:8080 is rejected, while
+	// user@example.com/path remains relative.
+	if at := strings.LastIndexByte(front, '@'); at >= 0 {
+		if classifyTarget(raw[at+1:]) == formAuthority {
+			return formCredentials
+		}
+	}
+	// A bracketed IPv6 literal cannot begin a path, so it is always a host.
+	if strings.HasPrefix(front, "[") {
+		return formAuthority
+	}
+
+	colon := strings.IndexByte(front, ':')
+	switch {
+	case colon <= 0:
+		return formReference
+	case strings.HasPrefix(raw[colon+1:], "//"):
+		return formAbsolute
+	case isRequestScheme(front[:colon]):
+		// Do not treat https:443/path as a host named "https" and send it over
+		// plain HTTP. Known schemes without "//" remain invalid URLs.
+		return formAbsolute
+	case isPort(front[colon+1:]):
+		return formAuthority
+	default:
+		return formAbsolute
+	}
+}
+
+// isPort accepts one or more ASCII digits. net/url also accepts out-of-range
+// values such as 99999, so this checks the syntax without parsing the number.
+func isPort(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range len(s) {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isRequestScheme(head string) bool {
+	switch strings.ToLower(head) {
+	case "http", "https", "ws", "wss":
+		return true
+	}
+	return false
+}
+
+// parse adds http:// when the target is a host without a scheme.
+func (f targetForm) parse(raw string) (*url.URL, error) {
+	if f == formAuthority {
+		return url.Parse("http://" + raw)
+	}
+	return url.Parse(raw)
+}
+
 // apply rejects a scheme the request cannot use and maps http and https onto ws
 // and wss, so a single http base-url serves REST and WebSocket requests alike.
 func (s requestScheme) apply(u *url.URL) error {
-	if u.Hostname() == "" {
-		return targetError("request url host is empty")
-	}
-
 	if s == schemeHTTP {
-		if u.Scheme != "http" && u.Scheme != "https" {
+		switch u.Scheme {
+		case "http", "https":
+			return nil
+		case "ws", "wss":
+			// A ws:// URL still needs @websocket; the method alone does not
+			// start a WebSocket session.
+			return targetError("websocket request url needs a @websocket directive")
+		default:
 			return targetError("request url scheme must be http or https")
 		}
-		return nil
 	}
 
 	switch u.Scheme {

--- a/internal/protocol/httpx/target_form_test.go
+++ b/internal/protocol/httpx/target_form_test.go
@@ -1,0 +1,114 @@
+package httpx
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestClassifyTarget(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want targetForm
+	}{
+		// Relative references continue to use base-url.
+		{"", formReference},
+		{"users", formReference},
+		{"/users", formReference},
+		{"../health", formReference},
+		{"?page=2", formReference},
+		{"#section", formReference},
+		{"//up.example.com/x", formReference},
+		{"example.com/users", formReference},
+		{"example.com", formReference},
+		{"files/a:b", formReference},
+		{"a/b:c/d", formReference},
+		{":8080/users", formReference},
+		{":", formReference},
+
+		// Hosts without a scheme.
+		{"localhost:8080/users", formAuthority},
+		{"localhost:8080", formAuthority},
+		{"localhost:8080?q=1", formAuthority},
+		{"127.0.0.1:8080/users", formAuthority},
+		{"proxy.example.com:443", formAuthority},
+		{"[::1]:8080/users", formAuthority},
+		{"[::1]/path", formAuthority},
+		{"[::1]", formAuthority},
+		{"{{host}}:8080/x", formAuthority},
+		// A URL in a query or fragment must not affect how the request URL is
+		// classified.
+		{"localhost:8080/path?next=http://example.com", formAuthority},
+		{"localhost:8080/path#next=http://example.com", formAuthority},
+
+		// Explicit and opaque URI schemes.
+		{"http://x/y", formAbsolute},
+		{"https://x/y", formAbsolute},
+		{"ws://x/y", formAbsolute},
+		{"wss://x/y", formAbsolute},
+		{"HTTP://x/y", formAbsolute},
+		{"ftp://x/y", formAbsolute},
+		// A known scheme without "//" is an invalid absolute URL, not a host.
+		// Reading "https:443/path" as a host would reach a server called
+		// "https" over plain HTTP.
+		{"https:443/path", formAbsolute},
+		{"http:8080/path", formAbsolute},
+		{"ws:8080/path", formAbsolute},
+		{"localhost:/path", formAbsolute},
+		{"localhost:80a/x", formAbsolute},
+		{"mailto:someone@example.com", formAbsolute},
+		{"data:text/html,x", formAbsolute},
+		{"javascript:alert(1)", formAbsolute},
+		{"a:b/c", formAbsolute},
+		{"example.com:8080@evil.com/x", formAbsolute},
+	}
+
+	// Reject userinfo before a schemeless host because net/http would turn it
+	// into an Authorization header.
+	credentials := []struct {
+		raw  string
+		want targetForm
+	}{
+		{"user:pass@example.com:8080/x", formCredentials},
+		{"user@example.com:8080/path", formCredentials},
+		{"user@127.0.0.1:8080/path", formCredentials},
+		{"user@localhost:8080", formCredentials},
+		{"user@[::1]:8080/x", formCredentials},
+		{"[::1]@evil.com:8080/x", formCredentials},
+		{"u%40b@example.com:8080/x", formCredentials},
+		{"a@b@example.com:8080/x", formCredentials},
+		// An "@" with no host and port after it is an ordinary path character.
+		{"user@example.com/path", formReference},
+		{"user@example.com", formReference},
+		{"/users/user@example.com", formReference},
+		{"mailto:someone@example.com", formAbsolute},
+	}
+
+	tests = append(tests, credentials...)
+
+	names := map[targetForm]string{
+		formReference:   "reference",
+		formAbsolute:    "absolute",
+		formAuthority:   "authority",
+		formCredentials: "credentials",
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			if got := classifyTarget(tt.raw); got != tt.want {
+				t.Fatalf("classifyTarget(%q) = %s, want %s", tt.raw, names[got], names[tt.want])
+			}
+		})
+	}
+}
+
+// Keep isPort's syntax check in sync with net/url. An empty port is the one
+// deliberate exception: net/url allows localhost:/x, but Resterm rejects it.
+func TestIsPortAgreesWithNetURL(t *testing.T) {
+	for _, port := range []string{"8080", "0", "80", "08080", "99999", "65536", "80a", "+80", "-80", "8_080"} {
+		t.Run(port, func(t *testing.T) {
+			_, err := url.Parse("http://localhost:" + port + "/x")
+			if got, want := isPort(port), err == nil; got != want {
+				t.Fatalf("isPort(%q) = %v, but url.Parse accepts it = %v (%v)", port, got, want, err)
+			}
+		})
+	}
+}

--- a/internal/protocol/httpx/target_matrix_test.go
+++ b/internal/protocol/httpx/target_matrix_test.go
@@ -1,0 +1,101 @@
+package httpx
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// Generate combinations to check that a schemeless target never introduces
+// credentials or a destination host that was not present in the input.
+func TestResolveRequestTargetSchemelessInvariants(t *testing.T) {
+	userinfos := []string{"", "user@", "user:pass@", "user:@", ":pass@", "u%40b@", "user@host@"}
+	hosts := []string{"example.com", "127.0.0.1", "localhost", "[::1]", "sub.example.com"}
+	ports := []string{"", ":8080", ":443", ":80a", ":"}
+	paths := []string{"", "/", "/p", "/p/q"}
+	queries := []string{"", "?a=1", "?next=http://evil.example", "?next=https://evil.example/x"}
+	frags := []string{"", "#f", "#next=http://evil.example"}
+
+	checked := 0
+	for _, ui := range userinfos {
+		for _, h := range hosts {
+			for _, p := range ports {
+				for _, path := range paths {
+					for _, q := range queries {
+						for _, f := range frags {
+							raw := ui + h + p + path + q + f
+							checked++
+							u := resolveChecked(t, raw)
+							// Userinfo must not change the destination to the
+							// host after the "@".
+							if u != nil && ui != "" && u.Hostname() != "" &&
+								u.Hostname() != strings.Trim(h, "[]") {
+								t.Errorf("target %q resolved to host %q, want %q", raw, u.Hostname(), h)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	t.Logf("checked %d schemeless targets", checked)
+}
+
+// These malformed targets exercise delimiters and encodings that could change
+// the parsed host.
+func TestResolveRequestTargetHostileTargets(t *testing.T) {
+	for _, raw := range []string{
+		`localhost:8080\@evil.example/x`,
+		`localhost:8080%2F@evil.example/x`,
+		"localhost:8080/x\r\nHost: evil.example",
+		"localhost:8080\t/x",
+		"localhost:8080#@evil.example",
+		"localhost:8080?@evil.example",
+		"localhost:8080/..;@evil.example",
+		"localhost:8080@@evil.example/x",
+		"localhost:8080:9090/x",
+		"localhost:8080./x",
+		"localhost:8080\\evil.example",
+		"[::1]:8080@evil.example/x",
+		"user@localhost:8080@evil.example/x",
+		// These start like bracketed hosts but place userinfo after the bracket.
+		// They must be rejected rather than sent to the host after the "@".
+		"[::1]@evil.example/x",
+		"[::1]@evil.example:8080/x",
+		"[foo]@evil.example/x",
+		"[::1]x@evil.example/x",
+		"\u0435xample.com:8080/x", // A Cyrillic lookalike host.
+	} {
+		t.Run(raw, func(t *testing.T) {
+			resolveChecked(t, raw)
+		})
+	}
+}
+
+// resolveChecked returns the resolved URL after checking common safety rules.
+// It returns nil when the target is rejected.
+func resolveChecked(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	got, err := resolveRequestTarget(raw, "", nil, schemeHTTP)
+	if err != nil {
+		return nil
+	}
+
+	u, parseErr := url.Parse(got)
+	if parseErr != nil {
+		t.Fatalf("target %q resolved to unparseable %q: %v", raw, got, parseErr)
+	}
+
+	// net/http turns URL.User into an Authorization header, so a target that
+	// never named a scheme must never come back carrying credentials.
+	if u.User != nil {
+		t.Errorf("target %q resolved to %q, which carries userinfo %q", raw, got, u.User)
+	}
+
+	// A delimiter or query value must not introduce a different destination.
+	if u.Hostname() != "" && !strings.Contains(raw, u.Hostname()) {
+		t.Errorf("target %q resolved to host %q, which it never named", raw, u.Hostname())
+	}
+	return u
+}

--- a/internal/protocol/httpx/target_test.go
+++ b/internal/protocol/httpx/target_test.go
@@ -1,6 +1,7 @@
 package httpx
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -21,15 +22,110 @@ func TestResolveRequestTargetRFCReferences(t *testing.T) {
 		{name: "parent segment", target: "../health", base: base, want: "https://api.example.com/health"},
 		{name: "query only", target: "?page=2", base: base, want: "https://api.example.com/v1/?page=2"},
 		{name: "network path", target: "//uploads.example.com/x", base: base, want: "https://uploads.example.com/x"},
-		{name: "base without trailing slash", target: "users", base: "https://api.example.com/v1", want: "https://api.example.com/users"},
+		{
+			name:   "base without trailing slash",
+			target: "users",
+			base:   "https://api.example.com/v1",
+			want:   "https://api.example.com/users",
+		},
 		{name: "encoded path", target: "files/a%2Fb", base: base, want: "https://api.example.com/v1/files/a%2Fb"},
-		{name: "uppercase base scheme", target: "users", base: "HTTPS://api.example.com/v1/", want: "https://api.example.com/v1/users"},
-		{name: "absolute ignores invalid base", target: "https://other.example/x%2Fy?z=%2F", base: "://invalid", want: "https://other.example/x%2Fy?z=%2F"},
+		{
+			name:   "uppercase base scheme",
+			target: "users",
+			base:   "HTTPS://api.example.com/v1/",
+			want:   "https://api.example.com/v1/users",
+		},
+		{
+			name:   "absolute ignores invalid base",
+			target: "https://other.example/x%2Fy?z=%2F",
+			base:   "://invalid",
+			want:   "https://other.example/x%2Fy?z=%2F",
+		},
 		{name: "uppercase absolute scheme", target: "HTTPS://other.example/x", want: "https://other.example/x"},
-		{name: "websocket relative", target: "socket", base: base, scheme: schemeWebSocket, want: "wss://api.example.com/v1/socket"},
-		{name: "websocket explicit HTTP", target: "http://socket.example/x", base: "://invalid", scheme: schemeWebSocket, want: "ws://socket.example/x"},
-		{name: "websocket explicit WSS", target: "wss://socket.example/x", scheme: schemeWebSocket, want: "wss://socket.example/x"},
-		{name: "websocket uppercase WSS", target: "WSS://socket.example/x", scheme: schemeWebSocket, want: "wss://socket.example/x"},
+		{name: "host and port", target: "localhost:8080/users", want: "http://localhost:8080/users"},
+		{name: "host and port only", target: "localhost:8080", want: "http://localhost:8080"},
+		{name: "ipv4 host and port", target: "127.0.0.1:8080/users", want: "http://127.0.0.1:8080/users"},
+		{name: "ipv6 host and port", target: "[::1]:8080/users", want: "http://[::1]:8080/users"},
+		{name: "authority form", target: "proxy.example.com:443", want: "http://proxy.example.com:443"},
+		{name: "host and port with query", target: "localhost:8080/a?b=1", want: "http://localhost:8080/a?b=1"},
+		{
+			name:   "url valued query",
+			target: "localhost:8080/p?next=http://example.com",
+			want:   "http://localhost:8080/p?next=http://example.com",
+		},
+		{
+			name:   "url valued query with tls",
+			target: "localhost:8080/p?next=https://example.com/x&a=1",
+			want:   "http://localhost:8080/p?next=https://example.com/x&a=1",
+		},
+		{
+			name:   "url valued fragment",
+			target: "localhost:8080/p#next=http://example.com",
+			want:   "http://localhost:8080/p#next=http://example.com",
+		},
+		{name: "ipv6 without port", target: "[::1]/path", want: "http://[::1]/path"},
+		{name: "ipv6 bare", target: "[::1]", want: "http://[::1]"},
+		{
+			name:   "explicit userinfo is kept",
+			target: "http://user:pass@example.com/x",
+			want:   "http://user:pass@example.com/x",
+		},
+		{
+			name:   "host and port ignores base",
+			target: "localhost:8080/users",
+			base:   base,
+			want:   "http://localhost:8080/users",
+		},
+		{
+			name:   "bare name stays relative",
+			target: "example.com/users",
+			base:   base,
+			want:   "https://api.example.com/v1/example.com/users",
+		},
+		{
+			name:   "at sign in a path stays relative",
+			target: "user@example.com/path",
+			base:   base,
+			want:   "https://api.example.com/v1/user@example.com/path",
+		},
+		{
+			name:   "at sign in a path segment",
+			target: "users/user@example.com",
+			base:   base,
+			want:   "https://api.example.com/v1/users/user@example.com",
+		},
+		{
+			name:   "websocket host and port",
+			target: "localhost:8080/socket",
+			scheme: schemeWebSocket,
+			want:   "ws://localhost:8080/socket",
+		},
+		{
+			name:   "websocket relative",
+			target: "socket",
+			base:   base,
+			scheme: schemeWebSocket,
+			want:   "wss://api.example.com/v1/socket",
+		},
+		{
+			name:   "websocket explicit HTTP",
+			target: "http://socket.example/x",
+			base:   "://invalid",
+			scheme: schemeWebSocket,
+			want:   "ws://socket.example/x",
+		},
+		{
+			name:   "websocket explicit WSS",
+			target: "wss://socket.example/x",
+			scheme: schemeWebSocket,
+			want:   "wss://socket.example/x",
+		},
+		{
+			name:   "websocket uppercase WSS",
+			target: "WSS://socket.example/x",
+			scheme: schemeWebSocket,
+			want:   "wss://socket.example/x",
+		},
 	}
 
 	for _, tt := range tests {
@@ -57,6 +153,119 @@ func TestResolveRequestTargetExpandsTargetAndBase(t *testing.T) {
 	}
 	if want := "https://api.example.com/v2/users/42"; got != want {
 		t.Fatalf("resolveRequestTarget() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRequestTargetExpandsBeforeFillingInScheme(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		target string
+		base   string
+		want   string
+	}{
+		{name: "host and port", host: "localhost:8080", target: "{{host}}/users", want: "http://localhost:8080/users"},
+		{name: "ipv4 and port", host: "127.0.0.1:9000", target: "{{host}}/users", want: "http://127.0.0.1:9000/users"},
+		{
+			name:   "variable carries scheme",
+			host:   "http://example.com",
+			target: "{{host}}/users",
+			want:   "http://example.com/users",
+		},
+		{
+			name:   "bare name needs base",
+			host:   "example.com",
+			target: "{{host}}/users",
+			base:   "https://api.example.com/v1/",
+			want:   "https://api.example.com/v1/example.com/users",
+		},
+		{
+			name:   "scheme outside the template",
+			host:   "example.com",
+			target: "http://{{host}}/users",
+			want:   "http://example.com/users",
+		},
+		{
+			name:   "port inside the template",
+			host:   "8080",
+			target: "localhost:{{host}}/users",
+			want:   "http://localhost:8080/users",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{"host": tt.host}))
+			got, err := resolveRequestTarget(tt.target, tt.base, resolver, schemeHTTP)
+			if err != nil {
+				t.Fatalf("resolveRequestTarget() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveRequestTarget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveRequestTargetBareHostVariableNeedsBaseURL(t *testing.T) {
+	resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{"host": "example.com"}))
+
+	_, err := resolveRequestTarget("{{host}}/users", "", resolver, schemeHTTP)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if want := "requires a base-url setting"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want it to contain %q", err, want)
+	}
+}
+
+// Compare the parts sent over HTTP because net/url may normalize equivalent
+// input when it serializes a URL.
+func TestResolveRequestTargetPreservesAbsoluteURLs(t *testing.T) {
+	for _, raw := range []string{
+		"https://something:443/hello?name=david&hello#makesthat&not?",
+		"https://x/p?a=1&b=2&b=3&c=&d#frag",
+		"https://x/a%2Fb/c?q=%2F&r=a+b&s=a%20b#f%2Fg",
+		"http://x/p?next=https://y/z?deep=1#anchor",
+		"https://x/" + "über/päth?q=ü#ünicode",
+		"https://user:pass@x:8443/p?q=1#f",
+		"https://x/p;matrix=1/q?a[]=1&a[]=2",
+		"https://x?onlyquery#onlyfrag",
+		"https://x/p?q={{tpl}}&r=b",
+		"http://x:8080",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			want, err := url.Parse(raw)
+			if err != nil {
+				t.Fatalf("url.Parse(%q) error = %v", raw, err)
+			}
+
+			resolved, err := resolveRequestTarget(raw, "", nil, schemeHTTP)
+			if err != nil {
+				t.Fatalf("resolveRequestTarget() error = %v", err)
+			}
+			got, err := url.Parse(resolved)
+			if err != nil {
+				t.Fatalf("resolved %q does not parse: %v", resolved, err)
+			}
+
+			for _, f := range []struct {
+				name      string
+				want, got string
+			}{
+				{"scheme", want.Scheme, got.Scheme},
+				{"host", want.Host, got.Host},
+				{"escaped path", want.EscapedPath(), got.EscapedPath()},
+				{"query", want.RawQuery, got.RawQuery},
+				{"fragment", want.Fragment, got.Fragment},
+				{"userinfo", want.User.String(), got.User.String()},
+				{"request uri", want.RequestURI(), got.RequestURI()},
+			} {
+				if f.want != f.got {
+					t.Errorf("%s = %q, want %q (resolved %q)", f.name, f.got, f.want, resolved)
+				}
+			}
+		})
 	}
 }
 
@@ -99,15 +308,86 @@ func TestResolveRequestTargetReportsExpansionAndProtocolErrors(t *testing.T) {
 		scheme   requestScheme
 		want     string
 	}{
-		{name: "missing target variable", target: "{{path}}", base: "https://api.example.com/", resolver: vars.NewResolver(), want: "expand url"},
-		{name: "empty expanded target", target: "{{path}}", base: "https://api.example.com/", resolver: vars.NewResolver(vars.NewMapProvider("env", map[string]string{"path": ""})), want: "request url is empty"},
-		{name: "missing base variable", target: "users", base: "{{api}}", resolver: vars.NewResolver(), want: "expand base-url"},
+		{
+			name:     "missing target variable",
+			target:   "{{path}}",
+			base:     "https://api.example.com/",
+			resolver: vars.NewResolver(),
+			want:     "expand url",
+		},
+		{
+			name:     "empty expanded target",
+			target:   "{{path}}",
+			base:     "https://api.example.com/",
+			resolver: vars.NewResolver(vars.NewMapProvider("env", map[string]string{"path": ""})),
+			want:     "request url is empty",
+		},
+		{
+			name:     "missing base variable",
+			target:   "users",
+			base:     "{{api}}",
+			resolver: vars.NewResolver(),
+			want:     "expand base-url",
+		},
 		{name: "unsupported HTTP scheme", target: "ftp://api.example.com/x", want: "scheme must be http or https"},
+		{name: "mailto is not a host", target: "mailto:someone@example.com", want: "request url host is empty"},
+		{
+			name:   "credentials are not a host",
+			target: "user:pass@example.com:8080/x",
+			want:   "must not carry credentials",
+		},
+		{name: "non numeric port", target: "a:b/c", want: "request url host is empty"},
+		{name: "data url", target: "data:text/html,x", want: "request url host is empty"},
+		{name: "port without host", target: ":8080/users", want: "missing protocol scheme"},
+		{name: "https without slashes", target: "https:443/path", want: "request url host is empty"},
+		{name: "http without slashes", target: "http:8080/path", want: "request url host is empty"},
+		{name: "ws without slashes", target: "ws:8080/path", want: "request url host is empty"},
+		{name: "empty port", target: "localhost:/path", want: "request url host is empty"},
+		{name: "non numeric port", target: "localhost:80a/x", want: "request url host is empty"},
+		{name: "credentials before a host", target: "example.com:8080@evil.com/x", want: "request url host is empty"},
+		{name: "userinfo without a password", target: "user@example.com:8080/path", want: "must not carry credentials"},
+		{name: "userinfo before an ip", target: "user@127.0.0.1:8080/path", want: "must not carry credentials"},
+		{name: "userinfo before an ipv6 host", target: "user@[::1]:8080/x", want: "must not carry credentials"},
+		{
+			name:   "websocket scheme without directive",
+			target: "ws://example.com/s",
+			want:   "needs a @websocket directive",
+		},
+		{
+			name:   "secure websocket scheme without directive",
+			target: "wss://example.com/s",
+			want:   "needs a @websocket directive",
+		},
+		{name: "unexpanded host in scheme url", target: "http://{{host}}/status", want: "invalid character"},
+		{name: "unexpanded host with port", target: "{{host}}:8080/x", want: "parse request url"},
 		{name: "missing target host", target: "https:///x", want: "request url host is empty"},
-		{name: "base expands to empty", target: "users", base: "{{api}}", resolver: vars.NewResolver(vars.NewMapProvider("env", map[string]string{"api": ""})), want: "requires a base-url setting"},
-		{name: "websocket fragment", target: "socket#section", base: "https://api.example.com/", scheme: schemeWebSocket, want: "must not contain a fragment"},
-		{name: "websocket empty fragment", target: "socket#", base: "https://api.example.com/", scheme: schemeWebSocket, want: "must not contain a fragment"},
-		{name: "unsupported websocket scheme", target: "ftp://api.example.com/socket", scheme: schemeWebSocket, want: "scheme must be ws, wss, http or https"},
+		{
+			name:     "base expands to empty",
+			target:   "users",
+			base:     "{{api}}",
+			resolver: vars.NewResolver(vars.NewMapProvider("env", map[string]string{"api": ""})),
+			want:     "requires a base-url setting",
+		},
+		{
+			name:   "websocket fragment",
+			target: "socket#section",
+			base:   "https://api.example.com/",
+			scheme: schemeWebSocket,
+			want:   "must not contain a fragment",
+		},
+		{
+			name:   "websocket empty fragment",
+			target: "socket#",
+			base:   "https://api.example.com/",
+			scheme: schemeWebSocket,
+			want:   "must not contain a fragment",
+		},
+		{
+			name:   "unsupported websocket scheme",
+			target: "ftp://api.example.com/socket",
+			scheme: schemeWebSocket,
+			want:   "scheme must be ws, wss, http or https",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
* feat(http): fill in http when a target names a host and a port
* feat(http): refuse a schemeless target that carries userinfo
* fix(http): name the missing `@websocket` directive on a ws request url
* refactor(http): classify a request target before parsing it
* docs: describe schemeless targets and variable expansion