### PR TITLE
RST-342: harden credentials, resource limits, and stream reporting

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,9 @@ These flags are shared by `resterm` and `resterm run` when request execution is 
 | `--timeout <duration>` | `-t <duration>` | Default HTTP timeout. |
 | `--insecure` | `-k` | Skip TLS certificate verification. |
 | `--follow` | `-L` | Follow redirects. Pass `--follow=false` or `-L=false` to disable it. |
+| `--max-redirects <n>` | | Maximum redirects to follow. The default is 10. Use `0` to disable redirects. |
 | `--proxy <url>` | `-x <url>` | HTTP proxy URL. |
+| `--max-response-size <size>` | | Largest response body to read, such as `100mb`. The default is 32 MiB. Use `none` to remove the limit. |
 | `--compare <envs>` | `-C <envs>` | Default comma/space-delimited compare targets. |
 | `--compare-base <env>` | `-B <env>` | Baseline environment for compare runs. |
 | `--compare-group <group>` |  | In grouped mode, vary this group while holding all other groups fixed. |

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -1524,7 +1524,7 @@ If the server returns a non-2xx status or a content type other than `text/event-
 | `context_canceled` | The run was cancelled. |
 | `error` | The stream failed. `summary.error` contains the error message. |
 
-Reaching `idle`, `duration`, `max-events`, or `max-bytes` ends the stream without an error. The saved data includes everything read before the limit was reached.
+Reaching `idle`, `duration`, `max-events`, or `max-bytes` ends the stream without an error. The saved data includes everything read before the limit was reached. If the stream ends for any other reason, the request fails and `summary.error` contains the error message. Resterm still saves the transcript.
 
 ### WebSockets (`@websocket`, `@ws`)
 
@@ -1564,7 +1564,17 @@ Supported `@ws` steps:
 | `@ws wait <duration>` | Pause for the specified duration (e.g. `500ms`). |
 | `@ws close [code] [reason]` | Close the connection with an optional status code (defaults to `1000`). |
 
-Handshake failures surface the HTTP response so upgrade issues are easy to debug. Successful sessions stream events into the UI and history with metadata for direction, opcode, sizes, and close status. The summary exposed to templates and scripts includes `sentCount`, `receivedCount`, `duration`, `closedBy`, `closeCode`, and `closeReason`.
+When the handshake fails, Resterm shows the HTTP response to help you find the problem. During a successful session, events appear in the UI and history together with their direction, opcode, size, and close status. Templates and scripts can read `sentCount`, `receivedCount`, `duration`, `closedBy`, `closeCode`, `closeReason`, and `dropped` from the summary. `closedBy` has one of these values:
+
+| Value | Meaning |
+| --- | --- |
+| `server` | The server closed the connection. |
+| `client` | Resterm closed the connection through `@ws close` or after the last step. |
+| `timeout` | The session reached its `idle` or `duration` limit. |
+| `canceled` | The run was cancelled. |
+| `error` | The session failed. `closeReason` contains the error message. |
+
+Only `error` and `canceled` cause the request to fail. Resterm keeps the transcript in every case.
 
 > **Heads-up:** When you keep a WebSocket URL in `@const`, `@global`, or `@var`, write the request line as `GET {{ws.url}}` (or whichever variable you use). The parser needs the explicit method to recognise the line as a WebSocket request before template expansion. Literal `ws://` / `wss://` URLs without a method still work when written directly.
 
@@ -1913,7 +1923,7 @@ Objects:
 - `stream`
   - `enabled()` - returns `true` when the current response is an SSE or WebSocket transcript.
   - `kind()` - returns `"sse"` or `"websocket"`.
-  - `summary()` - copy of the transcript summary (`sentCount`, `receivedCount`, `eventCount`, `duration`, etc.). `dropped` is always present; require it to be `0` when a test or capture needs the complete transcript. SSE failures use `reason: "error"` and put the detailed message in `error`.
+  - `summary()` - copy of the transcript summary (`sentCount`, `receivedCount`, `eventCount`, `duration`, etc.). The summary always includes `dropped`. If a test or capture needs every event, check that its value is `0`. For an SSE failure, `reason` is `"error"` and `error` contains the error message. Resterm also fails the request when the stream fails, so a test does not need to check for that separately.
   - `events()` - array of event objects (`data`/`comment` for SSE, `type`/`text`/`base64`/`direction` for WebSockets).
   - `onEvent(fn)` - registers a callback invoked for each event after the script runs; useful for assertions over the entire stream.
   - `onClose(fn)` - registers a callback invoked once with the summary after all events replay.
@@ -2222,14 +2232,17 @@ A template can also provide part of the URL. Both `GET http://{{host}}/users` an
 
   These rules cannot be changed:
 
-  - Credentials are never sent when a redirect moves from HTTPS to HTTP.
+  - If a redirect chain moves from HTTPS to HTTP, Resterm stops sending credentials for the rest of the chain. This also applies if a later redirect returns to HTTPS or to the original origin. The HTTP server controls every redirect that follows.
   - A `Cookie` header is never copied to another origin. The cookie jar may still add cookies that belong to the new origin.
   - OAuth token requests stay on the token endpoint's origin. A 307 or 308 redirect can resend the client secret in the body, so removing headers would not protect it.
+  - When a redirect goes to another origin, Resterm sends only the origin of the previous URL in the `Referer` header. It removes the path and query, so a key added with `@auth ... query` does not reach the new origin. Resterm checks each redirect separately. If the next URL has the same origin, the `Referer` keeps the full previous URL, even if an earlier redirect crossed an origin boundary. Resterm leaves an explicitly set `Referer` unchanged.
+
 - Resterm follows up to 10 redirects by default. Set another limit with `@setting max-redirects 20` or `--max-redirects`. Use `0` or `none` to stop at the first redirect. `@setting followredirects false` also stops at the first redirect. There is no unlimited setting because the request must stop if the server sends a redirect loop.
 - Response bodies are limited to 32 MiB. Change the limit with `@setting max-response-size 100mb`, `@setting max-response-size none`, or `--max-response-size`. Resterm checks the size after decompressing the body. A larger body stops the request with an error.
 - SSE lines are limited to 4 MiB and SSE events to 8 MiB. Change these limits with `@sse max-line-bytes` and `@sse max-event-bytes`. A larger line or event stops the stream with an error naming the limit to raise. Reaching `@sse max-bytes` ends the stream without an error. WebSocket messages are limited to 32 KiB unless `@websocket max-message-bytes` sets another limit.
 - Most events arrive as a single `data:` line, so the line limit is the one they reach first. Raise `max-line-bytes` along with `max-event-bytes` when a single line carries the whole payload. Base64 adds about a third to a payload, so a 3 MiB file needs roughly 4 MiB of headroom.
-- Resterm limits the stream data kept in memory. An SSE session keeps up to 1024 events and 16 MiB, or twice `max-event-bytes` when that is larger. The size of an SSE event includes its data, comment, id, name, and other saved fields. A WebSocket session and its saved transcript each have an 8 MiB limit. The Stream pane keeps up to 5000 events or 16 MiB. The summary reports removed events as `dropped`.
+- Resterm limits how much stream data it keeps in memory. An SSE session keeps up to 1024 events and 16 MiB, or twice `max-event-bytes` when that is larger. The size of an SSE event includes its data, comment, id, name, and other saved fields. A WebSocket session and its saved transcript each have an 8 MiB limit. The Stream pane keeps up to 5000 events or 16 MiB. If Resterm removes older events, the summary counts them in `dropped`. The Stream tab shows `Transcript incomplete` when its view is missing events.
+- Reaching `max-events`, `max-bytes`, `idle`, or `duration` is a normal way for a stream to end. Other problems fail the request. These include a read error, an SSE line or event that exceeds its limit, and a WebSocket session that ends with `closedBy: error`. Resterm still saves and reports the transcript it collected. With detailed exit codes, a stream error returns `26` and a cancelled run returns `130`.
 - Requests use an in-memory cookie jar per environment. Cookies are isolated between environments, and `@setting no-cookies true` disables cookies for a request without clearing the stored jar. Use `Ctrl+Shift+G` (or `g Shift+G`) to clear cookies for the current environment.
 - TLS per request: `# @settings http-root-cas=a.pem http-client-cert=cert.pem http-client-key=key.pem http-insecure=true` for a single line, or `@setting key value` per line (`http-root-cas` accepts space/comma/semicolon separated lists; paths are relative). GraphQL/REST/WebSocket/SSE all share these HTTP settings.
 - Use `@no-log` to omit sensitive bodies from history snapshots.
@@ -2271,7 +2284,8 @@ Resterm does not keep these actions inside the workspace. Review files you did n
 ### Safety limits
 
 - **Scripts.** Each script block stops after 30 seconds or when the run is canceled. Script memory has no limit.
