### PR TITLE
fix(poll): timeout response and repeat durations

### DIFF
--- a/internal/engine/headless/cmp.go
+++ b/internal/engine/headless/cmp.go
@@ -92,15 +92,10 @@ func compareRow(meta core.RowMeta, out engine.RequestResult) engine.CompareRow {
 		Skipped:        out.Skipped,
 		SkipReason:     strings.TrimSpace(out.SkipReason),
 		Canceled:       canceled,
+		Duration:       out.Timing.Elapsed(),
 	}
 	if canceled {
 		row.Err = nil
-	}
-	switch {
-	case row.Response != nil:
-		row.Duration = row.Response.Duration
-	case row.GRPC != nil:
-		row.Duration = row.GRPC.Duration
 	}
 	return row
 }

--- a/internal/engine/headless/cmp_test.go
+++ b/internal/engine/headless/cmp_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/engine/request"
@@ -213,5 +214,62 @@ func TestExecuteGroupedCompareValidatesAllProfilesBeforeRequest(t *testing.T) {
 	}
 	if calls != 0 {
 		t.Fatalf("compare made %d requests before validation", calls)
+	}
+}
+
+func TestCompareRowDurationIncludesPollWaits(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		status := "pending"
+		if calls%3 == 0 {
+			status = "completed"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"status":%q}`, status); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	cl := newHTTPClientWithFactory(func(httpx.Options) (*http.Client, error) {
+		return srv.Client(), nil
+	})
+	rt := rtrun.New(rtrun.Config{Client: cl})
+	t.Cleanup(func() { _ = rt.Close() })
+	cfg := engine.Config{Client: cl}
+	eng := newWithDeps(request.New(cfg, rt), rt, cfg)
+
+	const every = 100 * time.Millisecond
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    srv.URL + "/jobs/1",
+		Metadata: restfile.RequestMetadata{
+			Name: "poll",
+			Poll: &restfile.PollSpec{
+				Every:   every,
+				Timeout: 10 * time.Second,
+				Until: restfile.ResponsePredicate{
+					Expression: `response.json().status == "completed"`,
+				},
+			},
+		},
+	}
+	doc := &restfile.Document{Path: "test.http", Requests: []*restfile.Request{req}}
+
+	out, err := eng.ExecuteCompare(doc, req, &restfile.CompareSpec{
+		Environments: []string{"one", "two"},
+		Baseline:     "one",
+	}, testSelection(""))
+	if err != nil {
+		t.Fatalf("ExecuteCompare: %v", err)
+	}
+	if len(out.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(out.Rows))
+	}
+	for _, row := range out.Rows {
+		if row.Duration < 2*every {
+			t.Fatalf("row %q duration = %s, want at least two poll waits", row.Environment, row.Duration)
+		}
 	}
 }

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"cmp"
 	"slices"
 	"time"
 
@@ -117,6 +118,12 @@ type Timing struct {
 	End       time.Time
 	Total     time.Duration
 	Transport time.Duration
+}
+
+// Elapsed is the wall time the run took, including @poll and @retry waits. It
+// falls back to transport time for results that were not timed.
+func (t Timing) Elapsed() time.Duration {
+	return cmp.Or(t.Total, t.Transport)
 }
 
 type CompareResult struct {

--- a/internal/exec/repeat.go
+++ b/internal/exec/repeat.go
@@ -28,6 +28,9 @@ type repeatRun struct {
 	poll   *restfile.PollSpec
 	retry  *restfile.RetrySpec
 
+	// A poll deadline can interrupt an attempt, and the partial response it
+	// returns must not replace the last completed one.
+	last   *httpx.Response
 	counts RepeatCount
 	warned bool
 }
@@ -125,6 +128,9 @@ func (x *repeatRun) retryCycle(ctx context.Context) (cycle, error) {
 		x.counts.Attempts++
 		resp, err := x.send(ctx)
 		at := time.Now()
+		if err == nil {
+			x.last = resp
+		}
 		x.progress(RepeatAttempt, resp, 0, err)
 
 		if ctx.Err() != nil {
@@ -251,6 +257,7 @@ func (x *repeatRun) exhausted(ctx context.Context, resp *httpx.Response) HTTPRes
 func (x *repeatRun) failed(resp *httpx.Response, err error) HTTPResult {
 	switch {
 	case errors.Is(err, ErrPollTimeout):
+		resp = x.last
 		err = diag.WrapAs(
 			diag.ClassTimeout,
 			fmt.Errorf(

--- a/internal/exec/repeat_test.go
+++ b/internal/exec/repeat_test.go
@@ -110,7 +110,12 @@ func TestRunHTTPResponseRetryHonorsRetryAfter(t *testing.T) {
 		client := repeatTestClient(func(req *http.Request) (*http.Response, error) {
 			attempts++
 			if attempts == 1 {
-				return repeatTestResponse(req, http.StatusServiceUnavailable, "busy", http.Header{"Retry-After": {"1"}}), nil
+				return repeatTestResponse(
+					req,
+					http.StatusServiceUnavailable,
+					"busy",
+					http.Header{"Retry-After": {"1"}},
+				), nil
 			}
 			return repeatTestResponse(req, http.StatusOK, "ok", nil), nil
 		})
@@ -230,6 +235,75 @@ func TestRunHTTPPollTimeoutKeepsLastResponseWithoutFinalizing(t *testing.T) {
 	})
 }
 
+func TestRunHTTPPollTimeoutDuringAttemptKeepsLastCompletedResponse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		attempts := 0
+		client := repeatTestClient(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return repeatTestResponse(req, http.StatusAccepted, "pending", nil), nil
+			}
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})
+		req := repeatTestRequest(nil)
+		req.Metadata.Poll = &restfile.PollSpec{
+			Every:   200 * time.Millisecond,
+			Timeout: time.Second,
+			Until:   restfile.ResponsePredicate{Expression: "false"},
+		}
+		result := Runner{Hooks: HTTPHooks{
+			EvaluatePredicate: func(PredicateInput) (bool, error) { return false, nil },
+		}}.RunHTTP(HTTPInput{
+			Client:           client,
+			Context:          t.Context(),
+			Req:              req,
+			EffectiveTimeout: 10 * time.Second,
+		})
+		if result.Err == nil || diag.ClassOf(result.Err) != diag.ClassTimeout {
+			t.Fatalf("RunHTTP() error = %v, want timeout", result.Err)
+		}
+		if result.Response == nil {
+			t.Fatal("last response = nil, want the completed attempt")
+		}
+		if got := string(result.Response.Body); got != "pending" {
+			t.Fatalf("last response body = %q, want %q", got, "pending")
+		}
+		if result.Response.StatusCode != http.StatusAccepted {
+			t.Fatalf("last response status = %d, want %d", result.Response.StatusCode, http.StatusAccepted)
+		}
+	})
+}
+
+func TestRunHTTPPollTimeoutWithoutCompletedAttemptHasNoResponse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := repeatTestClient(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})
+		req := repeatTestRequest(nil)
+		req.Metadata.Poll = &restfile.PollSpec{
+			Every:   200 * time.Millisecond,
+			Timeout: time.Second,
+			Until:   restfile.ResponsePredicate{Expression: "false"},
+		}
+		result := Runner{Hooks: HTTPHooks{
+			EvaluatePredicate: func(PredicateInput) (bool, error) { return false, nil },
+		}}.RunHTTP(HTTPInput{
+			Client:           client,
+			Context:          t.Context(),
+			Req:              req,
+			EffectiveTimeout: 10 * time.Second,
+		})
+		if result.Err == nil || diag.ClassOf(result.Err) != diag.ClassTimeout {
+			t.Fatalf("RunHTTP() error = %v, want timeout", result.Err)
+		}
+		if result.Response != nil {
+			t.Fatalf("response = %+v, want nil", result.Response)
+		}
+	})
+}
+
 func TestRunHTTPRetryWhenExhaustionIsFailedTest(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		client := repeatTestClient(func(req *http.Request) (*http.Response, error) {
@@ -253,7 +327,8 @@ func TestRunHTTPRetryWhenExhaustionIsFailedTest(t *testing.T) {
 		if result.Err != nil {
 			t.Fatalf("RunHTTP() error = %v", result.Err)
 		}
-		if len(result.Tests) != 1 || result.Tests[0].Passed || !strings.Contains(result.Tests[0].Message, "3 attempts") {
+		if len(result.Tests) != 1 || result.Tests[0].Passed ||
+			!strings.Contains(result.Tests[0].Message, "3 attempts") {
 			t.Fatalf("retry exhaustion tests = %+v", result.Tests)
 		}
 	})
@@ -365,7 +440,12 @@ func TestInvalidRetryAfterWarnsOnce(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		warnings := 0
 		client := repeatTestClient(func(req *http.Request) (*http.Response, error) {
-			return repeatTestResponse(req, http.StatusServiceUnavailable, "busy", http.Header{"Retry-After": {"later"}}), nil
+			return repeatTestResponse(
+				req,
+				http.StatusServiceUnavailable,
+				"busy",
+				http.Header{"Retry-After": {"later"}},
+			), nil
 		})
 		result := Runner{Hooks: HTTPHooks{
 			EvaluatePredicate: statusPredicate(http.StatusServiceUnavailable),

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"time"
+
 	"github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/engine/core"
 	xexec "github.com/unkn0wn-root/resterm/internal/exec"
@@ -60,6 +62,7 @@ type responseMsg struct {
 	historyDone    bool
 	latGen         int
 	target         runTarget
+	elapsed        time.Duration
 }
 
 // runTarget remembers which response pane a run was launched from so a late

--- a/internal/ui/model_compare_run.go
+++ b/internal/ui/model_compare_run.go
@@ -291,6 +291,7 @@ func (m *Model) consumeCompareRow(
 		Canceled:       canceled,
 		Skipped:        msg.skipped,
 		SkipReason:     msg.skipReason,
+		Duration:       msg.elapsed,
 	}
 	if state.group != "" {
 		result.Profile, _ = msg.selection.Profile(state.group)
@@ -528,7 +529,7 @@ func (m *Model) buildCompareHistoryResult(result compareResult) history.CompareR
 		Profile:              result.Profile,
 		EnvironmentSelection: history.EnvironmentSelection(result.Selection.Groups()),
 		Status:               status,
-		Duration:             compareRowDuration(&result),
+		Duration:             result.Duration,
 		RequestText:          strings.TrimSpace(result.RequestText),
 	}
 

--- a/internal/ui/model_compare_state.go
+++ b/internal/ui/model_compare_state.go
@@ -33,6 +33,7 @@ type compareResult struct {
 	Canceled       bool
 	Skipped        bool
 	SkipReason     string
+	Duration       time.Duration
 }
 
 func (m *Model) resetCompareState() {
@@ -104,7 +105,7 @@ func buildCompareBundle(results []compareResult, baseline string) *compareBundle
 			Result:   res,
 			Status:   status,
 			Code:     code,
-			Duration: compareRowDuration(res),
+			Duration: res.Duration,
 			Summary:  summarizeCompareDelta(base, res),
 		})
 	}
@@ -143,19 +144,6 @@ func compareRowStatus(result *compareResult) (string, string) {
 		return result.GRPC.StatusCode.String(), fmt.Sprintf("%d", result.GRPC.StatusCode)
 	default:
 		return "pending", "-"
-	}
-}
-
-func compareRowDuration(result *compareResult) time.Duration {
-	switch {
-	case result == nil:
-		return 0
-	case result.Response != nil:
-		return result.Response.Duration
-	case result.GRPC != nil:
-		return result.GRPC.Duration
-	default:
-		return 0
 	}
 }
 

--- a/internal/ui/model_compare_test.go
+++ b/internal/ui/model_compare_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/engine/core"
@@ -143,5 +144,33 @@ func TestCompareSpecForRequestRequiresMetadata(t *testing.T) {
 	}
 	if spec := model.compareSpecForRequest(req); spec != nil {
 		t.Fatalf("expected nil spec when request lacks metadata, got %#v", spec)
+	}
+}
+
+func TestConsumeCompareRowKeepsPollWallTime(t *testing.T) {
+	m := New(Config{})
+	st := &compareState{}
+	msg := m.responseMsgFromRunState(engine.RequestResult{
+		Environment: "dev",
+		Response:    &httpx.Response{Status: "200 OK", StatusCode: 200, Duration: 5 * time.Millisecond},
+		Timing:      engine.Timing{Total: 30 * time.Second, Transport: 5 * time.Millisecond},
+	}, false)
+
+	if _, _ = m.consumeCompareRow(
+		st,
+		&restfile.Request{Method: "GET", URL: "https://example.com"},
+		"dev",
+		msg,
+	); len(
+		st.results,
+	) != 1 {
+		t.Fatalf("rows = %d, want 1", len(st.results))
+	}
+	if got := st.results[0].Duration; got != 30*time.Second {
+		t.Fatalf("row duration = %s, want 30s", got)
+	}
+	bundle := buildCompareBundle(st.results, "dev")
+	if bundle.Rows[0].Duration != 30*time.Second {
+		t.Fatalf("bundle row duration = %s, want 30s", bundle.Rows[0].Duration)
 	}
 }

--- a/internal/ui/model_engine_consume.go
+++ b/internal/ui/model_engine_consume.go
@@ -59,6 +59,7 @@ func (m *Model) responseMsgFromRunState(res engine.RequestResult, done bool) res
 		preview:        res.Preview,
 		explain:        res.Explain,
 		historyDone:    done,
+		elapsed:        res.Timing.Elapsed(),
 	}
 }
 

--- a/internal/ui/model_workflow_display_test.go
+++ b/internal/ui/model_workflow_display_test.go
@@ -3,7 +3,11 @@ package ui
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/engine/core"
+	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 )
 
@@ -24,5 +28,28 @@ func TestWorkflowRunSubjectForEachUsesRequestBaseTitle(t *testing.T) {
 
 	if got, want := st.runSubject(), requestBaseTitle(req); got != want {
 		t.Fatalf("runSubject() = %q, want %q", got, want)
+	}
+}
+
+func TestWorkflowStepDurationIncludesPollWaits(t *testing.T) {
+	res := engine.RequestResult{
+		Executed: &restfile.Request{Method: "GET", URL: "https://example.com/jobs/1"},
+		Response: &httpx.Response{Status: "200 OK", StatusCode: 200, Duration: 5 * time.Millisecond},
+		Timing:   engine.Timing{Total: 30 * time.Second, Transport: 5 * time.Millisecond},
+	}
+	out := workflowResultFromRun(restfile.WorkflowStep{}, core.StepMeta{}, res, time.Minute)
+	if out.Duration != 30*time.Second {
+		t.Fatalf("step duration = %s, want 30s", out.Duration)
+	}
+}
+
+func TestWorkflowStepDurationFallsBackToStepWallTime(t *testing.T) {
+	res := engine.RequestResult{
+		Executed: &restfile.Request{Method: "GET", URL: "https://example.com/jobs/1"},
+		Skipped:  true,
+	}
+	out := workflowResultFromRun(restfile.WorkflowStep{}, core.StepMeta{}, res, 7*time.Millisecond)
+	if out.Duration != 7*time.Millisecond {
+		t.Fatalf("step duration = %s, want 7ms", out.Duration)
 	}
 }

--- a/internal/ui/model_workflow_run.go
+++ b/internal/ui/model_workflow_run.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"strings"
@@ -414,7 +415,7 @@ func workflowResultFromRun(
 ) workflowStepResult {
 	out := workflowStepResult{
 		Step:       step,
-		Duration:   dur,
+		Duration:   cmp.Or(res.Timing.Elapsed(), dur),
 		Iteration:  meta.Iter,
 		Total:      meta.Total,
 		Branch:     meta.Branch,
@@ -446,18 +447,12 @@ func workflowResultFromRun(
 	switch {
 	case res.Response != nil:
 		out.Status = res.Response.Status
-		if res.Response.Duration > 0 {
-			out.Duration = res.Response.Duration
-		}
 		if res.Response.StatusCode >= 400 && res.Err == nil && !hasExp {
 			ok = false
 			out.Message = fmt.Sprintf("unexpected status code %d", res.Response.StatusCode)
 		}
 	case res.GRPC != nil:
 		out.Status = res.GRPC.StatusCode.String()
-		if res.GRPC.Duration > 0 {
-			out.Duration = res.GRPC.Duration
-		}
 	case res.Stream != nil || len(res.Transcript) > 0:
 		out.Status = strings.TrimSpace(streamSummaryText(res.Stream))
 		if out.Status == "" {


### PR DESCRIPTION
A poll deadline that lands mid-attempt made HTTP return an empty partial response, and the repeat runner returned that instead of the last completed one. Track the most recent completed response and use it when the deadline
interrupts an attempt. With no completed attempt the result now carries no response at all, so the TUI stops claiming a response is shown and history stops recording status code 0.