### PR TITLE
RST-340: infix operator

### DIFF
--- a/_examples/rts/rts_all_features.http
+++ b/_examples/rts/rts_all_features.http
@@ -9,7 +9,8 @@
 ### RTS Core Expressions + Standard Library
 # @name RTS_Core
 # @description Exercises expressions, operators, rts stdlib, and module calls.
-# @assert response.statusCode == 200
+# @assert response.statusCode in [200, 201, 204]
+# @assert response.statusCode not in [400, 404, 500]
 # @assert response.json("args.mode") == helpers.mode(env)
 # @assert response.json("args.tag") == loops.sampleTag
 # @assert response.json("headers.X-Encoded") == base64.encode("hello")

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -1241,7 +1241,7 @@ RestermScript (RST) powers templates (`{{= ... }}`) and directive expressions. I
 | `@apply` | `# @apply use=jsonApi,use=authProd` | Reuse named `@patch` profiles; entries run left-to-right and resolve file scope first, then globals. |
 | `@when` | `# @when vars.has("token")` | Run the request only when the expression is truthy. |
 | `@skip-if` | `# @skip-if env.mode == "dry-run"` | Skip the request when the expression is truthy. |
-| `@assert` | `# @assert response.statusCode == 200` | Evaluate an assertion after the response arrives. |
+| `@assert` | `# @assert response.statusCode in [200, 201]` | Evaluate an assertion after the response arrives. |
 | `@for-each` | `# @for-each json.file("users.json") as user` | Repeat the request for each item in a list. |
 | `@rts pre-request` | `# @rts pre-request` | Run a pre-request RST block with request/vars mutation helpers. Use `@assert` for RST response checks. The full `# @script pre-request lang=rts` form remains supported. |
 

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -113,7 +113,7 @@ Listed from tightest to loosest. Each level binds more tightly than the one belo
 - Unary: `not` or `!`, `try`, and unary `-`.
 - Multiplicative: `*`, `/`, and `%`.
 - Additive: `+` and `-`.
-- Comparison: `<`, `<=`, `>`, and `>=`.
+- Comparison: `<`, `<=`, `>`, `>=`, `in`, and `not in`.
 - Equality: `==` and `!=`.
 - Logical AND: `and` or `&&`.
 - Logical OR: `or` or `||`.
@@ -122,7 +122,52 @@ Listed from tightest to loosest. Each level binds more tightly than the one belo
 
 `??` sits near the bottom, so it binds looser than arithmetic, comparison, and both logical operators. `a ?? b + c` means `a ?? (b + c)`, and `a ?? b or c` means `a ?? (b or c)`. Parenthesise when you want the other grouping.
 
-`+` adds numbers or concatenates strings. Non numeric values are converted to string using `str()`. Comparisons only work for numbers or strings, and equality only works for primitive types.
+`+` adds numbers or concatenates strings. Non numeric values are converted to string using `str()`. Ordering comparisons only work for numbers or strings, and equality only works for primitive types.
+
+### Membership operators
+
+`value in container` is the infix form of `contains(container, value)`. `value not in container` applies the same membership test and negates its result:
+
+```rts
+response.statusCode in [200, 201, 204]
+"json" in response.header("Content-Type")
+"request_id" in response.json()
+response.statusCode not in [400, 404, 500]
+```
+
+The container determines how membership works:
+
+- A list compares each item to the value with RestermScript equality. Kinds must match, primitive values compare by value, and lists, dicts, functions, and objects are never deeply equal.
+- A string converts the value with `str()` and tests for a substring. The empty string is contained in every string.
+- A dict converts the value with `str()` and checks for an exact, case-sensitive key. `null` converts to the empty string, so `null in dict` asks for a `""` key.
+- Any other container is an evaluation error.
+
+Host bindings such as `response`, `vars`, and `env` are objects, not containers, so they take the error branch instead of testing membership. Use the accessor each one already provides: `vars.has("token")` rather than `"token" in vars`, and `"request_id" in response.json()` rather than `"request_id" in response`.
+
+`not in` is one comparison operator. Because unary `not` binds more tightly than every binary operator, write `value not in container`, not `not value in container`, when you want to negate membership. Like the existing ordering operators, membership is left-associative; comparisons are not rewritten into chained tests.
+
+`in` is contextual rather than reserved. It remains valid as a binding, function or module name, member, and dict key when it is not between two expressions:
+
+```rts
+let in = {in: true}
+in.in
+```
+
+In `.rts` modules and `@rts` blocks, a line may end after either membership operator:
+
+```rts
+let allowed = code in
+  [200, 201, 204]
+```
+
+Request-file directives retain their delimiter-based multiline rule. Open a group when a directive needs to span lines:
+
+```http
+# @assert (
+#   response.statusCode in
+#   [200, 201, 204]
+# )
+```
 
 ### Logical operators
 