-- **Redirects.** Resterm removes credential headers when a redirect goes to another origin. It also removes custom headers named by `@auth`. It cannot remove secrets from a request body. A 307 or 308 redirect can send the same body to the new target. OAuth token requests cannot leave the token endpoint's origin. See [HTTP Transport & Settings](#http-transport--settings).
+- **Redirects.** When a redirect goes to another origin, Resterm removes credential headers and any custom headers named by `@auth`. It also removes the path and query from the `Referer`, so a key in the query does not travel to the new origin. If the chain moves from HTTPS to HTTP, Resterm stops sending credentials for the rest of that chain. Resterm cannot remove secrets from a request body. A 307 or 308 redirect can send the same body to the new target. OAuth token requests cannot leave the token endpoint's origin. See [HTTP Transport & Settings](#http-transport--settings).
+- **Streams.** A stream can end normally when it reaches a configured limit. If it ends because of an error, the request fails. Resterm still saves and reports the events it collected.
 - **Response size.** Response bodies, SSE lines and events, WebSocket messages, and saved stream data have size limits.
 - **Secrets in output.** Resterm masks secrets it knows about and credential headers in history, explain output, and errors. Telemetry removes usernames, passwords, and fragments from URLs. It replaces query values with `REDACTED`.
 

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -19,6 +19,7 @@
 - [SSH Tunnels](#ssh-tunnels)
 - [Kubernetes Port-Forwards](#kubernetes-port-forwards)
 - [HTTP Transport & Settings](#http-transport--settings)
+- [Security](#security)
 - [Collection Sharing](#collection-sharing)
 - [Response History & Diffing](#response-history--diffing)
 - [CLI Reference](#cli-reference)
@@ -882,7 +883,7 @@ Some directives can span multiple comment lines. Resterm keeps reading while the
 | `@trace` | `# @trace dns<=40ms total<=200ms tolerance=25ms` | Enable per-phase tracing and optional latency budgets. |
 | `@no-log` | `# @no-log` | Prevents the response body snippet from being stored in history. |
 | `@log-sensitive-headers` | `# @log-sensitive-headers [true\|false]` | Allow allowlisted sensitive headers (Authorization, Proxy-Authorization, API-token headers such as `X-API-Key`, `X-Access-Token`, `X-Auth-Key`, etc.) to appear in history; omit or set to `false` to keep them masked (default). |
-| `@setting` | `# @setting key value` | Generic settings (transport/TLS today: `base-url`, `timeout`, `proxy`, `followredirects`, `insecure`, `no-cookies`, `http-*`, `grpc-*`). |
+| `@setting` | `# @setting key value` | Set an HTTP, transport, or TLS option such as `timeout`, `proxy`, `max-redirects`, or `max-response-size`. |
 | `@settings` | `# @settings key1=val1 key2=val2 ...` | Batch settings on one line; supports the same keys as `@setting` and future prefixes. |
 | `@timeout` | `# @timeout 5s` | Equivalent to `@setting timeout 5s`. |
 
@@ -1503,11 +1504,27 @@ GET https://api.example.com/notifications
 | Token | Description |
 | --- | --- |
 | `duration` / `timeout` | Maximum lifetime of the stream. Resterm cancels the request once the timer elapses. |
-| `idle` / `idle-timeout` | Maximum quiet period between events before the session is closed. |
-| `max-events` | Stop reading after N events have been delivered. |
-| `max-bytes` / `limit-bytes` | Cap the total payload size and close once the limit is exceeded. |
+| `idle` / `idle-timeout` | Longest time to wait for more data. Resterm cancels the request if no data arrives before this time. This limit is separate from `duration`. |
+| `max-events` | Stop after this many events. |
+| `max-bytes` / `limit-bytes` | Maximum amount of stream data to read. The stream ends when it reaches this limit. |
+| `max-line-bytes` | Largest allowed line. The default is 4 MiB. A larger line stops the stream with an error. |
+| `max-event-bytes` | Largest allowed event, counting every line it is built from. The default is 8 MiB. A larger event stops the stream with an error. |
 
-If the server responds with a non-2xx status or a non-`text/event-stream` content type, Resterm falls back to a standard HTTP response so you can inspect the error. Successful streams produce a transcript (events plus metadata) that appears in the Stream tab and is saved in history. The summary exposed to templates and scripts includes `eventCount`, `byteCount`, `duration`, and `reason` (for example `eof`, `timeout`, `idle-timeout`).
+If the server returns a non-2xx status or a content type other than `text/event-stream`, Resterm shows a normal HTTP response so you can inspect it. For a successful stream, Resterm shows the events and their details in the Stream tab and saves them in history. Templates and scripts can read `eventCount`, `byteCount`, `duration`, and `reason` from the summary. `reason` has one of these values:
+
+| Reason | Meaning |
+| --- | --- |
+| `eof` | The server closed the stream. |
+| `timeout:idle` | The stream went quiet for longer than `idle`. |
+| `timeout:total` | The stream ran for longer than `duration`. |
+| `limit:max_events` | `max-events` was reached. |
+| `limit:max_bytes` | `max-bytes` was reached. |
+| `limit:line_bytes` | One line was larger than `max-line-bytes`. |
+| `limit:event_bytes` | One event was larger than `max-event-bytes`. |
+| `context_canceled` | The run was cancelled. |
+| `error` | The stream failed. `summary.error` contains the error message. |
+
+Reaching `idle`, `duration`, `max-events`, or `max-bytes` ends the stream without an error. The saved data includes everything read before the limit was reached.
 
 ### WebSockets (`@websocket`, `@ws`)
 
@@ -1860,7 +1877,7 @@ GRPC {{grpc.host}}
 
 ## Scripting API
 
-Scripts run in an ES5.1-compatible Goja VM.
+Scripts use ES5.1 JavaScript. Each script block stops after 30 seconds or when the run is cancelled. Scripts are not restricted to the workspace. See [Security](#security).
 
 ### Pre-request scripts (`@script pre-request`)
 
@@ -2194,6 +2211,25 @@ A template can also provide part of the URL. Both `GET http://{{host}}/users` an
 - HTTP version: `@setting http-version 1.1` (accepts `1.1`, `2`, `HTTP/1.1`, `HTTP/2`). A trailing `HTTP/1.1` on the request line also sets the version; explicit settings win. `2` is strict and fails if the response is not HTTP/2. WebSocket requests are incompatible with `2`.
 - HTTP/1.0 is not supported. Resterm rejects `http-version 1.0`, trailing `HTTP/1.0`, and other unsupported version tokens such as `HTTP/3`.
 - Only a trailing `HTTP/<major>` or `HTTP/<major>.<minor>` is read as a version. Any other trailing text stays part of the URL, so `GET https://example.com/a http/foo` requests `/a%20http/foo`.
+- Resterm removes credentials before following a redirect to another origin. An origin is the scheme, host, and port. Changing any of these creates a different origin. Resterm removes known credential headers and any custom header named by `@auth`, even when that header was already on the request.
+- Use `@setting forward-credentials-on-redirect` to send credentials to specific origins:
+
+  ```http
+  # @setting forward-credentials-on-redirect https://cdn.example.com https://media.example.com
+  ```
+
+  Matches are exact. A listed origin does not include its subdomains or other ports. `wss://` matches the same origin as `https://`, and `ws://` matches the same origin as `http://`. The default is `false`. Use `true` to send credentials to any origin. A list is safer because it only allows the named origins. An empty value is an error.
+
+  These rules cannot be changed:
+
+  - Credentials are never sent when a redirect moves from HTTPS to HTTP.
+  - A `Cookie` header is never copied to another origin. The cookie jar may still add cookies that belong to the new origin.
+  - OAuth token requests stay on the token endpoint's origin. A 307 or 308 redirect can resend the client secret in the body, so removing headers would not protect it.
+- Resterm follows up to 10 redirects by default. Set another limit with `@setting max-redirects 20` or `--max-redirects`. Use `0` or `none` to stop at the first redirect. `@setting followredirects false` also stops at the first redirect. There is no unlimited setting because the request must stop if the server sends a redirect loop.
+- Response bodies are limited to 32 MiB. Change the limit with `@setting max-response-size 100mb`, `@setting max-response-size none`, or `--max-response-size`. Resterm checks the size after decompressing the body. A larger body stops the request with an error.
+- SSE lines are limited to 4 MiB and SSE events to 8 MiB. Change these limits with `@sse max-line-bytes` and `@sse max-event-bytes`. A larger line or event stops the stream with an error naming the limit to raise. Reaching `@sse max-bytes` ends the stream without an error. WebSocket messages are limited to 32 KiB unless `@websocket max-message-bytes` sets another limit.
+- Most events arrive as a single `data:` line, so the line limit is the one they reach first. Raise `max-line-bytes` along with `max-event-bytes` when a single line carries the whole payload. Base64 adds about a third to a payload, so a 3 MiB file needs roughly 4 MiB of headroom.
+- Resterm limits the stream data kept in memory. An SSE session keeps up to 1024 events and 16 MiB, or twice `max-event-bytes` when that is larger. The size of an SSE event includes its data, comment, id, name, and other saved fields. A WebSocket session and its saved transcript each have an 8 MiB limit. The Stream pane keeps up to 5000 events or 16 MiB. The summary reports removed events as `dropped`.
 - Requests use an in-memory cookie jar per environment. Cookies are isolated between environments, and `@setting no-cookies true` disables cookies for a request without clearing the stored jar. Use `Ctrl+Shift+G` (or `g Shift+G`) to clear cookies for the current environment.
 - TLS per request: `# @settings http-root-cas=a.pem http-client-cert=cert.pem http-client-key=key.pem http-insecure=true` for a single line, or `@setting key value` per line (`http-root-cas` accepts space/comma/semicolon separated lists; paths are relative). GraphQL/REST/WebSocket/SSE all share these HTTP settings.
 - Use `@no-log` to omit sensitive bodies from history snapshots.
@@ -2202,7 +2238,7 @@ A template can also provide part of the URL. Both `GET http://{{host}}/users` an
 - If the SQLite history file is detected as corrupted, Resterm quarantines it to `history.db.corrupt-<timestamp>` and initializes a fresh `history.db`.
 - Custom root CAs replace system roots by default (strict). Set `http-root-mode append` or `grpc-root-mode append` if you want to keep system roots in addition to your own.
 - File-level defaults: place `# @setting key value` or `# @settings key1=val1 ...` before the first request to apply to all requests in that file. Request-level overrides still win.
-- Settings are generic. Today the recognized prefixes are transport/TLS (`base-url`, `http-*`, `grpc-*`, `timeout`, `proxy`, `followredirects`, `insecure`, `no-cookies`). Future features can add more prefixes; unknown keys are ignored for now to stay forward-compatible.
+- HTTP, transport, and TLS settings include `base-url`, `http-*`, `grpc-*`, `timeout`, `proxy`, `followredirects`, `max-redirects`, `forward-credentials-on-redirect`, `max-response-size`, `insecure`, and `no-cookies`. Resterm ignores unknown keys.
 - Boolean settings (`followredirects`, `insecure`, `no-cookies`, `http-insecure`, `grpc-insecure`) accept `true`/`false`, `yes`/`no`, `on`/`off`, and `1`/`0`. A key written on its own is a flag meaning `true`, so `# @setting insecure`, `# @settings insecure`, and `# @setting insecure true` are the same thing. `@setting` also accepts the `key=value` spelling, so `# @setting insecure=false` means what `# @settings insecure=false` does.
 - Settings validate their values. A value outside a setting's vocabulary fails the request instead of falling back to a default, so a typo cannot silently leave TLS verification or redirects at the wrong setting. This covers booleans, `timeout` (a Go duration such as `30s`), `proxy` (a URL with a scheme and host, such as `http://host:8080`), `http-version`, and `http-root-mode`/`grpc-root-mode`. A non-empty `base-url` is resolved and validated only when a relative HTTP-family target needs it. Writing a key with an empty value (`# @settings insecure=`, or `"settings.insecure": ""` in an environment file) is reported as a missing value rather than treated as a flag.
 - Environment defaults: `resterm.env.json` can carry global settings under the `settings.` prefix (e.g., `"settings.base-url": "https://api.example.com/v1/"`, `"settings.http-root-cas": "ca-dev.pem"`, `"settings.grpc-insecure": "false"`). Precedence is global (env) < file < request.
@@ -2217,6 +2253,31 @@ Body helpers:
 - GraphQL payloads are normalized automatically.
 
 ---
+
+## Security
+
+### Request files can run commands and scripts
+
+A `.http` or `.rest` file can:
+
+- run a command through `@auth command`
+- read files inside or outside the workspace
+- run JavaScript from script and test blocks
+- write files through `response.saveBody`
+- connect to hosts through a proxy, SSH tunnel, or Kubernetes port-forward
+
+Resterm does not keep these actions inside the workspace. Review files you did not write before running them. Only run request files, imported collections, and `.rts` files from sources you trust.
+
+### Safety limits
+
+- **Scripts.** Each script block stops after 30 seconds or when the run is canceled. Script memory has no limit.
+- **Redirects.** Resterm removes credential headers when a redirect goes to another origin. It also removes custom headers named by `@auth`. It cannot remove secrets from a request body. A 307 or 308 redirect can send the same body to the new target. OAuth token requests cannot leave the token endpoint's origin. See [HTTP Transport & Settings](#http-transport--settings).
+- **Response size.** Response bodies, SSE lines and events, WebSocket messages, and saved stream data have size limits.
+- **Secrets in output.** Resterm masks secrets it knows about and credential headers in history, explain output, and errors. Telemetry removes usernames, passwords, and fragments from URLs. It replaces query values with `REDACTED`.
+
+### Telemetry
+
+When `@trace` sends data to an OTLP collector, the collector receives the host and path of each request. Resterm replaces query values with `REDACTED` and removes usernames, passwords, and fragments from URLs. It applies the same rules to URLs in errors, including redirect targets. Request and response bodies are never sent. Use a collector you trust.
 
 ## Collection Sharing
 

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -1345,7 +1345,7 @@ Expressions can reference:
 - `response.statusCode`, `response.statusText`, `response.text()`
 - `response.headers["header-name"]` or `response.header("Header-Name")` for a single-valued header
 - `response.json.path` shorthand (equivalent to `response.json().path`)
-- `stream.kind()`, `stream.summary().sentCount`, `stream.events()[0].text` for streaming transcripts (available when the request used `@sse` or `@websocket`)
+- `stream.kind()`, `stream.summary().sentCount`, `stream.summary().dropped`, and `stream.events()[0].text` for streaming transcripts (available when the request used `@sse` or `@websocket`). A non-zero `dropped` value means the retained transcript is incomplete.
 - `vars.*`, `env.*`, `last.*`, imported `@use` modules, and other RestermScript helpers
 
 Example:
@@ -1510,7 +1510,7 @@ GET https://api.example.com/notifications
 | `max-line-bytes` | Largest allowed line. The default is 4 MiB. A larger line stops the stream with an error. |
 | `max-event-bytes` | Largest allowed event, counting every line it is built from. The default is 8 MiB. A larger event stops the stream with an error. |
 
-If the server returns a non-2xx status or a content type other than `text/event-stream`, Resterm shows a normal HTTP response so you can inspect it. For a successful stream, Resterm shows the events and their details in the Stream tab and saves them in history. Templates and scripts can read `eventCount`, `byteCount`, `duration`, and `reason` from the summary. `reason` has one of these values:
+If the server returns a non-2xx status or a content type other than `text/event-stream`, Resterm shows a normal HTTP response so you can inspect it. For a successful stream, Resterm shows the events and their details in the Stream tab and saves them in history. Templates and scripts can read `eventCount`, `byteCount`, `duration`, `reason`, `error`, and `dropped` from the summary. A non-zero `dropped` value means the retained transcript is incomplete. `reason` has one of these values:
 
 | Reason | Meaning |
 | --- | --- |
@@ -1913,7 +1913,7 @@ Objects:
 - `stream`
   - `enabled()` - returns `true` when the current response is an SSE or WebSocket transcript.
   - `kind()` - returns `"sse"` or `"websocket"`.
-  - `summary()` - copy of the transcript summary (`sentCount`, `receivedCount`, `eventCount`, `duration`, etc.).
+  - `summary()` - copy of the transcript summary (`sentCount`, `receivedCount`, `eventCount`, `duration`, etc.). `dropped` is always present; require it to be `0` when a test or capture needs the complete transcript. SSE failures use `reason: "error"` and put the detailed message in `error`.
   - `events()` - array of event objects (`data`/`comment` for SSE, `type`/`text`/`base64`/`direction` for WebSockets).
   - `onEvent(fn)` - registers a callback invoked for each event after the script runs; useful for assertions over the entire stream.
   - `onClose(fn)` - registers a callback invoked once with the summary after all events replay.

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -740,7 +740,7 @@ Other expressions run before the current request completes. Use `last` for the p
 
 ### stream
 
-`stream` provides streaming metadata for SSE and WebSocket requests. It includes helpers such as `stream.enabled()`, `stream.kind()`, `stream.summary()`, and `stream.events()`. Summary and event shapes depend on the stream type (for SSE: `eventCount`, `byteCount`, `duration`, `reason`; for WebSocket: `sentCount`, `receivedCount`, `duration`, `closedBy`, `closeCode`, `closeReason`).
+`stream` provides information about SSE and WebSocket requests. Its helpers include `stream.enabled()`, `stream.kind()`, `stream.summary()`, and `stream.events()`. The summary and event fields depend on the stream type. SSE summaries include `eventCount`, `byteCount`, `duration`, `reason`, `error`, and `dropped`. WebSocket summaries include `sentCount`, `receivedCount`, `duration`, `closedBy`, `closeCode`, `closeReason`, and `dropped`. A non-zero `dropped` value means that some events are missing from the transcript. If a stream fails, its request fails too.
 
 ### mock
 

--- a/headless/build.go
+++ b/headless/build.go
@@ -185,28 +185,26 @@ func httpOptions(opt HTTPOptions) (httpx.Options, error) {
 		ProxyURL:           str.Trim(opt.ProxyURL),
 	}
 	if opt.MaxRedirects != nil {
-		if *opt.MaxRedirects < 0 {
-			return httpx.Options{}, UsageError{err: fmt.Errorf(
-				"http.maxRedirects: %d must be non-negative",
-				*opt.MaxRedirects,
-			)}
+		if err := nonNegative("http.maxRedirects", int64(*opt.MaxRedirects)); err != nil {
+			return httpx.Options{}, err
 		}
 		out.MaxRedirects = restfile.OptOf(*opt.MaxRedirects)
 	}
 	if opt.MaxResponseBytes != nil {
-		if *opt.MaxResponseBytes < 0 {
-			return httpx.Options{}, UsageError{err: fmt.Errorf(
-				"http.maxResponseBytes: %d must be non-negative",
-				*opt.MaxResponseBytes,
-			)}
+		if err := nonNegative("http.maxResponseBytes", *opt.MaxResponseBytes); err != nil {
+			return httpx.Options{}, err
 		}
-		if *opt.MaxResponseBytes == 0 {
-			out.MaxResponseBytes = bytesize.Unlimited()
-		} else {
-			out.MaxResponseBytes = bytesize.Of(*opt.MaxResponseBytes)
-		}
+		// Zero means no limit, the same as max-response-size none.
+		out.MaxResponseBytes = bytesize.Of(*opt.MaxResponseBytes)
 	}
 	return out, nil
+}
+
+func nonNegative(name string, value int64) error {
+	if value < 0 {
+		return UsageError{err: fmt.Errorf("%s: %d must be non-negative", name, value)}
+	}
+	return nil
 }
 
 func grpcOptions(opt GRPCOptions) grpcx.Options {

--- a/headless/build.go
+++ b/headless/build.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
 	"github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
@@ -68,7 +69,9 @@ func buildOptions(o Options) (runner.Options, error) {
 	if err := b.buildCompare(); err != nil {
 		return runner.Options{}, err
 	}
-	b.buildHTTP()
+	if err := b.buildHTTP(); err != nil {
+		return runner.Options{}, err
+	}
 	b.buildGRPC()
 	b.finalize()
 	return b.out, nil
@@ -148,8 +151,13 @@ func (b *builder) buildCompare() error {
 	return nil
 }
 
-func (b *builder) buildHTTP() {
-	b.out.HTTPOptions = httpOptions(b.opt.HTTP)
+func (b *builder) buildHTTP() error {
+	opts, err := httpOptions(b.opt.HTTP)
+	if err != nil {
+		return err
+	}
+	b.out.HTTPOptions = opts
+	return nil
 }
 
 func (b *builder) buildGRPC() {
@@ -169,13 +177,36 @@ func (b *builder) finalize() {
 	b.out.Profile = b.opt.Profile.Enabled
 }
 
-func httpOptions(opt HTTPOptions) httpx.Options {
-	return httpx.Options{
+func httpOptions(opt HTTPOptions) (httpx.Options, error) {
+	out := httpx.Options{
 		Timeout:            timeoutOf(opt.Timeout),
 		FollowRedirects:    boolOr(opt.FollowRedirects, true),
 		InsecureSkipVerify: opt.InsecureSkipVerify,
 		ProxyURL:           str.Trim(opt.ProxyURL),
 	}
+	if opt.MaxRedirects != nil {
+		if *opt.MaxRedirects < 0 {
+			return httpx.Options{}, UsageError{err: fmt.Errorf(
+				"http.maxRedirects: %d must be non-negative",
+				*opt.MaxRedirects,
+			)}
+		}
+		out.MaxRedirects = restfile.OptOf(*opt.MaxRedirects)
+	}
+	if opt.MaxResponseBytes != nil {
+		if *opt.MaxResponseBytes < 0 {
+			return httpx.Options{}, UsageError{err: fmt.Errorf(
+				"http.maxResponseBytes: %d must be non-negative",
+				*opt.MaxResponseBytes,
+			)}
+		}
+		if *opt.MaxResponseBytes == 0 {
+			out.MaxResponseBytes = bytesize.Unlimited()
+		} else {
+			out.MaxResponseBytes = bytesize.Of(*opt.MaxResponseBytes)
+		}
+	}
+	return out, nil
 }
 
 func grpcOptions(opt GRPCOptions) grpcx.Options {

--- a/headless/options.go
+++ b/headless/options.go
@@ -86,6 +86,8 @@ type Selection struct {
 type HTTPOptions struct {
 	Timeout            time.Duration `json:"timeout,omitempty"`
 	FollowRedirects    *bool         `json:"followRedirects,omitempty"`
+	MaxRedirects       *int          `json:"maxRedirects,omitempty"`
+	MaxResponseBytes   *int64        `json:"maxResponseBytes,omitempty"`
 	InsecureSkipVerify bool          `json:"insecureSkipVerify,omitempty"`
 	ProxyURL           string        `json:"proxyURL,omitempty"`
 }

--- a/headless/run_test.go
+++ b/headless/run_test.go
@@ -310,6 +310,12 @@ func TestBuildOptionsUseDefaults(t *testing.T) {
 	if got.HTTPOptions.Timeout != DefaultHTTPTimeout || !got.HTTPOptions.FollowRedirects {
 		t.Fatalf("unexpected http defaults: %+v", got.HTTPOptions)
 	}
+	if _, ok := got.HTTPOptions.MaxRedirects.Get(); ok {
+		t.Fatalf("default MaxRedirects is explicitly set: %+v", got.HTTPOptions.MaxRedirects)
+	}
+	if got.HTTPOptions.MaxResponseBytes.Set() {
+		t.Fatalf("default MaxResponseBytes is explicitly set: %+v", got.HTTPOptions.MaxResponseBytes)
+	}
 	if v, ok := got.GRPCOptions.DefaultPlaintext.Get(); !ok || !v {
 		t.Fatalf("unexpected grpc defaults: %+v", got.GRPCOptions)
 	}
@@ -352,6 +358,84 @@ func TestBuildOptionsRespectExplicitBoolOptions(t *testing.T) {
 	}
 	if got.GRPCOptions.DefaultPlaintext.Or(true) {
 		t.Fatalf("expected plaintext=false, got %+v", got.GRPCOptions)
+	}
+}
+
+func TestBuildOptionsRespectHTTPBounds(t *testing.T) {
+	dir := t.TempDir()
+	maxRedirects := 3
+	maxResponseBytes := int64(64 << 20)
+	got, err := buildOptions(Options{
+		Source: Source{Path: filepath.Join(dir, "one.http")},
+		HTTP: HTTPOptions{
+			MaxRedirects:     &maxRedirects,
+			MaxResponseBytes: &maxResponseBytes,
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildOptions: %v", err)
+	}
+	if value, ok := got.HTTPOptions.MaxRedirects.Get(); !ok || value != maxRedirects {
+		t.Fatalf("MaxRedirects = %d (set %t), want %d", value, ok, maxRedirects)
+	}
+	if value := got.HTTPOptions.MaxResponseBytes.Or(-1); value != maxResponseBytes {
+		t.Fatalf("MaxResponseBytes = %d, want %d", value, maxResponseBytes)
+	}
+}
+
+func TestBuildOptionsAllowDisablingHTTPBounds(t *testing.T) {
+	dir := t.TempDir()
+	zeroRedirects := 0
+	unlimitedResponse := int64(0)
+	got, err := buildOptions(Options{
+		Source: Source{Path: filepath.Join(dir, "one.http")},
+		HTTP: HTTPOptions{
+			MaxRedirects:     &zeroRedirects,
+			MaxResponseBytes: &unlimitedResponse,
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildOptions: %v", err)
+	}
+	if value, ok := got.HTTPOptions.MaxRedirects.Get(); !ok || value != 0 {
+		t.Fatalf("MaxRedirects = %d (set %t), want an explicit zero", value, ok)
+	}
+	if !got.HTTPOptions.MaxResponseBytes.Set() || got.HTTPOptions.MaxResponseBytes.Or(-1) != 0 {
+		t.Fatalf("MaxResponseBytes = %+v, want an explicit unlimited budget",
+			got.HTTPOptions.MaxResponseBytes)
+	}
+}
+
+func TestBuildOptionsRejectNegativeHTTPBounds(t *testing.T) {
+	negativeInt := -1
+	negativeInt64 := int64(-1)
+	tests := []struct {
+		name string
+		http HTTPOptions
+		want string
+	}{
+		{
+			name: "redirects",
+			http: HTTPOptions{MaxRedirects: &negativeInt},
+			want: "http.maxRedirects",
+		},
+		{
+			name: "response bytes",
+			http: HTTPOptions{MaxResponseBytes: &negativeInt64},
+			want: "http.maxResponseBytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildOptions(Options{
+				Source: Source{Path: filepath.Join(t.TempDir(), "one.http")},
+				HTTP:   tt.http,
+			})
+			if !IsUsageError(err) || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want a usage error containing %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/headless/types_test.go
+++ b/headless/types_test.go
@@ -77,6 +77,16 @@ func TestJSONTags(t *testing.T) {
 			name: "FollowRedirects",
 			tag:  "followRedirects,omitempty",
 		},
+		{
+			typ:  reflect.TypeFor[HTTPOptions](),
+			name: "MaxRedirects",
+			tag:  "maxRedirects,omitempty",
+		},
+		{
+			typ:  reflect.TypeFor[HTTPOptions](),
+			name: "MaxResponseBytes",
+			tag:  "maxResponseBytes,omitempty",
+		},
 		{typ: reflect.TypeFor[GRPCOptions](), name: "Plaintext", tag: "plaintext,omitempty"},
 		{typ: reflect.TypeFor[Report](), name: "SchemaVersion", tag: ""},
 		{typ: reflect.TypeFor[Report](), name: "FilePath", tag: ""},

--- a/internal/bytesize/budget.go
+++ b/internal/bytesize/budget.go
@@ -1,0 +1,34 @@
+package bytesize
+
+import "strings"
+
+type Budget struct {
+	limit int64
+	set   bool
+}
+
+func Of(limit int64) Budget { return Budget{limit: limit, set: true} }
+
+func Unlimited() Budget { return Budget{set: true} }
+
+func (b Budget) Set() bool { return b.set }
+
+func (b Budget) Or(def int64) int64 {
+	if !b.set {
+		return def
+	}
+	return b.limit
+}
+
+func ParseBudget(raw string) (Budget, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "none", "off", "unlimited":
+		return Unlimited(), nil
+	}
+
+	size, err := Parse(raw)
+	if err != nil {
+		return Budget{}, err
+	}
+	return Of(size), nil
+}

--- a/internal/bytesize/budget_test.go
+++ b/internal/bytesize/budget_test.go
@@ -1,0 +1,50 @@
+package bytesize
+
+import "testing"
+
+func TestParseBudget(t *testing.T) {
+	const noDefault = 4096
+
+	tests := []struct {
+		raw     string
+		want    int64
+		wantErr bool
+	}{
+		{raw: "100mb", want: 100 << 20},
+		{raw: "512", want: 512},
+		{raw: "none", want: 0},
+		{raw: "Unlimited", want: 0},
+		{raw: " off ", want: 0},
+		{raw: "0", want: 0},
+		{raw: "later", wantErr: true},
+		{raw: "-5", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := ParseBudget(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseBudget(%q) error = %v, wantErr %t", tt.raw, err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if limit := got.Or(noDefault); limit != tt.want {
+				t.Fatalf("ParseBudget(%q).Or(%d) = %d, want %d", tt.raw, noDefault, limit, tt.want)
+			}
+		})
+	}
+}
+
+func TestBudgetZeroValueTakesTheDefault(t *testing.T) {
+	var b Budget
+	if b.Set() {
+		t.Fatal("the zero value reports itself as configured")
+	}
+	if got := b.Or(4096); got != 4096 {
+		t.Fatalf("Or(4096) = %d, want the default", got)
+	}
+	if got := Of(0).Or(4096); got != 0 {
+		t.Fatalf("Of(0).Or(4096) = %d, want no limit", got)
+	}
+}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
@@ -28,6 +29,8 @@ type ExecFlags struct {
 	Insecure          bool
 	Follow            bool
 	ProxyURL          string
+	MaxResponseSize   string
+	MaxRedirects      int
 	Recursive         bool
 	CompareTargetsRaw string
 	CompareBaseline   string
@@ -50,9 +53,10 @@ type ExecConfig struct {
 func NewExecFlags() ExecFlags {
 	tc := telemetry.ConfigFromEnv(os.Getenv)
 	return ExecFlags{
-		Timeout:   30 * time.Second,
-		Follow:    true,
-		telemetry: tc,
+		Timeout:      30 * time.Second,
+		Follow:       true,
+		MaxRedirects: httpx.DefaultMaxRedirects,
+		telemetry:    tc,
 	}
 }
 
@@ -74,7 +78,21 @@ func (f *ExecFlags) Bind(fs *flag.FlagSet) {
 	DurationVarAliases(fs, &f.Timeout, f.Timeout, "Request timeout", "timeout", "t")
 	BoolVarAliases(fs, &f.Insecure, false, "Skip TLS certificate verification", "insecure", "k")
 	BoolVarAliases(fs, &f.Follow, f.Follow, "Follow redirects", "follow", "L")
+	IntVarAliases(
+		fs,
+		&f.MaxRedirects,
+		f.MaxRedirects,
+		"Redirects to follow before giving up (0 follows none)",
+		"max-redirects",
+	)
 	StringVarAliases(fs, &f.ProxyURL, "", "HTTP proxy URL", "proxy", "x")
+	StringVarAliases(
+		fs,
+		&f.MaxResponseSize,
+		"",
+		"Response body limit such as 100mb, or none to read without a limit",
+		"max-response-size",
+	)
 	BoolVarAliases(
 		fs,
 		&f.Recursive,
@@ -219,6 +237,20 @@ func (f ExecFlags) ResolveSession(filePath string) (ExecConfig, error) {
 		FollowRedirects:    f.Follow,
 		InsecureSkipVerify: f.Insecure,
 		ProxyURL:           f.ProxyURL,
+	}
+	if f.MaxRedirects < 0 {
+		return ExecConfig{}, fmt.Errorf(
+			"invalid --max-redirects value: %d must be non-negative",
+			f.MaxRedirects,
+		)
+	}
+	httpOpts.MaxRedirects = restfile.OptOf(f.MaxRedirects)
+	if f.MaxResponseSize != "" {
+		limit, err := bytesize.ParseBudget(f.MaxResponseSize)
+		if err != nil {
+			return ExecConfig{}, fmt.Errorf("invalid --max-response-size value: %w", err)
+		}
+		httpOpts.MaxResponseBytes = limit
 	}
 	if filePath != "" {
 		httpOpts.BaseDir = filepath.Dir(filePath)

--- a/internal/engine/headless/history.go
+++ b/internal/engine/headless/history.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/engine/request"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
@@ -47,7 +48,7 @@ func redactText(text string, secs []string, maskHdr bool) string {
 		if colon <= 0 {
 			continue
 		}
-		if !request.IsSensitiveHeader(line[:colon]) {
+		if !header.Sensitive(line[:colon]) {
 			continue
 		}
 		rest := line[colon+1:]

--- a/internal/engine/request/auth.go
+++ b/internal/engine/request/auth.go
@@ -114,6 +114,21 @@ func InjectedAuthSecrets(
 	return out
 }
 
+func InjectedAuthHeaders(before, after *restfile.Request) []string {
+	if after == nil {
+		return nil
+	}
+	prev := reqHeaders(before)
+	var out []string
+	for name, values := range reqHeaders(after) {
+		if !slices.Equal(values, prev[name]) {
+			out = append(out, name)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
 func reqHeaders(req *restfile.Request) http.Header {
 	if req == nil {
 		return nil
@@ -181,7 +196,7 @@ func applyGRPCAuth(req *restfile.Request, res *vars.Resolver) error {
 		return nil
 	}
 
-	values, err := httpx.AuthValues(
+	plan, err := httpx.ResolveAuth(
 		req.Metadata.Auth,
 		res,
 		grpcAuthHeaders(req),
@@ -191,7 +206,7 @@ func applyGRPCAuth(req *restfile.Request, res *vars.Resolver) error {
 		return err
 	}
 
-	for _, v := range values {
+	for _, v := range plan.Values {
 		if v.Placement == httpx.AuthInQuery {
 			return diag.New(
 				diag.ClassAuth,
@@ -213,7 +228,6 @@ func setRequestHeaderIfMissing(req *restfile.Request, name, value string) bool {
 	return true
 }
 
-// AuthValues only looks at headers, so hand it the grpc metadata as headers too.
 func grpcAuthHeaders(req *restfile.Request) http.Header {
 	hdr := reqHeaders(req)
 	meta := req.GRPC.Metadata
@@ -263,7 +277,7 @@ func (e *Engine) EnsureCommandAuth(
 		return authcmd.Result{}, nil
 	}
 	if hdr, ok := e.commandAuthHeader(doc, auth, res); ok && requestHeaderPresent(req, hdr) {
-		return authcmd.Result{}, nil
+		return authcmd.Result{Header: hdr}, nil
 	}
 	prep, err := e.PrepareCommandAuth(doc, auth, res, env, timeout)
 	if err != nil {
@@ -271,7 +285,7 @@ func (e *Engine) EnsureCommandAuth(
 	}
 	hdr := prep.HeaderName()
 	if requestHeaderPresent(req, hdr) {
-		return authcmd.Result{}, nil
+		return authcmd.Result{Header: hdr}, nil
 	}
 
 	ac, err := e.authCmdManager()
@@ -283,7 +297,7 @@ func (e *Engine) EnsureCommandAuth(
 		return authcmd.Result{}, diag.WrapAs(diag.ClassAuth, err, "resolve command auth")
 	}
 	if !setRequestHeaderIfMissing(req, out.Header, out.Value) {
-		return authcmd.Result{}, nil
+		return authcmd.Result{Header: out.Header}, nil
 	}
 	return out, nil
 }
@@ -335,18 +349,18 @@ func (e *Engine) EnsureOAuth(
 	opts httpx.Options,
 	env vars.ResolvedEnv,
 	timeout time.Duration,
-) error {
+) (string, error) {
 	auth := requestAuthOfType(req, restfile.AuthOAuth2)
 	if auth == nil {
-		return nil
+		return "", nil
 	}
 	oa, err := e.oauthManager()
 	if err != nil {
-		return err
+		return "", err
 	}
 	cfg, err := e.BuildOAuthConfig(auth, res)
 	if err != nil {
-		return err
+		return "", err
 	}
 	cfg = oa.MergeCachedConfig(env.Scope(), cfg)
 
@@ -354,13 +368,13 @@ func (e *Engine) EnsureOAuth(
 	// @grpc-metadata never fails on config we are about to discard.
 	hdr := cfg.Header
 	if requestHeaderPresent(req, hdr) {
-		return nil
+		return hdr, nil
 	}
 	if cfg.TokenURL == "" {
-		return diag.New(diag.ClassAuth, errOAuthTokenURLRequired)
+		return "", diag.New(diag.ClassAuth, errOAuthTokenURLRequired)
 	}
 	if e.oauthNeedsHeadlessSeed(oa, env.Scope(), cfg) {
-		return diag.New(diag.ClassAuth, errOAuthHeadlessSeedRequired)
+		return "", diag.New(diag.ClassAuth, errOAuthHeadlessSeedRequired)
 	}
 
 	tmo := oauthTimeout(cfg.GrantType, timeout)
@@ -369,10 +383,10 @@ func (e *Engine) EnsureOAuth(
 
 	tok, err := oa.Token(ctx, env.Scope(), cfg, opts)
 	if err != nil {
-		return diag.WrapAs(diag.ClassAuth, err, "fetch oauth token")
+		return "", diag.WrapAs(diag.ClassAuth, err, "fetch oauth token")
 	}
 	setRequestHeaderIfMissing(req, hdr, oauthHeaderValue(hdr, tok))
-	return nil
+	return hdr, nil
 }
 
 func (e *Engine) allowInteractiveOAuth() bool {

--- a/internal/engine/request/auth_headers_test.go
+++ b/internal/engine/request/auth_headers_test.go
@@ -1,0 +1,68 @@
+package request
+
+import (
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+func TestInjectedAuthHeaders(t *testing.T) {
+	withHeaders := func(pairs ...string) *restfile.Request {
+		h := make(http.Header)
+		for i := 0; i < len(pairs); i += 2 {
+			h.Set(pairs[i], pairs[i+1])
+		}
+		return &restfile.Request{Method: "GET", URL: "https://example.com", Headers: h}
+	}
+
+	tests := []struct {
+		name   string
+		before *restfile.Request
+		after  *restfile.Request
+		want   []string
+	}{
+		{
+			name:   "nothing injected",
+			before: withHeaders("Accept", "application/json"),
+			after:  withHeaders("Accept", "application/json"),
+		},
+		{
+			name:   "custom command auth header",
+			before: withHeaders("Accept", "application/json"),
+			after:  withHeaders("Accept", "application/json", "X-Registry-Token", "secret"),
+			want:   []string{"X-Registry-Token"},
+		},
+		{
+			name:   "oauth header",
+			before: withHeaders(),
+			after:  withHeaders("Authorization", "Bearer secret"),
+			want:   []string{"Authorization"},
+		},
+		{
+			name:   "value replaced in place",
+			before: withHeaders("X-Api-Key", "placeholder"),
+			after:  withHeaders("X-Api-Key", "secret"),
+			want:   []string{"X-Api-Key"},
+		},
+		{
+			name:  "no snapshot to compare against",
+			after: withHeaders("X-Registry-Token", "secret"),
+			want:  []string{"X-Registry-Token"},
+		},
+		{
+			name:   "request went away",
+			before: withHeaders("X-Api-Key", "secret"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InjectedAuthHeaders(tt.before, tt.after)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("InjectedAuthHeaders() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/engine/request/auth_test.go
+++ b/internal/engine/request/auth_test.go
@@ -186,8 +186,6 @@ func TestEnsureCommandAuthCacheOnlyReuseInheritsSeededConfig(t *testing.T) {
 	}
 }
 
-// A cache-only directive inherits its header from the seeded entry, so an
-// unrelated Authorization header must not be mistaken for the auth output.
 func TestEnsureCommandAuthCacheOnlyReuseIgnoresUnrelatedAuthorization(t *testing.T) {
 	var calls int32
 
@@ -548,8 +546,6 @@ func oauthSpec(params map[string]string) *restfile.AuthSpec {
 	return &restfile.AuthSpec{Type: "oauth2", Params: params}
 }
 
-// An explicit credential means the oauth config is never used, so an
-// incomplete one must not fail the request.
 func TestEnsureOAuthSkipsIncompleteConfigWhenMetadataPresent(t *testing.T) {
 	eng := newTestEngine()
 	req := grpcAuthRequest(
@@ -557,7 +553,7 @@ func TestEnsureOAuthSkipsIncompleteConfigWhenMetadataPresent(t *testing.T) {
 		restfile.MetadataPair{Key: "authorization", Value: "Bearer manually-supplied"},
 	)
 
-	if err := eng.EnsureOAuth(
+	if _, err := eng.EnsureOAuth(
 		context.Background(),
 		req,
 		vars.NewResolver(),
@@ -579,7 +575,7 @@ func TestEnsureOAuthSkipsIncompleteConfigWhenHeaderPresent(t *testing.T) {
 		Metadata: restfile.RequestMetadata{Auth: oauthSpec(map[string]string{"client_id": "example"})},
 	}
 
-	if err := eng.EnsureOAuth(
+	if _, err := eng.EnsureOAuth(
 		context.Background(),
 		req,
 		vars.NewResolver(),
@@ -594,7 +590,6 @@ func TestEnsureOAuthSkipsIncompleteConfigWhenHeaderPresent(t *testing.T) {
 	}
 }
 
-// A custom header only counts as an override when it is the one oauth targets.
 func TestEnsureOAuthUnrelatedHeaderStillRequiresTokenURL(t *testing.T) {
 	eng := newTestEngine()
 	req := grpcAuthRequest(
@@ -602,7 +597,7 @@ func TestEnsureOAuthUnrelatedHeaderStillRequiresTokenURL(t *testing.T) {
 		restfile.MetadataPair{Key: "authorization", Value: "Bearer manually-supplied"},
 	)
 
-	err := eng.EnsureOAuth(
+	_, err := eng.EnsureOAuth(
 		context.Background(),
 		req,
 		vars.NewResolver(),
@@ -622,7 +617,7 @@ func TestEnsureOAuthWithoutOverrideStillRequiresTokenURL(t *testing.T) {
 	eng := newTestEngine()
 	req := grpcAuthRequest(oauthSpec(map[string]string{"client_id": "example"}))
 
-	err := eng.EnsureOAuth(
+	_, err := eng.EnsureOAuth(
 		context.Background(),
 		req,
 		vars.NewResolver(),
@@ -638,8 +633,6 @@ func TestEnsureOAuthWithoutOverrideStillRequiresTokenURL(t *testing.T) {
 	}
 }
 
-// argv is only needed to run the command, so an override skips its templates
-// the same way it skips the execution.
 func TestEnsureCommandAuthSkipsBrokenArgvWhenMetadataPresent(t *testing.T) {
 	called := int32(0)
 

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -1130,6 +1130,7 @@ func (f flow) ExecuteGRPC() xexec.RequestResult {
 		)
 	}
 	tests, globalChanges, testErr := x.eng.sc.RunTests(
+		x.sendCtx,
 		x.req.Metadata.Scripts,
 		scripts.TestInput{
 			Response:  respForScripts,

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -454,6 +454,10 @@ func (x *execCtx) preview() bool {
 	return x != nil && x.mod == ExecModePreview
 }
 
+func (x *execCtx) addCredentialHeaders(names ...string) {
+	x.opts.CredentialHeaders = append(x.opts.CredentialHeaders, names...)
+}
+
 func (x *execCtx) warn(warning Warning) {
 	x.exp.warn(string(warning))
 	if x.preview() || x.onWarning == nil {
@@ -808,8 +812,10 @@ func (x *execCtx) prepareAuth() *xrunResult {
 			return x.fail(err, "Auth preparation failed")
 		}
 		secs = CommandAuthSecrets(out)
+		x.addCredentialHeaders(out.Header)
 	default:
-		if err := x.eng.EnsureOAuth(x.sendCtx, x.req, x.res, x.opts, x.env, x.timeout); err != nil {
+		hdr, err := x.eng.EnsureOAuth(x.sendCtx, x.req, x.res, x.opts, x.env, x.timeout)
+		if err != nil {
 			x.exp.stage(
 				xplain.StageAuth,
 				xplain.StageError,
@@ -820,6 +826,7 @@ func (x *execCtx) prepareAuth() *xrunResult {
 			)
 			return x.fail(err, "Auth preparation failed")
 		}
+		x.addCredentialHeaders(hdr)
 		if err := applyGRPCAuth(x.req, x.res); err != nil {
 			x.exp.stage(
 				xplain.StageAuth,
@@ -834,6 +841,7 @@ func (x *execCtx) prepareAuth() *xrunResult {
 		secs = InjectedAuthSecrets(x.req.Metadata.Auth, before, x.req)
 	}
 	x.secrets.Add(secs...)
+	x.addCredentialHeaders(InjectedAuthHeaders(before, x.req)...)
 	x.exp.stage(xplain.StageAuth, xplain.StageOK, xplain.SummaryAuthPrepared, before, x.req)
 	return nil
 }

--- a/internal/engine/request/explain_redact.go
+++ b/internal/engine/request/explain_redact.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	xplain "github.com/unkn0wn-root/resterm/internal/explain"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
@@ -52,7 +53,7 @@ func (e *Engine) redactExplainReport(
 		rep.Final.BodyNote = redactSecretText(rep.Final.BodyNote, secs)
 		for i := range rep.Final.Headers {
 			h := &rep.Final.Headers[i]
-			if IsSensitiveHeader(h.Name) {
+			if header.Sensitive(h.Name) {
 				if strings.TrimSpace(h.Value) != "" {
 					h.Value = explainMask
 				}
@@ -127,7 +128,7 @@ func (e *Engine) explainSecrets(
 }
 
 func redactExplainChangeValue(field, val string, secs []string) string {
-	if hdr, ok := explainHeaderField(field); ok && IsSensitiveHeader(hdr) {
+	if hdr, ok := explainHeaderField(field); ok && header.Sensitive(hdr) {
 		if strings.TrimSpace(val) == "" {
 			return val
 		}
@@ -170,5 +171,5 @@ func shouldMaskExplainPair(key, val string) bool {
 	if !ok {
 		return false
 	}
-	return IsSensitiveHeader(name)
+	return header.Sensitive(name)
 }

--- a/internal/engine/request/history.go
+++ b/internal/engine/request/history.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/binaryview"
 	"github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/history"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
@@ -218,7 +219,7 @@ func redactText(text string, secs []string, maskHdr bool) string {
 		if colon <= 0 {
 			continue
 		}
-		if !IsSensitiveHeader(ln[:colon]) {
+		if !header.Sensitive(ln[:colon]) {
 			continue
 		}
 		rest := ln[colon+1:]

--- a/internal/engine/request/redact.go
+++ b/internal/engine/request/redact.go
@@ -8,34 +8,6 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
-var sensHdr = map[string]struct{}{
-	"api-key":                 {},
-	"apikey":                  {},
-	"authorization":           {},
-	"proxy-authorization":     {},
-	"x-access-token":          {},
-	"x-amz-security-token":    {},
-	"x-api-key":               {},
-	"x-apikey":                {},
-	"x-auth-email":            {},
-	"x-auth-key":              {},
-	"x-auth-token":            {},
-	"x-aws-access-token":      {},
-	"x-aws-secret-access-key": {},
-	"x-client-secret":         {},
-	"x-csrf-token":            {},
-	"x-goog-api-key":          {},
-	"x-refresh-token":         {},
-	"x-secret-key":            {},
-	"x-token":                 {},
-	"x-xsrf-token":            {},
-}
-
-func IsSensitiveHeader(name string) bool {
-	_, ok := sensHdr[strings.ToLower(strings.TrimSpace(name))]
-	return ok
-}
-
 // Results are redacted at the engine boundary because errors and test output
 // can be rendered directly by the UI, workflows, and history. The complete
 // secret set is returned for callers that render additional text. Wrapped

--- a/internal/engine/request/text.go
+++ b/internal/engine/request/text.go
@@ -182,6 +182,8 @@ func renderSSEDirectiveLine(opts restfile.SSEOptions) string {
 		durationDirectivePart("idle", opts.IdleTimeout),
 		intDirectivePart("max-events", opts.MaxEvents),
 		int64DirectivePart("max-bytes", opts.MaxBytes),
+		int64DirectivePart("max-line-bytes", opts.MaxLineBytes),
+		int64DirectivePart("max-event-bytes", opts.MaxEventBytes),
 	)
 }
 

--- a/internal/exec/http.go
+++ b/internal/exec/http.go
@@ -381,7 +381,7 @@ func convertSSETranscript(t *httpx.SSETranscript) *scripts.StreamInfo {
 	if t == nil {
 		return nil
 	}
-	info := &scripts.StreamInfo{Kind: "sse"}
+	info := &scripts.StreamInfo{Kind: "sse", Err: t.Summary.Err()}
 	info.Summary = map[string]any{
 		"eventCount": t.Summary.EventCount,
 		"byteCount":  t.Summary.ByteCount,
@@ -412,7 +412,7 @@ func convertWebSocketTranscript(t *httpx.WebSocketTranscript) *scripts.StreamInf
 	if t == nil {
 		return nil
 	}
-	info := &scripts.StreamInfo{Kind: "websocket"}
+	info := &scripts.StreamInfo{Kind: "websocket", Err: t.Summary.Err()}
 	info.Summary = map[string]any{
 		"sentCount":     t.Summary.SentCount,
 		"receivedCount": t.Summary.ReceivedCount,

--- a/internal/exec/http.go
+++ b/internal/exec/http.go
@@ -285,6 +285,7 @@ func (r Runner) finalizeHTTP(
 	}
 	traceInput := scripts.NewTraceInput(resp.Timeline, traceSpec)
 	tests, globalChanges, testErr := in.Scripts.RunTests(
+		in.Context,
 		in.Req.Metadata.Scripts,
 		scripts.TestInput{
 			Response:  respForScripts,

--- a/internal/exec/http.go
+++ b/internal/exec/http.go
@@ -387,6 +387,8 @@ func convertSSETranscript(t *httpx.SSETranscript) *scripts.StreamInfo {
 		"byteCount":  t.Summary.ByteCount,
 		"duration":   t.Summary.Duration,
 		"reason":     t.Summary.Reason,
+		"dropped":    t.Summary.Dropped,
+		"error":      t.Summary.Error,
 	}
 	if len(t.Events) > 0 {
 		events := make([]map[string]any, len(t.Events))
@@ -418,6 +420,7 @@ func convertWebSocketTranscript(t *httpx.WebSocketTranscript) *scripts.StreamInf
 		"closedBy":      t.Summary.ClosedBy,
 		"closeCode":     t.Summary.CloseCode,
 		"closeReason":   t.Summary.CloseReason,
+		"dropped":       t.Summary.Dropped,
 	}
 	if len(t.Events) > 0 {
 		events := make([]map[string]any, len(t.Events))

--- a/internal/exec/http_test.go
+++ b/internal/exec/http_test.go
@@ -55,7 +55,11 @@ func TestRunnerRunHTTPSSE(t *testing.T) {
 		Metadata: restfile.RequestMetadata{
 			Scripts: []restfile.ScriptBlock{{
 				Kind: "test",
-				Body: `{% tests.assert(response.json().summary.eventCount === 1, "event count"); %}`,
+				Body: `{%
+						const summary = stream.summary();
+						tests.assert(response.json().summary.eventCount === 1, "event count");
+						tests.assert(summary.dropped === 0, "complete transcript");
+					%}`,
 			}},
 		},
 	}
@@ -94,17 +98,44 @@ func TestRunnerRunHTTPSSE(t *testing.T) {
 	if res.Stream == nil || res.Stream.Kind != "sse" {
 		t.Fatalf("expected sse stream info, got %+v", res.Stream)
 	}
-	if len(res.Tests) != 1 {
-		t.Fatalf("expected 1 test result, got %d", len(res.Tests))
+	if len(res.Tests) != 2 {
+		t.Fatalf("expected 2 test results, got %d", len(res.Tests))
 	}
-	if !res.Tests[0].Passed {
-		t.Fatalf("expected test to pass, got %+v", res.Tests[0])
+	for _, result := range res.Tests {
+		if !result.Passed {
+			t.Fatalf("expected test to pass, got %+v", result)
+		}
 	}
 	if seenStream == nil {
 		t.Fatalf("expected capture hook to observe stream info")
 	}
 	if seenStream.kind != "sse" || seenStream.count != 1 {
 		t.Fatalf("unexpected stream info %+v", seenStream)
+	}
+}
+
+func TestConvertSSETranscriptExposesCompletionMetadata(t *testing.T) {
+	info := convertSSETranscript(&httpx.SSETranscript{
+		Summary: httpx.SSESummary{
+			Reason:  "error",
+			Dropped: 4,
+			Error:   "read sse stream: boom",
+		},
+	})
+	if got := info.Summary["dropped"]; got != int64(4) {
+		t.Fatalf("summary.dropped = %#v, want 4", got)
+	}
+	if got := info.Summary["error"]; got != "read sse stream: boom" {
+		t.Fatalf("summary.error = %#v, want the stream error", got)
+	}
+}
+
+func TestConvertWebSocketTranscriptExposesDroppedEvents(t *testing.T) {
+	info := convertWebSocketTranscript(&httpx.WebSocketTranscript{
+		Summary: httpx.WebSocketSummary{Dropped: 3},
+	})
+	if got := info.Summary["dropped"]; got != int64(3) {
+		t.Fatalf("summary.dropped = %#v, want 3", got)
 	}
 }
 

--- a/internal/http/header/header_test.go
+++ b/internal/http/header/header_test.go
@@ -97,3 +97,62 @@ func TestNormalizeKeepsEveryValueAsAList(t *testing.T) {
 		t.Fatal("Normalize retained the caller's value slice")
 	}
 }
+
+func TestSensitive(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "Authorization", want: true},
+		{name: "authorization", want: true},
+		{name: "  X-API-Key  ", want: true},
+		{name: "x-auth-token", want: true},
+		{name: "Proxy-Authorization", want: true},
+		{name: "Cookie", want: true},
+		{name: "Cookie2", want: true},
+		{name: "X-Goog-Api-Key", want: true},
+		{name: "Content-Type", want: false},
+		{name: "X-Request-Id", want: false},
+		{name: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Sensitive(tt.name); got != tt.want {
+				t.Fatalf("Sensitive(%q) = %t, want %t", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetMatchesNamesByIdentity(t *testing.T) {
+	s := NewSet("X-Registry-Token", " x-tenant ", "", "   ")
+
+	for _, name := range []string{"x-registry-token", "X-REGISTRY-TOKEN", " X-Tenant "} {
+		if !s.Has(name) {
+			t.Errorf("Has(%q) = false, want the stored identity to match", name)
+		}
+	}
+	if s.Has("x-other") {
+		t.Error("Has(x-other) = true, want an absent name to miss")
+	}
+	if len(s) != 2 {
+		t.Fatalf("len(Set) = %d, want the blank names dropped", len(s))
+	}
+	if (Set)(nil).Has("authorization") {
+		t.Error("a nil Set reports a name")
+	}
+}
+
+func TestIsCookie(t *testing.T) {
+	for _, name := range []string{"Cookie", "COOKIE2", " cookie "} {
+		if !IsCookie(name) {
+			t.Errorf("IsCookie(%q) = false", name)
+		}
+	}
+	for _, name := range []string{"Authorization", "Set-Cookie", ""} {
+		if IsCookie(name) {
+			t.Errorf("IsCookie(%q) = true", name)
+		}
+	}
+}

--- a/internal/http/header/sensitive.go
+++ b/internal/http/header/sensitive.go
@@ -1,0 +1,62 @@
+package header
+
+import "strings"
+
+type Set map[string]struct{}
+
+func NewSet(names ...string) Set {
+	s := make(Set, len(names))
+	s.Add(names...)
+	return s
+}
+
+func (s Set) Add(names ...string) {
+	for _, name := range names {
+		if key := identity(name); key != "" {
+			s[key] = struct{}{}
+		}
+	}
+}
+
+func (s Set) Has(name string) bool {
+	_, ok := s[identity(name)]
+	return ok
+}
+
+func identity(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+var sensitive = Set{
+	"api-key":                 {},
+	"apikey":                  {},
+	"authorization":           {},
+	"cookie":                  {},
+	"cookie2":                 {},
+	"proxy-authorization":     {},
+	"x-access-token":          {},
+	"x-amz-security-token":    {},
+	"x-api-key":               {},
+	"x-apikey":                {},
+	"x-auth-email":            {},
+	"x-auth-key":              {},
+	"x-auth-token":            {},
+	"x-aws-access-token":      {},
+	"x-aws-secret-access-key": {},
+	"x-client-secret":         {},
+	"x-csrf-token":            {},
+	"x-goog-api-key":          {},
+	"x-refresh-token":         {},
+	"x-secret-key":            {},
+	"x-token":                 {},
+	"x-xsrf-token":            {},
+}
+
+var cookies = Set{
+	"cookie":  {},
+	"cookie2": {},
+}
+
+func Sensitive(name string) bool { return sensitive.Has(name) }
+
+func IsCookie(name string) bool { return cookies.Has(name) }

--- a/internal/http/origin/origin.go
+++ b/internal/http/origin/origin.go
@@ -1,0 +1,145 @@
+package origin
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+type Origin struct {
+	scheme string
+	host   string
+	port   string
+}
+
+var httpSchemes = map[string]string{
+	"http":  "http",
+	"https": "https",
+	"ws":    "http",
+	"wss":   "https",
+}
+
+var defaultPorts = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
+func Of(u *url.URL) Origin {
+	if u == nil {
+		return Origin{}
+	}
+
+	scheme, dialed := httpSchemes[strings.ToLower(u.Scheme)]
+	host := strings.ToLower(u.Hostname())
+	if !dialed || host == "" {
+		return Origin{}
+	}
+	port := u.Port()
+	if port == "" {
+		port = defaultPorts[scheme]
+	}
+	return Origin{scheme: scheme, host: host, port: port}
+}
+
+func Parse(raw string) (Origin, error) {
+	text := strings.TrimSpace(raw)
+	u, err := url.Parse(text)
+	if err != nil {
+		return Origin{}, fmt.Errorf("%q is not an origin: %w", raw, err)
+	}
+
+	switch {
+	case u.User != nil:
+		return Origin{}, fmt.Errorf("%q is not an origin: it carries user information", raw)
+	case u.Path != "" && u.Path != "/", u.RawQuery != "", u.Fragment != "":
+		return Origin{}, fmt.Errorf("%q is not an origin: it names more than a host", raw)
+	}
+
+	o := Of(u)
+	if !o.Valid() {
+		return Origin{}, fmt.Errorf(
+			"%q is not an origin: expected a scheme and host such as https://cdn.example.com",
+			raw,
+		)
+	}
+	return o, nil
+}
+
+func (o Origin) Valid() bool { return o.scheme != "" }
+
+func (o Origin) Secure() bool { return o.scheme == "https" }
+
+func (o Origin) String() string {
+	if !o.Valid() {
+		return ""
+	}
+	if o.port == defaultPorts[o.scheme] {
+		return o.scheme + "://" + o.host
+	}
+	return o.scheme + "://" + o.host + ":" + o.port
+}
+
+func Same(a, b *url.URL) bool {
+	x := Of(a)
+	return x.Valid() && x == Of(b)
+}
+
+type Set struct {
+	all     bool
+	origins []Origin
+}
+
+func Any() Set { return Set{all: true} }
+
+func NewSet(origins ...Origin) Set {
+	kept := make([]Origin, 0, len(origins))
+	for _, o := range origins {
+		if o.Valid() && !slices.Contains(kept, o) {
+			kept = append(kept, o)
+		}
+	}
+	if len(kept) == 0 {
+		return Set{}
+	}
+	return Set{origins: kept}
+}
+
+func ParseSet(raw string) (Set, error) {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '\t' || r == '\n'
+	})
+
+	origins := make([]Origin, 0, len(fields))
+	for _, field := range fields {
+		o, err := Parse(field)
+		if err != nil {
+			return Set{}, err
+		}
+		origins = append(origins, o)
+	}
+	return NewSet(origins...), nil
+}
+
+func (s Set) Empty() bool { return !s.all && len(s.origins) == 0 }
+
+func (s Set) Allows(o Origin) bool {
+	if !o.Valid() {
+		return false
+	}
+	return s.all || slices.Contains(s.origins, o)
+}
+
+func (s Set) String() string {
+	switch {
+	case s.all:
+		return "any origin"
+	case len(s.origins) == 0:
+		return "none"
+	}
+	names := make([]string, len(s.origins))
+	for i, o := range s.origins {
+		names[i] = o.String()
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/http/origin/origin_test.go
+++ b/internal/http/origin/origin_test.go
@@ -1,0 +1,177 @@
+package origin
+
+import (
+	"net/url"
+	"testing"
+)
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return u
+}
+
+func TestOfNormalizes(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		same bool
+	}{
+		{name: "identical", a: "https://a.example.com/x", b: "https://a.example.com/y", same: true},
+		{name: "default port", a: "https://a.example.com", b: "https://a.example.com:443", same: true},
+		{name: "host case", a: "https://A.Example.COM", b: "https://a.example.com", same: true},
+		{name: "scheme case", a: "HTTPS://a.example.com", b: "https://a.example.com", same: true},
+		{name: "userinfo is not part of it", a: "https://u:p@a.example.com", b: "https://a.example.com", same: true},
+		{name: "subdomain", a: "https://example.com", b: "https://a.example.com"},
+		{name: "port", a: "https://a.example.com", b: "https://a.example.com:8443"},
+		{name: "scheme", a: "https://a.example.com", b: "http://a.example.com"},
+		{name: "http default port against https", a: "http://a.example.com:443", b: "https://a.example.com"},
+		{
+			name: "wss shares the https origin",
+			a:    "wss://a.example.com/socket",
+			b:    "https://a.example.com",
+			same: true,
+		},
+		{name: "ws shares the http origin", a: "ws://a.example.com/socket", b: "http://a.example.com", same: true},
+		{name: "ws is not the https origin", a: "ws://a.example.com", b: "https://a.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Same(mustParse(t, tt.a), mustParse(t, tt.b)); got != tt.same {
+				t.Fatalf("Same(%s, %s) = %t, want %t", tt.a, tt.b, got, tt.same)
+			}
+		})
+	}
+}
+
+func TestSameNeedsAnOrigin(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{name: "relative", a: "/path", b: "/path"},
+		{name: "no host", a: "https://", b: "https://"},
+		{name: "unknown scheme", a: "file:///etc/passwd", b: "file:///etc/passwd"},
+		{name: "one side relative", a: "https://a.example.com", b: "/path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if Same(mustParse(t, tt.a), mustParse(t, tt.b)) {
+				t.Fatalf("Same(%s, %s) = true, want false", tt.a, tt.b)
+			}
+		})
+	}
+	if Same(nil, nil) {
+		t.Fatal("Same(nil, nil) = true, want false")
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{raw: "https://cdn.example.com", want: "https://cdn.example.com"},
+		{raw: "https://cdn.example.com/", want: "https://cdn.example.com"},
+		{raw: "https://cdn.example.com:8443", want: "https://cdn.example.com:8443"},
+		{raw: "https://cdn.example.com:443", want: "https://cdn.example.com"},
+		{raw: "  HTTP://CDN.example.com  ", want: "http://cdn.example.com"},
+		{raw: "wss://stream.example.com", want: "https://stream.example.com"},
+		{raw: "ws://stream.example.com:9000", want: "http://stream.example.com:9000"},
+		{raw: "https://cdn.example.com/assets", wantErr: true},
+		{raw: "https://cdn.example.com?a=1", wantErr: true},
+		{raw: "https://cdn.example.com#f", wantErr: true},
+		{raw: "https://user:pass@cdn.example.com", wantErr: true},
+		{raw: "cdn.example.com", wantErr: true},
+		{raw: "file:///tmp", wantErr: true},
+		{raw: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := Parse(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Parse(%q) error = %v, wantErr %t", tt.raw, err, tt.wantErr)
+			}
+			if err == nil && got.String() != tt.want {
+				t.Fatalf("Parse(%q) = %q, want %q", tt.raw, got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestSet(t *testing.T) {
+	cdn, err := Parse("https://cdn.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := Parse("https://other.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !(Set{}).Empty() || (Set{}).Allows(cdn) {
+		t.Fatal("the zero Set allows an origin, want none")
+	}
+	if !Any().Allows(cdn) || Any().Empty() {
+		t.Fatal("Any() does not allow every origin")
+	}
+	if Any().Allows(Origin{}) {
+		t.Fatal("Any() allows a URL that has no origin")
+	}
+
+	set := NewSet(cdn, cdn, Origin{})
+	if !set.Allows(cdn) || set.Allows(other) {
+		t.Fatalf("NewSet holds the wrong origins: %s", set)
+	}
+	if set.String() != "https://cdn.example.com" {
+		t.Fatalf("String() = %q", set.String())
+	}
+}
+
+func TestParseSet(t *testing.T) {
+	set, err := ParseSet("https://a.example.com, https://b.example.com;https://c.example.com")
+	if err != nil {
+		t.Fatalf("ParseSet: %v", err)
+	}
+	for _, raw := range []string{"https://a.example.com", "https://b.example.com", "https://c.example.com"} {
+		o, err := Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !set.Allows(o) {
+			t.Fatalf("%s is missing from %s", raw, set)
+		}
+	}
+	if _, err := ParseSet("https://a.example.com nonsense"); err == nil {
+		t.Fatal("ParseSet accepted a value that is not an origin")
+	}
+	if set, err := ParseSet("   "); err != nil || !set.Empty() {
+		t.Fatalf("ParseSet(blank) = %v, %v, want an empty set", set, err)
+	}
+}
+
+func TestSecure(t *testing.T) {
+	for raw, want := range map[string]bool{
+		"https://a.example.com": true,
+		"wss://a.example.com":   true,
+		"http://a.example.com":  false,
+		"ws://a.example.com":    false,
+	} {
+		o, err := Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := o.Secure(); got != want {
+			t.Fatalf("%s Secure() = %t, want %t", raw, got, want)
+		}
+	}
+}

--- a/internal/intellisense/directives.go
+++ b/internal/intellisense/directives.go
@@ -692,6 +692,18 @@ var directiveArgs = map[directive.Name][]Item{
 			Placeholder: "1mb",
 		},
 		{
+			Label:       "max-line-bytes=",
+			Summary:     "Largest SSE line to buffer",
+			Insert:      "max-line-bytes=1mb",
+			Placeholder: "1mb",
+		},
+		{
+			Label:       "max-event-bytes=",
+			Summary:     "Largest SSE event to buffer",
+			Insert:      "max-event-bytes=1mb",
+			Placeholder: "1mb",
+		},
+		{
 			Label:       "limit-bytes=",
 			Summary:     "Stop after N bytes (alias)",
 			Insert:      "limit-bytes=1mb",

--- a/internal/intellisense/directives.go
+++ b/internal/intellisense/directives.go
@@ -152,6 +152,24 @@ var settingArgs = []Item{
 		Placeholder: "true",
 	},
 	{
+		Label:       "forward-credentials-on-redirect=",
+		Summary:     "Origins a redirect may carry credentials to",
+		Insert:      "forward-credentials-on-redirect=https://cdn.example.com",
+		Placeholder: "https://cdn.example.com",
+	},
+	{
+		Label:       "max-redirects=",
+		Summary:     "Redirects to follow (count or none)",
+		Insert:      "max-redirects=20",
+		Placeholder: "20",
+	},
+	{
+		Label:       "max-response-size=",
+		Summary:     "Response body limit (size or none)",
+		Insert:      "max-response-size=100mb",
+		Placeholder: "100mb",
+	},
+	{
 		Label:       "http-version=",
 		Summary:     "HTTP protocol version (1.1|2)",
 		Insert:      "http-version=1.1",

--- a/internal/oauth/exchange_test.go
+++ b/internal/oauth/exchange_test.go
@@ -1,0 +1,53 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
+)
+
+func TestTokenExchangeIgnoresTheRequestRedirectTrust(t *testing.T) {
+	var reached atomic.Bool
+	elsewhere := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"leaked","token_type":"Bearer"}`))
+	}))
+	defer elsewhere.Close()
+
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, elsewhere.URL+"/token", http.StatusTemporaryRedirect)
+	}))
+	defer idp.Close()
+
+	forward, err := httpx.ParseForwardCredentials("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager(httpx.NewClient(nil))
+	_, err = mgr.Token(context.Background(), "dev", Config{
+		TokenURL:     idp.URL + "/token",
+		ClientID:     "id",
+		ClientSecret: "secret",
+		GrantType:    GrantClientCredentials,
+	}, httpx.Options{
+		FollowRedirects:    true,
+		ForwardCredentials: forward,
+	})
+
+	if err == nil {
+		t.Fatal("the token exchange followed a redirect off its origin")
+	}
+	if !strings.Contains(err.Error(), "refusing to follow a redirect") {
+		t.Fatalf("error = %v, want the confinement to be the reason", err)
+	}
+	if reached.Load() {
+		t.Fatal("the redirect target received the token request")
+	}
+}

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -111,6 +111,8 @@ func (m *Manager) Token(
 	cfg Config,
 	opts httpx.Options,
 ) (Token, error) {
+	// A 307 or 308 redirect can resend the client secret in the request body.
+	opts.ConfineToOrigin = true
 	cfg, key, fallback := m.lookupKeys(env, cfg)
 
 	if token, ok, usedKey := m.cachedToken(key, fallback); ok && token.valid() {

--- a/internal/parser/builder/sse/builder.go
+++ b/internal/parser/builder/sse/builder.go
@@ -69,15 +69,35 @@ func (b *Builder) applyOption(name, value string) error {
 		}
 		b.options.MaxEvents = n
 	case "max-bytes", "limit-bytes":
-		size, err := bytesize.Parse(value)
+		size, err := sseSize(name, value)
 		if err != nil {
-			return fmt.Errorf("invalid @sse %s %q: %w", name, value, err)
+			return err
 		}
 		b.options.MaxBytes = size
+	case "max-line-bytes":
+		size, err := sseSize(name, value)
+		if err != nil {
+			return err
+		}
+		b.options.MaxLineBytes = size
+	case "max-event-bytes":
+		size, err := sseSize(name, value)
+		if err != nil {
+			return err
+		}
+		b.options.MaxEventBytes = size
 	default:
 		return directive.UnknownOption(directive.SSE, name)
 	}
 	return nil
+}
+
+func sseSize(name, value string) (int64, error) {
+	size, err := bytesize.Parse(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid @sse %s %q: %w", name, value, err)
+	}
+	return size, nil
 }
 
 func sseDuration(name, value string) (time.Duration, error) {

--- a/internal/protocol/httpx/auth.go
+++ b/internal/protocol/httpx/auth.go
@@ -12,7 +12,6 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
-// AuthPlacement identifies where a resolved auth value belongs on the wire.
 type AuthPlacement int
 
 const (
@@ -26,17 +25,32 @@ type AuthValue struct {
 	Value     string
 }
 
-// AuthValues resolves auth without mutating a request. This lets HTTP and gRPC
-// share expansion while the engine still registers the values for redaction.
-// Existing headers are never overwritten.
-func AuthValues(
+type AuthPlan struct {
+	Values  []AuthValue
+	Targets []string
+}
+
+func (p *AuthPlan) claim(name string) {
+	p.Targets = append(p.Targets, name)
+}
+
+func (p *AuthPlan) header(name, value string) {
+	p.Values = append(p.Values, AuthValue{Placement: AuthInHeader, Name: name, Value: value})
+}
+
+func (p *AuthPlan) query(name, value string) {
+	p.Values = append(p.Values, AuthValue{Placement: AuthInQuery, Name: name, Value: value})
+}
+
+func ResolveAuth(
 	auth *restfile.AuthSpec,
 	resolver *vars.Resolver,
 	existing http.Header,
 	component diag.Component,
-) ([]AuthValue, error) {
+) (AuthPlan, error) {
+	var plan AuthPlan
 	if auth == nil || len(auth.Params) == 0 {
-		return nil, nil
+		return plan, nil
 	}
 
 	kind := auth.Kind()
@@ -64,67 +78,66 @@ func AuthValues(
 		out, err := expandResult(param)
 		return out.Value, err
 	}
-	hdr := func(name, value string) []AuthValue {
-		return []AuthValue{{Placement: AuthInHeader, Name: name, Value: value}}
-	}
-
 	switch kind {
 	case restfile.AuthBasic:
+		plan.claim(authorizationHeader)
 		if header.Present(existing, authorizationHeader) {
-			return nil, nil
+			return plan, nil
 		}
 		user, err := expand(authParamUsername)
 		if err != nil {
-			return nil, err
+			return AuthPlan{}, err
 		}
 		pass, err := expand(authParamPassword)
 		if err != nil {
-			return nil, err
+			return AuthPlan{}, err
 		}
 		encoded := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
-		return hdr(authorizationHeader, basicPrefix+encoded), nil
+		plan.header(authorizationHeader, basicPrefix+encoded)
 
 	case restfile.AuthBearer:
+		plan.claim(authorizationHeader)
 		if header.Present(existing, authorizationHeader) {
-			return nil, nil
+			return plan, nil
 		}
 		token, err := expand(authParamToken)
 		if err != nil {
-			return nil, err
+			return AuthPlan{}, err
 		}
-		return hdr(authorizationHeader, bearerTokenPrefix+token), nil
+		plan.header(authorizationHeader, bearerTokenPrefix+token)
 
 	case restfile.AuthAPIKey:
 		placement, err := expandResult(authParamPlacement)
 		if err != nil {
-			return nil, err
+			return AuthPlan{}, err
 		}
 		name, err := expand(authParamName)
 		if err != nil {
-			return nil, err
+			return AuthPlan{}, err
 		}
 		switch util.LowerTrim(placement.Value) {
 		case authPlacementQuery:
 			value, err := expand(authParamValue)
 			if err != nil {
-				return nil, err
+				return AuthPlan{}, err
 			}
-			return []AuthValue{{Placement: AuthInQuery, Name: name, Value: value}}, nil
+			plan.query(name, value)
 		case "", authPlacementHeader:
 			if name == "" {
 				name = defaultAPIKeyHeader
 			}
+			plan.claim(name)
 			if header.Present(existing, name) {
-				return nil, nil
+				return plan, nil
 			}
 			value, err := expand(authParamValue)
 			if err != nil {
-				return nil, err
+				return AuthPlan{}, err
 			}
-			return hdr(name, value), nil
+			plan.header(name, value)
 		default:
 			if placement.HasUndefinedVariables {
-				return nil, nil
+				return AuthPlan{}, nil
 			}
 			msg := fmt.Sprintf(
 				"invalid apikey auth placement %q, expected header or query",
@@ -133,22 +146,26 @@ func AuthValues(
 			if at := auth.Origin(); at != "" {
 				msg += " (" + at + ")"
 			}
-			return nil, diag.New(diag.ClassAuth, msg, diag.WithComponent(component))
+			return AuthPlan{}, diag.New(diag.ClassAuth, msg, diag.WithComponent(component))
 		}
 
 	case restfile.AuthHeader:
 		name, err := expand(authParamHeader)
 		if err != nil {
-			return nil, err
+			return AuthPlan{}, err
 		}
-		if name == "" || header.Present(existing, name) {
-			return nil, nil
+		if name == "" {
+			return plan, nil
+		}
+		plan.claim(name)
+		if header.Present(existing, name) {
+			return plan, nil
 		}
 		value, err := expand(authParamValue)
 		if err != nil {
-			return nil, err
+			return AuthPlan{}, err
 		}
-		return hdr(name, value), nil
+		plan.header(name, value)
 	}
-	return nil, nil
+	return plan, nil
 }

--- a/internal/protocol/httpx/client.go
+++ b/internal/protocol/httpx/client.go
@@ -2,7 +2,6 @@ package httpx
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"time"
 
@@ -274,7 +273,7 @@ func (c *Client) executeHTTPRequest(
 		}
 	}()
 
-	body, err := io.ReadAll(httpResp.Body)
+	body, err := effectiveOpts.readBody(httpResp.Body)
 	if traceSess != nil {
 		traceSess.finishTransfer(err)
 	}
@@ -283,11 +282,7 @@ func (c *Client) executeHTTPRequest(
 			traceSess.fail(err)
 			traceSess.complete(buildTraceExtras(httpReq, httpResp, effectiveOpts, proxy))
 		}
-		return nil, diag.Wrap(
-			err,
-			"read response body",
-			diag.WithComponent(diag.ComponentHTTP),
-		)
+		return nil, err
 	}
 
 	if traceSess != nil {

--- a/internal/protocol/httpx/client.go
+++ b/internal/protocol/httpx/client.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/filelookup"
+	"github.com/unkn0wn-root/resterm/internal/http/origin"
 	"github.com/unkn0wn-root/resterm/internal/http/version"
 	"github.com/unkn0wn-root/resterm/internal/k8s"
 	"github.com/unkn0wn-root/resterm/internal/nettrace"
@@ -21,8 +23,14 @@ import (
 
 type Options struct {
 	Timeout            time.Duration
+	MaxResponseBytes   bytesize.Budget
 	BaseURL            string
 	FollowRedirects    bool
+	MaxRedirects       restfile.Opt[int]
+	CredentialHeaders  []string
+	ForwardCredentials origin.Set
+	ConfineToOrigin    bool
+
 	InsecureSkipVerify bool
 	ProxyURL           string
 	RootCAs            []string

--- a/internal/protocol/httpx/executor_test.go
+++ b/internal/protocol/httpx/executor_test.go
@@ -172,7 +172,7 @@ func TestApplyAuthenticationBasic(t *testing.T) {
 		Params: map[string]string{"username": "alice", "password": "secret"},
 	}
 	resolver := vars.NewResolver()
-	if err := client.applyAuthentication(httpReq, resolver, auth); err != nil {
+	if _, err := client.applyAuthentication(httpReq, resolver, auth); err != nil {
 		t.Fatalf("apply authentication: %v", err)
 	}
 	if got := httpReq.Header.Get("Authorization"); !strings.HasPrefix(got, "Basic ") {
@@ -193,7 +193,7 @@ func TestApplyAuthenticationBearer(t *testing.T) {
 		Params: map[string]string{"token": "token-123"},
 	}
 	resolver := vars.NewResolver()
-	if err := client.applyAuthentication(httpReq, resolver, auth); err != nil {
+	if _, err := client.applyAuthentication(httpReq, resolver, auth); err != nil {
 		t.Fatalf("apply authentication: %v", err)
 	}
 	if got := httpReq.Header.Get("Authorization"); got != "Bearer token-123" {

--- a/internal/protocol/httpx/executor_test.go
+++ b/internal/protocol/httpx/executor_test.go
@@ -1024,7 +1024,7 @@ func TestExecuteSSEReadErrorSummary(t *testing.T) {
 		URL:    "https://example.com/events",
 		SSE:    &restfile.SSERequest{},
 	}
-	resp, err := client.ExecuteSSE(context.Background(), req, vars.NewResolver(), Options{})
+	resp, err := client.ExecuteSSE(t.Context(), req, vars.NewResolver(), Options{})
 	if err != nil {
 		t.Fatalf("execute sse read error: %v", err)
 	}
@@ -1033,11 +1033,11 @@ func TestExecuteSSEReadErrorSummary(t *testing.T) {
 	if err := json.Unmarshal(resp.Body, &transcript); err != nil {
 		t.Fatalf("unmarshal transcript: %v", err)
 	}
-	if transcript.Summary.Reason == "" || transcript.Summary.Reason == "eof" {
-		t.Fatalf("expected error reason, got %q", transcript.Summary.Reason)
+	if transcript.Summary.Reason != sseReasonErr {
+		t.Fatalf("Reason = %q, want %q", transcript.Summary.Reason, sseReasonErr)
 	}
-	if !strings.Contains(transcript.Summary.Reason, "read sse stream") {
-		t.Fatalf("expected read error in reason, got %q", transcript.Summary.Reason)
+	if !strings.Contains(transcript.Summary.Error, "read sse stream") {
+		t.Fatalf("expected read error in summary.error, got %q", transcript.Summary.Error)
 	}
 }
 

--- a/internal/protocol/httpx/limits.go
+++ b/internal/protocol/httpx/limits.go
@@ -1,0 +1,59 @@
+package httpx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
+)
+
+const DefaultMaxResponseBytes = 32 << 20
+
+type ResponseTooLargeError struct {
+	Limit int64
+}
+
+func (e *ResponseTooLargeError) Error() string {
+	return fmt.Sprintf("response body exceeds the %d byte limit", e.Limit)
+}
+
+func (o Options) responseLimit() int64 {
+	return o.MaxResponseBytes.Or(DefaultMaxResponseBytes)
+}
+
+func (o Options) readBody(r io.Reader) ([]byte, error) {
+	body, err := readResponseBody(r, o.responseLimit())
+	if err != nil {
+		return nil, diag.WrapAs(
+			diag.ClassProtocol,
+			err,
+			"read response body",
+			diag.WithComponent(diag.ComponentHTTP),
+		)
+	}
+	return body, nil
+}
+
+func readResponseBody(r io.Reader, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		return io.ReadAll(r)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, &ResponseTooLargeError{Limit: limit}
+	}
+	return body, nil
+}
+
+const defaultWebSocketMessageBytes = 32 << 10
+
+func webSocketReadLimit(configured int64) int64 {
+	if configured > 0 {
+		return configured
+	}
+	return defaultWebSocketMessageBytes
+}

--- a/internal/protocol/httpx/limits_test.go
+++ b/internal/protocol/httpx/limits_test.go
@@ -31,13 +31,13 @@ func serveBytes(t *testing.T, contentType string, size int) *httptest.Server {
 	return srv
 }
 
-func tooLarge(t *testing.T, err error) *ResponseTooLargeError {
+func tooLarge(t *testing.T, err error) int64 {
 	t.Helper()
 	var limit *ResponseTooLargeError
 	if !errors.As(err, &limit) {
 		t.Fatalf("error = %v, want a ResponseTooLargeError", err)
 	}
-	return limit
+	return limit.Limit
 }
 
 func TestResponseBodyStopsAtTheLimit(t *testing.T) {
@@ -49,7 +49,7 @@ func TestResponseBodyStopsAtTheLimit(t *testing.T) {
 		nil,
 		Options{MaxResponseBytes: bytesize.Of(1 << 20), Timeout: 30 * time.Second},
 	)
-	if got := tooLarge(t, err).Limit; got != 1<<20 {
+	if got := tooLarge(t, err); got != 1<<20 {
 		t.Fatalf("Limit = %d, want %d", got, 1<<20)
 	}
 }

--- a/internal/protocol/httpx/limits_test.go
+++ b/internal/protocol/httpx/limits_test.go
@@ -2,8 +2,10 @@ package httpx
 
 import (
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -151,8 +153,35 @@ func TestSSEFallbackBodyStopsAtTheLimit(t *testing.T) {
 	tooLarge(t, err)
 }
 
+// countingConn records how much the client pulls off the socket. Counting what
+// the server managed to write instead would measure kernel socket buffers,
+// which hold megabytes on some machines and almost nothing on others.
+type countingConn struct {
+	net.Conn
+	read *atomic.Int64
+}
+
+func (c *countingConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	c.read.Add(int64(n))
+	return n, err
+}
+
+func countingDialClient(read *atomic.Int64) *Client {
+	return NewClientWithOptions(WithHTTPFactory(func(Options) (*http.Client, error) {
+		return &http.Client{Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				return &countingConn{Conn: conn, read: read}, nil
+			},
+		}}, nil
+	}))
+}
+
 func TestSSEStopsOnAnUnterminatedLine(t *testing.T) {
-	var written atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
@@ -160,9 +189,7 @@ func TestSSEStopsOnAnUnterminatedLine(t *testing.T) {
 		_, _ = w.Write([]byte("data: "))
 		chunk := []byte(strings.Repeat("A", 1<<16))
 		for range 512 {
-			n, err := w.Write(chunk)
-			written.Add(int64(n))
-			if err != nil {
+			if _, err := w.Write(chunk); err != nil {
 				return
 			}
 			if flusher != nil {
@@ -172,6 +199,7 @@ func TestSSEStopsOnAnUnterminatedLine(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	var read atomic.Int64
 	req := &restfile.Request{
 		Method: "GET",
 		URL:    srv.URL,
@@ -180,10 +208,12 @@ func TestSSEStopsOnAnUnterminatedLine(t *testing.T) {
 			TotalTimeout: 30 * time.Second,
 		}},
 	}
-	if _, err := NewClient(nil).ExecuteSSE(t.Context(), req, nil, Options{}); err != nil {
+	if _, err := countingDialClient(&read).ExecuteSSE(t.Context(), req, nil, Options{}); err != nil {
 		t.Fatalf("ExecuteSSE: %v", err)
 	}
-	if n := written.Load(); n > 1<<20 {
+	// The reader stops within one buffered fill of the limit. The transport has
+	// a buffer of its own, so allow for both plus the response headers.
+	if n := read.Load(); n > 64<<10 {
 		t.Fatalf("the reader consumed %d bytes of one line against a 1KiB stream limit", n)
 	}
 }

--- a/internal/protocol/httpx/limits_test.go
+++ b/internal/protocol/httpx/limits_test.go
@@ -1,0 +1,391 @@
+package httpx
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/stream"
+)
+
+func serveBytes(t *testing.T, contentType string, size int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		chunk := make([]byte, 1<<16)
+		for sent := 0; sent < size; sent += len(chunk) {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func tooLarge(t *testing.T, err error) *ResponseTooLargeError {
+	t.Helper()
+	var limit *ResponseTooLargeError
+	if !errors.As(err, &limit) {
+		t.Fatalf("error = %v, want a ResponseTooLargeError", err)
+	}
+	return limit
+}
+
+func TestResponseBodyStopsAtTheLimit(t *testing.T) {
+	srv := serveBytes(t, "application/octet-stream", 4<<20)
+
+	_, err := NewClient(nil).Execute(
+		t.Context(),
+		&restfile.Request{Method: "GET", URL: srv.URL},
+		nil,
+		Options{MaxResponseBytes: bytesize.Of(1 << 20), Timeout: 30 * time.Second},
+	)
+	if got := tooLarge(t, err).Limit; got != 1<<20 {
+		t.Fatalf("Limit = %d, want %d", got, 1<<20)
+	}
+}
+
+func TestResponseBodyAtTheLimitIsKept(t *testing.T) {
+	const size = 1 << 16
+	srv := serveBytes(t, "application/octet-stream", size)
+
+	resp, err := NewClient(nil).Execute(
+		t.Context(),
+		&restfile.Request{Method: "GET", URL: srv.URL},
+		nil,
+		Options{MaxResponseBytes: bytesize.Of(size), Timeout: 30 * time.Second},
+	)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(resp.Body) != size {
+		t.Fatalf("len(Body) = %d, want %d", len(resp.Body), size)
+	}
+}
+
+func TestResponseLimitCountsDecompressedBytes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "text/plain")
+		zw := gzip.NewWriter(w)
+		defer func() { _ = zw.Close() }()
+		chunk := make([]byte, 1<<16)
+		for sent := 0; sent < 8<<20; sent += len(chunk) {
+			if _, err := zw.Write(chunk); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(nil).Execute(
+		t.Context(),
+		&restfile.Request{Method: "GET", URL: srv.URL},
+		nil,
+		Options{MaxResponseBytes: bytesize.Of(1 << 20), Timeout: 30 * time.Second},
+	)
+	tooLarge(t, err)
+}
+
+func TestResponseLimitDefaultsAndOverrides(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+		want int64
+	}{
+		{name: "unset takes the default", want: DefaultMaxResponseBytes},
+		{name: "explicit size", opts: Options{MaxResponseBytes: bytesize.Of(1 << 20)}, want: 1 << 20},
+		{
+			name: "an unlimited budget removes the bound",
+			opts: Options{MaxResponseBytes: bytesize.Unlimited()},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.opts.responseLimit(); got != tt.want {
+				t.Fatalf("responseLimit() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxResponseSizeSetting(t *testing.T) {
+	var opts Options
+	if err := ApplyOptionSettings(&opts, map[string]string{"max-response-size": "2mb"}); err != nil {
+		t.Fatalf("ApplyOptionSettings: %v", err)
+	}
+	if got := opts.responseLimit(); got != 2<<20 {
+		t.Fatalf("responseLimit() = %d, want %d", got, 2<<20)
+	}
+	if err := ApplyOptionSettings(&opts, map[string]string{"max-response-size": "none"}); err != nil {
+		t.Fatalf("ApplyOptionSettings: %v", err)
+	}
+	if got := opts.responseLimit(); got != 0 {
+		t.Fatalf("responseLimit() = %d, want no limit", got)
+	}
+	if err := ApplyOptionSettings(&opts, map[string]string{"max-response-size": "soon"}); err == nil {
+		t.Fatal("ApplyOptionSettings() = nil, want an invalid size error")
+	}
+}
+
+func TestSSEFallbackBodyStopsAtTheLimit(t *testing.T) {
+	srv := serveBytes(t, "application/json", 4<<20)
+
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    srv.URL,
+		SSE:    &restfile.SSERequest{Options: restfile.SSEOptions{TotalTimeout: 30 * time.Second}},
+	}
+	_, err := NewClient(nil).ExecuteSSE(t.Context(), req, nil, Options{MaxResponseBytes: bytesize.Of(1 << 20)})
+	tooLarge(t, err)
+}
+
+func TestSSEStopsOnAnUnterminatedLine(t *testing.T) {
+	var written atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: "))
+		chunk := []byte(strings.Repeat("A", 1<<16))
+		for range 512 {
+			n, err := w.Write(chunk)
+			written.Add(int64(n))
+			if err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    srv.URL,
+		SSE: &restfile.SSERequest{Options: restfile.SSEOptions{
+			MaxBytes:     1 << 10,
+			TotalTimeout: 30 * time.Second,
+		}},
+	}
+	if _, err := NewClient(nil).ExecuteSSE(t.Context(), req, nil, Options{}); err != nil {
+		t.Fatalf("ExecuteSSE: %v", err)
+	}
+	if n := written.Load(); n > 1<<20 {
+		t.Fatalf("the reader consumed %d bytes of one line against a 1KiB stream limit", n)
+	}
+}
+
+func TestSSELineBudgetTracksTheStreamLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		opts restfile.SSEOptions
+		read int64
+		want int
+	}{
+		{name: "no stream limit", want: DefaultSSEMaxLineBytes},
+		{
+			name: "stream limit is larger",
+			opts: restfile.SSEOptions{MaxBytes: 8 << 20},
+			want: DefaultSSEMaxLineBytes,
+		},
+		{name: "stream limit is smaller", opts: restfile.SSEOptions{MaxBytes: 1024}, want: 1025},
+		{
+			name: "part of the stream is read",
+			opts: restfile.SSEOptions{MaxBytes: 1024},
+			read: 1000,
+			want: 25,
+		},
+		{
+			name: "line limit is configured",
+			opts: restfile.SSEOptions{MaxLineBytes: 4096},
+			want: 4096,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sseLimitsFor(tt.opts).lineBudget(tt.read); got != tt.want {
+				t.Fatalf("lineBudget() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebSocketReadLimit(t *testing.T) {
+	if got := webSocketReadLimit(0); got != defaultWebSocketMessageBytes {
+		t.Fatalf("webSocketReadLimit(0) = %d, want %d", got, defaultWebSocketMessageBytes)
+	}
+	if got := webSocketReadLimit(4096); got != 4096 {
+		t.Fatalf("webSocketReadLimit(4096) = %d, want 4096", got)
+	}
+}
+
+func sseServer(t *testing.T, write func(w http.ResponseWriter, flush func())) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		flush := func() {
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		write(w, flush)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func sseTranscript(t *testing.T, url string, opts restfile.SSEOptions) SSETranscript {
+	t.Helper()
+	if opts.TotalTimeout == 0 {
+		opts.TotalTimeout = 30 * time.Second
+	}
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    url,
+		SSE:    &restfile.SSERequest{Options: opts},
+	}
+	resp, err := NewClient(nil).ExecuteSSE(t.Context(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("ExecuteSSE: %v", err)
+	}
+
+	var out SSETranscript
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+	return out
+}
+
+func TestSSELineOverrunIsReported(t *testing.T) {
+	srv := sseServer(t, func(w http.ResponseWriter, flush func()) {
+		_, _ = w.Write([]byte("data: " + strings.Repeat("A", 4096)))
+		flush()
+		<-t.Context().Done()
+	})
+
+	sum := sseTranscript(t, srv.URL, restfile.SSEOptions{MaxLineBytes: 512}).Summary
+	if sum.Reason != sseReasonLineBytes {
+		t.Fatalf("Reason = %q, want %q", sum.Reason, sseReasonLineBytes)
+	}
+	if !strings.Contains(sum.Error, "max-line-bytes") {
+		t.Fatalf("Error = %q, want the limit and how to raise it", sum.Error)
+	}
+}
+
+func TestSSEEventOverrunIsReported(t *testing.T) {
+	srv := sseServer(t, func(w http.ResponseWriter, flush func()) {
+		for range 64 {
+			_, _ = w.Write([]byte("data: " + strings.Repeat("A", 256) + "\n"))
+			flush()
+		}
+		<-t.Context().Done()
+	})
+
+	sum := sseTranscript(t, srv.URL, restfile.SSEOptions{MaxEventBytes: 1024}).Summary
+	if sum.Reason != sseReasonEventBytes {
+		t.Fatalf("Reason = %q, want %q", sum.Reason, sseReasonEventBytes)
+	}
+	if !strings.Contains(sum.Error, "max-event-bytes") {
+		t.Fatalf("Error = %q, want the limit and how to raise it", sum.Error)
+	}
+}
+
+func TestSSEStreamLimitEndsCleanly(t *testing.T) {
+	srv := sseServer(t, func(w http.ResponseWriter, flush func()) {
+		for range 64 {
+			_, _ = w.Write([]byte("data: " + strings.Repeat("A", 256) + "\n\n"))
+			flush()
+		}
+		<-t.Context().Done()
+	})
+
+	sum := sseTranscript(t, srv.URL, restfile.SSEOptions{MaxBytes: 1024}).Summary
+	if sum.Reason != sseReasonMaxBytes {
+		t.Fatalf("Reason = %q, want %q", sum.Reason, sseReasonMaxBytes)
+	}
+}
+
+func TestSSETranscriptReportsDiscardedEvents(t *testing.T) {
+	const sent = 2000
+	srv := sseServer(t, func(w http.ResponseWriter, flush func()) {
+		for range sent {
+			_, _ = w.Write([]byte("data: " + strings.Repeat("A", 512) + "\n\n"))
+		}
+		flush()
+	})
+
+	transcript := sseTranscript(t, srv.URL, restfile.SSEOptions{})
+	if transcript.Summary.Dropped == 0 {
+		t.Fatal("Dropped = 0, want the discarded events to be reported")
+	}
+	if len(transcript.Events) >= sent {
+		t.Fatalf("kept %d events, want the buffer to have discarded some", len(transcript.Events))
+	}
+}
+
+func TestWebSocketAccumulatorStopsKeepingPayloadAtItsBudget(t *testing.T) {
+	message := func() *stream.Event {
+		return &stream.Event{
+			Kind:      stream.KindWebSocket,
+			Direction: stream.DirReceive,
+			Payload:   []byte(strings.Repeat("A", 256)),
+			Metadata:  map[string]string{wsMetaType: "text"},
+		}
+	}
+
+	acc := newWSAccumulator()
+	acc.limit = 4 * message().Size()
+
+	for range 8 {
+		acc.consume(message())
+	}
+
+	if acc.summary.ReceivedCount != 8 {
+		t.Fatalf("ReceivedCount = %d, want every message counted", acc.summary.ReceivedCount)
+	}
+	if len(acc.events) != 4 {
+		t.Fatalf("kept %d events, want 4 within the budget", len(acc.events))
+	}
+	if acc.summary.Dropped != 4 {
+		t.Fatalf("Dropped = %d, want 4", acc.summary.Dropped)
+	}
+}
+
+func TestWebSocketAccumulatorKeepsTheCloseEvent(t *testing.T) {
+	acc := newWSAccumulator()
+	acc.limit = 16
+
+	acc.consume(&stream.Event{
+		Direction: stream.DirReceive,
+		Payload:   []byte(strings.Repeat("A", 64)),
+		Metadata:  map[string]string{wsMetaType: "text"},
+	})
+	acc.consume(&stream.Event{
+		Direction: stream.DirReceive,
+		Metadata: map[string]string{
+			wsMetaType:        "close",
+			wsMetaClosedBy:    "server",
+			wsMetaCloseReason: "bye",
+		},
+	})
+
+	if acc.summary.ClosedBy != "server" || acc.summary.CloseReason != "bye" {
+		t.Fatalf("summary lost the close details: %+v", acc.summary)
+	}
+}

--- a/internal/protocol/httpx/options_apply.go
+++ b/internal/protocol/httpx/options_apply.go
@@ -1,14 +1,20 @@
 package httpx
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/directive"
+	"github.com/unkn0wn-root/resterm/internal/http/origin"
 	"github.com/unkn0wn-root/resterm/internal/http/version"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/util"
 )
 
 type optionSettingKey string
@@ -20,6 +26,9 @@ const (
 	optionSettingFollowRedirects optionSettingKey = "followredirects"
 	optionSettingInsecure        optionSettingKey = "insecure"
 	optionSettingNoCookies       optionSettingKey = "no-cookies"
+	optionSettingMaxResponse     optionSettingKey = "max-response-size"
+	optionSettingMaxRedirects    optionSettingKey = "max-redirects"
+	optionSettingForwardCreds    optionSettingKey = "forward-credentials-on-redirect"
 )
 
 // Settings come from a file the user edits, so name the key and what it takes.
@@ -119,6 +128,45 @@ func applyOptionSettings(opts *Options, settings map[string]string, strict bool)
 		}
 	}
 
+	if val, ok := settingValue(norm, optionSettingForwardCreds); ok {
+		switch allowed, err := ParseForwardCredentials(val); {
+		case err == nil:
+			opts.ForwardCredentials = allowed
+		case strict:
+			return invalidSetting(
+				optionSettingForwardCreds,
+				val,
+				"origins such as https://cdn.example.com, or true to allow any redirect target",
+			)
+		}
+	}
+
+	if val, ok := settingValue(norm, optionSettingMaxRedirects); ok {
+		switch limit, err := parseRedirectLimit(val); {
+		case err == nil:
+			opts.MaxRedirects = restfile.OptOf(limit)
+		case strict:
+			return invalidSetting(
+				optionSettingMaxRedirects,
+				val,
+				"a count such as 20, or none to stop at the first redirect",
+			)
+		}
+	}
+
+	if val, ok := settingValue(norm, optionSettingMaxResponse); ok {
+		switch size, err := bytesize.ParseBudget(val); {
+		case err == nil:
+			opts.MaxResponseBytes = size
+		case strict:
+			return invalidSetting(
+				optionSettingMaxResponse,
+				val,
+				"a size such as 100mb, or none to read without a limit",
+			)
+		}
+	}
+
 	if val, ok := settingValue(norm, optionSettingNoCookies); ok {
 		switch b, valid := directive.ParseBool(val); {
 		case !valid && strict:
@@ -129,6 +177,45 @@ func applyOptionSettings(opts *Options, settings map[string]string, strict bool)
 	}
 
 	return nil
+}
+
+func ParseForwardCredentials(val string) (origin.Set, error) {
+	word := util.LowerTrim(val)
+	if on, ok := directive.ParseBool(word); ok {
+		if on {
+			return origin.Any(), nil
+		}
+		return origin.Set{}, nil
+	}
+	switch word {
+	case "all", "any":
+		return origin.Any(), nil
+	case "none":
+		return origin.Set{}, nil
+	}
+
+	allowed, err := origin.ParseSet(val)
+	if err != nil {
+		return origin.Set{}, err
+	}
+	if allowed.Empty() {
+		return origin.Set{}, errors.New("expected an origin, or true or false")
+	}
+	return allowed, nil
+}
+
+func parseRedirectLimit(val string) (int, error) {
+	if util.LowerTrim(val) == "none" || directive.IsOff(val) {
+		return 0, nil
+	}
+	limit, err := strconv.Atoi(strings.TrimSpace(val))
+	if err != nil {
+		return 0, err
+	}
+	if limit < 0 {
+		return 0, errors.New("count must be non-negative")
+	}
+	return limit, nil
 }
 
 func settingValue[K ~string](settings map[string]string, key K) (string, bool) {

--- a/internal/protocol/httpx/redirect.go
+++ b/internal/protocol/httpx/redirect.go
@@ -1,0 +1,119 @@
+package httpx
+
+import (
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
+	"github.com/unkn0wn-root/resterm/internal/http/origin"
+)
+
+const DefaultMaxRedirects = 10
+
+// net/http can forward custom credential headers to another origin. The guard
+// removes them unless the user allows the target origin.
+type redirectGuard struct {
+	limit     int
+	confined  bool
+	creds     header.Set
+	forwardTo origin.Set
+}
+
+func newRedirectGuard(opts Options) redirectGuard {
+	return redirectGuard{
+		limit:     redirectLimit(opts),
+		confined:  opts.ConfineToOrigin,
+		creds:     header.NewSet(opts.CredentialHeaders...),
+		forwardTo: opts.ForwardCredentials,
+	}
+}
+
+func redirectPolicy(opts Options) func(*http.Request, []*http.Request) error {
+	return newRedirectGuard(opts).check
+}
+
+func (g redirectGuard) check(req *http.Request, via []*http.Request) error {
+	if g.limit <= 0 {
+		return http.ErrUseLastResponse
+	}
+	if len(via) > g.limit {
+		return diag.Newf(
+			diag.ClassProtocol,
+			"stopped after following %d redirects",
+			g.limit,
+		)
+	}
+
+	owner, previous := via[0], via[len(via)-1]
+	if origin.Same(owner.URL, req.URL) {
+		g.restore(req.Header, owner.Header)
+		return nil
+	}
+
+	if g.confined {
+		return diag.Newf(
+			diag.ClassProtocol,
+			"refusing to follow a redirect from %s to %s",
+			origin.Of(owner.URL),
+			origin.Of(req.URL),
+		)
+	}
+
+	deleteCookies(req.Header)
+
+	if keepsCredentials(previous.URL, req.URL, g.forwardTo) {
+		g.restore(req.Header, owner.Header)
+		return nil
+	}
+	g.strip(req.Header)
+	return nil
+}
+
+func (g redirectGuard) credential(name string) bool {
+	return g.creds.Has(name) || header.Sensitive(name)
+}
+
+func (g redirectGuard) strip(h http.Header) {
+	for name := range h {
+		if g.credential(name) {
+			// Header.Del can change the name, so delete this key directly.
+			delete(h, name)
+		}
+	}
+}
+
+func (g redirectGuard) restore(dst, initial http.Header) {
+	for name, values := range initial {
+		if _, present := dst[name]; present || header.IsCookie(name) {
+			continue
+		}
+		if g.credential(name) {
+			dst[name] = slices.Clone(values)
+		}
+	}
+}
+
+func keepsCredentials(previous, next *url.URL, forwardTo origin.Set) bool {
+	last, dst := origin.Of(previous), origin.Of(next)
+	if last.Secure() && !dst.Secure() {
+		return false
+	}
+	return forwardTo.Allows(dst)
+}
+
+func redirectLimit(opts Options) int {
+	if !opts.FollowRedirects {
+		return 0
+	}
+	return opts.MaxRedirects.Or(DefaultMaxRedirects)
+}
+
+func deleteCookies(h http.Header) {
+	for name := range h {
+		if header.IsCookie(name) {
+			delete(h, name)
+		}
+	}
+}

--- a/internal/protocol/httpx/redirect.go
+++ b/internal/protocol/httpx/redirect.go
@@ -12,6 +12,8 @@ import (
 
 const DefaultMaxRedirects = 10
 
+const refererHeader = "Referer"
+
 // net/http can forward custom credential headers to another origin. The guard
 // removes them unless the user allows the target origin.
 type redirectGuard struct {
@@ -46,24 +48,27 @@ func (g redirectGuard) check(req *http.Request, via []*http.Request) error {
 		)
 	}
 
+	// Credentials, cookies and confinement belong to the origin that owns the
+	// request. The Referer belongs to the single hop being taken, so it is
+	// compared against the previous URL instead.
 	owner, previous := via[0], via[len(via)-1]
-	if origin.Same(owner.URL, req.URL) {
-		g.restore(req.Header, owner.Header)
-		return nil
+	if !origin.Same(owner.URL, req.URL) {
+		if g.confined {
+			return diag.Newf(
+				diag.ClassProtocol,
+				"refusing to follow a redirect from %s to %s",
+				origin.Of(owner.URL),
+				origin.Of(req.URL),
+			)
+		}
+		deleteCookies(req.Header)
 	}
 
-	if g.confined {
-		return diag.Newf(
-			diag.ClassProtocol,
-			"refusing to follow a redirect from %s to %s",
-			origin.Of(owner.URL),
-			origin.Of(req.URL),
-		)
+	if !origin.Same(previous.URL, req.URL) {
+		narrowReferer(req.Header, owner.Header, previous.URL)
 	}
 
-	deleteCookies(req.Header)
-
-	if keepsCredentials(previous.URL, req.URL, g.forwardTo) {
+	if g.keepsCredentials(via, req.URL) {
 		g.restore(req.Header, owner.Header)
 		return nil
 	}
@@ -95,12 +100,41 @@ func (g redirectGuard) restore(dst, initial http.Header) {
 	}
 }
 
-func keepsCredentials(previous, next *url.URL, forwardTo origin.Set) bool {
-	last, dst := origin.Of(previous), origin.Of(next)
-	if last.Secure() && !dst.Secure() {
+func (g redirectGuard) keepsCredentials(via []*http.Request, next *url.URL) bool {
+	if leftTLS(via, next) {
 		return false
 	}
-	return forwardTo.Allows(dst)
+	return origin.Same(via[0].URL, next) || g.forwardTo.Allows(origin.Of(next))
+}
+
+// leftTLS reports whether the chain has gone from an https hop to a plain http
+// one. Trust does not come back if a later hop returns to https, because
+// whoever sat on the plain http hop picked every redirect after it.
+func leftTLS(via []*http.Request, next *url.URL) bool {
+	secure := false
+	for _, hop := range via {
+		o := origin.Of(hop.URL)
+		if secure && !o.Secure() {
+			return true
+		}
+		secure = secure || o.Secure()
+	}
+	return secure && !origin.Of(next).Secure()
+}
+
+// narrowReferer cuts the Referer down to an origin, the way a browser does
+// across a site boundary. net/http fills it in from the previous URL before this
+// policy runs, and that URL can carry a credential in its query. A Referer the
+// request set itself is left alone, and a hop without one does not gain one.
+func narrowReferer(dst, initial http.Header, previous *url.URL) {
+	if dst.Get(refererHeader) == "" || initial.Get(refererHeader) != "" {
+		return
+	}
+	if o := origin.Of(previous); o.Valid() {
+		dst.Set(refererHeader, o.String()+"/")
+		return
+	}
+	dst.Del(refererHeader)
 }
 
 func redirectLimit(opts Options) int {

--- a/internal/protocol/httpx/redirect_test.go
+++ b/internal/protocol/httpx/redirect_test.go
@@ -172,66 +172,104 @@ func TestRedirectWithinTheSameOriginKeepsCredentials(t *testing.T) {
 func TestKeepsCredentials(t *testing.T) {
 	tests := []struct {
 		name     string
-		previous string
+		chain    []string
 		next     string
 		forwards string
 		want     bool
 	}{
-		{name: "no forwarding", previous: "https://a.example.com/x", next: "https://cdn.example.net/y"},
+		{
+			name:  "back to the origin that owns them",
+			chain: []string{"https://a.example.com/x"},
+			next:  "https://a.example.com/y",
+			want:  true,
+		},
+		{
+			name:  "no forwarding",
+			chain: []string{"https://a.example.com/x"},
+			next:  "https://cdn.example.net/y",
+		},
 		{
 			name:     "named origin",
-			previous: "https://a.example.com/x",
+			chain:    []string{"https://a.example.com/x"},
 			next:     "https://cdn.example.net/y",
 			forwards: "https://cdn.example.net",
 			want:     true,
 		},
 		{
 			name:     "an origin outside the list stays outside",
-			previous: "https://a.example.com/x",
+			chain:    []string{"https://a.example.com/x"},
 			next:     "https://evil.example.net/y",
 			forwards: "https://cdn.example.net",
 		},
 		{
 			name:     "a listed origin on another port is another origin",
-			previous: "https://a.example.com/x",
+			chain:    []string{"https://a.example.com/x"},
 			next:     "https://cdn.example.net:8443/y",
 			forwards: "https://cdn.example.net",
 		},
 		{
 			name:     "any origin",
-			previous: "https://a.example.com/x",
+			chain:    []string{"https://a.example.com/x"},
 			next:     "https://anywhere.example.net/y",
 			forwards: "true",
 			want:     true,
 		},
 		{
 			name:     "any origin still refuses a downgrade",
-			previous: "https://a.example.com/x",
+			chain:    []string{"https://a.example.com/x"},
 			next:     "http://a.example.com/y",
 			forwards: "true",
 		},
 		{
 			name:     "a listed origin still refuses a downgrade",
-			previous: "https://a.example.com/x",
+			chain:    []string{"https://a.example.com/x"},
 			next:     "http://cdn.example.net/y",
 			forwards: "http://cdn.example.net",
 		},
 		{
 			name:     "a downgrade partway along a chain",
-			previous: "https://trusted.example.net/x",
+			chain:    []string{"https://a.example.com/x", "https://trusted.example.net/x"},
 			next:     "http://other.example.net/y",
 			forwards: "true",
 		},
 		{
+			name: "a downgrade earlier in the chain is not forgotten",
+			chain: []string{
+				"https://a.example.com/x",
+				"http://other.example.net/one",
+			},
+			next:     "http://other.example.net/two",
+			forwards: "true",
+		},
+		{
+			name: "climbing back onto https does not restore trust",
+			chain: []string{
+				"https://a.example.com/x",
+				"http://other.example.net/one",
+			},
+			next:     "https://a.example.com/y",
+			forwards: "true",
+		},
+		{
 			name:     "plain http to plain http is not a downgrade",
-			previous: "http://a.example.com/x",
+			chain:    []string{"http://a.example.com/x"},
 			next:     "http://cdn.example.net/y",
 			forwards: "http://cdn.example.net",
 			want:     true,
 		},
 		{
+			name: "a chain that never had TLS keeps forwarding",
+			chain: []string{
+				"http://a.example.com/x",
+				"http://other.example.net/one",
+			},
+			next:     "http://other.example.net/two",
+			forwards: "true",
+			want:     true,
+		},
+		{
 			name:     "an upgrade to https is allowed when the origin is listed",
-			previous: "http://a.example.com/x",
+			chain:    []string{"http://a.example.com/x"},
 			next:     "https://cdn.example.net/y",
 			forwards: "https://cdn.example.net",
 			want:     true,
@@ -240,10 +278,6 @@ func TestKeepsCredentials(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			previous, err := url.Parse(tt.previous)
-			if err != nil {
-				t.Fatal(err)
-			}
 			next, err := url.Parse(tt.next)
 			if err != nil {
 				t.Fatal(err)
@@ -254,11 +288,31 @@ func TestKeepsCredentials(t *testing.T) {
 					t.Fatalf("ParseForwardCredentials(%q): %v", tt.forwards, err)
 				}
 			}
-			if got := keepsCredentials(previous, next, forwards); got != tt.want {
-				t.Fatalf("keepsCredentials(%s, %s) = %t, want %t", tt.previous, tt.next, got, tt.want)
+			g := redirectGuard{forwardTo: forwards}
+			if got := g.keepsCredentials(chain(t, tt.chain...), next); got != tt.want {
+				t.Fatalf(
+					"keepsCredentials(%v, %s) = %t, want %t",
+					tt.chain,
+					tt.next,
+					got,
+					tt.want,
+				)
 			}
 		})
 	}
+}
+
+func chain(t *testing.T, urls ...string) []*http.Request {
+	t.Helper()
+	out := make([]*http.Request, len(urls))
+	for i, raw := range urls {
+		req, err := http.NewRequest(http.MethodGet, raw, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[i] = req
+	}
+	return out
 }
 
 func TestRedirectLoopStops(t *testing.T) {
@@ -924,5 +978,145 @@ func TestRedirectRefusesADowngradePartwayAlongAChain(t *testing.T) {
 		if leaked := got.Get(name); leaked != "" {
 			t.Errorf("%s left TLS partway along the chain as %q", name, leaked)
 		}
+	}
+}
+
+func TestRedirectNarrowsTheRefererToTheOrigin(t *testing.T) {
+	target := newRecorder(t)
+	first := redirectTo(t, otherHost(target.URL)+"/next")
+
+	execute(t, &restfile.Request{
+		Method: "GET",
+		URL:    first.URL + "/tokens",
+		Metadata: restfile.RequestMetadata{Auth: &restfile.AuthSpec{
+			Type: restfile.AuthAPIKey,
+			Params: map[string]string{
+				authParamName:      "api_key",
+				authParamValue:     "secret",
+				authParamPlacement: authPlacementQuery,
+			},
+		}},
+	}, Options{})
+
+	got := target.received(t).Get("Referer")
+	if strings.Contains(got, "secret") || strings.Contains(got, "/tokens") {
+		t.Fatalf("Referer = %q, want the path and query left behind", got)
+	}
+	if want := first.URL + "/"; got != want {
+		t.Fatalf("Referer = %q, want %q", got, want)
+	}
+}
+
+func TestRedirectKeepsTheRefererTheRequestSet(t *testing.T) {
+	target := newRecorder(t)
+	first := redirectTo(t, otherHost(target.URL)+"/next")
+
+	hdr := make(http.Header)
+	hdr.Set("Referer", "https://docs.example.com/guide")
+	execute(t, &restfile.Request{Method: "GET", URL: first.URL + "/start", Headers: hdr}, Options{})
+
+	if got := target.received(t).Get("Referer"); got != "https://docs.example.com/guide" {
+		t.Fatalf("Referer = %q, want the value the request set", got)
+	}
+}
+
+func TestRedirectWithinTheOriginKeepsTheWholeReferer(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/moved" {
+			got = req.Header.Clone()
+			return
+		}
+		http.Redirect(w, req, "/moved", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	execute(t, &restfile.Request{Method: "GET", URL: srv.URL + "/start?api_key=secret"}, Options{})
+
+	if want := srv.URL + "/start?api_key=secret"; got.Get("Referer") != want {
+		t.Fatalf("Referer = %q, want %q", got.Get("Referer"), want)
+	}
+}
+
+func TestRedirectNeverRestoresCredentialsAfterADowngrade(t *testing.T) {
+	last := newRecorder(t)
+	middle := redirectTo(t, otherHost(last.URL)+"/last")
+	first := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, middle.URL+"/next", http.StatusFound)
+	}))
+	defer first.Close()
+
+	forward, err := ParseForwardCredentials("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hdr := make(http.Header)
+	hdr.Set("Authorization", "Bearer secret")
+	hdr.Set("X-Api-Key", "secret")
+	execute(t, &restfile.Request{Method: "GET", URL: first.URL, Headers: hdr}, Options{
+		ForwardCredentials: forward,
+		InsecureSkipVerify: true,
+	})
+
+	got := last.received(t)
+	for _, name := range []string{"Authorization", "X-Api-Key"} {
+		if leaked := got.Get(name); leaked != "" {
+			t.Errorf("%s came back a hop after the chain left TLS, as %q", name, leaked)
+		}
+	}
+}
+
+func TestRedirectWithinTheOriginKeepsTheWholeRefererMidChain(t *testing.T) {
+	got := make(chan http.Header, 1)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/two" {
+			got <- r.Header.Clone()
+			return
+		}
+		http.Redirect(w, r, "/two", http.StatusFound)
+	}))
+	t.Cleanup(target.Close)
+	first := redirectTo(t, otherHost(target.URL)+"/one?secret=shh")
+
+	execute(t, &restfile.Request{Method: "GET", URL: first.URL + "/start"}, Options{})
+
+	want := otherHost(target.URL) + "/one?secret=shh"
+	select {
+	case hdr := <-got:
+		if hdr.Get("Referer") != want {
+			t.Fatalf("Referer = %q, want the whole URL of the same-origin hop %q", hdr.Get("Referer"), want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the redirect target was never reached")
+	}
+}
+
+func TestRedirectBackToTheOwnerOriginNarrowsTheReferer(t *testing.T) {
+	got := make(chan http.Header, 1)
+	var owner, hop *httptest.Server
+	owner = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/back" {
+			got <- r.Header.Clone()
+			return
+		}
+		http.Redirect(w, r, otherHost(hop.URL)+"/hop?secret=shh", http.StatusFound)
+	}))
+	t.Cleanup(owner.Close)
+	hop = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, owner.URL+"/back", http.StatusFound)
+	}))
+	t.Cleanup(hop.Close)
+
+	execute(t, &restfile.Request{Method: "GET", URL: owner.URL + "/start"}, Options{})
+
+	want := otherHost(hop.URL) + "/"
+	select {
+	case hdr := <-got:
+		if hdr.Get("Referer") != want {
+			t.Fatalf("Referer = %q, want only the origin the hop came from %q", hdr.Get("Referer"), want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the redirect target was never reached")
 	}
 }

--- a/internal/protocol/httpx/redirect_test.go
+++ b/internal/protocol/httpx/redirect_test.go
@@ -1,0 +1,928 @@
+package httpx
+
+import (
+	"context"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
+	"github.com/unkn0wn-root/resterm/internal/http/origin"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+type recorder struct {
+	*httptest.Server
+	got chan http.Header
+}
+
+func newRecorder(t *testing.T) *recorder {
+	t.Helper()
+	r := &recorder{got: make(chan http.Header, 4)}
+	r.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.got <- req.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(r.Close)
+	return r
+}
+
+func (r *recorder) received(t *testing.T) http.Header {
+	t.Helper()
+	select {
+	case h := <-r.got:
+		return h
+	case <-time.After(5 * time.Second):
+		t.Fatal("the redirect target was never reached")
+		return nil
+	}
+}
+
+func redirectTo(t *testing.T, target string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, target, http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func otherHost(rawURL string) string {
+	return strings.Replace(rawURL, "127.0.0.1", "localhost", 1)
+}
+
+func execute(t *testing.T, req *restfile.Request, opts Options) *Response {
+	t.Helper()
+	opts.FollowRedirects = true
+	if opts.Timeout == 0 {
+		opts.Timeout = 10 * time.Second
+	}
+	resp, err := NewClient(nil).Execute(t.Context(), req, nil, opts)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	return resp
+}
+
+func TestRedirectToAnotherHostDropsCredentials(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		value  string
+	}{
+		{name: "manual authorization", header: "Authorization", value: "Bearer secret"},
+		{name: "manual cookie", header: "Cookie", value: "session=secret"},
+		{name: "proxy authorization", header: "Proxy-Authorization", value: "Basic secret"},
+		{name: "api key auth", header: "X-API-Key", value: "secret"},
+		{name: "oauth custom header", header: "X-Auth-Token", value: "secret"},
+		{name: "command auth header", header: "X-Access-Token", value: "secret"},
+		{name: "google api key", header: "X-Goog-Api-Key", value: "secret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attacker := newRecorder(t)
+			origin := redirectTo(t, otherHost(attacker.URL)+"/steal")
+
+			hdr := make(http.Header)
+			hdr.Set(tt.header, tt.value)
+			hdr.Set("X-Trace-Id", "kept")
+			execute(t, &restfile.Request{Method: "GET", URL: origin.URL, Headers: hdr}, Options{})
+
+			got := attacker.received(t)
+			if leaked := got.Get(tt.header); leaked != "" {
+				t.Errorf("%s reached the redirect target as %q", tt.header, leaked)
+			}
+			if got.Get("X-Trace-Id") != "kept" {
+				t.Error("a header that carries no credential was dropped")
+			}
+		})
+	}
+}
+
+func TestRedirectDropsAPIKeyPlacedByAuthDirective(t *testing.T) {
+	attacker := newRecorder(t)
+	origin := redirectTo(t, otherHost(attacker.URL)+"/steal")
+
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    origin.URL,
+		Metadata: restfile.RequestMetadata{
+			Auth: &restfile.AuthSpec{
+				Type: restfile.AuthAPIKey,
+				Params: map[string]string{
+					authParamName:      "X-API-Key",
+					authParamValue:     "secret",
+					authParamPlacement: authPlacementHeader,
+				},
+			},
+		},
+	}
+	execute(t, req, Options{})
+
+	if leaked := attacker.received(t).Get("X-API-Key"); leaked != "" {
+		t.Errorf("X-API-Key reached the redirect target as %q", leaked)
+	}
+}
+
+func TestRedirectToAnotherPortDropsCredentials(t *testing.T) {
+	attacker := newRecorder(t)
+	origin := redirectTo(t, attacker.URL+"/steal")
+
+	hdr := make(http.Header)
+	hdr.Set("Authorization", "Bearer secret")
+	hdr.Set("X-API-Key", "secret")
+	execute(t, &restfile.Request{Method: "GET", URL: origin.URL, Headers: hdr}, Options{})
+
+	got := attacker.received(t)
+	for _, name := range []string{"Authorization", "X-API-Key"} {
+		if leaked := got.Get(name); leaked != "" {
+			t.Errorf("%s crossed a port boundary as %q", name, leaked)
+		}
+	}
+}
+
+func TestRedirectWithinTheSameOriginKeepsCredentials(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/moved" {
+			got = req.Header.Clone()
+			return
+		}
+		http.Redirect(w, req, "/moved", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	hdr := make(http.Header)
+	hdr.Set("Authorization", "Bearer secret")
+	hdr.Set("X-API-Key", "secret")
+	execute(t, &restfile.Request{Method: "GET", URL: srv.URL, Headers: hdr}, Options{})
+
+	if got.Get("Authorization") != "Bearer secret" || got.Get("X-API-Key") != "secret" {
+		t.Fatalf("a same origin redirect lost its credentials: %v", got)
+	}
+}
+
+func TestKeepsCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		previous string
+		next     string
+		forwards string
+		want     bool
+	}{
+		{name: "no forwarding", previous: "https://a.example.com/x", next: "https://cdn.example.net/y"},
+		{
+			name:     "named origin",
+			previous: "https://a.example.com/x",
+			next:     "https://cdn.example.net/y",
+			forwards: "https://cdn.example.net",
+			want:     true,
+		},
+		{
+			name:     "an origin outside the list stays outside",
+			previous: "https://a.example.com/x",
+			next:     "https://evil.example.net/y",
+			forwards: "https://cdn.example.net",
+		},
+		{
+			name:     "a listed origin on another port is another origin",
+			previous: "https://a.example.com/x",
+			next:     "https://cdn.example.net:8443/y",
+			forwards: "https://cdn.example.net",
+		},
+		{
+			name:     "any origin",
+			previous: "https://a.example.com/x",
+			next:     "https://anywhere.example.net/y",
+			forwards: "true",
+			want:     true,
+		},
+		{
+			name:     "any origin still refuses a downgrade",
+			previous: "https://a.example.com/x",
+			next:     "http://a.example.com/y",
+			forwards: "true",
+		},
+		{
+			name:     "a listed origin still refuses a downgrade",
+			previous: "https://a.example.com/x",
+			next:     "http://cdn.example.net/y",
+			forwards: "http://cdn.example.net",
+		},
+		{
+			name:     "a downgrade partway along a chain",
+			previous: "https://trusted.example.net/x",
+			next:     "http://other.example.net/y",
+			forwards: "true",
+		},
+		{
+			name:     "plain http to plain http is not a downgrade",
+			previous: "http://a.example.com/x",
+			next:     "http://cdn.example.net/y",
+			forwards: "http://cdn.example.net",
+			want:     true,
+		},
+		{
+			name:     "an upgrade to https is allowed when the origin is listed",
+			previous: "http://a.example.com/x",
+			next:     "https://cdn.example.net/y",
+			forwards: "https://cdn.example.net",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previous, err := url.Parse(tt.previous)
+			if err != nil {
+				t.Fatal(err)
+			}
+			next, err := url.Parse(tt.next)
+			if err != nil {
+				t.Fatal(err)
+			}
+			forwards := origin.Set{}
+			if tt.forwards != "" {
+				if forwards, err = ParseForwardCredentials(tt.forwards); err != nil {
+					t.Fatalf("ParseForwardCredentials(%q): %v", tt.forwards, err)
+				}
+			}
+			if got := keepsCredentials(previous, next, forwards); got != tt.want {
+				t.Fatalf("keepsCredentials(%s, %s) = %t, want %t", tt.previous, tt.next, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedirectLoopStops(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, "/next", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(nil).Execute(
+		t.Context(),
+		&restfile.Request{Method: "GET", URL: srv.URL},
+		nil,
+		Options{FollowRedirects: true, Timeout: 10 * time.Second},
+	)
+	if err == nil {
+		t.Fatal("Execute() = nil, want the redirect limit")
+	}
+	if !strings.Contains(err.Error(), "stopped after") {
+		t.Fatalf("Execute() = %v, want the redirect limit", err)
+	}
+}
+
+func TestRedirectsDisabledReturnTheRedirectItself(t *testing.T) {
+	attacker := newRecorder(t)
+	origin := redirectTo(t, otherHost(attacker.URL)+"/steal")
+
+	resp, err := NewClient(nil).Execute(
+		context.Background(),
+		&restfile.Request{Method: "GET", URL: origin.URL},
+		nil,
+		Options{Timeout: 10 * time.Second},
+	)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+}
+
+func TestRedirectKeepsCookiesTheJarOwns(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/moved":
+			got = req.Header.Clone()
+		default:
+			http.SetCookie(w, &http.Cookie{Name: "jar", Value: "kept", Path: "/"})
+			http.Redirect(w, req, "/moved", http.StatusFound)
+		}
+	}))
+	defer srv.Close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execute(t, &restfile.Request{Method: "GET", URL: srv.URL}, Options{CookieJar: jar})
+
+	if v := got.Get("Cookie"); !strings.Contains(v, "jar=kept") {
+		t.Fatalf("Cookie = %q, want the jar cookie", v)
+	}
+}
+
+func TestRedirectLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+		want int
+	}{
+		{name: "not following", want: 0},
+		{name: "unset takes the default", opts: Options{FollowRedirects: true}, want: DefaultMaxRedirects},
+		{
+			name: "explicit count",
+			opts: Options{FollowRedirects: true, MaxRedirects: restfile.OptOf(3)},
+			want: 3,
+		},
+		{
+			name: "zero follows none",
+			opts: Options{FollowRedirects: true, MaxRedirects: restfile.OptOf(0)},
+			want: 0,
+		},
+		{
+			name: "not following wins over a count",
+			opts: Options{MaxRedirects: restfile.OptOf(5)},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redirectLimit(tt.opts); got != tt.want {
+				t.Fatalf("redirectLimit() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedirectStopsAtTheConfiguredCount(t *testing.T) {
+	var hops atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		hops.Add(1)
+		http.Redirect(w, req, "/next", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(nil).Execute(
+		t.Context(),
+		&restfile.Request{Method: "GET", URL: srv.URL},
+		nil,
+		Options{FollowRedirects: true, MaxRedirects: restfile.OptOf(3), Timeout: 10 * time.Second},
+	)
+	if err == nil || !strings.Contains(err.Error(), "stopped after following 3 redirects") {
+		t.Fatalf("Execute() = %v, want the configured redirect limit", err)
+	}
+	if got := hops.Load(); got != 4 {
+		t.Fatalf("the server saw %d requests, want 4", got)
+	}
+}
+
+func TestMaxRedirectsZeroFollowsNone(t *testing.T) {
+	attacker := newRecorder(t)
+	origin := redirectTo(t, otherHost(attacker.URL)+"/steal")
+
+	resp, err := NewClient(nil).Execute(
+		t.Context(),
+		&restfile.Request{Method: "GET", URL: origin.URL},
+		nil,
+		Options{FollowRedirects: true, MaxRedirects: restfile.OptOf(0), Timeout: 10 * time.Second},
+	)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+}
+
+func TestMaxRedirectsSetting(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    int
+		wantErr bool
+	}{
+		{raw: "20", want: 20},
+		{raw: "0", want: 0},
+		{raw: "none", want: 0},
+		{raw: "Off", want: 0},
+		{raw: "-1", wantErr: true},
+		{raw: "many", wantErr: true},
+		{raw: "unlimited", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			var opts Options
+			err := ApplyOptionSettings(&opts, map[string]string{"max-redirects": tt.raw})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ApplyOptionSettings(%q) error = %v, wantErr %t", tt.raw, err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got, ok := opts.MaxRedirects.Get(); !ok || got != tt.want {
+				t.Fatalf("MaxRedirects = %d (set %t), want %d", got, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedirectDropsHeadersAuthNamed(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		req    func(url, header string) *restfile.Request
+		opts   Options
+	}{
+		{
+			name:   "apikey auth with a custom name",
+			header: "X-Registry-Token",
+			req: func(url, hdr string) *restfile.Request {
+				return &restfile.Request{
+					Method: "GET",
+					URL:    url,
+					Metadata: restfile.RequestMetadata{Auth: &restfile.AuthSpec{
+						Type: restfile.AuthAPIKey,
+						Params: map[string]string{
+							authParamName:      hdr,
+							authParamValue:     "secret",
+							authParamPlacement: authPlacementHeader,
+						},
+					}},
+				}
+			},
+		},
+		{
+			name:   "header auth with a custom name",
+			header: "X-Tenant-Credential",
+			req: func(url, hdr string) *restfile.Request {
+				return &restfile.Request{
+					Method: "GET",
+					URL:    url,
+					Metadata: restfile.RequestMetadata{Auth: &restfile.AuthSpec{
+						Type: restfile.AuthHeader,
+						Params: map[string]string{
+							authParamHeader: hdr,
+							authParamValue:  "secret",
+						},
+					}},
+				}
+			},
+		},
+		{
+			name:   "header the caller reports as a credential",
+			header: "X-Registry-Token",
+			req: func(url, hdr string) *restfile.Request {
+				h := make(http.Header)
+				h.Set(hdr, "secret")
+				return &restfile.Request{Method: "GET", URL: url, Headers: h}
+			},
+			opts: Options{CredentialHeaders: []string{"x-registry-token"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attacker := newRecorder(t)
+			origin := redirectTo(t, otherHost(attacker.URL)+"/steal")
+
+			execute(t, tt.req(origin.URL, tt.header), tt.opts)
+
+			if leaked := attacker.received(t).Get(tt.header); leaked != "" {
+				t.Errorf("%s reached the redirect target as %q", tt.header, leaked)
+			}
+		})
+	}
+}
+
+func TestRedirectKeepsAuthNamedHeadersWithinTheOrigin(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/moved" {
+			got = req.Header.Clone()
+			return
+		}
+		http.Redirect(w, req, "/moved", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	hdr := make(http.Header)
+	hdr.Set("X-Registry-Token", "secret")
+	execute(
+		t,
+		&restfile.Request{Method: "GET", URL: srv.URL, Headers: hdr},
+		Options{CredentialHeaders: []string{"X-Registry-Token"}},
+	)
+
+	if got.Get("X-Registry-Token") != "secret" {
+		t.Fatalf("a same origin redirect lost its credential: %v", got)
+	}
+}
+
+func TestBuildHTTPRequestReportsAuthPlacedHeaders(t *testing.T) {
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    "https://api.example.com/v1",
+		Metadata: restfile.RequestMetadata{Auth: &restfile.AuthSpec{
+			Type: restfile.AuthAPIKey,
+			Params: map[string]string{
+				authParamName:      "X-Registry-Token",
+				authParamValue:     "secret",
+				authParamPlacement: authPlacementHeader,
+			},
+		}},
+	}
+
+	_, opts, _, err := NewClient(nil).BuildHTTPRequest(t.Context(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+	if !slices.Contains(opts.CredentialHeaders, "X-Registry-Token") {
+		t.Fatalf("CredentialHeaders = %v, want the auth placed name", opts.CredentialHeaders)
+	}
+}
+
+func TestBuildHTTPRequestIgnoresQueryPlacedAuth(t *testing.T) {
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    "https://api.example.com/v1",
+		Metadata: restfile.RequestMetadata{Auth: &restfile.AuthSpec{
+			Type: restfile.AuthAPIKey,
+			Params: map[string]string{
+				authParamName:      "api_key",
+				authParamValue:     "secret",
+				authParamPlacement: authPlacementQuery,
+			},
+		}},
+	}
+
+	_, opts, _, err := NewClient(nil).BuildHTTPRequest(t.Context(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("BuildHTTPRequest: %v", err)
+	}
+	if len(opts.CredentialHeaders) != 0 {
+		t.Fatalf("CredentialHeaders = %v, want none", opts.CredentialHeaders)
+	}
+}
+
+func TestRedirectDropsAnAuthHeaderTheRequestSuppliedItself(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *restfile.AuthSpec
+	}{
+		{
+			name: "apikey auth",
+			auth: &restfile.AuthSpec{
+				Type: restfile.AuthAPIKey,
+				Params: map[string]string{
+					authParamName:      "X-Registry-Token",
+					authParamValue:     "from-directive",
+					authParamPlacement: authPlacementHeader,
+				},
+			},
+		},
+		{
+			name: "header auth",
+			auth: &restfile.AuthSpec{
+				Type: restfile.AuthHeader,
+				Params: map[string]string{
+					authParamHeader: "X-Registry-Token",
+					authParamValue:  "from-directive",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attacker := newRecorder(t)
+			origin := redirectTo(t, otherHost(attacker.URL)+"/steal")
+
+			hdr := make(http.Header)
+			hdr.Set("X-Registry-Token", "written-by-hand")
+			execute(t, &restfile.Request{
+				Method:   "GET",
+				URL:      origin.URL,
+				Headers:  hdr,
+				Metadata: restfile.RequestMetadata{Auth: tt.auth},
+			}, Options{})
+
+			if leaked := attacker.received(t).Get("X-Registry-Token"); leaked != "" {
+				t.Errorf("X-Registry-Token reached the redirect target as %q", leaked)
+			}
+		})
+	}
+}
+
+func TestResolveAuthReportsTheHeaderItTargets(t *testing.T) {
+	tests := []struct {
+		name     string
+		auth     *restfile.AuthSpec
+		existing string
+		want     []string
+		wantSet  bool
+	}{
+		{
+			name: "apikey places its value",
+			auth: &restfile.AuthSpec{Type: restfile.AuthAPIKey, Params: map[string]string{
+				authParamName:      "X-Registry-Token",
+				authParamValue:     "secret",
+				authParamPlacement: authPlacementHeader,
+			}},
+			want:    []string{"X-Registry-Token"},
+			wantSet: true,
+		},
+		{
+			name: "apikey defers to the request",
+			auth: &restfile.AuthSpec{Type: restfile.AuthAPIKey, Params: map[string]string{
+				authParamName:      "X-Registry-Token",
+				authParamValue:     "secret",
+				authParamPlacement: authPlacementHeader,
+			}},
+			existing: "X-Registry-Token",
+			want:     []string{"X-Registry-Token"},
+		},
+		{
+			name: "header auth defers to the request",
+			auth: &restfile.AuthSpec{Type: restfile.AuthHeader, Params: map[string]string{
+				authParamHeader: "X-Tenant-Credential",
+				authParamValue:  "secret",
+			}},
+			existing: "X-Tenant-Credential",
+			want:     []string{"X-Tenant-Credential"},
+		},
+		{
+			name: "bearer defers to the request",
+			auth: &restfile.AuthSpec{Type: restfile.AuthBearer, Params: map[string]string{
+				authParamToken: "secret",
+			}},
+			existing: "Authorization",
+			want:     []string{"Authorization"},
+		},
+		{
+			name: "apikey in the query targets no header",
+			auth: &restfile.AuthSpec{Type: restfile.AuthAPIKey, Params: map[string]string{
+				authParamName:      "api_key",
+				authParamValue:     "secret",
+				authParamPlacement: authPlacementQuery,
+			}},
+			wantSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := make(http.Header)
+			if tt.existing != "" {
+				existing.Set(tt.existing, "written-by-hand")
+			}
+
+			plan, err := ResolveAuth(tt.auth, nil, existing, diag.ComponentHTTP)
+			if err != nil {
+				t.Fatalf("ResolveAuth: %v", err)
+			}
+			if !slices.Equal(plan.Targets, tt.want) {
+				t.Fatalf("Headers = %v, want %v", plan.Targets, tt.want)
+			}
+			if got := len(plan.Values) > 0; got != tt.wantSet {
+				t.Fatalf("placed a value = %t, want %t", got, tt.wantSet)
+			}
+		})
+	}
+}
+
+func TestForwardCredentialsAllowsTheNamedOrigin(t *testing.T) {
+	attacker := newRecorder(t)
+	trusted := newRecorder(t)
+
+	for _, tt := range []struct {
+		name   string
+		target *recorder
+		want   string
+	}{
+		{name: "named origin", target: trusted, want: "Bearer secret"},
+		{name: "any other origin", target: attacker},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			origin := redirectTo(t, otherHost(tt.target.URL)+"/next")
+			forward, err := ParseForwardCredentials(otherHost(trusted.URL))
+			if err != nil {
+				t.Fatalf("ParseForwardCredentials: %v", err)
+			}
+
+			hdr := make(http.Header)
+			hdr.Set("Authorization", "Bearer secret")
+			execute(
+				t,
+				&restfile.Request{Method: "GET", URL: origin.URL, Headers: hdr},
+				Options{ForwardCredentials: forward},
+			)
+
+			if got := tt.target.received(t).Get("Authorization"); got != tt.want {
+				t.Fatalf("Authorization = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForwardCredentialsSetting(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{raw: "true", want: "any origin"},
+		{raw: "ALL", want: "any origin"},
+		{raw: "false", want: "none"},
+		{raw: "off", want: "none"},
+		{raw: "https://cdn.example.com", want: "https://cdn.example.com"},
+		{
+			raw:  "https://a.example.com,https://b.example.com",
+			want: "https://a.example.com, https://b.example.com",
+		},
+		{raw: "cdn.example.com", wantErr: true},
+		{raw: "https://cdn.example.com/assets", wantErr: true},
+		{raw: "", wantErr: true},
+		{raw: "   ", wantErr: true},
+		{raw: " , ; ", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			var opts Options
+			err := ApplyOptionSettings(&opts, map[string]string{
+				"forward-credentials-on-redirect": tt.raw,
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ApplyOptionSettings(%q) error = %v, wantErr %t", tt.raw, err, tt.wantErr)
+			}
+			if err == nil && opts.ForwardCredentials.String() != tt.want {
+				t.Fatalf("ForwardCredentials = %q, want %q", opts.ForwardCredentials, tt.want)
+			}
+		})
+	}
+}
+
+func TestForwardCredentialsLeavesCookiesToTheJar(t *testing.T) {
+	trusted := newRecorder(t)
+	origin := redirectTo(t, otherHost(trusted.URL)+"/next")
+
+	forward, err := ParseForwardCredentials(otherHost(trusted.URL))
+	if err != nil {
+		t.Fatalf("ParseForwardCredentials: %v", err)
+	}
+
+	hdr := make(http.Header)
+	hdr.Set("Authorization", "Bearer secret")
+	hdr.Set("Cookie", "session=secret")
+	execute(
+		t,
+		&restfile.Request{Method: "GET", URL: origin.URL, Headers: hdr},
+		Options{ForwardCredentials: forward},
+	)
+
+	got := trusted.received(t)
+	if got.Get("Authorization") != "Bearer secret" {
+		t.Fatalf("Authorization = %q, want the forwarded credential", got.Get("Authorization"))
+	}
+	if leaked := got.Get("Cookie"); leaked != "" {
+		t.Fatalf("Cookie = %q, want the jar to decide where cookies go", leaked)
+	}
+}
+
+func TestForwardCredentialsRefusesADowngradePartwayAlong(t *testing.T) {
+	last := newRecorder(t)
+	middle := redirectTo(t, otherHost(last.URL)+"/last")
+	first := redirectTo(t, middle.URL+"/next")
+
+	forward, err := ParseForwardCredentials("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hdr := make(http.Header)
+	hdr.Set("Authorization", "Bearer secret")
+	hdr.Set("X-Api-Key", "secret")
+	execute(
+		t,
+		&restfile.Request{Method: "GET", URL: first.URL, Headers: hdr},
+		Options{ForwardCredentials: forward},
+	)
+
+	got := last.received(t)
+	if got.Get("Authorization") == "" || got.Get("X-Api-Key") == "" {
+		t.Fatalf("an allowed plain HTTP chain lost its credentials: %v", got)
+	}
+}
+
+func hop(t *testing.T, opts Options, from, to string, copied http.Header) (*http.Request, error) {
+	t.Helper()
+
+	initial, err := http.NewRequest(http.MethodGet, from, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial.Header = copied.Clone()
+
+	next, err := http.NewRequest(http.MethodGet, to, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	next.Header = copied.Clone()
+
+	return next, redirectPolicy(opts)(next, []*http.Request{initial})
+}
+
+func TestRedirectDropsCookiesEvenWhenTheOriginIsTrusted(t *testing.T) {
+	forward, err := ParseForwardCredentials("https://cdn.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copied := make(http.Header)
+	copied.Set("Cookie", "session=secret")
+	copied.Set("Authorization", "Bearer secret")
+
+	next, err := hop(
+		t,
+		Options{FollowRedirects: true, ForwardCredentials: forward},
+		"https://example.com/x",
+		"https://cdn.example.com/y",
+		copied,
+	)
+	if err != nil {
+		t.Fatalf("redirect policy: %v", err)
+	}
+	if leaked := next.Header.Get("Cookie"); leaked != "" {
+		t.Errorf("Cookie = %q, want the jar to decide where cookies go", leaked)
+	}
+	if next.Header.Get("Authorization") != "Bearer secret" {
+		t.Error("the trusted origin lost the credential it was trusted with")
+	}
+}
+
+func TestRedirectKeepsCookiesWithinTheOrigin(t *testing.T) {
+	copied := make(http.Header)
+	copied.Set("Cookie", "session=secret")
+
+	next, err := hop(
+		t,
+		Options{FollowRedirects: true},
+		"https://example.com/x",
+		"https://example.com/y",
+		copied,
+	)
+	if err != nil {
+		t.Fatalf("redirect policy: %v", err)
+	}
+	if next.Header.Get("Cookie") != "session=secret" {
+		t.Fatal("a redirect inside the origin lost its cookies")
+	}
+}
+
+func TestConfinedRedirectIsRefused(t *testing.T) {
+	opts := Options{FollowRedirects: true, ConfineToOrigin: true}
+
+	if _, err := hop(t, opts, "https://idp.example.com/token", "https://idp.example.com/v2", nil); err != nil {
+		t.Fatalf("a redirect inside the origin was refused: %v", err)
+	}
+
+	_, err := hop(t, opts, "https://idp.example.com/token", "https://cdn.example.net/token", nil)
+	if err == nil {
+		t.Fatal("a redirect off the origin was followed")
+	}
+	if !strings.Contains(err.Error(), "https://cdn.example.net") {
+		t.Fatalf("error = %v, want it to name the destination", err)
+	}
+}
+
+func TestRedirectRefusesADowngradePartwayAlongAChain(t *testing.T) {
+	last := newRecorder(t)
+	middle := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, last.URL+"/last", http.StatusFound)
+	}))
+	defer middle.Close()
+	first := redirectTo(t, middle.URL+"/next")
+
+	forward, err := ParseForwardCredentials("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hdr := make(http.Header)
+	hdr.Set("Authorization", "Bearer secret")
+	hdr.Set("X-Api-Key", "secret")
+	execute(t, &restfile.Request{Method: "GET", URL: first.URL, Headers: hdr}, Options{
+		ForwardCredentials: forward,
+		InsecureSkipVerify: true,
+	})
+
+	got := last.received(t)
+	for _, name := range []string{"Authorization", "X-Api-Key"} {
+		if leaked := got.Get(name); leaked != "" {
+			t.Errorf("%s left TLS partway along the chain as %q", name, leaked)
+		}
+	}
+}

--- a/internal/protocol/httpx/request.go
+++ b/internal/protocol/httpx/request.go
@@ -69,13 +69,13 @@ func (c *Client) applyAuthentication(
 	req *http.Request,
 	resolver *vars.Resolver,
 	auth *restfile.AuthSpec,
-) error {
-	values, err := AuthValues(auth, resolver, req.Header, diag.ComponentHTTP)
+) ([]string, error) {
+	plan, err := ResolveAuth(auth, resolver, req.Header, diag.ComponentHTTP)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	for _, v := range values {
+	for _, v := range plan.Values {
 		switch v.Placement {
 		case AuthInQuery:
 			q := req.URL.Query()
@@ -85,7 +85,7 @@ func (c *Client) applyAuthentication(
 			req.Header.Set(v.Name, v.Value)
 		}
 	}
-	return nil
+	return plan.Targets, nil
 }
 
 type reqMeta struct {

--- a/internal/protocol/httpx/request_build.go
+++ b/internal/protocol/httpx/request_build.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
@@ -184,8 +185,10 @@ func (c *Client) buildHTTPRequest(
 		}
 	}
 
-	if err := c.applyAuthentication(httpReq, resolver, req.Metadata.Auth); err != nil {
+	placed, err := c.applyAuthentication(httpReq, resolver, req.Metadata.Auth)
+	if err != nil {
 		return nil, opts, err
 	}
+	opts.CredentialHeaders = slices.Concat(opts.CredentialHeaders, placed)
 	return httpReq, opts, nil
 }

--- a/internal/protocol/httpx/request_test.go
+++ b/internal/protocol/httpx/request_test.go
@@ -159,7 +159,7 @@ func TestApplyAuthenticationSkipsUnusedParams(t *testing.T) {
 		Params: map[string]string{"token": "{{missing}}"},
 	}
 
-	if err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
+	if _, err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
 		t.Fatalf("unexpected error for unused auth param: %v", err)
 	}
 	if got := httpReq.Header.Get("Authorization"); got != "Bearer explicit" {
@@ -173,15 +173,13 @@ func TestApplyAuthenticationSkipsUnusedParamsForLowercaseHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	// A block assigned straight into the header map keeps the case it was
-	// written with, so auth has to see the name without canonicalizing it.
 	httpReq.Header = http.Header{"authorization": {"Bearer explicit"}}
 	auth := &restfile.AuthSpec{
 		Type:   "bearer",
 		Params: map[string]string{"token": "{{missing}}"},
 	}
 
-	if err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
+	if _, err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
 		t.Fatalf("unexpected error for case-insensitive auth override: %v", err)
 	}
 	if got := header.Value(httpReq.Header, "Authorization"); got != "Bearer explicit" {
@@ -484,7 +482,7 @@ func TestApplyAuthenticationInvalidPlacementErrors(t *testing.T) {
 		},
 	}
 
-	err = c.applyAuthentication(httpReq, vars.NewResolver(), auth)
+	_, err = c.applyAuthentication(httpReq, vars.NewResolver(), auth)
 	if err == nil || !strings.Contains(err.Error(), `invalid apikey auth placement "qurey"`) {
 		t.Fatalf("expected invalid placement error, got %v", err)
 	}
@@ -504,7 +502,7 @@ func TestApplyAuthenticationEmptyPlacementDefaultsToHeader(t *testing.T) {
 		Params: map[string]string{"name": "X-Key", "value": "k-123"},
 	}
 
-	if err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
+	if _, err := c.applyAuthentication(httpReq, vars.NewResolver(), auth); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := httpReq.Header.Get("X-Key"); got != "k-123" {
@@ -555,7 +553,7 @@ func TestApplyAuthenticationLenientAPIKeyPlacement(t *testing.T) {
 				},
 			}
 
-			err = c.applyAuthentication(httpReq, vars.NewResolver().Lenient(), auth)
+			_, err = c.applyAuthentication(httpReq, vars.NewResolver().Lenient(), auth)
 			if tt.wantError == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/protocol/httpx/stream_sse.go
+++ b/internal/protocol/httpx/stream_sse.go
@@ -108,11 +108,11 @@ func (c *Client) StartSSE(
 
 	contentType := strings.ToLower(httpResp.Header.Get("Content-Type"))
 	if httpResp.StatusCode >= 400 || !strings.Contains(contentType, "text/event-stream") {
-		body, readErr := io.ReadAll(httpResp.Body)
+		body, readErr := effectiveOpts.readBody(httpResp.Body)
 		closeErr := httpResp.Body.Close()
 		cancel()
 		if readErr != nil {
-			return nil, nil, diag.WrapAs(diag.ClassProtocol, readErr, "read response body")
+			return nil, nil, readErr
 		}
 		if closeErr != nil {
 			return nil, nil, diag.WrapAs(diag.ClassProtocol, closeErr, "close response body")

--- a/internal/protocol/httpx/stream_sse.go
+++ b/internal/protocol/httpx/stream_sse.go
@@ -243,19 +243,13 @@ func CompleteSSE(handle *StreamHandle) (*Response, error) {
 		acc.summary.Error = serr.Error()
 	}
 	if acc.summary.Reason == "" {
-		if serr != nil {
-			acc.summary.Reason = serr.Error()
-		} else if state == stream.StateFailed {
+		if serr != nil || state == stream.StateFailed {
 			acc.summary.Reason = sseReasonErr
 		} else {
 			acc.summary.Reason = sseReasonEOF
 		}
 	} else if acc.summary.Reason == sseReasonEOF && (state == stream.StateFailed || serr != nil) {
-		if serr != nil {
-			acc.summary.Reason = serr.Error()
-		} else {
-			acc.summary.Reason = sseReasonErr
-		}
+		acc.summary.Reason = sseReasonErr
 	}
 
 	transcript := SSETranscript{Events: acc.events, Summary: acc.summary}

--- a/internal/protocol/httpx/stream_sse.go
+++ b/internal/protocol/httpx/stream_sse.go
@@ -113,6 +113,20 @@ type SSETranscript struct {
 	Summary SSESummary `json:"summary"`
 }
 
+// Err reports the failure that ended the stream. Reaching a configured limit or
+// timeout is a normal ending and returns nil. A broken read, or a line or event
+// larger than its limit, is a failure.
+func (s SSESummary) Err() error {
+	switch {
+	case s.Reason == sseReasonCanceled:
+		return diag.New(diag.ClassCanceled, cmp.Or(s.Error, "sse stream canceled"))
+	case s.Reason == sseReasonErr, s.Error != "":
+		return diag.New(diag.ClassProtocol, cmp.Or(s.Error, "sse stream failed"))
+	default:
+		return nil
+	}
+}
+
 func (c *Client) StartSSE(
 	ctx context.Context,
 	req *restfile.Request,
@@ -242,14 +256,14 @@ func CompleteSSE(handle *StreamHandle) (*Response, error) {
 	if acc.summary.Error == "" && serr != nil {
 		acc.summary.Error = serr.Error()
 	}
-	if acc.summary.Reason == "" {
-		if serr != nil || state == stream.StateFailed {
-			acc.summary.Reason = sseReasonErr
-		} else {
-			acc.summary.Reason = sseReasonEOF
-		}
-	} else if acc.summary.Reason == sseReasonEOF && (state == stream.StateFailed || serr != nil) {
+	// The run already set a reason naming the limit it stopped at, so keep it.
+	// Only "eof" gives way, because a failed session contradicts it.
+	failed := serr != nil || state == stream.StateFailed
+	switch {
+	case failed && (acc.summary.Reason == "" || acc.summary.Reason == sseReasonEOF):
 		acc.summary.Reason = sseReasonErr
+	case acc.summary.Reason == "":
+		acc.summary.Reason = sseReasonEOF
 	}
 
 	transcript := SSETranscript{Events: acc.events, Summary: acc.summary}

--- a/internal/protocol/httpx/stream_sse.go
+++ b/internal/protocol/httpx/stream_sse.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,8 +11,10 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/k8s"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
@@ -23,16 +26,68 @@ const (
 	sseMetaReason = "resterm.summary.reason"
 	sseMetaBytes  = "resterm.summary.bytes"
 	sseMetaEvents = "resterm.summary.events"
+	sseMetaError  = "resterm.summary.error"
 )
 
 const (
-	sseReasonEOF       = "eof"
-	sseReasonErr       = "error"
-	sseReasonIdle      = "timeout:idle"
-	sseReasonMaxBytes  = "limit:max_bytes"
-	sseReasonMaxEvents = "limit:max_events"
-	sseReasonCanceled  = "context_canceled"
+	sseReasonEOF        = "eof"
+	sseReasonErr        = "error"
+	sseReasonIdle       = "timeout:idle"
+	sseReasonMaxBytes   = "limit:max_bytes"
+	sseReasonMaxEvents  = "limit:max_events"
+	sseReasonLineBytes  = "limit:line_bytes"
+	sseReasonEventBytes = "limit:event_bytes"
+	sseReasonTotal      = "timeout:total"
+	sseReasonCanceled   = "context_canceled"
 )
+
+const (
+	DefaultSSEMaxLineBytes  = 4 << 20
+	DefaultSSEMaxEventBytes = 8 << 20
+	DefaultSSESessionBytes  = 16 << 20
+)
+
+var (
+	errSSELineTooLong   = errors.New("sse line exceeds the line limit")
+	errSSEEventTooLarge = errors.New("sse event exceeds the event limit")
+)
+
+type sseLimits struct {
+	stream int64
+	line   int64
+	event  int64
+}
+
+func sseLimitsFor(opts restfile.SSEOptions) sseLimits {
+	return sseLimits{
+		stream: opts.MaxBytes,
+		line:   cmp.Or(opts.MaxLineBytes, DefaultSSEMaxLineBytes),
+		event:  cmp.Or(opts.MaxEventBytes, DefaultSSEMaxEventBytes),
+	}
+}
+
+func (l sseLimits) sessionBytes() bytesize.Budget {
+	// Keep room for a full event and the summary event that follows it.
+	return bytesize.Of(max(int64(DefaultSSESessionBytes), 2*l.event))
+}
+
+func (l sseLimits) lineBudget(read int64) int {
+	budget := l.line
+	if l.stream > 0 {
+		budget = min(budget, l.stream-read+1)
+	}
+	return int(budget)
+}
+
+func sseOverrun(subject string, limit int64, option string) error {
+	return diag.Newf(
+		diag.ClassProtocol,
+		"sse %s exceeds %d bytes, raise it with @sse %s",
+		subject,
+		limit,
+		option,
+	)
+}
 
 type SSEEvent struct {
 	Index     int       `json:"index"`
@@ -49,6 +104,8 @@ type SSESummary struct {
 	ByteCount  int64         `json:"byteCount"`
 	Duration   time.Duration `json:"duration"`
 	Reason     string        `json:"reason"`
+	Dropped    int64         `json:"dropped,omitempty"`
+	Error      string        `json:"error,omitempty"`
 }
 
 type SSETranscript struct {
@@ -122,7 +179,9 @@ func (c *Client) StartSSE(
 
 	meta := buildStreamMeta(req, httpReq, httpResp, effectiveOpts.BaseDir, metaDefaults{})
 
-	session := stream.NewSession(streamCtx, stream.KindSSE, stream.Config{})
+	session := stream.NewSession(streamCtx, stream.KindSSE, stream.Config{
+		MaxBytes: sseLimitsFor(streamOpts).sessionBytes(),
+	})
 	session.MarkOpen()
 
 	go func() {
@@ -130,7 +189,7 @@ func (c *Client) StartSSE(
 		defer func() {
 			_ = httpResp.Body.Close()
 		}()
-		runSSESession(session, httpResp.Body, streamOpts)
+		runSSESession(session, httpResp.Body, streamOpts, cancel)
 	}()
 
 	return &StreamHandle{Session: session, Meta: meta}, nil, nil
@@ -167,6 +226,7 @@ func CompleteSSE(handle *StreamHandle) (*Response, error) {
 	}
 
 	stats := session.StatsSnapshot()
+	acc.summary.Dropped = int64(stats.Evicted)
 	if !stats.EndedAt.IsZero() {
 		acc.summary.Duration = stats.EndedAt.Sub(stats.StartedAt)
 	} else {
@@ -179,6 +239,9 @@ func CompleteSSE(handle *StreamHandle) (*Response, error) {
 		acc.summary.EventCount = len(acc.events)
 	}
 	state, serr := session.State()
+	if acc.summary.Error == "" && serr != nil {
+		acc.summary.Error = serr.Error()
+	}
 	if acc.summary.Reason == "" {
 		if serr != nil {
 			acc.summary.Reason = serr.Error()
@@ -207,124 +270,219 @@ func CompleteSSE(handle *StreamHandle) (*Response, error) {
 	}
 	headers.Set("Content-Type", streamContentTypeJSON)
 	headers.Set(StreamHeaderType, "sse")
-	headers.Set(
-		StreamHeaderSummary,
-		fmt.Sprintf(
-			"events=%d bytes=%d reason=%s",
-			transcript.Summary.EventCount,
-			transcript.Summary.ByteCount,
-			transcript.Summary.Reason,
-		),
-	)
+	headers.Set(StreamHeaderSummary, sseSummaryLine(transcript.Summary))
 
 	return streamResp(handle.Meta, headers, body, acc.summary.Duration), nil
 }
 
 // Idle timer watches for activity resets - each incoming byte triggers a reset.
 // The drain logic after Stop() handles the race where the timer fires just before we reset.
-func runSSESession(session *stream.Session, body io.ReadCloser, opts restfile.SSEOptions) {
+func runSSESession(
+	session *stream.Session,
+	body io.ReadCloser,
+	opts restfile.SSEOptions,
+	stopRead context.CancelFunc,
+) {
+	limits := sseLimitsFor(opts)
+	run := &sseRun{
+		session: session,
+		reader:  bufio.NewReader(body),
+		opts:    opts,
+		limits:  limits,
+		builder: sseEventBuilder{limit: limits.event},
+		summary: SSESummary{Reason: sseReasonEOF},
+	}
+
 	ctx := session.Context()
-	reader := bufio.NewReader(body)
-	summary := SSESummary{Reason: sseReasonEOF}
-
-	var (
-		builder    sseEventBuilder
-		index      int
-		byteCount  int64
-		eventCount int
-	)
-
-	idleReset, stopIdle := startIdleWatch(ctx, opts.IdleTimeout, func() {
-		summary.Reason = sseReasonIdle
-		session.Cancel()
+	var stopIdle func()
+	run.idle, stopIdle = startIdleWatch(ctx, opts.IdleTimeout, func() {
+		run.idled.Store(true)
+		// Cancel the request because stopping the session does not unblock the read.
+		stopRead()
 	})
 	defer stopIdle()
 
+	run.finish(ctx, run.loop(ctx))
+}
+
+type sseRun struct {
+	session *stream.Session
+	reader  *bufio.Reader
+	opts    restfile.SSEOptions
+	limits  sseLimits
+	builder sseEventBuilder
+	summary SSESummary
+	failure error
+	idle    chan<- struct{}
+	idled   atomic.Bool
+	index   int
+	events  int
+	bytes   int64
+}
+
+func (r *sseRun) loop(ctx context.Context) error {
 	for {
-		if opts.MaxBytes > 0 && byteCount >= opts.MaxBytes {
-			if summary.Reason == "" || summary.Reason == sseReasonEOF {
-				summary.Reason = sseReasonMaxBytes
-			}
-			break
+		if r.capped() {
+			r.stop(sseReasonMaxBytes)
+			return nil
 		}
 
-		line, err := reader.ReadString('\n')
-		if len(line) > 0 {
-			byteCount += int64(len(line))
-			if idleReset != nil {
-				select {
-				case idleReset <- struct{}{}:
-				default:
-				}
+		line, err := r.next()
+
+		if errors.Is(err, errSSELineTooLong) {
+			if r.capped() {
+				r.summary.Reason = sseReasonMaxBytes
+				return nil
 			}
+			r.summary.Reason = sseReasonLineBytes
+			r.failure = sseOverrun("line", r.limits.line, "max-line-bytes")
+			return nil
 		}
 
-		limitReached := opts.MaxBytes > 0 && byteCount >= opts.MaxBytes
+		capped := r.capped()
 
 		if err != nil && !errors.Is(err, io.EOF) {
-			session.Close(diag.WrapAs(diag.ClassProtocol, err, "read sse stream"))
-			return
+			if ctx.Err() != nil {
+				r.stop(r.ended(ctx))
+				return nil
+			}
+			return diag.WrapAs(diag.ClassProtocol, err, "read sse stream")
 		}
 
-		trimmed := strings.TrimRight(line, "\r\n")
-		if trimmed == "" {
-			if evt, ok := builder.finalize(index); ok {
-				publishSSEEvent(session, evt)
-				index++
-				eventCount++
-				if opts.MaxEvents > 0 && eventCount >= opts.MaxEvents {
-					summary.Reason = sseReasonMaxEvents
-					break
-				}
+		if trimmed := strings.TrimRight(line, "\r\n"); trimmed == "" {
+			if r.flush() && r.opts.MaxEvents > 0 && r.events >= r.opts.MaxEvents {
+				r.summary.Reason = sseReasonMaxEvents
+				return nil
 			}
-		} else {
-			if err := builder.consume(trimmed); err != nil {
-				session.Close(err)
-				return
+		} else if cerr := r.builder.consume(trimmed); cerr != nil {
+			if !errors.Is(cerr, errSSEEventTooLarge) {
+				return cerr
 			}
+			r.summary.Reason = sseReasonEventBytes
+			r.failure = sseOverrun("event", r.limits.event, "max-event-bytes")
+			return nil
 		}
 
-		if limitReached {
-			if summary.Reason == "" || summary.Reason == sseReasonEOF {
-				summary.Reason = sseReasonMaxBytes
-			}
-			break
+		if capped {
+			r.stop(sseReasonMaxBytes)
+			return nil
 		}
 
 		if errors.Is(err, io.EOF) {
-			if evt, ok := builder.finalize(index); ok {
-				publishSSEEvent(session, evt)
-				eventCount++
-			}
-			break
+			r.flush()
+			return nil
 		}
 
 		if ctx.Err() != nil {
-			if summary.Reason == "" || summary.Reason == sseReasonEOF {
-				summary.Reason = sseReasonCanceled
-			}
-			break
+			r.stop(r.ended(ctx))
+			return nil
 		}
 	}
+}
 
-	summary.EventCount = eventCount
-	summary.ByteCount = byteCount
-
-	metadata := map[string]string{
-		sseMetaReason: summary.Reason,
-		sseMetaBytes:  strconv.FormatInt(summary.ByteCount, 10),
-		sseMetaEvents: strconv.Itoa(summary.EventCount),
+func (r *sseRun) next() (string, error) {
+	line, err := readSSELine(r.reader, r.limits.lineBudget(r.bytes))
+	if len(line) > 0 {
+		r.bytes += int64(len(line))
+		select {
+		case r.idle <- struct{}{}:
+		default:
+		}
 	}
-	session.Publish(&stream.Event{
+	return line, err
+}
+
+func (r *sseRun) capped() bool {
+	return r.limits.stream > 0 && r.bytes >= r.limits.stream
+}
+
+func (r *sseRun) ended(ctx context.Context) string {
+	switch {
+	case r.idled.Load():
+		return sseReasonIdle
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return sseReasonTotal
+	default:
+		return sseReasonCanceled
+	}
+}
+
+func (r *sseRun) stop(reason string) {
+	if r.summary.Reason == "" || r.summary.Reason == sseReasonEOF {
+		r.summary.Reason = reason
+	}
+}
+
+func (r *sseRun) flush() bool {
+	evt, ok := r.builder.finalize(r.index)
+	if !ok {
+		return false
+	}
+	publishSSEEvent(r.session, evt)
+	r.index++
+	r.events++
+	return true
+}
+
+func (r *sseRun) finish(ctx context.Context, err error) {
+	if err != nil {
+		r.session.Close(err)
+		return
+	}
+
+	// The transport may report a cancelled read as EOF, so check the context.
+	if ctx.Err() != nil {
+		r.stop(r.ended(ctx))
+	}
+
+	r.summary.EventCount = r.events
+	r.summary.ByteCount = r.bytes
+	metadata := map[string]string{
+		sseMetaReason: r.summary.Reason,
+		sseMetaBytes:  strconv.FormatInt(r.summary.ByteCount, 10),
+		sseMetaEvents: strconv.Itoa(r.summary.EventCount),
+	}
+	if r.failure != nil {
+		metadata[sseMetaError] = r.failure.Error()
+	}
+	r.session.Publish(&stream.Event{
 		Kind:      stream.KindSSE,
 		Direction: stream.DirNA,
 		Timestamp: time.Now(),
 		Metadata:  metadata,
 	})
 
-	var closeErr error
-	if ctx.Err() != nil && summary.Reason == sseReasonCanceled {
+	closeErr := r.failure
+	if closeErr == nil && ctx.Err() != nil && r.summary.Reason == sseReasonCanceled {
 		closeErr = ctx.Err()
 	}
-	session.Close(closeErr)
+	r.session.Close(closeErr)
+}
+
+func readSSELine(r *bufio.Reader, limit int) (string, error) {
+	var line strings.Builder
+	for {
+		chunk, err := r.ReadSlice('\n')
+		if line.Len()+len(chunk) > limit {
+			line.Write(chunk[:limit-line.Len()])
+			return line.String(), errSSELineTooLong
+		}
+		line.Write(chunk)
+		if !errors.Is(err, bufio.ErrBufferFull) {
+			return line.String(), err
+		}
+	}
+}
+
+func sseSummaryLine(sum SSESummary) string {
+	line := fmt.Sprintf(
+		"events=%d bytes=%d reason=%s",
+		sum.EventCount,
+		sum.ByteCount,
+		sum.Reason,
+	)
+	if sum.Dropped > 0 {
+		line += fmt.Sprintf(" dropped=%d", sum.Dropped)
+	}
+	return line
 }

--- a/internal/protocol/httpx/stream_sse_parser.go
+++ b/internal/protocol/httpx/stream_sse_parser.go
@@ -55,30 +55,18 @@ func (a *sseAccumulator) consume(evt *stream.Event) {
 				a.summary.EventCount = count
 			}
 		}
+		if failure, ok := evt.Metadata[sseMetaError]; ok {
+			a.summary.Error = failure
+		}
 	}
 }
 
 func publishSSEEvent(session *stream.Session, evt SSEEvent) {
-	payload := []byte(evt.Data)
-	metadata := make(map[string]string)
-	if evt.Event != "" {
-		metadata["sse.event"] = evt.Event
-	}
-	if evt.ID != "" {
-		metadata["sse.id"] = evt.ID
-	}
-	if evt.Comment != "" {
-		metadata["sse.comment"] = evt.Comment
-	}
-	if evt.Retry > 0 {
-		metadata["sse.retry"] = strconv.Itoa(evt.Retry)
-	}
 	session.Publish(&stream.Event{
 		Kind:      stream.KindSSE,
 		Direction: stream.DirReceive,
 		Timestamp: evt.Timestamp,
-		Metadata:  metadata,
-		Payload:   payload,
+		Payload:   []byte(evt.Data),
 		SSE: stream.SSEMetadata{
 			Name:    evt.Event,
 			ID:      evt.ID,
@@ -89,6 +77,8 @@ func publishSSEEvent(session *stream.Session, evt SSEEvent) {
 }
 
 type sseEventBuilder struct {
+	limit    int64
+	size     int64
 	id       string
 	event    string
 	comment  []string
@@ -98,6 +88,11 @@ type sseEventBuilder struct {
 }
 
 func (b *sseEventBuilder) consume(line string) error {
+	if b.limit > 0 && b.size+int64(len(line)) > b.limit {
+		return errSSEEventTooLarge
+	}
+	b.size += int64(len(line))
+
 	switch {
 	case strings.HasPrefix(line, "data:"):
 		b.data = append(b.data, strings.TrimLeft(line[5:], " \t"))
@@ -144,7 +139,7 @@ func (b *sseEventBuilder) finalize(index int) (SSEEvent, bool) {
 	if b.hasRetry {
 		evt.Retry = b.retry
 	}
-	*b = sseEventBuilder{}
+	*b = sseEventBuilder{limit: b.limit}
 	return evt, true
 }
 

--- a/internal/protocol/httpx/stream_sse_test.go
+++ b/internal/protocol/httpx/stream_sse_test.go
@@ -1,0 +1,432 @@
+package httpx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/stream"
+	"github.com/unkn0wn-root/resterm/internal/vars"
+)
+
+func idledRun(t *testing.T, reason string) *sseRun {
+	t.Helper()
+
+	session := stream.NewSession(context.Background(), stream.KindSSE, stream.Config{})
+	session.MarkOpen()
+	t.Cleanup(func() { session.Close(nil) })
+
+	run := &sseRun{session: session, summary: SSESummary{Reason: reason}}
+	run.idled.Store(true)
+	return run
+}
+
+func TestSSERunReportsAnIdleTimeoutOnEveryExit(t *testing.T) {
+	stopped, stop := context.WithCancel(context.Background())
+	stop()
+
+	tests := []struct {
+		name    string
+		reached string
+		want    string
+	}{
+		{name: "the read ended at eof", reached: sseReasonEOF, want: sseReasonIdle},
+		{name: "the loop named nothing", want: sseReasonIdle},
+		{name: "the loop saw the cancellation", reached: sseReasonIdle, want: sseReasonIdle},
+		{name: "a limit was reached first", reached: sseReasonMaxEvents, want: sseReasonMaxEvents},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run := idledRun(t, tt.reached)
+			run.finish(stopped, nil)
+
+			if run.summary.Reason != tt.want {
+				t.Fatalf("Reason = %q, want %q", run.summary.Reason, tt.want)
+			}
+			if got := publishedReason(t, run.session); got != tt.want {
+				t.Fatalf("published reason = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSERunNamesWhatCancelledTheRead(t *testing.T) {
+	deadline, cancelDeadline := context.WithDeadline(
+		context.Background(),
+		time.Now().Add(-time.Second),
+	)
+	defer cancelDeadline()
+
+	stopped, stop := context.WithCancel(context.Background())
+	stop()
+
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		idled bool
+		want  string
+	}{
+		{name: "the idle watcher", ctx: stopped, idled: true, want: sseReasonIdle},
+		{name: "the total timeout", ctx: deadline, want: sseReasonTotal},
+		{name: "the caller gave up", ctx: stopped, want: sseReasonCanceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run := idledRun(t, sseReasonEOF)
+			run.idled.Store(tt.idled)
+			if got := run.ended(tt.ctx); got != tt.want {
+				t.Fatalf("ended() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func publishedReason(t *testing.T, session *stream.Session) string {
+	t.Helper()
+	for _, evt := range session.EventsSnapshot() {
+		if reason, ok := evt.Metadata[sseMetaReason]; ok {
+			return reason
+		}
+	}
+	t.Fatal("no summary event was published")
+	return ""
+}
+
+func quietSSE(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "data: ping\n\n")
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func readQuietSSE(t *testing.T, opts restfile.SSEOptions) (SSESummary, time.Duration) {
+	t.Helper()
+
+	req := &restfile.Request{
+		Method: "GET",
+		URL:    quietSSE(t),
+		SSE:    &restfile.SSERequest{Options: opts},
+	}
+	start := time.Now()
+	resp, err := NewClient(nil).ExecuteSSE(t.Context(), req, nil, Options{})
+	took := time.Since(start)
+	if err != nil {
+		t.Fatalf("ExecuteSSE: %v", err)
+	}
+
+	var transcript SSETranscript
+	if err := json.Unmarshal(resp.Body, &transcript); err != nil {
+		t.Fatalf("unmarshal transcript: %v", err)
+	}
+	return transcript.Summary, took
+}
+
+func TestSSEIdleTimeoutEndsTheReadRatherThanWaitingForTheTotal(t *testing.T) {
+	const idle = 100 * time.Millisecond
+
+	tests := []struct {
+		name  string
+		total time.Duration
+	}{
+		{name: "a total timeout it must not wait for", total: 10 * time.Second},
+		{name: "no total timeout to fall back on", total: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary, took := readQuietSSE(t, restfile.SSEOptions{
+				IdleTimeout:  idle,
+				TotalTimeout: tt.total,
+			})
+
+			if summary.Reason != sseReasonIdle {
+				t.Fatalf("Reason = %q, want %q", summary.Reason, sseReasonIdle)
+			}
+			if took > 20*idle {
+				t.Fatalf("took %s, want the idle timeout to end the read near %s", took, idle)
+			}
+			if summary.EventCount != 1 {
+				t.Fatalf("EventCount = %d, want the event read before the stall", summary.EventCount)
+			}
+		})
+	}
+}
+
+func TestSSETotalTimeoutEndsWithASummaryRatherThanAReadError(t *testing.T) {
+	const total = 250 * time.Millisecond
+
+	summary, took := readQuietSSE(t, restfile.SSEOptions{TotalTimeout: total})
+
+	if summary.Reason != sseReasonTotal {
+		t.Fatalf("Reason = %q, want %q", summary.Reason, sseReasonTotal)
+	}
+	if summary.Error != "" {
+		t.Fatalf("Error = %q, want a reached limit to read as a clean stop", summary.Error)
+	}
+	if took < total {
+		t.Fatalf("took %s, want it to run for the whole %s", took, total)
+	}
+	if summary.EventCount != 1 {
+		t.Fatalf("EventCount = %d, want the event read before the stall", summary.EventCount)
+	}
+}
+
+func eofOnCancel(t *testing.T) *Client {
+	t.Helper()
+	return newTestClientWithHTTPFactory(func(Options) (*http.Client, error) {
+		rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			reader, writer := io.Pipe()
+			go func() {
+				_, _ = io.WriteString(writer, "data: ping\n\n")
+				<-req.Context().Done()
+				_ = writer.Close()
+			}()
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Proto:      "HTTP/1.1",
+				Header:     make(http.Header),
+				Body:       reader,
+				Request:    req,
+			}
+			resp.Header.Set("Content-Type", "text/event-stream")
+			return resp, nil
+		})
+		return &http.Client{Transport: rt}, nil
+	})
+}
+
+func TestSSENamesTheLimitWhenACancelledReadEndsAtEOF(t *testing.T) {
+	const limit = 150 * time.Millisecond
+
+	tests := []struct {
+		name        string
+		opts        restfile.SSEOptions
+		callerGives bool
+		want        string
+	}{
+		{
+			name: "the total timeout",
+			opts: restfile.SSEOptions{TotalTimeout: limit},
+			want: sseReasonTotal,
+		},
+		{
+			name: "the idle timeout",
+			opts: restfile.SSEOptions{IdleTimeout: limit, TotalTimeout: time.Minute},
+			want: sseReasonIdle,
+		},
+		{
+			name:        "the caller giving up",
+			opts:        restfile.SSEOptions{TotalTimeout: time.Minute},
+			callerGives: true,
+			want:        sseReasonCanceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.callerGives {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				time.AfterFunc(limit, cancel)
+				defer cancel()
+			}
+
+			req := &restfile.Request{
+				Method: "GET",
+				URL:    "https://example.com/events",
+				SSE:    &restfile.SSERequest{Options: tt.opts},
+			}
+			resp, err := eofOnCancel(t).ExecuteSSE(ctx, req, vars.NewResolver(), Options{})
+			if err != nil {
+				t.Fatalf("ExecuteSSE: %v", err)
+			}
+
+			var transcript SSETranscript
+			if err := json.Unmarshal(resp.Body, &transcript); err != nil {
+				t.Fatalf("unmarshal transcript: %v", err)
+			}
+			if transcript.Summary.Reason != tt.want {
+				t.Fatalf("Reason = %q, want %q", transcript.Summary.Reason, tt.want)
+			}
+			if transcript.Summary.EventCount != 1 {
+				t.Fatalf("EventCount = %d, want the event read before the stall",
+					transcript.Summary.EventCount)
+			}
+		})
+	}
+}
+
+func multiLineSSE(t *testing.T, lines, each int) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for range lines {
+			fmt.Fprintf(w, "data: %s\n", strings.Repeat("x", each))
+		}
+		fmt.Fprint(w, "\n")
+		w.(http.Flusher).Flush()
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func readSSE(t *testing.T, url string, opts restfile.SSEOptions) SSETranscript {
+	t.Helper()
+	opts.TotalTimeout = 30 * time.Second
+	req := &restfile.Request{Method: "GET", URL: url, SSE: &restfile.SSERequest{Options: opts}}
+	resp, err := NewClient(nil).ExecuteSSE(t.Context(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("ExecuteSSE: %v", err)
+	}
+	var transcript SSETranscript
+	if err := json.Unmarshal(resp.Body, &transcript); err != nil {
+		t.Fatalf("unmarshal transcript: %v", err)
+	}
+	return transcript
+}
+
+func transcriptBytes(tr SSETranscript) int {
+	total := 0
+	for _, evt := range tr.Events {
+		total += len(evt.Data)
+	}
+	return total
+}
+
+func TestSSEKeepsAnEventTheLimitsAllow(t *testing.T) {
+	const each = 2 << 20
+
+	tests := []struct {
+		name  string
+		lines int
+		opts  restfile.SSEOptions
+	}{
+		{name: "a 6 MiB event on the defaults", lines: 3},
+		{
+			name:  "a 24 MiB event once the limits allow it",
+			lines: 12,
+			opts:  restfile.SSEOptions{MaxLineBytes: 4 << 20, MaxEventBytes: 32 << 20},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := readSSE(t, multiLineSSE(t, tt.lines, each), tt.opts)
+
+			if tr.Summary.Reason != sseReasonEOF {
+				t.Fatalf("Reason = %q, want %q", tr.Summary.Reason, sseReasonEOF)
+			}
+			if tr.Summary.Dropped != 0 {
+				t.Fatalf("Dropped = %d, want an allowed event to survive", tr.Summary.Dropped)
+			}
+			want := tt.lines*each + tt.lines - 1
+			if got := transcriptBytes(tr); got != want {
+				t.Fatalf("transcript holds %d bytes, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestSSEReportsEventsTheBufferDiscarded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for range 24 {
+			fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", 1<<20))
+			w.(http.Flusher).Flush()
+		}
+	}))
+	defer srv.Close()
+
+	tr := readSSE(t, srv.URL, restfile.SSEOptions{})
+
+	if tr.Summary.EventCount != 24 {
+		t.Fatalf("EventCount = %d, want every event to be read", tr.Summary.EventCount)
+	}
+	if tr.Summary.Dropped == 0 {
+		t.Fatal("Dropped = 0, want the discarded events to be counted")
+	}
+	if got := int64(tr.Summary.EventCount - len(tr.Events)); got != tr.Summary.Dropped {
+		t.Fatalf("Dropped = %d, want the %d events missing from the transcript",
+			tr.Summary.Dropped, got)
+	}
+}
+
+func TestSSEKeepsSeveralLargeEventsInTheTranscript(t *testing.T) {
+	const (
+		events = 4
+		each   = 3 << 20
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for range events {
+			fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", each))
+			w.(http.Flusher).Flush()
+		}
+	}))
+	defer srv.Close()
+
+	tr := readSSE(t, srv.URL, restfile.SSEOptions{})
+
+	if tr.Summary.Dropped != 0 {
+		t.Fatalf("Dropped = %d, want %d MiB of events to fit the buffer", tr.Summary.Dropped,
+			(events*each)>>20)
+	}
+	if len(tr.Events) != events {
+		t.Fatalf("transcript holds %d events, want %d", len(tr.Events), events)
+	}
+}
+
+func TestSSEBudgetsEventsThatCarryOnlyAComment(t *testing.T) {
+	const (
+		count = 40
+		each  = 1 << 20
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for range count {
+			fmt.Fprintf(w, ": %s\n\n", strings.Repeat("x", each))
+			w.(http.Flusher).Flush()
+		}
+	}))
+	defer srv.Close()
+
+	tr := readSSE(t, srv.URL, restfile.SSEOptions{})
+
+	if tr.Summary.EventCount != count {
+		t.Fatalf("EventCount = %d, want every event to be read", tr.Summary.EventCount)
+	}
+
+	retained := 0
+	for _, evt := range tr.Events {
+		retained += len(evt.Comment) + len(evt.Data)
+	}
+	if retained > DefaultSSESessionBytes {
+		t.Fatalf("transcript retained %d bytes, want at most the %d byte budget",
+			retained, DefaultSSESessionBytes)
+	}
+	if tr.Summary.Dropped == 0 {
+		t.Fatal("Dropped = 0, want the comments the buffer discarded to be counted")
+	}
+}

--- a/internal/protocol/httpx/stream_sse_test.go
+++ b/internal/protocol/httpx/stream_sse_test.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/stream"
 	"github.com/unkn0wn-root/resterm/internal/vars"
@@ -106,7 +108,7 @@ func quietSSE(t *testing.T) string {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "data: ping\n\n")
+		_, _ = fmt.Fprint(w, "data: ping\n\n")
 		w.(http.Flusher).Flush()
 		<-r.Context().Done()
 	}))
@@ -278,9 +280,9 @@ func multiLineSSE(t *testing.T, lines, each int) string {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		for range lines {
-			fmt.Fprintf(w, "data: %s\n", strings.Repeat("x", each))
+			_, _ = fmt.Fprintf(w, "data: %s\n", strings.Repeat("x", each))
 		}
-		fmt.Fprint(w, "\n")
+		_, _ = fmt.Fprint(w, "\n")
 		w.(http.Flusher).Flush()
 	}))
 	t.Cleanup(srv.Close)
@@ -349,7 +351,7 @@ func TestSSEReportsEventsTheBufferDiscarded(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		for range 24 {
-			fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", 1<<20))
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", 1<<20))
 			w.(http.Flusher).Flush()
 		}
 	}))
@@ -379,7 +381,7 @@ func TestSSEKeepsSeveralLargeEventsInTheTranscript(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		for range events {
-			fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", each))
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", each))
 			w.(http.Flusher).Flush()
 		}
 	}))
@@ -406,7 +408,7 @@ func TestSSEBudgetsEventsThatCarryOnlyAComment(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		for range count {
-			fmt.Fprintf(w, ": %s\n\n", strings.Repeat("x", each))
+			_, _ = fmt.Fprintf(w, ": %s\n\n", strings.Repeat("x", each))
 			w.(http.Flusher).Flush()
 		}
 	}))
@@ -428,5 +430,60 @@ func TestSSEBudgetsEventsThatCarryOnlyAComment(t *testing.T) {
 	}
 	if tr.Summary.Dropped == 0 {
 		t.Fatal("Dropped = 0, want the comments the buffer discarded to be counted")
+	}
+}
+
+func TestSSESummaryErr(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary SSESummary
+		class   diag.Class
+	}{
+		{name: "server closed the stream", summary: SSESummary{Reason: sseReasonEOF}},
+		{name: "stopped at max events", summary: SSESummary{Reason: sseReasonMaxEvents}},
+		{name: "stopped at max bytes", summary: SSESummary{Reason: sseReasonMaxBytes}},
+		{name: "went quiet", summary: SSESummary{Reason: sseReasonIdle}},
+		{name: "ran out of time", summary: SSESummary{Reason: sseReasonTotal}},
+		{
+			name:    "read failed",
+			summary: SSESummary{Reason: sseReasonErr, Error: "read sse stream: boom"},
+			class:   diag.ClassProtocol,
+		},
+		{
+			name:    "line over the limit",
+			summary: SSESummary{Reason: sseReasonLineBytes, Error: "sse line exceeds 16 bytes"},
+			class:   diag.ClassProtocol,
+		},
+		{
+			name:    "event over the limit",
+			summary: SSESummary{Reason: sseReasonEventBytes, Error: "sse event exceeds 16 bytes"},
+			class:   diag.ClassProtocol,
+		},
+		{
+			name:    "canceled",
+			summary: SSESummary{Reason: sseReasonCanceled, Error: "context canceled"},
+			class:   diag.ClassCanceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.summary.Err()
+			if tt.class == "" {
+				if err != nil {
+					t.Fatalf("Err() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Err() = nil, want a %s failure", tt.class)
+			}
+			if got := diag.Classes(err); !slices.Contains(got, tt.class) {
+				t.Fatalf("Err() classes = %v, want %s", got, tt.class)
+			}
+			if tt.summary.Error != "" && err.Error() != tt.summary.Error {
+				t.Fatalf("Err() = %q, want %q", err, tt.summary.Error)
+			}
+		})
 	}
 }

--- a/internal/protocol/httpx/stream_ws.go
+++ b/internal/protocol/httpx/stream_ws.go
@@ -188,9 +188,7 @@ func (c *Client) StartWebSocket(
 	}
 	runtime.touchActivity()
 
-	if wsOpts.MaxMessageBytes > 0 {
-		conn.SetReadLimit(wsOpts.MaxMessageBytes)
-	}
+	conn.SetReadLimit(webSocketReadLimit(wsOpts.MaxMessageBytes))
 
 	if wsOpts.IdleTimeout > 0 {
 		go runtime.idleWatch(wsOpts.IdleTimeout)

--- a/internal/protocol/httpx/stream_ws.go
+++ b/internal/protocol/httpx/stream_ws.go
@@ -58,6 +58,7 @@ type WebSocketSummary struct {
 	ClosedBy      string        `json:"closedBy"`
 	CloseCode     int           `json:"closeCode,omitempty"`
 	CloseReason   string        `json:"closeReason,omitempty"`
+	Dropped       int64         `json:"dropped,omitempty"`
 }
 
 type WebSocketTranscript struct {
@@ -320,11 +321,7 @@ func (c *Client) CompleteWebSocket(
 	}
 	headers.Set("Content-Type", streamContentTypeJSON)
 	headers.Set(StreamHeaderType, "websocket")
-	headers.Set(StreamHeaderSummary, fmt.Sprintf(
-		"sent=%d recv=%d closed=%s",
-		transcript.Summary.SentCount,
-		transcript.Summary.ReceivedCount,
-		transcript.Summary.ClosedBy))
+	headers.Set(StreamHeaderSummary, webSocketSummaryLine(transcript.Summary))
 
 	meta := handle.Meta
 	if meta.Status == "" {
@@ -337,6 +334,19 @@ func (c *Client) CompleteWebSocket(
 		meta.Proto = "HTTP/1.1"
 	}
 	return streamResp(meta, headers, body, acc.summary.Duration), nil
+}
+
+func webSocketSummaryLine(sum WebSocketSummary) string {
+	line := fmt.Sprintf(
+		"sent=%d recv=%d closed=%s",
+		sum.SentCount,
+		sum.ReceivedCount,
+		sum.ClosedBy,
+	)
+	if sum.Dropped > 0 {
+		line += fmt.Sprintf(" dropped=%d", sum.Dropped)
+	}
+	return line
 }
 
 func buildWebSocketFallback(

--- a/internal/protocol/httpx/stream_ws.go
+++ b/internal/protocol/httpx/stream_ws.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"slices"
 	"time"
@@ -148,7 +147,7 @@ func (c *Client) StartWebSocket(
 	if err != nil {
 		handshakeCancel()
 		if resp != nil {
-			fallback, convErr := buildWebSocketFallback(resp, req, start)
+			fallback, convErr := buildWebSocketFallback(resp, req, start, effectiveOpts)
 			if convErr != nil {
 				return nil, nil, convErr
 			}
@@ -344,6 +343,7 @@ func buildWebSocketFallback(
 	httpResp *http.Response,
 	req *restfile.Request,
 	started time.Time,
+	opts Options,
 ) (*Response, error) {
 	if httpResp == nil {
 		return nil, diag.New(diag.ClassProtocol, "websocket handshake response unavailable")
@@ -351,10 +351,10 @@ func buildWebSocketFallback(
 
 	var body []byte
 	if httpResp.Body != nil {
-		data, err := io.ReadAll(httpResp.Body)
+		data, err := opts.readBody(httpResp.Body)
 		closeErr := httpResp.Body.Close()
 		if err != nil {
-			return nil, diag.WrapAs(diag.ClassProtocol, err, "read websocket handshake body")
+			return nil, err
 		}
 		if closeErr != nil {
 			return nil, diag.WrapAs(diag.ClassProtocol, closeErr, "close websocket handshake body")

--- a/internal/protocol/httpx/stream_ws.go
+++ b/internal/protocol/httpx/stream_ws.go
@@ -1,6 +1,7 @@
 package httpx
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,6 +24,15 @@ const (
 	wsMetaClosedBy    = "resterm.ws.closed.by"
 	wsMetaCloseCode   = "resterm.ws.close.code"
 	wsMetaCloseReason = "resterm.ws.close.reason"
+)
+
+// Values used for WebSocketSummary.ClosedBy.
+const (
+	wsClosedByServer   = "server"
+	wsClosedByClient   = "client"
+	wsClosedByTimeout  = "timeout"
+	wsClosedByCanceled = "canceled"
+	wsClosedByError    = "error"
 )
 
 const defaultWebSocketSendQueue = 32
@@ -64,6 +74,25 @@ type WebSocketSummary struct {
 type WebSocketTranscript struct {
 	Events  []WebSocketEvent `json:"events"`
 	Summary WebSocketSummary `json:"summary"`
+}
+
+// Err reports the failure that ended the session. A close either side asked for
+// and a timeout are normal endings and return nil.
+func (s WebSocketSummary) Err() error {
+	switch s.ClosedBy {
+	case wsClosedByCanceled:
+		return diag.New(
+			diag.ClassCanceled,
+			cmp.Or(s.CloseReason, "websocket stream canceled"),
+		)
+	case wsClosedByError:
+		return diag.New(
+			diag.ClassProtocol,
+			cmp.Or(s.CloseReason, "websocket stream failed"),
+		)
+	default:
+		return nil
+	}
 }
 
 type WebSocketHandle struct {
@@ -257,7 +286,7 @@ func (c *Client) CompleteWebSocket(
 	defer listener.Cancel()
 
 	acc := newWSAccumulator()
-	retentionDropped := listener.Snapshot.Evicted
+	lost := listener.Snapshot.Evicted
 	for _, evt := range listener.Snapshot.Events {
 		acc.consume(evt)
 	}
@@ -298,8 +327,9 @@ func (c *Client) CompleteWebSocket(
 	}
 
 	<-eventsDone
-	retentionDropped += listener.Dropped()
-	acc.summary.Dropped += int64(retentionDropped)
+	// The listener's count is only final once it has drained.
+	lost += listener.Dropped()
+	acc.summary.Dropped += int64(lost)
 
 	state, stateErr := session.State()
 	stats := session.StatsSnapshot()

--- a/internal/protocol/httpx/stream_ws.go
+++ b/internal/protocol/httpx/stream_ws.go
@@ -257,6 +257,7 @@ func (c *Client) CompleteWebSocket(
 	defer listener.Cancel()
 
 	acc := newWSAccumulator()
+	retentionDropped := listener.Snapshot.Evicted
 	for _, evt := range listener.Snapshot.Events {
 		acc.consume(evt)
 	}
@@ -297,6 +298,8 @@ func (c *Client) CompleteWebSocket(
 	}
 
 	<-eventsDone
+	retentionDropped += listener.Dropped()
+	acc.summary.Dropped += int64(retentionDropped)
 
 	state, stateErr := session.State()
 	stats := session.StatsSnapshot()

--- a/internal/protocol/httpx/stream_ws_accumulator.go
+++ b/internal/protocol/httpx/stream_ws_accumulator.go
@@ -7,16 +7,30 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/stream"
 )
 
+const DefaultWebSocketTranscriptBytes = 8 << 20
+
 type wsAccumulator struct {
 	events  []WebSocketEvent
 	summary WebSocketSummary
+	bytes   int64
+	limit   int64
 }
 
 func newWSAccumulator() *wsAccumulator {
 	return &wsAccumulator{
-		events:  make([]WebSocketEvent, 0, 16),
-		summary: WebSocketSummary{},
+		events: make([]WebSocketEvent, 0, 16),
+		limit:  DefaultWebSocketTranscriptBytes,
 	}
+}
+
+func (a *wsAccumulator) keep(evt *stream.Event) bool {
+	size := evt.Size()
+	if a.limit > 0 && a.bytes+size > a.limit {
+		a.summary.Dropped++
+		return false
+	}
+	a.bytes += size
+	return true
 }
 
 func (a *wsAccumulator) consume(evt *stream.Event) {
@@ -67,7 +81,9 @@ func (a *wsAccumulator) consume(evt *stream.Event) {
 				jsonEvt.Reason = evt.WS.Reason
 			}
 		}
-		a.events = append(a.events, jsonEvt)
+		if a.keep(evt) {
+			a.events = append(a.events, jsonEvt)
+		}
 		if evt.Direction == stream.DirSend {
 			a.summary.SentCount++
 		} else {

--- a/internal/protocol/httpx/stream_ws_accumulator.go
+++ b/internal/protocol/httpx/stream_ws_accumulator.go
@@ -16,6 +16,7 @@ type wsAccumulator struct {
 	summary WebSocketSummary
 	bytes   int64
 	limit   int64
+	closed  bool
 }
 
 func newWSAccumulator() *wsAccumulator {
@@ -91,7 +92,12 @@ func (a *wsAccumulator) consume(evt *stream.Event) {
 		} else {
 			a.summary.ReceivedCount++
 		}
-		if typ == "close" {
+		// Both sides send a close frame, so only the first one names who ended
+		// the session. A close resterm sends is published before the reply it
+		// gets back, and a close it never managed to send is not published at
+		// all, which leaves the peer's frame first.
+		if typ == "close" && !a.closed {
+			a.closed = true
 			if meta != nil {
 				if by, ok := meta[wsMetaClosedBy]; ok {
 					a.summary.ClosedBy = by

--- a/internal/protocol/httpx/stream_ws_accumulator.go
+++ b/internal/protocol/httpx/stream_ws_accumulator.go
@@ -1,7 +1,9 @@
 package httpx
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
 	"strconv"
 
 	"github.com/unkn0wn-root/resterm/internal/stream"
@@ -138,21 +140,30 @@ func directionToString(dir stream.Direction) string {
 	}
 }
 
+// applyWebSocketSummaryDefaults fills in who ended a session when the events did
+// not say. A timeout and a canceled run get their own names because neither one
+// is a failure.
 func applyWebSocketSummaryDefaults(sum *WebSocketSummary, state stream.State, stateErr error) {
 	if sum == nil {
 		return
 	}
 	if sum.ClosedBy == "" {
-		if state == stream.StateFailed || stateErr != nil {
-			sum.ClosedBy = "error"
-			if sum.CloseReason == "" && stateErr != nil {
-				sum.CloseReason = stateErr.Error()
-			}
-		} else {
-			sum.ClosedBy = "client"
+		switch {
+		case errors.Is(stateErr, context.Canceled):
+			sum.ClosedBy = wsClosedByCanceled
+		case errors.Is(stateErr, context.DeadlineExceeded):
+			sum.ClosedBy = wsClosedByTimeout
+		case state == stream.StateFailed || stateErr != nil:
+			sum.ClosedBy = wsClosedByError
+		default:
+			sum.ClosedBy = wsClosedByClient
 		}
 	}
-	if sum.CloseReason == "" && stateErr != nil && sum.ClosedBy == "error" {
+	if sum.CloseReason != "" || stateErr == nil {
+		return
+	}
+	switch sum.ClosedBy {
+	case wsClosedByCanceled, wsClosedByTimeout, wsClosedByError:
 		sum.CloseReason = stateErr.Error()
 	}
 }

--- a/internal/protocol/httpx/stream_ws_runtime.go
+++ b/internal/protocol/httpx/stream_ws_runtime.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"nhooyr.io/websocket"
@@ -32,6 +33,9 @@ type wsRuntime struct {
 	endErr error
 	done   bool
 	once   sync.Once
+	// closeStarted is claimed by whoever sends the first close frame, so the
+	// connection is never closed a second time.
+	closeStarted atomic.Bool
 }
 
 func (rt *wsRuntime) publishReceive(evt *stream.Event) {
@@ -393,6 +397,9 @@ func (rt *wsRuntime) performWrite(msg wsOutbound) error {
 		}
 		return nil
 	case wsOutboundClose:
+		if !rt.closeStarted.CompareAndSwap(false, true) {
+			return nil
+		}
 		session.MarkClosing()
 		metadata := maps.Clone(msg.metadata)
 		if metadata == nil {
@@ -433,13 +440,16 @@ func (rt *wsRuntime) shutdown() {
 		if rt.cancel != nil {
 			rt.cancel()
 		}
+		// A close that already started sent its own frame and ends the session
+		// its own way. Closing again reports a second, bogus failure.
+		if !rt.closeStarted.CompareAndSwap(false, true) {
+			return
+		}
 		if err := rt.conn.Close(websocket.StatusNormalClosure, ""); err != nil &&
 			!errors.Is(err, net.ErrClosed) && !errors.Is(err, context.Canceled) {
-			if rt.session != nil {
-				rt.session.Close(
-					diag.WrapAs(diag.ClassProtocol, err, "close websocket connection"),
-				)
-			}
+			rt.session.Close(
+				diag.WrapAs(diag.ClassProtocol, err, "close websocket connection"),
+			)
 		}
 	})
 }

--- a/internal/protocol/httpx/stream_ws_runtime.go
+++ b/internal/protocol/httpx/stream_ws_runtime.go
@@ -169,6 +169,9 @@ func (rt *wsRuntime) readLoop() {
 		if err != nil {
 			var ce websocket.CloseError
 			if errors.As(err, &ce) {
+				// Read completes the close handshake before returning a close error.
+				// Do not let shutdown try to close the connection again.
+				rt.closeStarted.Store(true)
 				meta := map[string]string{
 					wsMetaType:        "close",
 					wsMetaClosedBy:    wsClosedByServer,

--- a/internal/protocol/httpx/stream_ws_runtime.go
+++ b/internal/protocol/httpx/stream_ws_runtime.go
@@ -167,7 +167,7 @@ func (rt *wsRuntime) readLoop() {
 			if errors.As(err, &ce) {
 				meta := map[string]string{
 					wsMetaType:        "close",
-					wsMetaClosedBy:    "server",
+					wsMetaClosedBy:    wsClosedByServer,
 					wsMetaCloseCode:   strconv.Itoa(int(ce.Code)),
 					wsMetaCloseReason: ce.Reason,
 				}
@@ -233,7 +233,7 @@ func (rt *wsRuntime) idleWatch(limit time.Duration) {
 			return
 		case <-timer.C:
 			meta := map[string]string{
-				wsMetaClosedBy:    "timeout",
+				wsMetaClosedBy:    wsClosedByTimeout,
 				wsMetaCloseReason: fmt.Sprintf("idle timeout after %s", limit),
 			}
 			rt.closeTerminalNow(&stream.Event{
@@ -399,7 +399,7 @@ func (rt *wsRuntime) performWrite(msg wsOutbound) error {
 			metadata = map[string]string{}
 		}
 		metadata[wsMetaType] = "close"
-		metadata[wsMetaClosedBy] = "client"
+		metadata[wsMetaClosedBy] = wsClosedByClient
 		metadata[wsMetaCloseCode] = strconv.Itoa(int(msg.code))
 		if msg.reason != "" {
 			metadata[wsMetaCloseReason] = msg.reason

--- a/internal/protocol/httpx/stream_ws_test.go
+++ b/internal/protocol/httpx/stream_ws_test.go
@@ -115,7 +115,7 @@ func TestExecuteWebSocketChat(t *testing.T) {
 		URL:    wsURL,
 		WebSocket: &restfile.WebSocketRequest{
 			Options: restfile.WebSocketOptions{
-				IdleTimeout: 500 * time.Millisecond,
+				IdleTimeout: 2 * time.Second,
 			},
 			Steps: []restfile.WebSocketStep{
 				{Type: restfile.WebSocketStepSendText, Value: "Hello from resterm!"},
@@ -142,16 +142,17 @@ func TestExecuteWebSocketChat(t *testing.T) {
 		t.Fatalf("expected websocket stream header, got %q", got)
 	}
 
-	var transcript struct {
-		Events []struct {
-			Direction string `json:"direction"`
-			Type      string `json:"type"`
-			Text      string `json:"text"`
-		}
-	}
+	var transcript WebSocketTranscript
 	if err := json.Unmarshal(resp.Body, &transcript); err != nil {
 		t.Fatalf("failed to decode transcript: %v", err)
 	}
+	if err := transcript.Summary.Err(); err != nil {
+		t.Fatalf("scripted close ended as a stream failure: %v", err)
+	}
+	if transcript.Summary.ClosedBy != wsClosedByClient {
+		t.Fatalf("scripted close ended by %q, want %q", transcript.Summary.ClosedBy, wsClosedByClient)
+	}
+
 	foundPong := false
 	for _, evt := range transcript.Events {
 		if evt.Direction == "send" && evt.Type == "pong" && evt.Text == "client-pong" {
@@ -161,6 +162,140 @@ func TestExecuteWebSocketChat(t *testing.T) {
 	}
 	if !foundPong {
 		t.Fatalf("expected pong event in transcript: %+v", transcript.Events)
+	}
+}
+
+func TestWebSocketShutdownDoesNotRepeatAStartedClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	session := stream.NewSession(ctx, stream.KindWebSocket, stream.Config{})
+	session.MarkOpen()
+	session.MarkClosing()
+
+	runtime := &wsRuntime{
+		session: session,
+		writeCh: make(chan wsOutbound),
+		cancel:  cancel,
+	}
+	runtime.closeStarted.Store(true)
+	runtime.shutdown()
+
+	state, err := session.State()
+	if state != stream.StateClosing || err != nil {
+		t.Fatalf("shutdown changed a closing session to state %v with error %v", state, err)
+	}
+}
+
+// Both sides send a close frame. Only the first one says who ended the session.
+func TestAccumulatorKeepsTheFirstCloseFrame(t *testing.T) {
+	acc := newWSAccumulator()
+	acc.consume(&stream.Event{
+		Kind:      stream.KindWebSocket,
+		Direction: stream.DirSend,
+		Metadata: map[string]string{
+			wsMetaType:        "close",
+			wsMetaClosedBy:    wsClosedByClient,
+			wsMetaCloseCode:   "1000",
+			wsMetaCloseReason: "resterm closed",
+		},
+	})
+	acc.consume(&stream.Event{
+		Kind:      stream.KindWebSocket,
+		Direction: stream.DirReceive,
+		Metadata: map[string]string{
+			wsMetaType:        "close",
+			wsMetaClosedBy:    wsClosedByServer,
+			wsMetaCloseCode:   "1001",
+			wsMetaCloseReason: "server going away",
+		},
+	})
+
+	if acc.summary.ClosedBy != wsClosedByClient {
+		t.Fatalf("closedBy = %q, want the side that closed first", acc.summary.ClosedBy)
+	}
+	if acc.summary.CloseCode != 1000 || acc.summary.CloseReason != "resterm closed" {
+		t.Fatalf("close = %d %q, want the first frame kept",
+			acc.summary.CloseCode, acc.summary.CloseReason)
+	}
+}
+
+func TestWebSocketAutoCloseIsAttributedToTheClient(t *testing.T) {
+	server, cleanup := startEchoWebSocketServer(t)
+	defer cleanup()
+
+	req := &restfile.Request{
+		Method:    http.MethodGet,
+		URL:       strings.Replace(server.URL, "http", "ws", 1) + "/ws",
+		WebSocket: &restfile.WebSocketRequest{},
+	}
+	resp, err := NewClient(nil).ExecuteWebSocket(t.Context(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("ExecuteWebSocket: %v", err)
+	}
+
+	var transcript WebSocketTranscript
+	if err := json.Unmarshal(resp.Body, &transcript); err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+	if transcript.Summary.ClosedBy != wsClosedByClient {
+		t.Fatalf("closedBy = %q, want %q", transcript.Summary.ClosedBy, wsClosedByClient)
+	}
+	if err := transcript.Summary.Err(); err != nil {
+		t.Fatalf("an auto close ended as a stream failure: %v", err)
+	}
+}
+
+// The server has to win the close for this to mean anything, so the session is
+// never completed. Completing it would send a close of our own first.
+func TestWebSocketServerCloseIsAttributedToTheServer(t *testing.T) {
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := httptest.NewUnstartedServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+			if err != nil {
+				return
+			}
+			_ = conn.Close(websocket.StatusGoingAway, "server going away")
+		}),
+	)
+	server.Listener = ln
+	server.Start()
+	defer server.Close()
+
+	req := &restfile.Request{
+		Method:    http.MethodGet,
+		URL:       strings.Replace(server.URL, "http", "ws", 1) + "/ws",
+		WebSocket: &restfile.WebSocketRequest{},
+	}
+	handle, fallback, err := NewClient(nil).StartWebSocket(t.Context(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("StartWebSocket: %v", err)
+	}
+	if fallback != nil {
+		t.Fatalf("expected a live websocket handle, got a fallback response")
+	}
+	t.Cleanup(handle.Session.Cancel)
+
+	select {
+	case <-handle.Session.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("the session did not end after the server closed it")
+	}
+
+	acc := newWSAccumulator()
+	for _, evt := range handle.Session.EventsSnapshot() {
+		acc.consume(evt)
+	}
+	state, stateErr := handle.Session.State()
+	applyWebSocketSummaryDefaults(&acc.summary, state, stateErr)
+
+	if acc.summary.ClosedBy != wsClosedByServer {
+		t.Fatalf("closedBy = %q, want %q", acc.summary.ClosedBy, wsClosedByServer)
+	}
+	if acc.summary.CloseReason != "server going away" {
+		t.Fatalf("closeReason = %q, want the reason the server sent", acc.summary.CloseReason)
 	}
 }
 

--- a/internal/protocol/httpx/stream_ws_test.go
+++ b/internal/protocol/httpx/stream_ws_test.go
@@ -299,6 +299,66 @@ func TestWebSocketServerCloseIsAttributedToTheServer(t *testing.T) {
 	}
 }
 
+func TestWebSocketServerCloseDuringOutboundPublication(t *testing.T) {
+	closeNow := make(chan struct{}, 1)
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := httptest.NewUnstartedServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+			if err != nil {
+				return
+			}
+			<-closeNow
+			_ = conn.Close(websocket.StatusGoingAway, "server going away")
+		}),
+	)
+	server.Listener = ln
+	server.Start()
+	defer server.Close()
+	defer func() {
+		select {
+		case closeNow <- struct{}{}:
+		default:
+		}
+	}()
+
+	conn, _, err := websocket.Dial(
+		t.Context(),
+		strings.Replace(server.URL, "http", "ws", 1),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+
+	session := stream.NewSession(t.Context(), stream.KindWebSocket, stream.Config{})
+	session.MarkOpen()
+	runtime := &wsRuntime{
+		conn:    conn,
+		session: session,
+		writeCh: make(chan wsOutbound),
+		cancel:  session.Cancel,
+	}
+
+	if !runtime.beginOutbound() {
+		t.Fatal("begin outbound publication")
+	}
+	closeNow <- struct{}{}
+	runtime.readLoop()
+	runtime.finishOutbound(nil, false)
+
+	state, stateErr := session.State()
+	if stateErr != nil {
+		t.Fatalf("normal server close became a session failure: %v", stateErr)
+	}
+	if state != stream.StateClosed {
+		t.Fatalf("session state = %v, want %v", state, stream.StateClosed)
+	}
+}
+
 func TestExecuteWebSocketPingPayloadTranscript(t *testing.T) {
 	server, cleanup := startEchoWebSocketServer(t)
 	defer cleanup()

--- a/internal/protocol/httpx/stream_ws_test.go
+++ b/internal/protocol/httpx/stream_ws_test.go
@@ -8,12 +8,14 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"nhooyr.io/websocket"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/k8s"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/stream"
@@ -283,6 +285,64 @@ func TestApplyWebSocketSummaryDefaults(t *testing.T) {
 	applyWebSocketSummaryDefaults(&sumClient, stream.StateClosed, nil)
 	if sumClient.ClosedBy != "client" {
 		t.Fatalf("expected default closedBy to client, got %q", sumClient.ClosedBy)
+	}
+
+	sumCanceled := WebSocketSummary{}
+	applyWebSocketSummaryDefaults(&sumCanceled, stream.StateFailed, context.Canceled)
+	if sumCanceled.ClosedBy != wsClosedByCanceled {
+		t.Fatalf("closedBy = %q, want a canceled run named as one", sumCanceled.ClosedBy)
+	}
+
+	sumTimeout := WebSocketSummary{}
+	applyWebSocketSummaryDefaults(&sumTimeout, stream.StateFailed, context.DeadlineExceeded)
+	if sumTimeout.ClosedBy != wsClosedByTimeout {
+		t.Fatalf("closedBy = %q, want the elapsed duration named as a timeout", sumTimeout.ClosedBy)
+	}
+}
+
+func TestWebSocketSummaryErr(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary WebSocketSummary
+		class   diag.Class
+	}{
+		{name: "server closed", summary: WebSocketSummary{ClosedBy: wsClosedByServer}},
+		{name: "client closed", summary: WebSocketSummary{ClosedBy: wsClosedByClient}},
+		{name: "timed out", summary: WebSocketSummary{ClosedBy: wsClosedByTimeout}},
+		{
+			name:    "read failed",
+			summary: WebSocketSummary{ClosedBy: wsClosedByError, CloseReason: "read: boom"},
+			class:   diag.ClassProtocol,
+		},
+		{
+			name: "canceled",
+			summary: WebSocketSummary{
+				ClosedBy:    wsClosedByCanceled,
+				CloseReason: "context canceled",
+			},
+			class: diag.ClassCanceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.summary.Err()
+			if tt.class == "" {
+				if err != nil {
+					t.Fatalf("Err() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Err() = nil, want a %s failure", tt.class)
+			}
+			if got := diag.Classes(err); !slices.Contains(got, tt.class) {
+				t.Fatalf("Err() classes = %v, want %s", got, tt.class)
+			}
+			if err.Error() != tt.summary.CloseReason {
+				t.Fatalf("Err() = %q, want %q", err, tt.summary.CloseReason)
+			}
+		})
 	}
 }
 

--- a/internal/protocol/httpx/transport.go
+++ b/internal/protocol/httpx/transport.go
@@ -155,14 +155,13 @@ func applyTunnel(
 }
 
 func newHTTPClient(transport *http.Transport, opts Options) *http.Client {
-	client := &http.Client{Transport: transport, Jar: opts.CookieJar}
+	client := &http.Client{
+		Transport:     transport,
+		Jar:           opts.CookieJar,
+		CheckRedirect: redirectPolicy(opts),
+	}
 	if opts.Timeout > 0 {
 		client.Timeout = opts.Timeout
-	}
-	if !opts.FollowRedirects {
-		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
 	}
 	return client
 }

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -465,10 +465,12 @@ type SSERequest struct {
 }
 
 type SSEOptions struct {
-	TotalTimeout time.Duration
-	IdleTimeout  time.Duration
-	MaxEvents    int
-	MaxBytes     int64
+	TotalTimeout  time.Duration
+	IdleTimeout   time.Duration
+	MaxEvents     int
+	MaxBytes      int64
+	MaxLineBytes  int64
+	MaxEventBytes int64
 }
 
 type WebSocketRequest struct {

--- a/internal/runner/failure.go
+++ b/internal/runner/failure.go
@@ -23,6 +23,8 @@ func resultFailure(res Result) runfail.Failure {
 		return runfail.FromErrorSource(res.Err, "error")
 	case res.ScriptErr != nil:
 		return runfail.Script(res.ScriptErr.Error(), "scriptError")
+	case streamFailed(res.Stream):
+		return runfail.FromErrorSource(res.Stream.Err, "stream")
 	case anyScriptTestFailed(res.Tests):
 		return runfail.Assertion(scriptTestFailureMessage(res.Tests), "tests")
 	case traceFailed(res.Trace):
@@ -57,6 +59,8 @@ func stepFailure(step StepResult) runfail.Failure {
 		return runfail.FromErrorSource(step.Err, "error")
 	case step.ScriptErr != nil:
 		return runfail.Script(step.ScriptErr.Error(), "scriptError")
+	case streamFailed(step.Stream):
+		return runfail.FromErrorSource(step.Stream.Err, "stream")
 	case anyScriptTestFailed(step.Tests):
 		return runfail.Assertion(scriptTestFailureMessage(step.Tests), "tests")
 	case traceFailed(step.Trace):

--- a/internal/runner/report_fmt.go
+++ b/internal/runner/report_fmt.go
@@ -344,6 +344,9 @@ func formatStream(info *StreamInfo) *runfmt.Stream {
 		EventCount:     info.EventCount,
 		TranscriptPath: str.Trim(info.TranscriptPath),
 	}
+	if info.Err != nil {
+		out.Error = info.Err.Error()
+	}
 	if len(info.Summary) > 0 {
 		out.Summary = runfmt.CloneAnyMap(info.Summary)
 	}

--- a/internal/runner/report_fmt_test.go
+++ b/internal/runner/report_fmt_test.go
@@ -264,3 +264,13 @@ func TestReportModelUsesResponseDuration(t *testing.T) {
 		t.Fatalf("expected response duration fallback, got %+v", got.Results)
 	}
 }
+
+func TestFormatStreamCarriesTheFailure(t *testing.T) {
+	got := formatStream(&StreamInfo{Kind: "sse", Err: errors.New("sse line exceeds 16 bytes")})
+	if got.Error != "sse line exceeds 16 bytes" {
+		t.Fatalf("Error = %q, want the stream failure", got.Error)
+	}
+	if plain := formatStream(&StreamInfo{Kind: "sse"}); plain.Error != "" {
+		t.Fatalf("Error = %q, want a complete transcript to report none", plain.Error)
+	}
+}

--- a/internal/runner/run.go
+++ b/internal/runner/run.go
@@ -145,6 +145,9 @@ type StreamInfo struct {
 	EventCount     int
 	Summary        map[string]any
 	TranscriptPath string
+	// Err reports a stream that did not finish cleanly. The events it collected
+	// are still reported and still written as an artifact.
+	Err error
 }
 
 type TraceInfo struct {
@@ -360,7 +363,7 @@ func skippedRequestResult(req *restfile.Request, env vars.Environment, reason st
 }
 
 func requestFailed(item Result) bool {
-	if item.Err != nil || item.ScriptErr != nil {
+	if item.Err != nil || item.ScriptErr != nil || streamFailed(item.Stream) {
 		return true
 	}
 	for _, test := range item.Tests {
@@ -597,6 +600,10 @@ func traceFailed(info *TraceInfo) bool {
 	return info != nil && info.Summary != nil && len(info.Summary.Breaches) > 0
 }
 
+func streamFailed(info *StreamInfo) bool {
+	return info != nil && info.Err != nil
+}
+
 func streamResult(info *scripts.StreamInfo) *StreamInfo {
 	if info == nil {
 		return nil
@@ -604,6 +611,7 @@ func streamResult(info *scripts.StreamInfo) *StreamInfo {
 	out := &StreamInfo{
 		Kind:       str.Trim(info.Kind),
 		EventCount: streamEventCount(info),
+		Err:        info.Err,
 	}
 	if len(info.Summary) > 0 {
 		out.Summary = cloneStreamSummary(info.Summary)
@@ -662,7 +670,8 @@ func stepFailed(step StepResult) bool {
 	if step.Failure.Code != "" {
 		return true
 	}
-	if step.Canceled || step.Err != nil || step.ScriptErr != nil || traceFailed(step.Trace) {
+	if step.Canceled || step.Err != nil || step.ScriptErr != nil ||
+		streamFailed(step.Stream) || traceFailed(step.Trace) {
 		return true
 	}
 	for _, test := range step.Tests {

--- a/internal/runner/run_test.go
+++ b/internal/runner/run_test.go
@@ -17,6 +17,7 @@ import (
 	histdb "github.com/unkn0wn-root/resterm/internal/history/sqlite"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/runx/fail"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -1981,5 +1982,114 @@ func TestRunRejectsUnseededHeadlessOAuthAuthorizationCode(t *testing.T) {
 	}
 	if calls != 0 {
 		t.Fatalf("expected request to stop before network call, got %d calls", calls)
+	}
+}
+
+func TestRunFailsOnTruncatedStreamAndKeepsTheTranscript(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "stream.http")
+	artifacts := filepath.Join(dir, "artifacts")
+	src := strings.Join([]string{
+		"### Events",
+		"# @name events",
+		"# @sse max-line-bytes=16",
+		"GET https://example.com/events",
+		"",
+	}, "\n")
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	client := newHTTPClientWithFactory(func(httpx.Options) (*http.Client, error) {
+		return &http.Client{
+			Transport: transportFunc(func(req *http.Request) (*http.Response, error) {
+				hdr := make(http.Header)
+				hdr.Set("Content-Type", "text/event-stream")
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Proto:      "HTTP/1.1",
+					Header:     hdr,
+					Body: io.NopCloser(
+						strings.NewReader("data: " + strings.Repeat("x", 4096) + "\n\n"),
+					),
+					Request: req,
+				}, nil
+			}),
+		}, nil
+	})
+
+	rep, err := RunContext(context.Background(), Options{
+		FilePath:      file,
+		WorkspaceRoot: dir,
+		ArtifactDir:   artifacts,
+		Client:        client,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Failed != 1 {
+		t.Fatalf("report failed = %d, want the truncated stream to fail the run", rep.Failed)
+	}
+
+	res := rep.Results[0]
+	if res.Passed {
+		t.Fatal("a stream that stopped at its line limit was reported as passing")
+	}
+	if res.Failure.Code != runfail.CodeProtocol || res.Failure.Source != "stream" {
+		t.Fatalf("Failure = %+v, want a protocol failure sourced from the stream", res.Failure)
+	}
+	if !strings.Contains(res.Failure.Message, "max-line-bytes") {
+		t.Fatalf("Failure.Message = %q, want the limit to raise", res.Failure.Message)
+	}
+	if res.Stream == nil || res.Stream.TranscriptPath == "" {
+		t.Fatalf("Stream = %+v, want the transcript kept", res.Stream)
+	}
+	if _, err := os.ReadFile(res.Stream.TranscriptPath); err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+}
+
+func TestRunPassesWhenAStreamStopsAtAnEventLimit(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "stream.http")
+	src := strings.Join([]string{
+		"### Events",
+		"# @name events",
+		"# @sse max-events=1",
+		"GET https://example.com/events",
+		"",
+	}, "\n")
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	client := newHTTPClientWithFactory(func(httpx.Options) (*http.Client, error) {
+		return &http.Client{
+			Transport: transportFunc(func(req *http.Request) (*http.Response, error) {
+				hdr := make(http.Header)
+				hdr.Set("Content-Type", "text/event-stream")
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Proto:      "HTTP/1.1",
+					Header:     hdr,
+					Body:       io.NopCloser(strings.NewReader("data: one\n\ndata: two\n\n")),
+					Request:    req,
+				}, nil
+			}),
+		}, nil
+	})
+
+	rep, err := RunContext(context.Background(), Options{
+		FilePath:      file,
+		WorkspaceRoot: dir,
+		Client:        client,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !rep.Results[0].Passed {
+		t.Fatalf("a stream that stopped where it was told to failed: %+v", rep.Results[0].Failure)
 	}
 }

--- a/internal/runx/report/fmt.go
+++ b/internal/runx/report/fmt.go
@@ -155,6 +155,9 @@ func resultLine(res Result) string {
 		return fmt.Sprintf("%s [%s]", base, res.ScriptError)
 	}
 
+	if msg := streamFailureText(res.Stream); msg != "" {
+		return fmt.Sprintf("%s [%s]", base, msg)
+	}
 	if n := failedTestCount(res.Tests); n > 0 {
 		return fmt.Sprintf("%s [%d test(s) failed]", base, n)
 	}
@@ -271,6 +274,9 @@ func stepLine(step Step) string {
 		return fmt.Sprintf("%s [%s]", base, step.ScriptError)
 	}
 
+	if msg := streamFailureText(step.Stream); msg != "" {
+		return fmt.Sprintf("%s [%s]", base, msg)
+	}
 	if n := failedTestCount(step.Tests); n > 0 {
 		return fmt.Sprintf("%s [%d test(s) failed]", base, n)
 	}
@@ -315,6 +321,13 @@ func failedTests(tests []Test) []Test {
 		}
 	}
 	return out
+}
+
+func streamFailureText(info *Stream) string {
+	if info == nil {
+		return ""
+	}
+	return info.Error
 }
 
 func traceFailureText(info *Trace) string {

--- a/internal/runx/report/json.go
+++ b/internal/runx/report/json.go
@@ -160,6 +160,7 @@ type jsonStream struct {
 	EventCount     int            `json:"eventCount,omitempty"`
 	Summary        map[string]any `json:"summary,omitempty"`
 	TranscriptPath string         `json:"transcriptPath,omitempty"`
+	Error          string         `json:"error,omitempty"`
 }
 
 type jsonTrace struct {
@@ -515,6 +516,7 @@ func (stream *Stream) json() *jsonStream {
 		Kind:           stream.Kind,
 		EventCount:     stream.EventCount,
 		TranscriptPath: stream.TranscriptPath,
+		Error:          stream.Error,
 	}
 	if len(stream.Summary) > 0 {
 		out.Summary = jsonAnyMap(stream.Summary)

--- a/internal/runx/report/model.go
+++ b/internal/runx/report/model.go
@@ -204,6 +204,7 @@ type Stream struct {
 	EventCount     int
 	Summary        map[string]any
 	TranscriptPath string
+	Error          string
 }
 
 type Trace struct {

--- a/internal/scripts/guard.go
+++ b/internal/scripts/guard.go
@@ -1,0 +1,41 @@
+package scripts
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dop251/goja"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
+)
+
+const DefaultScriptTimeout = 30 * time.Second
+
+func guardVM(ctx context.Context, vm *goja.Runtime, budget time.Duration) func() {
+	timer := time.AfterFunc(budget, func() {
+		vm.Interrupt(diag.Newf(
+			diag.ClassTimeout,
+			"script exceeded the %s time limit",
+			budget,
+		))
+	})
+	stop := context.AfterFunc(ctx, func() {
+		vm.Interrupt(context.Cause(ctx))
+	})
+
+	return func() {
+		timer.Stop()
+		stop()
+	}
+}
+
+func stopReason(ctx context.Context, err error) error {
+	var interrupted *goja.InterruptedError
+	if errors.As(err, &interrupted) {
+		if reason, ok := interrupted.Value().(error); ok {
+			return reason
+		}
+	}
+	return context.Cause(ctx)
+}

--- a/internal/scripts/guard_test.go
+++ b/internal/scripts/guard_test.go
@@ -1,0 +1,117 @@
+package scripts
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/unkn0wn-root/resterm/internal/prerequest"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+func endlessScript(kind string) []restfile.ScriptBlock {
+	return []restfile.ScriptBlock{{Kind: kind, Lang: "js", Body: "while (true) {}"}}
+}
+
+func TestRunTestsStopsAtTheScriptTimeout(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunner(nil)
+	runner.timeout = 50 * time.Millisecond
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := runner.RunTests(
+			context.Background(),
+			endlessScript("test"),
+			TestInput{Response: &Response{}},
+		)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("RunTests() = nil, want the script time limit")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunTests did not stop at its time limit")
+	}
+}
+
+func TestRunTestsStopsWhenTheCallerCancels(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runner := NewRunner(nil)
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := runner.RunTests(ctx, endlessScript("test"), TestInput{Response: &Response{}})
+		done <- err
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunTests() = %v, want context.Canceled", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunTests did not stop when the caller cancelled")
+	}
+}
+
+func TestPreRequestStopsAtTheScriptTimeout(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunner(nil)
+	runner.timeout = 50 * time.Millisecond
+	req := &restfile.Request{Method: "GET", URL: "https://example.com"}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := runner.RunPreRequest(
+			endlessScript("pre-request"),
+			prerequest.Input{Request: req},
+		)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("RunPreRequest() = nil, want the script time limit")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunPreRequest did not stop at its time limit")
+	}
+}
+
+func TestGuardReleasesItsWatcher(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	before := runtime.NumGoroutine()
+	runner := NewRunner(nil)
+	for range 50 {
+		if _, _, err := runner.RunTests(
+			ctx,
+			[]restfile.ScriptBlock{{Kind: "test", Lang: "js", Body: "1 + 1;"}},
+			TestInput{Response: &Response{}},
+		); err != nil {
+			t.Fatalf("RunTests: %v", err)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() > before+5 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if leaked := runtime.NumGoroutine() - before; leaked > 5 {
+		t.Fatalf("%d goroutines outlived their scripts", leaked)
+	}
+}

--- a/internal/scripts/runner.go
+++ b/internal/scripts/runner.go
@@ -1,10 +1,10 @@
 package scripts
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -25,7 +25,12 @@ import (
 )
 
 type Runner struct {
-	fs filelookup.FileSystem
+	fs      filelookup.FileSystem
+	timeout time.Duration
+}
+
+func (r *Runner) scriptTimeout() time.Duration {
+	return cmp.Or(r.timeout, DefaultScriptTimeout)
 }
 
 func NewRunner(fs filelookup.FileSystem) *Runner {
@@ -96,13 +101,21 @@ func (r *Runner) RunPreRequest(
 }
 
 func (r *Runner) RunTests(
+	ctx context.Context,
 	scripts []restfile.ScriptBlock,
 	input TestInput,
 ) ([]TestResult, vars.Globals, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var aggregated []TestResult
 	var changes vars.Globals
 
 	for idx, block := range scripts {
+		if err := ctx.Err(); err != nil {
+			return aggregated, changes, err
+		}
 		if kind := strings.ToLower(block.Kind); kind != "test" && kind != "tests" {
 			continue
 		}
@@ -118,7 +131,7 @@ func (r *Runner) RunTests(
 			continue
 		}
 
-		results, globals, err := r.executeTestScript(script, input)
+		results, globals, err := r.executeTestScript(ctx, script, input)
 		if err != nil {
 			return aggregated, changes, diag.WrapAsf(diag.ClassScript, err, "test script %d", idx+1)
 		}
@@ -136,17 +149,8 @@ func (r *Runner) executePreRequestScript(
 	api *preRequestAPI,
 ) error {
 	vm := goja.New()
-	if ctx != nil {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if done := ctx.Done(); done != nil {
-			go func() {
-				<-done
-				vm.Interrupt(ctx.Err())
-			}()
-		}
-	}
+	stopGuard := guardVM(ctx, vm, r.scriptTimeout())
+	defer stopGuard()
 
 	if err := bindCommon(vm); err != nil {
 		return diag.WrapAs(diag.ClassScript, err, "bind console api")
@@ -160,16 +164,9 @@ func (r *Runner) executePreRequestScript(
 		return diag.WrapAs(diag.ClassScript, err, "bind vars api")
 	}
 
-	_, err := vm.RunString(script)
-	if err != nil {
-		if ctx != nil {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			var interrupted *goja.InterruptedError
-			if errors.As(err, &interrupted) && ctx.Err() != nil {
-				return ctx.Err()
-			}
+	if _, err := vm.RunString(script); err != nil {
+		if reason := stopReason(ctx, err); reason != nil {
+			return reason
 		}
 		return diag.WrapAs(diag.ClassScript, err, "execute pre-request script")
 	}
@@ -177,10 +174,14 @@ func (r *Runner) executePreRequestScript(
 }
 
 func (r *Runner) executeTestScript(
+	ctx context.Context,
 	script string,
 	input TestInput,
 ) ([]TestResult, vars.Globals, error) {
 	vm := goja.New()
+	stopGuard := guardVM(ctx, vm, r.scriptTimeout())
+	defer stopGuard()
+
 	streamInfo := input.Stream.Clone()
 	tester := newTestAPI(input, streamInfo)
 	tester.vm = vm
@@ -218,12 +219,17 @@ func (r *Runner) executeTestScript(
 		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "bind trace api")
 	}
 
-	_, err := vm.RunString(script)
-	if err != nil {
+	if _, err := vm.RunString(script); err != nil {
+		if reason := stopReason(ctx, err); reason != nil {
+			return nil, vars.Globals{}, reason
+		}
 		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "execute test script")
 	}
 
 	if err := streamBinding.replay(); err != nil {
+		if reason := stopReason(ctx, err); reason != nil {
+			return nil, vars.Globals{}, reason
+		}
 		return nil, vars.Globals{}, diag.WrapAs(diag.ClassScript, err, "execute stream callbacks")
 	}
 	return tester.results(), tester.globalChanges(), nil

--- a/internal/scripts/runner_test.go
+++ b/internal/scripts/runner_test.go
@@ -233,6 +233,7 @@ client.test("vars carried", function () {
 	}
 	testBlocks := []restfile.ScriptBlock{{Kind: "test", FilePath: "test.js"}}
 	results, globals, err := runner.RunTests(
+		t.Context(),
 		testBlocks,
 		TestInput{Response: response, Variables: preResult.Variables.Map(), BaseDir: dir},
 	)
@@ -274,6 +275,7 @@ func TestRunTestsScripts(t *testing.T) {
 	}
 
 	results, globals, err := runner.RunTests(
+		t.Context(),
 		scripts,
 		TestInput{Response: response, Variables: map[string]string{}},
 	)
@@ -356,6 +358,7 @@ client.test("response stream access", function () {
 });`
 
 	results, globals, err := runner.RunTests(
+		t.Context(),
 		[]restfile.ScriptBlock{{Kind: "test", Body: script}},
 		TestInput{
 			Response:  response,
@@ -400,6 +403,7 @@ func TestResponseAPIUsesWireForBinary(t *testing.T) {
 });`
 
 	results, globals, err := runner.RunTests(
+		t.Context(),
 		[]restfile.ScriptBlock{{Kind: "test", Body: script}},
 		TestInput{
 			Response:  response,
@@ -502,7 +506,7 @@ func TestRunTestsKeepsSecretValuesThroughDelete(t *testing.T) {
 vars.global.delete("token");`,
 	}}
 	var sec vars.Secrets
-	_, changes, err := runner.RunTests(scripts, TestInput{Response: resp, Secrets: &sec})
+	_, changes, err := runner.RunTests(t.Context(), scripts, TestInput{Response: resp, Secrets: &sec})
 	if err != nil {
 		t.Fatalf("run tests: %v", err)
 	}
@@ -556,7 +560,7 @@ func TestTestScriptsGlobalMutation(t *testing.T) {
   vars.global.set("token", "after");
 });`,
 	}}
-	results, globals, err := runner.RunTests(scripts, TestInput{
+	results, globals, err := runner.RunTests(t.Context(), scripts, TestInput{
 		Response:  resp,
 		Variables: map[string]string{},
 		Globals: vars.CollectNames(map[string]vars.GlobalMutation{
@@ -675,6 +679,7 @@ func TestTraceBindingProvidesTimeline(t *testing.T) {
 });`
 
 	results, globals, err := runner.RunTests(
+		t.Context(),
 		[]restfile.ScriptBlock{{Kind: "test", Body: script}},
 		TestInput{
 			Response:  response,
@@ -707,6 +712,7 @@ func TestTraceBindingDisabled(t *testing.T) {
   tests.assert(trace.withinBudget() === true, "within budget default");
 });`
 	results, _, err := runner.RunTests(
+		t.Context(),
 		[]restfile.ScriptBlock{{Kind: "test", Body: script}},
 		TestInput{Response: resp},
 	)
@@ -751,6 +757,7 @@ func TestResponseAPIExposesBinaryHelpers(t *testing.T) {
 	}
 
 	results, _, err := runner.RunTests(
+		t.Context(),
 		[]restfile.ScriptBlock{{Kind: "test", Body: script}},
 		TestInput{Response: resp, Variables: map[string]string{}},
 	)

--- a/internal/scripts/stream_info.go
+++ b/internal/scripts/stream_info.go
@@ -7,13 +7,16 @@ type StreamInfo struct {
 	Kind    string
 	Summary map[string]any
 	Events  []map[string]any
+	// Err reports a stream that did not finish cleanly. Scripts still see the
+	// events that arrived.
+	Err error
 }
 
 func (info *StreamInfo) Clone() *StreamInfo {
 	if info == nil {
 		return nil
 	}
-	clone := &StreamInfo{Kind: info.Kind}
+	clone := &StreamInfo{Kind: info.Kind, Err: info.Err}
 	if len(info.Summary) > 0 {
 		clone.Summary = make(map[string]any, len(info.Summary))
 		maps.Copy(clone.Summary, info.Summary)

--- a/internal/settings/keys.go
+++ b/internal/settings/keys.go
@@ -7,12 +7,15 @@ import (
 )
 
 var httpSettingKeys = map[string]struct{}{
-	"base-url":        {},
-	"timeout":         {},
-	"proxy":           {},
-	"followredirects": {},
-	"insecure":        {},
-	"no-cookies":      {},
+	"base-url":                        {},
+	"timeout":                         {},
+	"proxy":                           {},
+	"followredirects":                 {},
+	"insecure":                        {},
+	"no-cookies":                      {},
+	"max-response-size":               {},
+	"max-redirects":                   {},
+	"forward-credentials-on-redirect": {},
 }
 
 // IsHTTPKey reports whether key is a supported HTTP setting key.

--- a/internal/stream/event.go
+++ b/internal/stream/event.go
@@ -46,6 +46,17 @@ type Event struct {
 	WS  WSMetadata
 }
 
+func (e *Event) Size() int64 {
+	if e == nil {
+		return 0
+	}
+	size := len(e.Payload) + len(e.SSE.Name) + len(e.SSE.ID) + len(e.SSE.Comment) + len(e.WS.Reason)
+	for key, value := range e.Metadata {
+		size += len(key) + len(value)
+	}
+	return int64(size)
+}
+
 type SSEMetadata struct {
 	Name    string
 	ID      string

--- a/internal/stream/ringbuffer.go
+++ b/internal/stream/ringbuffer.go
@@ -1,20 +1,24 @@
 package stream
 
 type ringBuffer struct {
-	items []*Event
-	size  int
-	count int
-	head  int
+	items    []*Event
+	size     int
+	count    int
+	head     int
+	bytes    int64
+	maxBytes int64
+	evicted  uint64
 }
 
-func newRingBuffer(size int) *ringBuffer {
+func newRingBuffer(size int, maxBytes int64) *ringBuffer {
 	if size <= 0 {
 		size = 1
 	}
 
 	return &ringBuffer{
-		items: make([]*Event, size),
-		size:  size,
+		items:    make([]*Event, size),
+		size:     size,
+		maxBytes: maxBytes,
 	}
 }
 
@@ -23,15 +27,29 @@ func (r *ringBuffer) append(evt *Event) {
 		return
 	}
 
-	if r.count < r.size {
-		idx := (r.head + r.count) % r.size
-		r.items[idx] = evt
-		r.count++
+	if r.count == r.size {
+		r.evictOldest()
+	}
+	r.items[(r.head+r.count)%r.size] = evt
+	r.count++
+	size := evt.Size()
+	r.bytes += size
+	if size == 0 {
 		return
 	}
 
-	r.items[r.head] = evt
+	// Keep the newest event even when it is larger than the byte limit.
+	for r.maxBytes > 0 && r.bytes > r.maxBytes && r.count > 1 {
+		r.evictOldest()
+	}
+}
+
+func (r *ringBuffer) evictOldest() {
+	r.bytes -= r.items[r.head].Size()
+	r.items[r.head] = nil
 	r.head = (r.head + 1) % r.size
+	r.count--
+	r.evicted++
 }
 
 func (r *ringBuffer) snapshot() []*Event {
@@ -40,9 +58,8 @@ func (r *ringBuffer) snapshot() []*Event {
 	}
 
 	out := make([]*Event, r.count)
-	for i := 0; i < r.count; i++ {
-		idx := (r.head + i) % r.size
-		out[i] = r.items[idx]
+	for i := range r.count {
+		out[i] = r.items[(r.head+i)%r.size]
 	}
 	return out
 }

--- a/internal/stream/ringbuffer_test.go
+++ b/internal/stream/ringbuffer_test.go
@@ -1,0 +1,147 @@
+package stream
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
+)
+
+func payload(n int) *Event {
+	return &Event{Payload: make([]byte, n)}
+}
+
+func TestRingBufferEvictsToStayWithinItsByteBudget(t *testing.T) {
+	r := newRingBuffer(16, 100)
+	for range 8 {
+		r.append(payload(30))
+	}
+
+	if got := r.count; got != 3 {
+		t.Fatalf("count = %d, want 3", got)
+	}
+	if r.bytes > 100 {
+		t.Fatalf("bytes = %d, want at most 100", r.bytes)
+	}
+	if r.evicted != 5 {
+		t.Fatalf("evicted = %d, want 5", r.evicted)
+	}
+}
+
+func TestRingBufferKeepsAnEventLargerThanTheBudget(t *testing.T) {
+	r := newRingBuffer(16, 100)
+	r.append(payload(50))
+	r.append(payload(4096))
+
+	if got := r.count; got != 1 {
+		t.Fatalf("count = %d, want 1", got)
+	}
+	if got := len(r.snapshot()[0].Payload); got != 4096 {
+		t.Fatalf("kept an event of %d bytes, want the newest", got)
+	}
+}
+
+func TestRingBufferWithoutAByteBudgetKeepsEverythingItHolds(t *testing.T) {
+	r := newRingBuffer(4, 0)
+	for range 4 {
+		r.append(payload(1 << 20))
+	}
+	if got := r.count; got != 4 {
+		t.Fatalf("count = %d, want 4", got)
+	}
+}
+
+func TestRingBufferStillEvictsOnCount(t *testing.T) {
+	r := newRingBuffer(2, 0)
+	for i := range 5 {
+		r.append(&Event{Payload: []byte{byte(i)}})
+	}
+	snap := r.snapshot()
+	if len(snap) != 2 || snap[0].Payload[0] != 3 || snap[1].Payload[0] != 4 {
+		t.Fatalf("snapshot = %v, want the last two events", snap)
+	}
+}
+
+func TestSessionReportsEvictedEvents(t *testing.T) {
+	s := NewSession(context.Background(), KindSSE, Config{BufferSize: 8, MaxBytes: bytesize.Of(100)})
+	for range 8 {
+		s.Publish(payload(40))
+	}
+	if got := s.StatsSnapshot().Evicted; got == 0 {
+		t.Fatal("Evicted = 0, want the discarded events to be counted")
+	}
+}
+
+func TestSessionByteBudgetDefaultsAndOptsOut(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  bytesize.Budget
+		want int64
+	}{
+		{name: "unset takes the default", want: DefaultMaxBytes},
+		{name: "explicit budget", raw: bytesize.Of(4096), want: 4096},
+		{name: "an unlimited budget removes it", raw: bytesize.Unlimited(), want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.raw.Or(DefaultMaxBytes); got != tt.want {
+				t.Fatalf("MaxBytes = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRingBufferKeepsAnOversizedEventBehindAWeightlessOne(t *testing.T) {
+	r := newRingBuffer(16, 100)
+	r.append(payload(4096))
+	r.append(&Event{Kind: KindSSE})
+
+	snap := r.snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("snapshot holds %d events, want both", len(snap))
+	}
+	if got := len(snap[0].Payload); got != 4096 {
+		t.Fatalf("the oversized event kept %d bytes, want 4096", got)
+	}
+	if r.evicted != 0 {
+		t.Fatalf("evicted = %d, want a payload-free event to evict nothing", r.evicted)
+	}
+}
+
+func TestRingBufferCountsEventsThatCarryNoPayload(t *testing.T) {
+	comment := func(n int) *Event {
+		return &Event{Kind: KindSSE, SSE: SSEMetadata{Comment: strings.Repeat("x", n)}}
+	}
+
+	r := newRingBuffer(64, 100)
+	for range 8 {
+		r.append(comment(30))
+	}
+
+	if r.count != 3 {
+		t.Fatalf("count = %d, want the buffer to evict down to its budget", r.count)
+	}
+	if r.bytes > 100 {
+		t.Fatalf("bytes = %d, want at most 100", r.bytes)
+	}
+	if r.evicted != 5 {
+		t.Fatalf("evicted = %d, want 5", r.evicted)
+	}
+}
+
+func TestEventSizeCountsEveryRetainedField(t *testing.T) {
+	evt := &Event{
+		Payload:  []byte("ab"),
+		Metadata: map[string]string{"k": "vv"},
+		SSE:      SSEMetadata{Name: "nnn", ID: "i", Comment: "cccc"},
+		WS:       WSMetadata{Reason: "rr"},
+	}
+	if got := evt.Size(); got != 15 {
+		t.Fatalf("Size() = %d, want 15", got)
+	}
+	if got := (*Event)(nil).Size(); got != 0 {
+		t.Fatalf("nil Size() = %d, want 0", got)
+	}
+}

--- a/internal/stream/session.go
+++ b/internal/stream/session.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
 )
 
 type DropPolicy int
@@ -15,10 +17,13 @@ const (
 	DropListener
 )
 
+const DefaultMaxBytes = 8 << 20
+
 type Config struct {
 	BufferSize     int
 	ListenerBuffer int
 	DropPolicy     DropPolicy
+	MaxBytes       bytesize.Budget
 }
 
 func defaultConfig(cfg Config) Config {
@@ -28,7 +33,6 @@ func defaultConfig(cfg Config) Config {
 	if cfg.ListenerBuffer <= 0 {
 		cfg.ListenerBuffer = 64
 	}
-
 	switch cfg.DropPolicy {
 	case DropNewest, DropOldest, DropListener:
 	default:
@@ -66,6 +70,7 @@ type Stats struct {
 	EventsTotal uint64
 	BytesTotal  uint64
 	Dropped     uint64
+	Evicted     uint64
 }
 
 type listener struct {
@@ -107,7 +112,7 @@ func NewSession(parent context.Context, kind Kind, cfg Config) *Session {
 		cancel:    cancel,
 		cfg:       cfg,
 		state:     StateConnecting,
-		events:    newRingBuffer(cfg.BufferSize),
+		events:    newRingBuffer(cfg.BufferSize, cfg.MaxBytes.Or(DefaultMaxBytes)),
 		listeners: make(map[int]*listener),
 		done:      make(chan struct{}),
 		stats: Stats{
@@ -236,8 +241,9 @@ func (s *Session) Publish(evt *Event) {
 
 	s.mu.Lock()
 	s.events.append(evt)
+	s.stats.Evicted = s.events.evicted
 	s.stats.EventsTotal++
-	s.stats.BytesTotal += uint64(len(evt.Payload))
+	s.stats.BytesTotal += uint64(evt.Size())
 	listeners := make([]*listener, 0, len(s.listeners))
 	for _, l := range s.listeners {
 		listeners = append(listeners, l)

--- a/internal/stream/session.go
+++ b/internal/stream/session.go
@@ -85,12 +85,21 @@ type Listener struct {
 	C        <-chan *Event
 	Cancel   func()
 	Snapshot Snapshot
+	dropped  func() uint64
+}
+
+func (l Listener) Dropped() uint64 {
+	if l.dropped == nil {
+		return 0
+	}
+	return l.dropped()
 }
 
 type Snapshot struct {
-	Events []*Event
-	State  State
-	Err    error
+	Events  []*Event
+	State   State
+	Err     error
+	Evicted uint64
 }
 
 var sessionCounter uint64
@@ -177,12 +186,17 @@ func (s *Session) Subscribe() Listener {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	snapshot := Snapshot{
-		Events: s.events.snapshot(),
-		State:  s.state,
-		Err:    s.err,
+		Events:  s.events.snapshot(),
+		State:   s.state,
+		Err:     s.err,
+		Evicted: s.stats.Evicted,
 	}
 	if s.ended() {
-		return Listener{C: closedEvents, Cancel: func() {}, Snapshot: snapshot}
+		return Listener{
+			C:        closedEvents,
+			Cancel:   func() {},
+			Snapshot: snapshot,
+		}
 	}
 
 	id := s.nextLID
@@ -199,6 +213,7 @@ func (s *Session) Subscribe() Listener {
 			s.removeListener(id)
 		},
 		Snapshot: snapshot,
+		dropped:  l.dropped,
 	}
 }
 
@@ -250,64 +265,72 @@ func (s *Session) Publish(evt *Event) {
 	}
 	s.mu.Unlock()
 
-	dropped := 0
+	var dropped uint64
 	for _, l := range listeners {
-		if !l.emit(evt) {
-			dropped++
-		}
+		dropped += l.emit(evt)
 	}
 	if dropped > 0 {
 		s.mu.Lock()
-		s.stats.Dropped += uint64(dropped)
+		s.stats.Dropped += dropped
 		s.mu.Unlock()
 	}
 }
 
-func (l *listener) emit(evt *Event) bool {
+func (l *listener) emit(evt *Event) uint64 {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	if l.closed {
-		return false
+		l.dropCnt++
+		return 1
 	}
 
 	switch l.policy {
 	case DropNewest:
 		select {
 		case l.ch <- evt:
-			return true
+			return 0
 		default:
 			l.dropCnt++
-			return false
+			return 1
 		}
 	case DropListener:
 		select {
 		case l.ch <- evt:
-			return true
+			return 0
 		default:
 			l.dropCnt++
 			l.closed = true
 			close(l.ch)
-			return false
+			return 1
 		}
 	default: // DropOldest - when buffer is full, try to discard one old event to make room
 		select {
 		case l.ch <- evt:
-			return true
+			return 0
 		default:
+			var dropped uint64
 			select {
 			case <-l.ch:
+				l.dropCnt++
+				dropped++
 			default:
 			}
 			select {
 			case l.ch <- evt:
-				return true
+				return dropped
 			default:
 				l.dropCnt++
-				return false
+				return dropped + 1
 			}
 		}
 	}
+}
+
+func (l *listener) dropped() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.dropCnt
 }
 
 func (s *Session) MarkOpen() {

--- a/internal/stream/session.go
+++ b/internal/stream/session.go
@@ -85,14 +85,16 @@ type Listener struct {
 	C        <-chan *Event
 	Cancel   func()
 	Snapshot Snapshot
-	dropped  func() uint64
+	sub      *listener
 }
 
+// Dropped counts the events this listener never received. Events lost before it
+// subscribed are counted by Snapshot.Evicted instead.
 func (l Listener) Dropped() uint64 {
-	if l.dropped == nil {
+	if l.sub == nil {
 		return 0
 	}
-	return l.dropped()
+	return l.sub.dropped()
 }
 
 type Snapshot struct {
@@ -213,7 +215,7 @@ func (s *Session) Subscribe() Listener {
 			s.removeListener(id)
 		},
 		Snapshot: snapshot,
-		dropped:  l.dropped,
+		sub:      l,
 	}
 }
 

--- a/internal/stream/session_test.go
+++ b/internal/stream/session_test.go
@@ -70,6 +70,47 @@ func TestSessionDropNewestPolicy(t *testing.T) {
 	listener.Cancel()
 }
 
+func TestSessionDropOldestPolicyReportsLoss(t *testing.T) {
+	s := NewSession(
+		t.Context(),
+		KindSSE,
+		Config{ListenerBuffer: 1, DropPolicy: DropOldest},
+	)
+	s.MarkOpen()
+	listener := s.Subscribe()
+	t.Cleanup(listener.Cancel)
+
+	s.Publish(&Event{Kind: KindSSE, Direction: DirReceive, Payload: []byte("first")})
+	s.Publish(&Event{Kind: KindSSE, Direction: DirReceive, Payload: []byte("second")})
+
+	select {
+	case evt := <-listener.C:
+		if string(evt.Payload) != "second" {
+			t.Fatalf("received %q, want the newest event", evt.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the newest event")
+	}
+	if got := listener.Dropped(); got != 1 {
+		t.Fatalf("listener dropped %d events, want 1", got)
+	}
+	if got := s.StatsSnapshot().Dropped; got != 1 {
+		t.Fatalf("session dropped %d events, want 1", got)
+	}
+}
+
+func TestSessionSnapshotReportsEvictedEvents(t *testing.T) {
+	s := NewSession(t.Context(), KindWebSocket, Config{BufferSize: 1})
+	s.Publish(&Event{Kind: KindWebSocket, Payload: []byte("first")})
+	s.Publish(&Event{Kind: KindWebSocket, Payload: []byte("second")})
+
+	listener := s.Subscribe()
+	t.Cleanup(listener.Cancel)
+	if got := listener.Snapshot.Evicted; got != 1 {
+		t.Fatalf("snapshot evicted %d events, want 1", got)
+	}
+}
+
 func TestSessionSubscribeAfterClose(t *testing.T) {
 	s := NewSession(context.Background(), KindGRPC, Config{})
 	s.Publish(&Event{Kind: KindGRPC, Direction: DirReceive, Payload: []byte("last")})

--- a/internal/telemetry/redact.go
+++ b/internal/telemetry/redact.go
@@ -1,0 +1,128 @@
+package telemetry
+
+import (
+	"net/url"
+	"strings"
+)
+
+const redactedValue = "REDACTED"
+
+type safeURL struct {
+	full   string
+	target string
+}
+
+func sanitizeURL(u *url.URL) safeURL {
+	if u == nil {
+		return safeURL{}
+	}
+
+	clean := *u
+	clean.User = nil
+	clean.RawQuery = redactQuery(u.RawQuery)
+	clean.Fragment = ""
+	clean.RawFragment = ""
+
+	return safeURL{full: clean.String(), target: clean.RequestURI()}
+}
+
+func redactQuery(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, "&")
+	for i, part := range parts {
+		if key, _, ok := strings.Cut(part, "="); ok {
+			parts[i] = key + "=" + redactedValue
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+var scrubSchemes = []string{"https", "http", "wss", "ws"}
+
+func scrubText(text string) string {
+	var out strings.Builder
+	rest := text
+	for {
+		at := indexURL(rest)
+		if at < 0 {
+			break
+		}
+		out.WriteString(rest[:at])
+		raw, tail := splitURL(rest[at:])
+		out.WriteString(sanitizeRawURL(raw))
+		rest = tail
+	}
+	if out.Len() == 0 {
+		return text
+	}
+	out.WriteString(rest)
+	return out.String()
+}
+
+func indexURL(text string) int {
+	for at := 0; at < len(text); at++ {
+		i := strings.IndexByte(text[at:], ':')
+		if i < 0 {
+			return -1
+		}
+		at += i
+		if !strings.HasPrefix(text[at:], "://") {
+			continue
+		}
+		if start, ok := schemeStart(text[:at]); ok {
+			return start
+		}
+	}
+	return -1
+}
+
+func schemeStart(text string) (int, bool) {
+	for _, scheme := range scrubSchemes {
+		start := len(text) - len(scheme)
+		if start < 0 || !strings.EqualFold(text[start:], scheme) {
+			continue
+		}
+		if start > 0 && inScheme(text[start-1]) {
+			return 0, false
+		}
+		return start, true
+	}
+	return 0, false
+}
+
+func inScheme(ch byte) bool {
+	switch {
+	case ch >= 'a' && ch <= 'z', ch >= 'A' && ch <= 'Z', ch >= '0' && ch <= '9':
+		return true
+	default:
+		return ch == '+' || ch == '-' || ch == '.'
+	}
+}
+
+func splitURL(text string) (string, string) {
+	end := len(text)
+	for i := range len(text) {
+		if endsURL(text[i]) {
+			end = i
+			break
+		}
+	}
+	for end > 0 && strings.IndexByte(".,;:!?", text[end-1]) >= 0 {
+		end--
+	}
+	return text[:end], text[end:]
+}
+
+func endsURL(ch byte) bool {
+	return ch <= ' ' || ch == 0x7f || strings.IndexByte(`"'<>\^`+"`"+`{}|`, ch) >= 0
+}
+
+func sanitizeRawURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	return sanitizeURL(u).full
+}

--- a/internal/telemetry/redact_test.go
+++ b/internal/telemetry/redact_test.go
@@ -1,0 +1,273 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/unkn0wn-root/resterm/internal/nettrace"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+func startedSpan(t *testing.T, target string) (*tracetest.SpanRecorder, RequestSpan) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	inst, err := New(Config{ServiceName: "resterm-test"}, WithSpanProcessor(recorder))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = inst.Shutdown(context.Background()) })
+
+	httpReq, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	_, span := inst.Start(context.Background(), RequestStart{
+		Request:     &restfile.Request{Method: http.MethodGet, URL: target},
+		HTTPRequest: httpReq,
+	})
+	return recorder, span
+}
+
+func assertNoSecrets(t *testing.T, recorder *tracetest.SpanRecorder, secrets ...string) {
+	t.Helper()
+	for _, span := range recorder.Ended() {
+		for _, attr := range span.Attributes() {
+			assertClean(t, string(attr.Key), attr.Value.AsString(), secrets)
+		}
+		assertClean(t, "status", span.Status().Description, secrets)
+		for _, evt := range span.Events() {
+			for _, attr := range evt.Attributes {
+				assertClean(t, evt.Name+"/"+string(attr.Key), attr.Value.AsString(), secrets)
+			}
+		}
+	}
+}
+
+func assertClean(t *testing.T, where, text string, secrets []string) {
+	t.Helper()
+	for _, secret := range secrets {
+		if strings.Contains(text, secret) {
+			t.Errorf("%s carries %q: %s", where, secret, text)
+		}
+	}
+}
+
+func TestSpanKeepsQuerySecretsOffTheWire(t *testing.T) {
+	const target = "https://api.example.com/v1/things?api_key=SECRETKEY&sig=SIGNED&page=2"
+
+	recorder, span := startedSpan(t, target)
+	span.End(RequestResult{StatusCode: 200})
+
+	assertNoSecrets(t, recorder, "SECRETKEY", "SIGNED")
+
+	attrs := spanAttributes(t, recorder)
+	if got := attrs["http.url"]; got != "https://api.example.com/v1/things?api_key=REDACTED&sig=REDACTED&page=REDACTED" {
+		t.Fatalf("http.url = %q", got)
+	}
+	if got := attrs["http.target"]; got != "/v1/things?api_key=REDACTED&sig=REDACTED&page=REDACTED" {
+		t.Fatalf("http.target = %q", got)
+	}
+}
+
+func TestSpanNeverCarriesURLCredentials(t *testing.T) {
+	const target = "https://alice:hunter2@api.example.com/v1/things"
+
+	recorder, span := startedSpan(t, target)
+	span.End(RequestResult{StatusCode: 200})
+
+	assertNoSecrets(t, recorder, "alice", "hunter2")
+}
+
+func TestSpanScrubsTheErrorItRecords(t *testing.T) {
+	const target = "https://alice:hunter2@api.example.com/v1?api_key=SECRETKEY"
+
+	recorder, span := startedSpan(t, target)
+	span.End(RequestResult{Err: errors.New(
+		`perform request: Get "https://alice:***@api.example.com/v1?api_key=SECRETKEY": dial tcp: refused`,
+	)})
+
+	assertNoSecrets(t, recorder, "SECRETKEY", "hunter2")
+}
+
+func TestSpanScrubsTraceErrors(t *testing.T) {
+	const target = "https://api.example.com/v1?token=SECRETKEY"
+
+	recorder, span := startedSpan(t, target)
+	span.RecordTrace(&nettrace.Timeline{
+		Err: `Get "https://api.example.com/v1?token=SECRETKEY": timeout`,
+		Phases: []nettrace.Phase{{
+			Kind: nettrace.PhaseDNS,
+			Err:  `lookup for https://api.example.com/v1?token=SECRETKEY failed`,
+		}},
+	}, nil)
+	span.End(RequestResult{StatusCode: 500})
+
+	assertNoSecrets(t, recorder, "SECRETKEY")
+}
+
+func TestRedactQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty"},
+		{name: "single value", raw: "api_key=secret", want: "api_key=REDACTED"},
+		{name: "several values", raw: "a=1&b=2", want: "a=REDACTED&b=REDACTED"},
+		{name: "empty value", raw: "a=", want: "a=REDACTED"},
+		{name: "bare key carries no value", raw: "verbose", want: "verbose"},
+		{name: "mixed", raw: "verbose&token=abc", want: "verbose&token=REDACTED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactQuery(tt.raw); got != tt.want {
+				t.Fatalf("redactQuery(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeURLDropsFragmentsAndUserinfo(t *testing.T) {
+	u, err := url.Parse("https://alice:hunter2@example.com/p?a=1#access_token=SECRET")
+	if err != nil {
+		t.Fatal(err)
+	}
+	safe := sanitizeURL(u)
+	if safe.full != "https://example.com/p?a=REDACTED" {
+		t.Fatalf("full = %q", safe.full)
+	}
+	if safe.target != "/p?a=REDACTED" {
+		t.Fatalf("target = %q", safe.target)
+	}
+}
+
+func spanAttributes(t *testing.T, recorder *tracetest.SpanRecorder) map[string]string {
+	t.Helper()
+	out := make(map[string]string)
+	for _, span := range recorder.Ended() {
+		for _, attr := range span.Attributes() {
+			out[string(attr.Key)] = attr.Value.AsString()
+		}
+	}
+	return out
+}
+
+func TestSpanScrubsARedirectedURLItNeverSaw(t *testing.T) {
+	recorder, span := startedSpan(t, "https://api.example.com/v1")
+	span.End(RequestResult{Err: errors.New(
+		`perform request: Get "https://cdn.example.net/blob?X-Amz-Signature=SIGNED&token=SECRETKEY": timeout`,
+	)})
+
+	assertNoSecrets(t, recorder, "SIGNED", "SECRETKEY")
+}
+
+func TestSpanScrubsRedirectCredentialsInTraceErrors(t *testing.T) {
+	recorder, span := startedSpan(t, "https://api.example.com/v1")
+	span.RecordTrace(&nettrace.Timeline{
+		Err: `dial https://bob:hunter2@evil.example.net/p?sig=SIGNED failed`,
+	}, nil)
+	span.End(RequestResult{StatusCode: 502})
+
+	assertNoSecrets(t, recorder, "hunter2", "SIGNED", "bob")
+}
+
+func TestScrubText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no url", in: "dial tcp: connection refused", want: "dial tcp: connection refused"},
+		{
+			name: "quoted url",
+			in:   `Get "https://h/p?a=1": timeout`,
+			want: `Get "https://h/p?a=REDACTED": timeout`,
+		},
+		{
+			name: "trailing colon is not part of the url",
+			in:   "fetch https://h/p?a=1: timeout",
+			want: "fetch https://h/p?a=REDACTED: timeout",
+		},
+		{
+			name: "userinfo removed",
+			in:   "get https://u:p@h/x now",
+			want: "get https://h/x now",
+		},
+		{
+			name: "two urls",
+			in:   "https://a/x?k=1 redirected to https://b/y?k=2",
+			want: "https://a/x?k=REDACTED redirected to https://b/y?k=REDACTED",
+		},
+		{
+			name: "uppercase scheme",
+			in:   "HTTPS://h/p?a=1 failed",
+			want: "https://h/p?a=REDACTED failed",
+		},
+		{
+			name: "fragment dropped",
+			in:   "opened https://h/p#access_token=SECRET ok",
+			want: "opened https://h/p ok",
+		},
+		{
+			name: "scheme without a host is left alone",
+			in:   "see http:// for details",
+			want: "see http:// for details",
+		},
+		{
+			name: "already redacted text is unchanged",
+			in:   "https://h/p?a=REDACTED",
+			want: "https://h/p?a=REDACTED",
+		},
+		{
+			name: "word ending in http is not a scheme",
+			in:   "xhttp://h/p?a=1",
+			want: "xhttp://h/p?a=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scrubText(tt.in); got != tt.want {
+				t.Fatalf("scrubText(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScrubTextCoversWebSocketURLs(t *testing.T) {
+	in := `dial wss://api.example.com/socket?token=SECRETKEY: handshake failed`
+	want := `dial wss://api.example.com/socket?token=REDACTED: handshake failed`
+	if got := scrubText(in); got != want {
+		t.Fatalf("scrubText() = %q, want %q", got, want)
+	}
+}
+
+func FuzzScrubText(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"https://h/p?a=1",
+		`Get "https://u:p@h/p?a=1": timeout`,
+		"http://",
+		"xhttps://h",
+		"https://h/p#f",
+		"::://",
+		"ws://h/s?t=1",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, in string) {
+		once := scrubText(in)
+		if twice := scrubText(once); twice != once {
+			t.Fatalf("scrubText is not settled: %q then %q", once, twice)
+		}
+	})
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -115,7 +115,7 @@ func (m *manager) Start(ctx context.Context, info RequestStart) (context.Context
 		return ctx, noopSpan{}
 	}
 
-	attrs := buildSpanAttributes(info)
+	attrs := buildSpanAttributes(info, sanitizeURL(info.HTTPRequest.URL))
 	spanName := spanNameFor(info)
 	ctx, span := m.tracer.Start(
 		ctx,
@@ -160,7 +160,7 @@ func (rs *requestSpan) RecordTrace(tl *nettrace.Timeline, report *nettrace.Repor
 	if strings.TrimSpace(tl.Err) != "" {
 		rs.span.AddEvent(
 			"resterm.trace.error",
-			trace.WithAttributes(attribute.String("resterm.error", tl.Err)),
+			trace.WithAttributes(attribute.String("resterm.error", scrubText(tl.Err))),
 		)
 	}
 
@@ -179,7 +179,10 @@ func (rs *requestSpan) RecordTrace(tl *nettrace.Timeline, report *nettrace.Repor
 			attrs = append(attrs, attribute.Bool("resterm.trace.cached", true))
 		}
 		if strings.TrimSpace(phase.Err) != "" {
-			attrs = append(attrs, attribute.String("resterm.trace.phase_error", phase.Err))
+			attrs = append(
+				attrs,
+				attribute.String("resterm.trace.phase_error", scrubText(phase.Err)),
+			)
 		}
 
 		options := []trace.EventOption{trace.WithAttributes(attrs...)}
@@ -217,9 +220,9 @@ func (rs *requestSpan) End(result RequestResult) {
 	statusMsg := ""
 
 	if result.Err != nil {
-		rs.span.RecordError(result.Err)
+		rs.span.RecordError(scrubbedError(result.Err))
 		statusCode = codes.Error
-		statusMsg = result.Err.Error()
+		statusMsg = scrubText(result.Err.Error())
 	}
 
 	if result.Report != nil && len(result.Report.BudgetReport.Breaches) > 0 {
@@ -244,6 +247,20 @@ func (rs *requestSpan) End(result RequestResult) {
 	rs.span.SetStatus(statusCode, statusMsg)
 	rs.span.End()
 }
+
+func scrubbedError(err error) error {
+	text := scrubText(err.Error())
+	if text == err.Error() {
+		return err
+	}
+	return redactedError{text: text}
+}
+
+type redactedError struct {
+	text string
+}
+
+func (e redactedError) Error() string { return e.text }
 
 func Noop() Instrumenter {
 	return noopInstrumenter{}
@@ -300,7 +317,7 @@ func buildResourceAttributes(cfg Config) []attribute.KeyValue {
 	return attrs
 }
 
-func buildSpanAttributes(info RequestStart) []attribute.KeyValue {
+func buildSpanAttributes(info RequestStart, safe safeURL) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.Bool("resterm.trace.enabled", true),
 	}
@@ -319,11 +336,11 @@ func buildSpanAttributes(info RequestStart) []attribute.KeyValue {
 		if host := req.URL.Host; host != "" {
 			attrs = append(attrs, httpHostKey.String(host))
 		}
-		if target := req.URL.RequestURI(); target != "" {
-			attrs = append(attrs, semconv.HTTPTargetKey.String(target))
+		if safe.target != "" {
+			attrs = append(attrs, semconv.HTTPTargetKey.String(safe.target))
 		}
-		if full := req.URL.String(); full != "" {
-			attrs = append(attrs, semconv.HTTPURLKey.String(full))
+		if safe.full != "" {
+			attrs = append(attrs, semconv.HTTPURLKey.String(safe.full))
 		}
 	}
 

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -120,6 +120,8 @@ type updateCheckMsg struct {
 type streamEventMsg struct {
 	sessionID string
 	events    []*stream.Event
+	// dropped is a running total, not an increment.
+	dropped uint64
 }
 
 type streamStateMsg struct {
@@ -130,6 +132,7 @@ type streamStateMsg struct {
 
 type streamCompleteMsg struct {
 	sessionID string
+	dropped   uint64
 }
 
 // streamAttachMsg hands a session opened on the engine goroutine to the update

--- a/internal/ui/model_exec_test.go
+++ b/internal/ui/model_exec_test.go
@@ -37,7 +37,6 @@ import (
 	"nhooyr.io/websocket"
 )
 
-// runCmd flattens startRun's pair for tests that only need the command.
 func runCmd(cmd tea.Cmd, _ bool) tea.Cmd { return cmd }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -954,7 +953,7 @@ func TestEnsureOAuthSetsAuthorizationHeader(t *testing.T) {
 	}}
 	req := &restfile.Request{Metadata: restfile.RequestMetadata{Auth: auth}}
 	resolver := vars.NewResolver()
-	if err := model.requestSvc(httpx.Options{}).EnsureOAuth(
+	if _, err := model.requestSvc(httpx.Options{}).EnsureOAuth(
 		context.Background(),
 		req,
 		resolver,
@@ -976,7 +975,7 @@ func TestEnsureOAuthSetsAuthorizationHeader(t *testing.T) {
 	}
 
 	req2 := &restfile.Request{Metadata: restfile.RequestMetadata{Auth: auth}}
-	if err := model.requestSvc(httpx.Options{}).EnsureOAuth(
+	if _, err := model.requestSvc(httpx.Options{}).EnsureOAuth(
 		context.Background(),
 		req2,
 		resolver,
@@ -1015,7 +1014,7 @@ func TestEnsureOAuthSkipsWhenHeaderPresent(t *testing.T) {
 			}},
 		},
 	}
-	if err := model.requestSvc(httpx.Options{}).EnsureOAuth(
+	if _, err := model.requestSvc(httpx.Options{}).EnsureOAuth(
 		context.Background(),
 		req,
 		vars.NewResolver(),
@@ -1106,7 +1105,7 @@ func TestEnsureOAuthUsesEnvironmentOverride(t *testing.T) {
 	}}
 	req := &restfile.Request{Metadata: restfile.RequestMetadata{Auth: auth}}
 
-	if err := model.requestSvc(httpx.Options{}).EnsureOAuth(
+	if _, err := model.requestSvc(httpx.Options{}).EnsureOAuth(
 		context.Background(),
 		req,
 		vars.NewResolver(),
@@ -1117,7 +1116,7 @@ func TestEnsureOAuthUsesEnvironmentOverride(t *testing.T) {
 		t.Fatalf("ensureOAuth stage: %v", err)
 	}
 	req.Headers = nil
-	if err := model.requestSvc(httpx.Options{}).EnsureOAuth(
+	if _, err := model.requestSvc(httpx.Options{}).EnsureOAuth(
 		context.Background(),
 		req,
 		vars.NewResolver(),
@@ -1132,7 +1131,7 @@ func TestEnsureOAuthUsesEnvironmentOverride(t *testing.T) {
 	}
 
 	req.Headers = nil
-	if err := model.requestSvc(httpx.Options{}).EnsureOAuth(
+	if _, err := model.requestSvc(httpx.Options{}).EnsureOAuth(
 		context.Background(),
 		req,
 		vars.NewResolver(),
@@ -1169,7 +1168,7 @@ func TestEnsureOAuthCancelsWithContext(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		if err := model.requestSvc(httpx.Options{}).EnsureOAuth(
+		if _, err := model.requestSvc(httpx.Options{}).EnsureOAuth(
 			ctx,
 			req,
 			resolver,
@@ -2003,13 +2002,11 @@ func TestApplyNoCookiesSetting(t *testing.T) {
 		ws: workspace{sel: testSelection("dev")},
 	}
 
-	// Prepare the cookie jar
 	u, _ := url.Parse(srv.URL)
 	model.cookieStore().Jar(testEnv("dev").Scope()).SetCookies(u, []*http.Cookie{
 		{Name: "session", Value: "active"},
 	})
 
-	// First request to check the cookie is set by default
 	req := &restfile.Request{
 		Method: "GET",
 		URL:    srv.URL,
@@ -2035,7 +2032,6 @@ func TestApplyNoCookiesSetting(t *testing.T) {
 		t.Fatalf("expected cookie session=active in dev env, got %q", respBodyString)
 	}
 
-	// Second request with setting to skip cookies
 	reqWithSetting := &restfile.Request{
 		Method:   "GET",
 		URL:      srv.URL,

--- a/internal/ui/model_history.go
+++ b/internal/ui/model_history.go
@@ -17,6 +17,7 @@ import (
 	xexec "github.com/unkn0wn-root/resterm/internal/exec"
 	xplain "github.com/unkn0wn-root/resterm/internal/explain"
 	"github.com/unkn0wn-root/resterm/internal/history"
+	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
@@ -1000,7 +1001,7 @@ func redactSensitiveHeaders(text string) string {
 		if colon <= 0 {
 			continue
 		}
-		if !rqeng.IsSensitiveHeader(line[:colon]) {
+		if !header.Sensitive(line[:colon]) {
 			continue
 		}
 		rest := line[colon+1:]

--- a/internal/ui/model_stream.go
+++ b/internal/ui/model_stream.go
@@ -52,6 +52,7 @@ func (m *Model) attachStreamSession(session *stream.Session) *liveSession {
 	ls := newLiveSession(id, m.streamMaxEvents)
 	ls.kind = session.Kind()
 	listener := session.Subscribe()
+	ls.lost.evicted = listener.Snapshot.Evicted
 	ls.append(listener.Snapshot.Events)
 	ls.setState(listener.Snapshot.State, listener.Snapshot.Err)
 	m.liveSessions[id] = ls
@@ -116,18 +117,28 @@ func (m *Model) runStreamSession(session *stream.Session, listener stream.Listen
 		if len(batch) == 0 {
 			return
 		}
-		m.emitStreamMsg(streamEventMsg{sessionID: session.ID(), events: cloneEventSlice(batch)})
+		m.emitStreamMsg(streamEventMsg{
+			sessionID: session.ID(),
+			events:    cloneEventSlice(batch),
+			dropped:   listener.Dropped(),
+		})
 		batch = batch[:0]
+	}
+
+	// The last batch can be empty, so the final count goes on the completion
+	// message too.
+	finish := func() {
+		flush()
+		state, err := session.State()
+		m.emitStreamMsg(streamStateMsg{sessionID: session.ID(), state: state, err: err})
+		m.emitStreamMsg(streamCompleteMsg{sessionID: session.ID(), dropped: listener.Dropped()})
 	}
 
 	for {
 		if timer == nil {
 			evt, ok := <-listener.C
 			if !ok {
-				flush()
-				state, err := session.State()
-				m.emitStreamMsg(streamStateMsg{sessionID: session.ID(), state: state, err: err})
-				m.emitStreamMsg(streamCompleteMsg{sessionID: session.ID()})
+				finish()
 				return
 			}
 			batch = append(batch, evt)
@@ -142,10 +153,7 @@ func (m *Model) runStreamSession(session *stream.Session, listener stream.Listen
 					<-timer.C
 				}
 				timer = nil
-				flush()
-				state, err := session.State()
-				m.emitStreamMsg(streamStateMsg{sessionID: session.ID(), state: state, err: err})
-				m.emitStreamMsg(streamCompleteMsg{sessionID: session.ID()})
+				finish()
 				return
 			}
 			batch = append(batch, evt)
@@ -319,6 +327,7 @@ func (m *Model) handleStreamEvents(msg streamEventMsg) {
 	if ls == nil {
 		return
 	}
+	ls.lost.listener = msg.dropped
 	ls.append(msg.events)
 	if ls.state == stream.StateConnecting {
 		ls.state = stream.StateOpen
@@ -362,6 +371,7 @@ func (m *Model) handleStreamComplete(msg streamCompleteMsg) {
 	if ls == nil {
 		return
 	}
+	ls.lost.listener = msg.dropped
 	if ls.state != stream.StateFailed {
 		ls.state = stream.StateClosed
 	}
@@ -670,6 +680,12 @@ func (m *Model) formatStreamContent(ls *liveSession) string {
 	}
 	if ls.err != nil {
 		builder.WriteString(th.StreamError.Render(fmt.Sprintf("Error: %v", ls.err)))
+		builder.WriteByte('\n')
+	}
+	if lost := ls.lost.total(); lost > 0 {
+		builder.WriteString(th.StreamError.Render(
+			fmt.Sprintf("Transcript incomplete: %d events dropped", lost),
+		))
 		builder.WriteByte('\n')
 	}
 

--- a/internal/ui/model_stream_test.go
+++ b/internal/ui/model_stream_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -311,4 +312,65 @@ func newStreamFilterPromptModel(t *testing.T) Model {
 	model.requestSessions[req] = "stream-1"
 	model.liveSessions["stream-1"] = newLiveSession("stream-1", 10)
 	return model
+}
+
+func TestStreamPaneReportsEveryLossSource(t *testing.T) {
+	model := New(Config{})
+	sess := stream.NewSession(context.Background(), stream.KindSSE, stream.Config{BufferSize: 1})
+	sess.MarkOpen()
+	sess.Publish(&stream.Event{Kind: stream.KindSSE, Payload: []byte("evicted")})
+	sess.Publish(&stream.Event{Kind: stream.KindSSE, Payload: []byte("kept")})
+
+	ls := model.attachStreamSession(sess)
+	if ls == nil {
+		t.Fatal("the session did not attach")
+	}
+	t.Cleanup(sess.Cancel)
+	if ls.lost.evicted != 1 {
+		t.Fatalf("lost.evicted = %d, want the event the session had already dropped", ls.lost.evicted)
+	}
+
+	model.handleStreamEvents(streamEventMsg{
+		sessionID: ls.id,
+		events:    []*stream.Event{{Kind: stream.KindSSE, Payload: []byte("late")}},
+		dropped:   2,
+	})
+	if ls.lost.listener != 2 {
+		t.Fatalf("lost.listener = %d, want the listener's running total", ls.lost.listener)
+	}
+
+	ls.maxEvents = 1
+	ls.append(streamEvents(3, 8))
+	if ls.lost.trimmed == 0 {
+		t.Fatal("the pane trimmed events without recording the loss")
+	}
+
+	view := model.formatStreamContent(ls)
+	if !strings.Contains(view, "Transcript incomplete") {
+		t.Fatalf("stream pane does not mark the loss:\n%s", view)
+	}
+	if want := fmt.Sprintf("%d events dropped", ls.lost.total()); !strings.Contains(view, want) {
+		t.Fatalf("stream pane does not name the loss %q:\n%s", want, view)
+	}
+}
+
+func TestStreamPaneStaysQuietWhenNothingIsLost(t *testing.T) {
+	model := New(Config{})
+	ls := newLiveSession("sse-1", 10)
+	ls.append([]*stream.Event{{Kind: stream.KindSSE, Payload: []byte("one")}})
+
+	if view := model.formatStreamContent(ls); strings.Contains(view, "Transcript incomplete") {
+		t.Fatalf("a complete transcript was marked incomplete:\n%s", view)
+	}
+}
+
+func TestStreamCompletionCarriesTheFinalDropCount(t *testing.T) {
+	model := New(Config{})
+	ls := newLiveSession("sse-1", 10)
+	model.liveSessions[ls.id] = ls
+
+	model.handleStreamComplete(streamCompleteMsg{sessionID: ls.id, dropped: 7})
+	if ls.lost.listener != 7 {
+		t.Fatalf("lost.listener = %d, want the count the listener finished on", ls.lost.listener)
+	}
 }

--- a/internal/ui/stream_state.go
+++ b/internal/ui/stream_state.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -18,7 +19,9 @@ import (
 type liveSession struct {
 	id          string
 	events      []*stream.Event
+	bytes       int64
 	maxEvents   int
+	maxBytes    int64
 	state       stream.State
 	err         error
 	kind        stream.Kind
@@ -35,53 +38,73 @@ func (ls *liveSession) failed() bool {
 	return ls != nil && (ls.err != nil || ls.state == stream.StateFailed)
 }
 
+const defaultLiveSessionBytes = 16 << 20
+
 func newLiveSession(id string, max int) *liveSession {
 	if max <= 0 {
 		max = 5000
 	}
-	return &liveSession{id: id, maxEvents: max, pausedIndex: -1, bookmarkIdx: -1}
+	return &liveSession{
+		id:          id,
+		maxEvents:   max,
+		maxBytes:    defaultLiveSessionBytes,
+		pausedIndex: -1,
+		bookmarkIdx: -1,
+	}
 }
 
 func (ls *liveSession) append(events []*stream.Event) {
 	if len(events) == 0 {
 		return
 	}
-	ls.events = append(ls.events, cloneEventSlice(events)...)
-	if len(ls.events) > ls.maxEvents {
-		trim := len(ls.events) - ls.maxEvents
-		ls.events = append([]*stream.Event(nil), ls.events[trim:]...)
-		if ls.paused && ls.pausedIndex >= 0 {
-			ls.pausedIndex -= trim
-			if ls.pausedIndex < 0 {
-				ls.pausedIndex = 0
-			}
-			if ls.pausedIndex > len(ls.events) {
-				ls.pausedIndex = len(ls.events)
-			}
-		}
-		if len(ls.bookmarks) > 0 {
-			filtered := ls.bookmarks[:0]
-			for _, bm := range ls.bookmarks {
-				idx := bm.Index - trim
-				if idx < 0 {
-					continue
-				}
-				if idx > len(ls.events) {
-					idx = len(ls.events)
-				}
-				bm.Index = idx
-				filtered = append(filtered, bm)
-			}
-			ls.bookmarks = filtered
-			if len(ls.bookmarks) == 0 {
-				ls.bookmarkIdx = -1
-			} else if ls.bookmarkIdx >= len(ls.bookmarks) {
-				ls.bookmarkIdx = len(ls.bookmarks) - 1
-			}
-		}
+	added := cloneEventSlice(events)
+	ls.events = append(ls.events, added...)
+	for _, evt := range added {
+		ls.bytes += evt.Size()
 	}
+	ls.trimOverflow()
 	if ls.paused && ls.pausedIndex == -1 {
 		ls.pausedIndex = len(ls.events)
+	}
+}
+
+func (ls *liveSession) trimOverflow() {
+	trim := 0
+	bytes := ls.bytes
+	for trim < len(ls.events)-1 {
+		if len(ls.events)-trim <= ls.maxEvents && (ls.maxBytes <= 0 || bytes <= ls.maxBytes) {
+			break
+		}
+		bytes -= ls.events[trim].Size()
+		trim++
+	}
+	if trim == 0 {
+		return
+	}
+
+	ls.events = slices.Clone(ls.events[trim:])
+	ls.bytes = bytes
+	if ls.paused && ls.pausedIndex >= 0 {
+		ls.pausedIndex = min(max(ls.pausedIndex-trim, 0), len(ls.events))
+	}
+	if len(ls.bookmarks) == 0 {
+		return
+	}
+
+	filtered := ls.bookmarks[:0]
+	for _, bm := range ls.bookmarks {
+		idx := bm.Index - trim
+		if idx < 0 {
+			continue
+		}
+		bm.Index = min(idx, len(ls.events))
+		filtered = append(filtered, bm)
+	}
+	ls.bookmarks = filtered
+	if len(ls.bookmarks) == 0 {
+		ls.bookmarkIdx = -1
+	} else if ls.bookmarkIdx >= len(ls.bookmarks) {
+		ls.bookmarkIdx = len(ls.bookmarks) - 1
 	}
 }
 
@@ -92,6 +115,7 @@ func (ls *liveSession) reset() {
 		return
 	}
 	ls.events = nil
+	ls.bytes = 0
 	ls.filter = ""
 	ls.paused = false
 	ls.pausedIndex = -1

--- a/internal/ui/stream_state.go
+++ b/internal/ui/stream_state.go
@@ -22,6 +22,7 @@ type liveSession struct {
 	bytes       int64
 	maxEvents   int
 	maxBytes    int64
+	lost        streamLoss
 	state       stream.State
 	err         error
 	kind        stream.Kind
@@ -32,6 +33,18 @@ type liveSession struct {
 	bookmarkIdx int
 	bound       bool
 	done        bool
+}
+
+// streamLoss counts the events a pane is not showing, split by where they were
+// lost. The three sources update differently, so they cannot share a counter.
+type streamLoss struct {
+	evicted  uint64 // dropped by the session before the pane subscribed
+	listener uint64 // dropped on the way from the session to the pane
+	trimmed  uint64 // dropped by the pane's own limits
+}
+
+func (l streamLoss) total() uint64 {
+	return l.evicted + l.listener + l.trimmed
 }
 
 func (ls *liveSession) failed() bool {
@@ -82,6 +95,7 @@ func (ls *liveSession) trimOverflow() {
 		return
 	}
 
+	ls.lost.trimmed += uint64(trim)
 	ls.events = slices.Clone(ls.events[trim:])
 	ls.bytes = bytes
 	if ls.paused && ls.pausedIndex >= 0 {
@@ -109,7 +123,8 @@ func (ls *liveSession) trimOverflow() {
 }
 
 // reset empties the buffer and every view applied to it. The session itself
-// keeps running, so new events land in a clean transcript.
+// keeps running, so new events land in a clean transcript. Events the pane never
+// received stay counted, because clearing the view does not bring them back.
 func (ls *liveSession) reset() {
 	if ls == nil {
 		return

--- a/internal/ui/stream_state_bounds_test.go
+++ b/internal/ui/stream_state_bounds_test.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/stream"
+)
+
+func streamEvents(n, size int) []*stream.Event {
+	out := make([]*stream.Event, n)
+	for i := range out {
+		out[i] = &stream.Event{Payload: make([]byte, size)}
+	}
+	return out
+}
+
+func TestLiveSessionTrimsOnItsByteBudget(t *testing.T) {
+	ls := newLiveSession("s", 5000)
+	ls.maxBytes = 4096
+
+	ls.append(streamEvents(64, 1024))
+
+	if len(ls.events) > 4 {
+		t.Fatalf("kept %d events, want the byte budget to have trimmed them", len(ls.events))
+	}
+	if ls.bytes > ls.maxBytes {
+		t.Fatalf("bytes = %d, want at most %d", ls.bytes, ls.maxBytes)
+	}
+}
+
+func TestLiveSessionKeepsTheNewestEventWhateverItsSize(t *testing.T) {
+	ls := newLiveSession("s", 5000)
+	ls.maxBytes = 64
+
+	ls.append(streamEvents(1, 4096))
+
+	if len(ls.events) != 1 {
+		t.Fatalf("kept %d events, want the newest one", len(ls.events))
+	}
+}
+
+func TestLiveSessionStillTrimsOnItsEventCount(t *testing.T) {
+	ls := newLiveSession("s", 10)
+
+	ls.append(streamEvents(64, 8))
+
+	if len(ls.events) != 10 {
+		t.Fatalf("kept %d events, want 10", len(ls.events))
+	}
+}
+
+func TestLiveSessionTrimMovesBookmarksAndThePausedPosition(t *testing.T) {
+	ls := newLiveSession("s", 4)
+
+	ls.append(streamEvents(4, 8))
+	ls.addBookmark("first")
+	ls.setPaused(true)
+	ls.append(streamEvents(4, 8))
+
+	if ls.pausedIndex < 0 || ls.pausedIndex > len(ls.events) {
+		t.Fatalf("pausedIndex = %d, outside a buffer of %d", ls.pausedIndex, len(ls.events))
+	}
+	for _, bm := range ls.bookmarks {
+		if bm.Index < 0 || bm.Index > len(ls.events) {
+			t.Fatalf("bookmark index = %d, outside a buffer of %d", bm.Index, len(ls.events))
+		}
+	}
+}
+
+func TestLiveSessionResetClearsItsByteCount(t *testing.T) {
+	ls := newLiveSession("s", 5000)
+	ls.append(streamEvents(4, 1024))
+	ls.reset()
+
+	if ls.bytes != 0 {
+		t.Fatalf("bytes = %d after reset, want 0", ls.bytes)
+	}
+}
+
+func TestLiveSessionTrimsEventsThatCarryOnlyAComment(t *testing.T) {
+	comments := make([]*stream.Event, 64)
+	for i := range comments {
+		comments[i] = &stream.Event{
+			Kind: stream.KindSSE,
+			SSE:  stream.SSEMetadata{Comment: strings.Repeat("x", 1024)},
+		}
+	}
+
+	ls := newLiveSession("s", 5000)
+	ls.maxBytes = 4096
+	ls.append(comments)
+
+	if len(ls.events) > 4 {
+		t.Fatalf("kept %d events, want the byte budget to have trimmed them", len(ls.events))
+	}
+	if ls.bytes > 4096 {
+		t.Fatalf("bytes = %d, want at most the 4096 byte budget", ls.bytes)
+	}
+}


### PR DESCRIPTION
## Credentials

- Cross-origin redirects remove known credential headers and custom headers added by `@auth`.
- Cookies are not copied to another origin. The cookie jar can still add cookies that belong to the destination.
- `@setting forward-credentials-on-redirect` can allow forwarding to specific origins, or to any origin when explicitly enabled.
- Credentials are not restored after an HTTPS to HTTP redirect, even if a later redirect returns to HTTPS or the original origin.
- Cross-origin redirects send only the origin in `Referer`. Same-origin redirects keep the full URL.
- OAuth token requests cannot redirect outside the token endpoint origin. This prevents `307` and `308` redirects from forwarding client secrets in the request body.
- Telemetry removes URL user information and fragments, and replaces query values with `REDACTED`.
- Credential header handling is shared across history, errors, and explain output. `Cookie` and `Cookie2` are included.

## Configurable limits

- Response bodies are limited to 32 MiB after decompression. This can be changed with `@setting max-response-size`, `--max-response-size`, or `http.maxResponseBytes` in the headless API. Use `none` to disable the limit.
- Redirect chains are limited to 10 by default. This can be changed with `@setting max-redirects`, `--max-redirects`, or `http.maxRedirects`.
- SSE lines are limited to 4 MiB and complete events to 8 MiB. Both limits are configurable.
- WebSocket messages are limited to 32 KiB by default and can be configured with `max-message-bytes`.
- Retained stream data is limited by both event count and byte size.
- Script blocks stop after 30 seconds or when the request is cancelled.

## Stream failures and data loss

- Broken SSE and WebSocket streams now fail the request with a structured error while keeping the transcript.
- SSE summaries use consistent reasons and keep extra details in `summary.error`.
- SSE and WebSocket summaries report `dropped` events when retention or listener limits are reached.
- WebSocket summaries distinguish server, client, timeout, and cancellation closes.
- Cancelled runs exit with code 130.
- The Stream pane reports transcript loss instead of silently hiding it.

## Behavior changes

- Responses larger than 32 MiB now fail by default.
- Credential headers are no longer forwarded across origins unless explicitly allowed.
- Broken SSE or WebSocket streams now fail runs that previously appeared successful.

The last change may cause some existing CI runs to fail. This is intentional because incomplete or broken streams should not be reported as successful.