@@ -507,7 +552,7 @@ RTS provides a small standard library that covers common request needs without e
 
 - `rts.fail(msg)` stops evaluation and returns an error message.
 - `rts.len(x)` returns the length of a string, list, or dict.
-- `rts.contains(haystack, needle)` checks whether a value is contained in a string, list, or dict.
+- `rts.contains(container, value)` applies the same membership relation as `value in container`.
 - `rts.match(pattern, text)` applies a regular expression to text and returns true when it matches.
 - `rts.str(x)` converts a value to a string, using JSON for lists and dicts.
 - `rts.num(x[, def])` converts a value to a number, or returns `def` when conversion fails.
@@ -787,7 +832,7 @@ These directives are evaluated before pre-request scripts. If the condition is f
 
 ```
 # @assert response.statusCode == 200
-# @assert contains(response.header("Content-Type"), "json")
+# @assert "json" in response.header("Content-Type")
 ```
 
 Each expression is evaluated and truthy means pass. Use `response` for the current request response.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -4195,6 +4195,22 @@ GET https://example.com
 	}
 }
 
+func TestParseAllowsContextualInAsRTSBindingName(t *testing.T) {
+	tests := map[string]string{
+		"use alias":   "# @use ./rts/helpers.rts as in\n",
+		"for-each as": "# @for-each [1] as in\n",
+		"for-each in": "# @for-each in in [1]\n",
+	}
+	for name, directive := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := Parse("contextual-in.http", []byte(directive+"GET https://example.com\n"))
+			if len(doc.Errors) != 0 {
+				t.Fatalf("expected no parse errors, got %v", doc.Errors)
+			}
+		})
+	}
+}
+
 func TestParseRecordsAuthAndRequestOrigin(t *testing.T) {
 	src := `# @auth file bearer {{fileToken}}
 

--- a/internal/rts/ast.go
+++ b/internal/rts/ast.go
@@ -190,6 +190,8 @@ const (
 	OpLe
 	OpGt
 	OpGe
+	OpIn
+	OpNotIn
 	OpAnd
 	OpOr
 	OpCoalesce

--- a/internal/rts/contains.go
+++ b/internal/rts/contains.go
@@ -1,0 +1,32 @@
+package rts
+
+import (
+	"slices"
+	"strings"
+)
+
+// ValueContains is the language's membership relation. It backs in, not in,
+// and contains(container, value).
+func ValueContains(ctx *Ctx, pos Pos, container, value Value) (bool, error) {
+	switch container.K {
+	case VList:
+		return slices.ContainsFunc(container.L, func(v Value) bool {
+			return ValueEqual(v, value)
+		}), nil
+	case VStr:
+		s, err := ToStr(ctx, pos, value)
+		if err != nil {
+			return false, err
+		}
+		return strings.Contains(container.S, s), nil
+	case VDict:
+		key, err := ToStr(ctx, pos, value)
+		if err != nil {
+			return false, err
+		}
+		_, ok := container.M[key]
+		return ok, nil
+	default:
+		return false, Errf(ctx, pos, "membership container must be string, list, or dict")
+	}
+}

--- a/internal/rts/lexer_test.go
+++ b/internal/rts/lexer_test.go
@@ -59,6 +59,25 @@ func TestKeywordClassSwitchCase(t *testing.T) {
 	}
 }
 
+func TestLexerKeepsInAsAnIdentifier(t *testing.T) {
+	got := lexKinds("in object.in {in: 1}")
+	want := []Kind{
+		IDENT,
+		IDENT, DOT, IDENT,
+		LBRACE, IDENT, COLON, NUMBER, RBRACE,
+		AUTO_SEMI, EOF,
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("kinds: got %v, want %v", got, want)
+	}
+	if IsKeyword("in") {
+		t.Fatal("in must remain available as a binding name")
+	}
+	if got := KeywordClassOf("in"); got != KeywordNone {
+		t.Fatalf("in keyword class = %v, want none", got)
+	}
+}
+
 func TestLexerNoSemiInCaseList(t *testing.T) {
 	k := lexKinds("switch x {\ncase 1,\n2:\n}\n")
 	for i := 0; i < len(k)-1; i++ {

--- a/internal/rts/parser.go
+++ b/internal/rts/parser.go
@@ -681,7 +681,36 @@ func (p *Parser) parseEq() Expr {
 }
 
 func (p *Parser) parseCmp() Expr {
-	return p.parseBinary(p.parseAdd, cmpOp)
+	left := p.parseAdd()
+	for {
+		pos := p.cur.P
+		op, ok := cmpOp(p.cur.K)
+		membership := false
+		switch {
+		case ok:
+			p.next()
+		case p.cur.K == IDENT && p.cur.Lit == "in":
+			op = OpIn
+			membership = true
+			p.next()
+		case p.cur.K == KW_NOT && p.peek.K == IDENT && p.peek.Lit == "in":
+			op = OpNotIn
+			membership = true
+			p.next()
+			p.next()
+		default:
+			return left
+		}
+
+		// in stays an identifier in the lexer, so it receives an automatic
+		// semicolon at a line boundary. Once the parser has identified it as
+		// an operator, that semicolon is continuation rather than punctuation.
+		if membership && p.cur.K == AUTO_SEMI {
+			p.next()
+		}
+		right := p.parseAdd()
+		left = &Binary{P: pos, Op: op, Left: left, Right: right}
+	}
 }
 
 func (p *Parser) parseAdd() Expr {

--- a/internal/rts/parser_test.go
+++ b/internal/rts/parser_test.go
@@ -759,6 +759,94 @@ func TestParseLogicalSymbolOperators(t *testing.T) {
 	}
 }
 
+func TestParseMembershipOperators(t *testing.T) {
+	tests := []struct {
+		src string
+		op  BinOp
+	}{
+		{"value in container", OpIn},
+		{"value not in container", OpNotIn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.src, func(t *testing.T) {
+			bin, ok := mustParseExpr(t, tt.src).(*Binary)
+			if !ok || bin.Op != tt.op {
+				t.Fatalf("expected operator %v, got %#v", tt.op, bin)
+			}
+		})
+	}
+}
+
+func TestParseMembershipPrecedence(t *testing.T) {
+	eq, ok := mustParseExpr(t, "1 + 1 in [2] == true").(*Binary)
+	if !ok || eq.Op != OpEq {
+		t.Fatalf("expected equality at the top, got %#v", eq)
+	}
+	in, ok := eq.Left.(*Binary)
+	if !ok || in.Op != OpIn {
+		t.Fatalf("expected membership below equality, got %T", eq.Left)
+	}
+	if add, ok := in.Left.(*Binary); !ok || add.Op != OpAdd {
+		t.Fatalf("expected addition below membership, got %T", in.Left)
+	}
+
+	and, ok := mustParseExpr(t, "value in container and ready").(*Binary)
+	if !ok || and.Op != OpAnd {
+		t.Fatalf("expected and at the top, got %#v", and)
+	}
+	if member, ok := and.Left.(*Binary); !ok || member.Op != OpIn {
+		t.Fatalf("expected membership below and, got %T", and.Left)
+	}
+
+	member, ok := mustParseExpr(t, "1 < 2 in [true]").(*Binary)
+	if !ok || member.Op != OpIn {
+		t.Fatalf("expected left-associated membership, got %#v", member)
+	}
+	if less, ok := member.Left.(*Binary); !ok || less.Op != OpLt {
+		t.Fatalf("expected comparison on the left, got %T", member.Left)
+	}
+}
+
+func TestParseMembershipKeepsInContextual(t *testing.T) {
+	src := `module in
+let in = {in: 1}
+let member = in.in
+fn pick(in) { return {in: in}.in }
+in = pick(in)
+let present = in in [in]
+let negated = not in
+`
+	if _, err := ParseModule("test", []byte(src)); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+}
+
+func TestParseMembershipContinuesAfterOperator(t *testing.T) {
+	tests := map[string]string{
+		"in":      "let x = 1 in\n  [1]\n",
+		"not in":  "let x = 1 not in\n  [2]\n",
+		"comment": "let x = 1 in # allowed values\n  [1]\n",
+	}
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			mod, err := ParseModule("test", []byte(src))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if len(mod.Stmts) != 1 {
+				t.Fatalf("statements = %d, want 1", len(mod.Stmts))
+			}
+		})
+	}
+}
+
+func TestParseMembershipDoesNotContinueAfterExplicitSemicolon(t *testing.T) {
+	_, err := ParseModule("test", []byte("let x = 1 in;\n  [1]\n"))
+	if err == nil {
+		t.Fatal("expected explicit semicolon after in to be rejected")
+	}
+}
+
 func TestParseBangIsNot(t *testing.T) {
 	un, ok := mustParseExpr(t, "!a").(*Unary)
 	if !ok || un.Op != UnNot {

--- a/internal/rts/stdlib/core.go
+++ b/internal/rts/stdlib/core.go
@@ -3,7 +3,6 @@ package stdlib
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/unkn0wn-root/resterm/internal/rts"
@@ -70,29 +69,11 @@ func coreContains(ctx *rts.Ctx, pos rts.Pos, args []rts.Value) (rts.Value, error
 		return rts.Null(), err
 	}
 
-	h := na.Arg(0)
-	n := na.Arg(1)
-	s, err := na.ToStr(1)
+	ok, err := rts.ValueContains(ctx, pos, na.Arg(0), na.Arg(1))
 	if err != nil {
 		return rts.Null(), err
 	}
-
-	switch h.K {
-	case rts.VStr:
-		return rts.Bool(strings.Contains(h.S, s)), nil
-	case rts.VList:
-		for _, it := range h.L {
-			if rts.ValueEqual(it, n) {
-				return rts.Bool(true), nil
-			}
-		}
-		return rts.Bool(false), nil
-	case rts.VDict:
-		_, ok := h.M[s]
-		return rts.Bool(ok), nil
-	default:
-		return rts.Null(), rts.Errf(ctx, pos, "contains unsupported")
-	}
+	return rts.Bool(ok), nil
 }
 
 func coreMatch(ctx *rts.Ctx, pos rts.Pos, args []rts.Value) (rts.Value, error) {

--- a/internal/rts/stdlib/stdlib_test.go
+++ b/internal/rts/stdlib/stdlib_test.go
@@ -35,8 +35,21 @@ func evalExprMod(t *testing.T, ctx *rts.Ctx, modSrc, expr string) rts.Value {
 	return comp.Exp["__v"]
 }
 
+func evalExprErrCtx(t *testing.T, ctx *rts.Ctx, src string) error {
+	t.Helper()
+	mod, err := rts.ParseModule("test", []byte("export let __v = "+src))
+	if err != nil {
+		t.Fatalf("parse mod: %v", err)
+	}
+	if _, err := rts.Exec(ctx, mod, New()); err != nil {
+		return err
+	}
+	t.Fatalf("expected eval error for %q", src)
+	return nil
+}
+
 func TestStdlibCore(t *testing.T) {
-	ctx := rts.NewCtx(context.Background(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
+	ctx := rts.NewCtx(t.Context(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
 	v := evalExprCtx(t, ctx, "len([1,2,3])")
 	if v.K != rts.VNum || v.N != 3 {
 		t.Fatalf("expected 3")
@@ -48,6 +61,58 @@ func TestStdlibCore(t *testing.T) {
 	v = evalExprCtx(t, ctx, "match(\"a.*\", \"abc\")")
 	if v.K != rts.VBool || v.B != true {
 		t.Fatalf("expected true")
+	}
+}
+
+func TestContainsMatchesMembershipOperators(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator string
+		call     string
+	}{
+		{name: "list", operator: `2 in [1, 2]`, call: `contains([1, 2], 2)`},
+		{name: "string", operator: `"ell" in "hello"`, call: `contains("hello", "ell")`},
+		{name: "dict", operator: `"a" in {a: 1}`, call: `contains({a: 1}, "a")`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := rts.NewCtx(t.Context(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
+			op := evalExprCtx(t, ctx, tt.operator)
+			call := evalExprCtx(t, ctx, tt.call)
+			if op.K != rts.VBool || call.K != rts.VBool || op.B != call.B {
+				t.Fatalf("operator=%+v call=%+v, want matching bools", op, call)
+			}
+		})
+	}
+}
+
+func TestContainsListValueIsNotStringified(t *testing.T) {
+	mod := `fn f() { return 1 }`
+	for _, expr := range []string{
+		`f in [f]`,
+		`contains([f], f)`,
+		`rts.contains([f], f)`,
+		`stdlib.contains([f], f)`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			ctx := rts.NewCtx(t.Context(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
+			v := evalExprMod(t, ctx, mod, expr)
+			if v.K != rts.VBool || v.B {
+				t.Fatalf("%s = %+v, want false", expr, v)
+			}
+		})
+	}
+}
+
+func TestContainsAndMembershipRejectSameContainer(t *testing.T) {
+	for _, expr := range []string{`1 in 2`, `contains(2, 1)`} {
+		t.Run(expr, func(t *testing.T) {
+			ctx := rts.NewCtx(t.Context(), rts.Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
+			err := evalExprErrCtx(t, ctx, expr)
+			if !strings.Contains(err.Error(), "membership container must be string, list, or dict") {
+				t.Fatalf("error = %v, want unsupported membership container", err)
+			}
+		})
 	}
 }
 

--- a/internal/rts/vm.go
+++ b/internal/rts/vm.go
@@ -817,6 +817,15 @@ func (vm *VM) evalBin(env *Env, e *Binary) (Value, error) {
 		return Bool(!ValueEqual(l, r)), nil
 	case OpLt, OpLe, OpGt, OpGe:
 		return cmp(vm.ctx, e.Pos(), e.Op, l, r)
+	case OpIn, OpNotIn:
+		ok, err := ValueContains(vm.ctx, e.Pos(), r, l)
+		if err != nil {
+			return Null(), err
+		}
+		if e.Op == OpNotIn {
+			ok = !ok
+		}
+		return Bool(ok), nil
 	}
 
 	return Null(), Errf(vm.ctx, e.Pos(), "bad op")

--- a/internal/rts/vm_test.go
+++ b/internal/rts/vm_test.go
@@ -11,7 +11,7 @@ func evalExpr(t *testing.T, src string) Value {
 	if err != nil {
 		t.Fatalf("parse expr: %v", err)
 	}
-	ctx := NewCtx(context.Background(), Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
+	ctx := NewCtx(t.Context(), Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024})
 	vm := &VM{ctx: ctx}
 	env := NewEnv(nil)
 	for k, v := range testStdlib() {
@@ -30,7 +30,7 @@ func execModule(t *testing.T, src string) *Comp {
 		t.Fatalf("parse: %v", err)
 	}
 	ctx := NewCtx(
-		context.Background(),
+		t.Context(),
 		Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024, MaxSteps: 10000},
 	)
 	comp, err := Exec(ctx, m, testStdlib())
@@ -46,7 +46,7 @@ func execModuleErr(t *testing.T, src string, lim Limits) error {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if _, err := Exec(NewCtx(context.Background(), lim), m, testStdlib()); err != nil {
+	if _, err := Exec(NewCtx(t.Context(), lim), m, testStdlib()); err != nil {
 		return err
 	}
 	t.Fatalf("expected exec error")
@@ -65,6 +65,14 @@ func wantNum(t *testing.T, comp *Comp, name string, want float64) {
 	t.Helper()
 	v, ok := comp.Env.Get(name)
 	if !ok || v.K != VNum || v.N != want {
+		t.Fatalf("expected %s=%v, got %+v (ok=%v)", name, want, v, ok)
+	}
+}
+
+func wantBool(t *testing.T, comp *Comp, name string, want bool) {
+	t.Helper()
+	v, ok := comp.Env.Get(name)
+	if !ok || v.K != VBool || v.B != want {
 		t.Fatalf("expected %s=%v, got %+v (ok=%v)", name, want, v, ok)
 	}
 }
@@ -115,6 +123,92 @@ func TestEvalLogic(t *testing.T) {
 	v = evalExpr(t, "null ?? 3")
 	if v.K != VNum || v.N != 3 {
 		t.Fatalf("expected 3")
+	}
+}
+
+func TestEvalMembership(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{name: "list member", src: `2 in [1, 2, 3]`, want: true},
+		{name: "list missing", src: `4 in [1, 2, 3]`, want: false},
+		{name: "list kind mismatch", src: `"2" in [2]`, want: false},
+		{name: "list null", src: `null in [null]`, want: true},
+		{name: "list collections are not deeply equal", src: `[1] in [[1]]`, want: false},
+		{name: "string substring", src: `"ell" in "hello"`, want: true},
+		{name: "string missing", src: `"world" in "hello"`, want: false},
+		{name: "string empty value", src: `"" in "hello"`, want: true},
+		{name: "string converts number", src: `23 in "1234"`, want: true},
+		{name: "string converts collection", src: `[1] in "[1]"`, want: true},
+		{name: "dict key", src: `"a" in {a: 1}`, want: true},
+		{name: "dict key is exact", src: `"A" in {a: 1}`, want: false},
+		{name: "dict converts key", src: `1 in {"1": true}`, want: true},
+		{name: "not in", src: `2 not in [1, 3]`, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := evalExpr(t, tt.src)
+			if v.K != VBool || v.B != tt.want {
+				t.Fatalf("%s = %+v, want %v", tt.src, v, tt.want)
+			}
+		})
+	}
+}
+
+func TestMembershipListValueIsNotStringified(t *testing.T) {
+	comp := execModule(t, `
+fn f() { return 1 }
+let present = f in [f]
+let absent = f not in [f]
+`)
+	wantBool(t, comp, "present", false)
+	wantBool(t, comp, "absent", true)
+}
+
+func TestMembershipStringValueConversionErrors(t *testing.T) {
+	err := execModuleErr(t, `
+fn f() { return 1 }
+let value = f in "function"
+`, Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024, MaxSteps: 100})
+	if !strings.Contains(err.Error(), "cannot stringify") {
+		t.Fatalf("error = %v, want string conversion failure", err)
+	}
+}
+
+func TestMembershipRejectsUnsupportedContainers(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "null", src: "let value = 1 in null\n"},
+		{name: "bool through not in", src: "let value = 1 not in true\n"},
+		{name: "number", src: "let value = 1 in 2\n"},
+		{name: "native", src: "let value = 1 in str\n"},
+		{name: "object", src: "let value = 1 in (try 1)\n"},
+		{name: "function", src: "fn f() { return 1 }\nlet value = 1 in f\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := execModuleErr(
+				t,
+				tt.src,
+				Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024, MaxSteps: 100},
+			)
+			if !strings.Contains(err.Error(), "membership container must be string, list, or dict") {
+				t.Fatalf("error = %v, want unsupported membership container", err)
+			}
+		})
+	}
+
+	err := execModuleErr(
+		t,
+		"let value = 1 in 2\n",
+		Limits{MaxStr: 1024, MaxList: 1024, MaxDict: 1024, MaxSteps: 100},
+	)
+	if !strings.Contains(err.Error(), "test:1:15:") {
+		t.Fatalf("error = %v, want operator position test:1:15", err)
 	}
 }
 

--- a/internal/rtshost/engine_test.go
+++ b/internal/rtshost/engine_test.go
@@ -61,7 +61,7 @@ func testRuntime(t *testing.T) Runtime {
 
 func evalHost(t *testing.T, eng *Engine, rt Runtime, src string) rts.Value {
 	t.Helper()
-	v, err := eng.Eval(context.Background(), rt, src, testPos)
+	v, err := eng.Eval(t.Context(), rt, src, testPos)
 	if err != nil {
 		t.Fatalf("Eval(%s): %v", src, err)
 	}
@@ -208,11 +208,14 @@ func TestRuntimeResponseAndAssertionBindings(t *testing.T) {
 	for _, src := range []string{
 		`status == 200`,
 		`statusCode == 200`,
+		`statusCode in [199, 200, 201]`,
+		`response.statusCode in [200]`,
+		`response.statusCode not in [400, 500]`,
 		`statusText == "200 OK"`,
 		`header("Content-Type") == "application/json"`,
 		`text() == "{\"ok\":true}"`,
 	} {
-		v, err := eng.EvalAssertion(context.Background(), rt, src, testPos)
+		v, err := eng.EvalAssertion(t.Context(), rt, src, testPos)
 		if err != nil {
 			t.Errorf("EvalAssertion(%s): %v", src, err)
 			continue

--- a/internal/ui/editor_rts_highlighter.go
+++ b/internal/ui/editor_rts_highlighter.go
@@ -163,6 +163,9 @@ func (s *rtsRuneStyler) computeStyles(line []rune) []lipgloss.Style {
 			}
 			token := string(line[start:i])
 			class := rts.KeywordClassOf(token)
+			if class == rts.KeywordNone && token == "in" && rtsInIsOperator(line, start) {
+				class = rts.KeywordLogical
+			}
 			if class != rts.KeywordNone {
 				if style, ok := s.keywordStyleForClass(class); ok {
 					p.paint(start, i, style)
@@ -279,6 +282,44 @@ func isRTSCall(line []rune, end int) bool {
 func isRTSMethod(line []rune, start int) bool {
 	i := prevNonSpace(line, start-1)
 	return i >= 0 && line[i] == '.'
+}
+
+// in is a contextual keyword, so it reads as the membership operator only when
+// it follows a complete operand on the same line. not in is that same operator,
+// so a not right before it is part of it and not the operand
+func rtsInIsOperator(line []rune, start int) bool {
+	i := prevNonSpace(line, start-1)
+	if word, ws := wordEndingAt(line, i); word == "not" {
+		i = prevNonSpace(line, ws-1)
+	}
+	return rtsEndsOperand(line, i)
+}
+
+func rtsEndsOperand(line []rune, i int) bool {
+	if i < 0 {
+		return false
+	}
+	switch ch := line[i]; {
+	case ch == ')' || ch == ']' || ch == '}' || ch == '"' || ch == '\'':
+		return true
+	case isRTSIdent(ch):
+		word, _ := wordEndingAt(line, i)
+		class := rts.KeywordClassOf(word)
+		return class == rts.KeywordNone || class == rts.KeywordLiteral
+	default:
+		return false
+	}
+}
+
+func wordEndingAt(line []rune, i int) (string, int) {
+	if i < 0 || !isRTSIdent(line[i]) {
+		return "", -1
+	}
+	start := i
+	for start > 0 && isRTSIdent(line[start-1]) {
+		start--
+	}
+	return string(line[start : i+1]), start
 }
 
 func prevNonSpace(line []rune, idx int) int {

--- a/internal/ui/editor_rts_highlighter_test.go
+++ b/internal/ui/editor_rts_highlighter_test.go
@@ -176,3 +176,55 @@ func TestRTSRuneStylerHighlightsMethodCall(t *testing.T) {
 		t.Fatalf("method call style mismatch:\nwant %q\n got %q", want, got)
 	}
 }
+
+func TestRTSRuneStylerHighlightsMembershipOperator(t *testing.T) {
+	p := theme.DefaultTheme().EditorMetadata
+	p.RTSKeywordLogical = lipgloss.Color("#112233")
+	st := newRTSRuneStyler(p)
+	rs, ok := st.(*rtsRuneStyler)
+	if !ok {
+		t.Fatalf("expected rts rune styler")
+	}
+
+	logical, ok := rs.keywordStyleForClass(rts.KeywordLogical)
+	if !ok {
+		t.Fatalf("expected logical keyword style")
+	}
+
+	tests := []struct {
+		src      string
+		at       string
+		operator bool
+	}{
+		{src: "let ok = code in [200, 201]", at: "in [", operator: true},
+		{src: "let ok = code not in [400]", at: "in [", operator: true},
+		{src: `let ok = "json" in ct`, at: "in ct", operator: true},
+		{src: "let ok = pick(1) in [1]", at: "in [", operator: true},
+		{src: "let ok = true in [true]", at: "in [", operator: true},
+		{src: "let ok = 1 in [1]", at: "in [", operator: true},
+		{src: "let in = 1", at: "in =", operator: false},
+		{src: "let x = in.field", at: "in.", operator: false},
+		{src: "fn pick(in) {", at: "in)", operator: false},
+		{src: "let d = {in: 1}", at: "in:", operator: false},
+		{src: "let y = not in", at: "in", operator: false},
+		{src: "in = pick(in)", at: "in =", operator: false},
+	}
+	for i, tt := range tests {
+		t.Run(tt.src, func(t *testing.T) {
+			idx := strings.Index(tt.src, tt.at)
+			if idx < 0 {
+				t.Fatalf("anchor %q missing from %q", tt.at, tt.src)
+			}
+
+			styles := rs.StylesForLine([]rune(tt.src), i)
+			got := styles[idx].GetForeground()
+			want := logical.GetForeground()
+			if tt.operator && got != want {
+				t.Fatalf("in color = %v, want logical %v", got, want)
+			}
+			if !tt.operator && got == want {
+				t.Fatalf("in used the logical keyword color as a name")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds contextual in and not in membership operators to RestermScript:

```
response.statusCode in [200, 201, 204]
response.statusCode not in [400, 404, 500]
```

Supports list membership, string substrings, and dict keys. Existing `contains()` behavior remains available. `in` is not reserved, so existing identifiers such as `in`, `object.in`, and `{in: value}` remain valid. Syntax highlighting, documentation, and tests are included.