### PR TITLE
RST-344: keep stream transcripts on failure

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -1510,7 +1510,7 @@ GET https://api.example.com/notifications
 | `max-line-bytes` | Largest allowed line. The default is 4 MiB, or whatever `@setting sse-max-line-bytes` sets. A larger line stops the stream with an error. |
 | `max-event-bytes` | Largest allowed event, counting every line it is built from. The default is 8 MiB, or whatever `@setting sse-max-event-bytes` sets. A larger event stops the stream with an error. |
 
-If the server returns a non-2xx status or a content type other than `text/event-stream`, Resterm shows a normal HTTP response so you can inspect it. For a successful stream, Resterm shows the events and their details in the Stream tab and saves them in history. Templates and scripts can read `eventCount`, `byteCount`, `duration`, `reason`, `error`, and `dropped` from the summary. A non-zero `dropped` value means the retained transcript is incomplete. `reason` has one of these values:
+If the server returns a non-2xx status or a content type other than `text/event-stream`, Resterm shows a normal HTTP response so you can inspect it. For a successful stream, Resterm shows the events and their details in the Stream tab and saves them in history. Templates and scripts can read `eventCount`, `byteCount`, `duration`, `reason`, `error`, `errorClass`, and `dropped` from the summary. A non-zero `dropped` value means the retained transcript is incomplete. `reason` has one of these values:
 
 | Reason | Meaning |
 | --- | --- |
@@ -1522,7 +1522,7 @@ If the server returns a non-2xx status or a content type other than `text/event-
 | `limit:line_bytes` | One line was larger than `max-line-bytes`. |
 | `limit:event_bytes` | One event was larger than `max-event-bytes`. |
 | `context_canceled` | The run was cancelled. |
-| `error` | The stream failed. `summary.error` contains the error message. |
+| `error` | The stream failed. `summary.error` contains the error message and `summary.errorClass` names what kind of failure it was. |
 
 Reaching `idle`, `duration`, `max-events`, or `max-bytes` ends the stream without an error. The saved data includes everything read before the limit was reached. If the stream ends for any other reason, the request fails and `summary.error` contains the error message. Resterm still saves the transcript.
 
@@ -1564,7 +1564,7 @@ Supported `@ws` steps:
 | `@ws wait <duration>` | Pause for the specified duration (e.g. `500ms`). |
 | `@ws close [code] [reason]` | Close the connection with an optional status code (defaults to `1000`). |
 
-When the handshake fails, Resterm shows the HTTP response to help you find the problem. During a successful session, events appear in the UI and history together with their direction, opcode, size, and close status. Templates and scripts can read `sentCount`, `receivedCount`, `duration`, `closedBy`, `closeCode`, `closeReason`, and `dropped` from the summary. `closedBy` has one of these values:
+When the handshake fails, Resterm shows the HTTP response to help you find the problem. During a successful session, events appear in the UI and history together with their direction, opcode, size, and close status. Templates and scripts can read `sentCount`, `receivedCount`, `duration`, `closedBy`, `closeCode`, `closeReason`, `errorClass`, and `dropped` from the summary. `closedBy` has one of these values:
 
 | Value | Meaning |
 | --- | --- |
@@ -1572,7 +1572,7 @@ When the handshake fails, Resterm shows the HTTP response to help you find the p
 | `client` | Resterm closed the connection through `@ws close` or after the last step. |
 | `timeout` | The session reached its `idle` or `duration` limit. |
 | `canceled` | The run was cancelled. |
-| `error` | The session failed. `closeReason` contains the error message. |
+| `error` | The session failed. `closeReason` contains the error message and `errorClass` names what kind of failure it was. |
 
 Only `error` and `canceled` cause the request to fail. Resterm keeps the transcript in every case.
 
@@ -1923,7 +1923,7 @@ Objects:
 - `stream`
   - `enabled()` - returns `true` when the current response is an SSE or WebSocket transcript.
   - `kind()` - returns `"sse"` or `"websocket"`.
-  - `summary()` - copy of the transcript summary (`sentCount`, `receivedCount`, `eventCount`, `duration`, etc.). The summary always includes `dropped`. If a test or capture needs every event, check that its value is `0`. For an SSE failure, `reason` is `"error"` and `error` contains the error message. Resterm also fails the request when the stream fails, so a test does not need to check for that separately.
+  - `summary()` - copy of the transcript summary (`sentCount`, `receivedCount`, `eventCount`, `duration`, etc.). The summary always includes `dropped`. If a test or capture needs every event, check that its value is `0`. For an SSE failure, `reason` is `"error"`, `error` contains the error message, and `errorClass` names the kind of failure. Resterm also fails the request when the stream fails, so a test does not need to check for that separately.
   - `events()` - array of event objects (`data`/`comment` for SSE, `type`/`text`/`base64`/`direction` for WebSockets).
   - `onEvent(fn)` - registers a callback invoked for each event after the script runs; useful for assertions over the entire stream.
   - `onClose(fn)` - registers a callback invoked once with the summary after all events replay.
@@ -2248,7 +2248,7 @@ A template can also provide part of the URL. Both `GET http://{{host}}/users` an
   ```
 - Most events arrive as a single `data:` line, so the line limit is the one they reach first. Raise `max-line-bytes` along with `max-event-bytes` when a single line carries the whole payload. Base64 adds about a third to a payload, so a 3 MiB file needs roughly 4 MiB of headroom.
 - Resterm limits how much stream data it keeps in memory. An SSE session keeps up to 1024 events and 16 MiB, or twice `max-event-bytes` when that is larger. The size of an SSE event includes its data, comment, id, name, and other saved fields. A WebSocket session and its saved transcript each have an 8 MiB limit. The Stream pane keeps up to 5000 events or 16 MiB. If Resterm removes older events, the summary counts them in `dropped`. The Stream tab shows `Transcript incomplete` when its view is missing events.
-- Reaching `max-events`, `max-bytes`, `idle`, or `duration` is a normal way for a stream to end. Other problems fail the request. These include a read error, an SSE line or event that exceeds its limit, and a WebSocket session that ends with `closedBy: error`. Resterm still saves and reports the transcript it collected. With detailed exit codes, a stream error returns `26` and a cancelled run returns `130`.
+- Reaching `max-events`, `max-bytes`, `idle`, or `duration` is a normal way for a stream to end. Other problems fail the request. These include a read error, an SSE line or event that exceeds its limit, and a WebSocket session that ends with `closedBy: error`. Resterm still saves and reports the transcript it collected. With detailed exit codes, a cancelled run returns `130` and a stream error returns the code for the failure named in `summary.errorClass`: `21` for `network`, `22` for `tls`, `25` for `filesystem` such as an `@ws send-file` payload Resterm could not read, and `26` for `protocol`. A stream that failed for a reason Resterm cannot name reports `protocol`.
 - Requests use an in-memory cookie jar per environment. Cookies are isolated between environments, and `@setting no-cookies true` disables cookies for a request without clearing the stored jar. Use `Ctrl+Shift+G` (or `g Shift+G`) to clear cookies for the current environment.
 - TLS per request: `# @settings http-root-cas=a.pem http-client-cert=cert.pem http-client-key=key.pem http-insecure=true` for a single line, or `@setting key value` per line (`http-root-cas` accepts space/comma/semicolon separated lists; paths are relative). GraphQL/REST/WebSocket/SSE all share these HTTP settings.
 - Use `@no-log` to omit sensitive bodies from history snapshots.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -1522,9 +1522,10 @@ If the server returns a non-2xx status or a content type other than `text/event-
 | `limit:line_bytes` | One line was larger than `max-line-bytes`. |
 | `limit:event_bytes` | One event was larger than `max-event-bytes`. |
 | `context_canceled` | The run was cancelled. |
+| `context_deadline` | The run's deadline expired before the stream reached one of its own limits. |
 | `error` | The stream failed. `summary.error` contains the error message and `summary.errorClass` names what kind of failure it was. |
 
-Reaching `idle`, `duration`, `max-events`, or `max-bytes` ends the stream without an error. The saved data includes everything read before the limit was reached. If the stream ends for any other reason, the request fails and `summary.error` contains the error message. Resterm still saves the transcript.
+Reaching `idle`, `duration`, `max-events`, or `max-bytes` ends the stream without an error. The saved data includes everything read before the limit was reached. If the stream ends for any other reason, the request fails and `summary.error` contains the error message. Resterm still saves the transcript. A configured `duration` is a normal limit; an expired run deadline is a `timeout` failure.
 
 ### WebSockets (`@websocket`, `@ws`)
 
@@ -1570,11 +1571,11 @@ When the handshake fails, Resterm shows the HTTP response to help you find the p
 | --- | --- |
 | `server` | The server closed the connection. |
 | `client` | Resterm closed the connection through `@ws close` or after the last step. |
-| `timeout` | The session reached its `idle` or `duration` limit. |
+| `timeout` | The idle limit was reached, or the run's deadline expired. An idle timeout is a normal ending. An expired run deadline is a failure and sets `errorClass` to `timeout`. |
 | `canceled` | The run was cancelled. |
 | `error` | The session failed. `closeReason` contains the error message and `errorClass` names what kind of failure it was. |
 
-Only `error` and `canceled` cause the request to fail. Resterm keeps the transcript in every case.
+`error`, `canceled`, and a `timeout` with an `errorClass` cause the request to fail. Resterm keeps the transcript in every case.
 
 > **Heads-up:** When you keep a WebSocket URL in `@const`, `@global`, or `@var`, write the request line as `GET {{ws.url}}` (or whichever variable you use). The parser needs the explicit method to recognise the line as a WebSocket request before template expansion. Literal `ws://` / `wss://` URLs without a method still work when written directly.
 
@@ -2248,7 +2249,7 @@ A template can also provide part of the URL. Both `GET http://{{host}}/users` an
   ```
 - Most events arrive as a single `data:` line, so the line limit is the one they reach first. Raise `max-line-bytes` along with `max-event-bytes` when a single line carries the whole payload. Base64 adds about a third to a payload, so a 3 MiB file needs roughly 4 MiB of headroom.
 - Resterm limits how much stream data it keeps in memory. An SSE session keeps up to 1024 events and 16 MiB, or twice `max-event-bytes` when that is larger. The size of an SSE event includes its data, comment, id, name, and other saved fields. A WebSocket session and its saved transcript each have an 8 MiB limit. The Stream pane keeps up to 5000 events or 16 MiB. If Resterm removes older events, the summary counts them in `dropped`. The Stream tab shows `Transcript incomplete` when its view is missing events.
-- Reaching `max-events`, `max-bytes`, `idle`, or `duration` is a normal way for a stream to end. Other problems fail the request. These include a read error, an SSE line or event that exceeds its limit, and a WebSocket session that ends with `closedBy: error`. Resterm still saves and reports the transcript it collected. With detailed exit codes, a cancelled run returns `130` and a stream error returns the code for the failure named in `summary.errorClass`: `21` for `network`, `22` for `tls`, `25` for `filesystem` such as an `@ws send-file` payload Resterm could not read, and `26` for `protocol`. A stream that failed for a reason Resterm cannot name reports `protocol`.
+- Reaching `max-events`, `max-bytes`, `idle`, or `duration` is a normal way for a stream to end. Other problems fail the request. These include an expired run deadline, a read error, an SSE line or event that exceeds its limit, and a WebSocket session that ends with `closedBy: error`. Resterm still saves and reports the transcript it collected. With detailed exit codes, a cancelled run returns `130` and a stream error returns the code for the failure named in `summary.errorClass`: `20` for `timeout`, `21` for `network`, `22` for `tls`, `25` for `filesystem` such as an `@ws send-file` payload Resterm could not read, and `26` for `protocol`. A stream that failed for a reason Resterm cannot name reports `protocol`.
 - Requests use an in-memory cookie jar per environment. Cookies are isolated between environments, and `@setting no-cookies true` disables cookies for a request without clearing the stored jar. Use `Ctrl+Shift+G` (or `g Shift+G`) to clear cookies for the current environment.
 - TLS per request: `# @settings http-root-cas=a.pem http-client-cert=cert.pem http-client-key=key.pem http-insecure=true` for a single line, or `@setting key value` per line (`http-root-cas` accepts space/comma/semicolon separated lists; paths are relative). GraphQL/REST/WebSocket/SSE all share these HTTP settings.
 - Use `@no-log` to omit sensitive bodies from history snapshots.

--- a/docs/restermscript.md
+++ b/docs/restermscript.md
@@ -740,7 +740,7 @@ Other expressions run before the current request completes. Use `last` for the p
 
 ### stream
 
-`stream` provides information about SSE and WebSocket requests. Its helpers include `stream.enabled()`, `stream.kind()`, `stream.summary()`, and `stream.events()`. The summary and event fields depend on the stream type. SSE summaries include `eventCount`, `byteCount`, `duration`, `reason`, `error`, and `dropped`. WebSocket summaries include `sentCount`, `receivedCount`, `duration`, `closedBy`, `closeCode`, `closeReason`, and `dropped`. A non-zero `dropped` value means that some events are missing from the transcript. If a stream fails, its request fails too.
+`stream` provides information about SSE and WebSocket requests. Its helpers include `stream.enabled()`, `stream.kind()`, `stream.summary()`, and `stream.events()`. The summary and event fields depend on the stream type. SSE summaries include `eventCount`, `byteCount`, `duration`, `reason`, `error`, `errorClass`, and `dropped`. WebSocket summaries include `sentCount`, `receivedCount`, `duration`, `closedBy`, `closeCode`, `closeReason`, `errorClass`, and `dropped`. When a stream fails, `errorClass` names the kind of failure and decides the detailed exit code. A non-zero `dropped` value means that some events are missing from the transcript. If a stream fails, its request fails too.
 
 ### mock
 

--- a/headless/adapt.go
+++ b/headless/adapt.go
@@ -233,14 +233,14 @@ func streamFromFmt(stream *runfmt.Stream) *Stream {
 	if stream == nil {
 		return nil
 	}
-	out := &Stream{
+	return &Stream{
 		Kind:           stream.Kind,
 		EventCount:     stream.EventCount,
 		TranscriptPath: stream.TranscriptPath,
+		Error:          stream.Error,
 		// ReportModel already deep-clones stream summary maps.
 		Summary: stream.Summary,
 	}
-	return out
 }
 
 func traceFromFmt(trace *runfmt.Trace) *Trace {

--- a/headless/adapt_test.go
+++ b/headless/adapt_test.go
@@ -1,7 +1,9 @@
 package headless
 
 import (
+	"bytes"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -517,5 +519,35 @@ func TestReportFromRunnerStrings(t *testing.T) {
 		len(step.Trace.Breaches) != 1 ||
 		step.Trace.Breaches[0].Kind != "dns" {
 		t.Fatalf("expected step trace strings to be trimmed, got %+v", step.Trace)
+	}
+}
+
+// A caller reads the Report and then encodes it, so both directions are checked.
+func TestReportKeepsTheStreamError(t *testing.T) {
+	src := &runner.Report{
+		Results: []runner.Result{{
+			Kind:   runner.ResultKindRequest,
+			Name:   "events",
+			Method: "GET",
+			Target: "https://example.com/events",
+			Stream: &runner.StreamInfo{
+				Kind:       "sse",
+				EventCount: 3,
+				Err:        errors.New("sse stream failed"),
+			},
+		}},
+	}
+
+	rep := reportFromRunner(src)
+	if rep.Results[0].Stream == nil || rep.Results[0].Stream.Error != "sse stream failed" {
+		t.Fatalf("adapted stream = %+v, want the failure kept", rep.Results[0].Stream)
+	}
+
+	var out bytes.Buffer
+	if err := rep.WriteJSON(&out); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	if !strings.Contains(out.String(), `"error": "sse stream failed"`) {
+		t.Fatalf("json dropped the stream error:\n%s", out.String())
 	}
 }

--- a/headless/report.go
+++ b/headless/report.go
@@ -318,6 +318,7 @@ type Stream struct {
 	EventCount     int            `json:"eventCount,omitempty"`
 	Summary        map[string]any `json:"summary,omitempty"`
 	TranscriptPath string         `json:"transcriptPath,omitempty"`
+	Error          string         `json:"error,omitempty"`
 }
 
 // Trace contains trace summary metadata.
@@ -662,6 +663,7 @@ func toFormatStream(stream *Stream) *runfmt.Stream {
 		Kind:           stream.Kind,
 		EventCount:     stream.EventCount,
 		TranscriptPath: stream.TranscriptPath,
+		Error:          stream.Error,
 	}
 	if len(stream.Summary) > 0 {
 		out.Summary = runfmt.CloneAnyMap(stream.Summary)

--- a/headless/run_test.go
+++ b/headless/run_test.go
@@ -16,10 +16,14 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 
+	"nhooyr.io/websocket"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/engine"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 	"github.com/unkn0wn-root/resterm/internal/runner"
+	"github.com/unkn0wn-root/resterm/internal/runx/fail"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -771,4 +775,75 @@ func stableResult(src Result) Result {
 		out.Steps = append(out.Steps, step)
 	}
 	return out
+}
+
+func TestRunKeepsAWebSocketStepFailureClass(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = conn.Close(websocket.StatusNormalClosure, "bye")
+		}()
+		for {
+			typ, data, err := conn.Read(r.Context())
+			if err != nil {
+				return
+			}
+			if err := conn.Write(r.Context(), typ, data); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "ws.http")
+	src := fmt.Sprintf(
+		"# @name chat\n# @ws send hello\n# @ws send-file missing-payload.bin\nGET %s\n",
+		strings.Replace(srv.URL, "http", "ws", 1),
+	)
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	rep, err := Run(context.Background(), Options{Source: Source{Path: file}})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(rep.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(rep.Results))
+	}
+
+	res := rep.Results[0]
+	if res.Failure == nil {
+		t.Fatalf("result carries no failure: %+v", res)
+	}
+	if res.Failure.Code != FailureCode(runfail.CodeFilesystem) {
+		t.Fatalf("failure code = %q, want %q", res.Failure.Code, runfail.CodeFilesystem)
+	}
+	if res.Failure.ExitCode != runfail.ExitFilesystem {
+		t.Fatalf("exit code = %d, want %d", res.Failure.ExitCode, runfail.ExitFilesystem)
+	}
+	if res.Failure.Source != "stream" {
+		t.Fatalf("failure source = %q, want %q", res.Failure.Source, "stream")
+	}
+	if rep.ExitCode(ExitCodeDetailed) != runfail.ExitFilesystem {
+		t.Fatalf("report exit code = %d, want %d", rep.ExitCode(ExitCodeDetailed), runfail.ExitFilesystem)
+	}
+
+	if res.Stream == nil {
+		t.Fatalf("result kept no stream: %+v", res)
+	}
+	if !strings.Contains(res.Stream.Error, "send_file") {
+		t.Fatalf("stream error = %q, want the step that failed", res.Stream.Error)
+	}
+	if res.Stream.Summary["errorClass"] != string(diag.ClassFilesystem) {
+		t.Fatalf("stream summary = %+v, want a filesystem errorClass", res.Stream.Summary)
+	}
+	if res.Stream.Summary["sentCount"] != 1 {
+		t.Fatalf("sentCount = %v, want the frame sent before the failure",
+			res.Stream.Summary["sentCount"])
+	}
 }

--- a/internal/bytesize/budget.go
+++ b/internal/bytesize/budget.go
@@ -1,6 +1,9 @@
 package bytesize
 
-import "strings"
+import (
+	"math"
+	"strings"
+)
 
 type Budget struct {
 	limit int64
@@ -18,6 +21,15 @@ func (b Budget) Or(def int64) int64 {
 		return def
 	}
 	return b.limit
+}
+
+// Add stops at the largest byte size instead of wrapping, so a limit set near
+// that size does not go negative. Both values must be zero or more.
+func Add(a, b int64) int64 {
+	if sum := a + b; sum >= a {
+		return sum
+	}
+	return math.MaxInt64
 }
 
 func ParseBudget(raw string) (Budget, error) {

--- a/internal/bytesize/budget_test.go
+++ b/internal/bytesize/budget_test.go
@@ -1,6 +1,9 @@
 package bytesize
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestParseBudget(t *testing.T) {
 	const noDefault = 4096
@@ -46,5 +49,27 @@ func TestBudgetZeroValueTakesTheDefault(t *testing.T) {
 	}
 	if got := Of(0).Or(4096); got != 0 {
 		t.Fatalf("Of(0).Or(4096) = %d, want no limit", got)
+	}
+}
+
+func TestAddCapsInsteadOfWrapping(t *testing.T) {
+	tests := []struct {
+		name string
+		a    int64
+		b    int64
+		want int64
+	}{
+		{name: "ordinary sizes", a: 1 << 20, b: 1, want: 1<<20 + 1},
+		{name: "zero", want: 0},
+		{name: "one past the maximum", a: math.MaxInt64, b: 1, want: math.MaxInt64},
+		{name: "twice the maximum", a: math.MaxInt64, b: math.MaxInt64, want: math.MaxInt64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Add(tt.a, tt.b); got != tt.want {
+				t.Fatalf("Add(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -3,6 +3,7 @@ package diag
 import (
 	"errors"
 	"fmt"
+	"slices"
 )
 
 // Class identifies the stable failure class for a diagnostic.
@@ -25,6 +26,25 @@ const (
 	ClassUI         Class = "ui"
 	ClassInternal   Class = "internal"
 )
+
+var classes = []Class{
+	ClassConfig, ClassParse, ClassTimeout, ClassCanceled, ClassNetwork,
+	ClassTLS, ClassAuth, ClassProtocol, ClassRoute, ClassFilesystem,
+	ClassScript, ClassHistory, ClassUI, ClassInternal,
+}
+
+// Known reports whether c is one of the classes resterm uses. The zero value
+// and ClassUnknown are not.
+func (c Class) Known() bool { return slices.Contains(classes, c) }
+
+// KnownOr returns c when it is a known class, otherwise fallback. A transcript
+// another build wrote can name a class this one does not have.
+func (c Class) KnownOr(fallback Class) Class {
+	if c.Known() {
+		return c
+	}
+	return fallback
+}
 
 // Component identifies where a diagnostic originated.
 type Component string
@@ -98,7 +118,8 @@ func Newf(class Class, format string, args ...any) error {
 	return New(class, fmt.Sprintf(format, args...))
 }
 
-// Wrap records operation context on err while preserving err for errors.Is/As.
+// Wrap records operation context on err while preserving err for errors.Is/As
+// and the class err already carries.
 func Wrap(err error, operation string, opts ...Option) error {
 	if err == nil {
 		return nil

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -418,3 +418,41 @@ func assertChainLines(t *testing.T, err error, want []string) {
 		}
 	}
 }
+
+func TestClassKnown(t *testing.T) {
+	tests := []struct {
+		name  string
+		class diag.Class
+		known bool
+	}{
+		{name: "a class", class: diag.ClassFilesystem, known: true},
+		{name: "the zero value", class: ""},
+		{name: "unknown", class: diag.ClassUnknown},
+		{name: "a name this build does not have", class: "wormhole"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.class.Known(); got != tt.known {
+				t.Fatalf("Known() = %t, want %t", got, tt.known)
+			}
+			want := tt.class
+			if !tt.known {
+				want = diag.ClassNetwork
+			}
+			if got := tt.class.KnownOr(diag.ClassNetwork); got != want {
+				t.Fatalf("KnownOr(%q) = %q, want %q", diag.ClassNetwork, got, want)
+			}
+		})
+	}
+}
+
+func TestWrapKeepsTheCauseClass(t *testing.T) {
+	cause := diag.New(diag.ClassFilesystem, "open payload.bin: no such file")
+	if got := diag.ClassOf(diag.Wrap(cause, "websocket step 2:send_file")); got != diag.ClassFilesystem {
+		t.Fatalf("ClassOf() = %q, want %q", got, diag.ClassFilesystem)
+	}
+	if got := diag.ClassOf(diag.Wrap(errors.New("boom"), "read")); got != diag.ClassUnknown {
+		t.Fatalf("ClassOf() = %q, want %q", got, diag.ClassUnknown)
+	}
+}

--- a/internal/exec/http.go
+++ b/internal/exec/http.go
@@ -389,6 +389,7 @@ func convertSSETranscript(t *httpx.SSETranscript) *scripts.StreamInfo {
 		"reason":     t.Summary.Reason,
 		"dropped":    t.Summary.Dropped,
 		"error":      t.Summary.Error,
+		"errorClass": string(t.Summary.ErrorClass),
 	}
 	if len(t.Events) > 0 {
 		events := make([]map[string]any, len(t.Events))
@@ -421,6 +422,7 @@ func convertWebSocketTranscript(t *httpx.WebSocketTranscript) *scripts.StreamInf
 		"closeCode":     t.Summary.CloseCode,
 		"closeReason":   t.Summary.CloseReason,
 		"dropped":       t.Summary.Dropped,
+		"errorClass":    string(t.Summary.ErrorClass),
 	}
 	if len(t.Events) > 0 {
 		events := make([]map[string]any, len(t.Events))

--- a/internal/http/origin/origin.go
+++ b/internal/http/origin/origin.go
@@ -2,6 +2,7 @@ package origin
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"slices"
 	"strings"
@@ -75,9 +76,16 @@ func (o Origin) String() string {
 		return ""
 	}
 	if o.port == defaultPorts[o.scheme] {
-		return o.scheme + "://" + o.host
+		return o.scheme + "://" + hostLiteral(o.host)
 	}
-	return o.scheme + "://" + o.host + ":" + o.port
+	return o.scheme + "://" + net.JoinHostPort(o.host, o.port)
+}
+
+func hostLiteral(host string) string {
+	if strings.ContainsRune(host, ':') {
+		return "[" + host + "]"
+	}
+	return host
 }
 
 func Same(a, b *url.URL) bool {

--- a/internal/http/origin/origin.go
+++ b/internal/http/origin/origin.go
@@ -3,6 +3,7 @@ package origin
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"net/url"
 	"slices"
 	"strings"
@@ -32,7 +33,7 @@ func Of(u *url.URL) Origin {
 	}
 
 	scheme, dialed := httpSchemes[strings.ToLower(u.Scheme)]
-	host := strings.ToLower(u.Hostname())
+	host := normalizeHost(u.Hostname())
 	if !dialed || host == "" {
 		return Origin{}
 	}
@@ -82,6 +83,23 @@ func (o Origin) String() string {
 	// The host is stored unescaped, so the zone id of a link-local IPv6
 	// address needs its percent sign back before the text is a URL again.
 	return u.String()
+}
+
+// normalizeHost lowercases the name or address but leaves the zone id of an
+// IPv6 address alone. The operating system decides what a zone id names, so two
+// that differ only in case are not known to be one interface, and treating them
+// as one would send credentials across a redirect that changed interface. Only
+// an IPv6 address carries a zone. Everything else is case insensitive all the
+// way through, including the percent-encoded octets of an international name.
+func normalizeHost(host string) string {
+	addr, zone, ok := strings.Cut(host, "%")
+	if !ok {
+		return strings.ToLower(host)
+	}
+	if ip, err := netip.ParseAddr(addr); err != nil || !ip.Is6() {
+		return strings.ToLower(host)
+	}
+	return strings.ToLower(addr) + "%" + zone
 }
 
 func hostLiteral(host string) string {

--- a/internal/http/origin/origin.go
+++ b/internal/http/origin/origin.go
@@ -75,10 +75,13 @@ func (o Origin) String() string {
 	if !o.Valid() {
 		return ""
 	}
-	if o.port == defaultPorts[o.scheme] {
-		return o.scheme + "://" + hostLiteral(o.host)
+	u := url.URL{Scheme: o.scheme, Host: hostLiteral(o.host)}
+	if o.port != defaultPorts[o.scheme] {
+		u.Host = net.JoinHostPort(o.host, o.port)
 	}
-	return o.scheme + "://" + net.JoinHostPort(o.host, o.port)
+	// The host is stored unescaped, so the zone id of a link-local IPv6
+	// address needs its percent sign back before the text is a URL again.
+	return u.String()
 }
 
 func hostLiteral(host string) string {

--- a/internal/http/origin/origin_test.go
+++ b/internal/http/origin/origin_test.go
@@ -175,3 +175,40 @@ func TestSecure(t *testing.T) {
 		}
 	}
 }
+
+func TestStringBracketsIPv6(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "ipv4", raw: "https://127.0.0.1:8443", want: "https://127.0.0.1:8443"},
+		{name: "host", raw: "https://cdn.example.com", want: "https://cdn.example.com"},
+		{name: "ipv6 on the default port", raw: "https://[::1]", want: "https://[::1]"},
+		{name: "ipv6 with a port", raw: "https://[::1]:8443", want: "https://[::1]:8443"},
+		{
+			name: "ipv6 written out",
+			raw:  "http://[2001:db8::1]:8080",
+			want: "http://[2001:db8::1]:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, err := Parse(tt.raw)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tt.raw, err)
+			}
+			if got := o.String(); got != tt.want {
+				t.Fatalf("String() = %q, want %q", got, tt.want)
+			}
+			back, err := Parse(o.String())
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", o.String(), err)
+			}
+			if back != o {
+				t.Fatalf("Parse(%q) = %v, want the origin it came from", o.String(), back)
+			}
+		})
+	}
+}

--- a/internal/http/origin/origin_test.go
+++ b/internal/http/origin/origin_test.go
@@ -191,6 +191,16 @@ func TestStringBracketsIPv6(t *testing.T) {
 			raw:  "http://[2001:db8::1]:8080",
 			want: "http://[2001:db8::1]:8080",
 		},
+		{
+			name: "link local ipv6 with a zone",
+			raw:  "https://[fe80::1%25en0]",
+			want: "https://[fe80::1%25en0]",
+		},
+		{
+			name: "link local ipv6 with a zone and a port",
+			raw:  "https://[fe80::1%25en0]:8443",
+			want: "https://[fe80::1%25en0]:8443",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/http/origin/origin_test.go
+++ b/internal/http/origin/origin_test.go
@@ -38,6 +38,51 @@ func TestOfNormalizes(t *testing.T) {
 		},
 		{name: "ws shares the http origin", a: "ws://a.example.com/socket", b: "http://a.example.com", same: true},
 		{name: "ws is not the https origin", a: "ws://a.example.com", b: "https://a.example.com"},
+		{
+			name: "ipv6 address case",
+			a:    "https://[FE80::1]",
+			b:    "https://[fe80::1]",
+			same: true,
+		},
+		// The operating system decides what a zone id names, so a differently
+		// cased one is not known to be the same interface.
+		{
+			name: "ipv6 zone case",
+			a:    "https://[fe80::1%25En0]",
+			b:    "https://[fe80::1%25en0]",
+		},
+		{
+			name: "matching ipv6 zone",
+			a:    "https://[FE80::1%25En0]/x",
+			b:    "https://[fe80::1%25En0]/y",
+			same: true,
+		},
+		// A name has no zone, so the percent sign it decodes to is just part of
+		// the name and folds case with the rest of it.
+		{
+			name: "percent in a registered name",
+			a:    "https://EXAMPLE%25FOO.com",
+			b:    "https://example%25foo.com",
+			same: true,
+		},
+		{
+			name: "international name case",
+			a:    "https://M%C3%9CNCHEN.de",
+			b:    "https://m%C3%BCnchen.de",
+			same: true,
+		},
+		// Only an IPv6 address has a zone, so nothing here is worth preserving.
+		{
+			name: "percent after an ipv4 address",
+			a:    "https://127.0.0.1%25FOO",
+			b:    "https://127.0.0.1%25foo",
+			same: true,
+		},
+		{
+			name: "zone on an ipv4 mapped address",
+			a:    "https://[::ffff:127.0.0.1%25En0]",
+			b:    "https://[::ffff:127.0.0.1%25en0]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -176,7 +221,7 @@ func TestSecure(t *testing.T) {
 	}
 }
 
-func TestStringBracketsIPv6(t *testing.T) {
+func TestStringRoundTripsThroughParse(t *testing.T) {
 	tests := []struct {
 		name string
 		raw  string
@@ -200,6 +245,16 @@ func TestStringBracketsIPv6(t *testing.T) {
 			name: "link local ipv6 with a zone and a port",
 			raw:  "https://[fe80::1%25en0]:8443",
 			want: "https://[fe80::1%25en0]:8443",
+		},
+		{
+			name: "a zone keeps its case",
+			raw:  "https://[FE80::1%25En0]:8443",
+			want: "https://[fe80::1%25En0]:8443",
+		},
+		{
+			name: "international name",
+			raw:  "https://M%C3%9CNCHEN.de",
+			want: "https://m%C3%BCnchen.de",
 		},
 	}
 

--- a/internal/protocol/httpx/limits.go
+++ b/internal/protocol/httpx/limits.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/unkn0wn-root/resterm/internal/bytesize"
 	"github.com/unkn0wn-root/resterm/internal/diag"
 )
 
@@ -40,7 +41,7 @@ func readResponseBody(r io.Reader, limit int64) ([]byte, error) {
 		return io.ReadAll(r)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	body, err := io.ReadAll(io.LimitReader(r, bytesize.Add(limit, 1)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/protocol/httpx/limits_test.go
+++ b/internal/protocol/httpx/limits_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -71,6 +72,18 @@ func TestResponseBodyAtTheLimitIsKept(t *testing.T) {
 	}
 	if len(resp.Body) != size {
 		t.Fatalf("len(Body) = %d, want %d", len(resp.Body), size)
+	}
+}
+
+func TestResponseBodyAcceptsTheLargestLimit(t *testing.T) {
+	const body = "hello world"
+
+	got, err := readResponseBody(strings.NewReader(body), math.MaxInt64)
+	if err != nil {
+		t.Fatalf("readResponseBody: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body = %q, want %q", got, body)
 	}
 }
 
@@ -233,6 +246,11 @@ func TestSSELineBudgetTracksTheStreamLimit(t *testing.T) {
 			want: DefaultSSEMaxLineBytes,
 		},
 		{name: "stream limit is smaller", opts: restfile.SSEOptions{MaxBytes: 1024}, want: 1025},
+		{
+			name: "the largest stream limit still budgets a line",
+			opts: restfile.SSEOptions{MaxBytes: math.MaxInt64},
+			want: DefaultSSEMaxLineBytes,
+		},
 		{
 			name: "part of the stream is read",
 			opts: restfile.SSEOptions{MaxBytes: 1024},

--- a/internal/protocol/httpx/redirect_test.go
+++ b/internal/protocol/httpx/redirect_test.go
@@ -1120,3 +1120,18 @@ func TestRedirectBackToTheOwnerOriginNarrowsTheReferer(t *testing.T) {
 		t.Fatal("the redirect target was never reached")
 	}
 }
+
+// The narrowed Referer goes out on the wire, so an IPv6 hop keeps its brackets.
+func TestNarrowRefererBracketsAnIPv6Hop(t *testing.T) {
+	previous, err := url.Parse("https://[2001:db8::1]:8443/tokens?api_key=secret")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+
+	dst := http.Header{refererHeader: []string{previous.String()}}
+	narrowReferer(dst, http.Header{}, previous)
+
+	if want := "https://[2001:db8::1]:8443/"; dst.Get(refererHeader) != want {
+		t.Fatalf("Referer = %q, want %q", dst.Get(refererHeader), want)
+	}
+}

--- a/internal/protocol/httpx/redirect_test.go
+++ b/internal/protocol/httpx/redirect_test.go
@@ -1123,10 +1123,7 @@ func TestRedirectBackToTheOwnerOriginNarrowsTheReferer(t *testing.T) {
 
 // The narrowed Referer goes out on the wire, so an IPv6 hop keeps its brackets.
 func TestNarrowRefererBracketsAnIPv6Hop(t *testing.T) {
-	previous, err := url.Parse("https://[2001:db8::1]:8443/tokens?api_key=secret")
-	if err != nil {
-		t.Fatalf("url.Parse: %v", err)
-	}
+	previous := mustParseURL(t, "https://[2001:db8::1]:8443/tokens?api_key=secret")
 
 	dst := http.Header{refererHeader: []string{previous.String()}}
 	narrowReferer(dst, http.Header{}, previous)
@@ -1134,4 +1131,51 @@ func TestNarrowRefererBracketsAnIPv6Hop(t *testing.T) {
 	if want := "https://[2001:db8::1]:8443/"; dst.Get(refererHeader) != want {
 		t.Fatalf("Referer = %q, want %q", dst.Get(refererHeader), want)
 	}
+}
+
+// The operating system decides what an IPv6 zone id names, so a redirect that
+// only changes its case may be reaching another interface. Credentials stay
+// behind unless the zone matches.
+func TestRedirectStripsCredentialsWhenOnlyTheIPv6ZoneCaseDiffers(t *testing.T) {
+	tests := []struct {
+		name string
+		next string
+		keep bool
+	}{
+		{name: "same zone", next: "https://[fe80::1%25en0]/next", keep: true},
+		{name: "zone case differs", next: "https://[fe80::1%25En0]/next"},
+		{name: "another zone", next: "https://[fe80::1%25en1]/next"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner := &http.Request{
+				URL:    mustParseURL(t, "https://[fe80::1%25en0]/tokens"),
+				Header: http.Header{"Authorization": []string{"Bearer secret"}},
+			}
+			next := &http.Request{
+				URL:    mustParseURL(t, tt.next),
+				Header: http.Header{"Authorization": []string{"Bearer secret"}},
+			}
+
+			guard := newRedirectGuard(Options{FollowRedirects: true})
+			if err := guard.check(next, []*http.Request{owner}); err != nil {
+				t.Fatalf("check: %v", err)
+			}
+
+			got := next.Header.Get("Authorization") != ""
+			if got != tt.keep {
+				t.Fatalf("credentials kept = %t, want %t", got, tt.keep)
+			}
+		})
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return u
 }

--- a/internal/protocol/httpx/stream_helpers.go
+++ b/internal/protocol/httpx/stream_helpers.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"slices"
 	"time"
@@ -15,9 +16,18 @@ type metaDefaults struct {
 	proto  string
 }
 
-func ctxWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+// errStreamLimit identifies an SSE duration limit. It must not be used for
+// timeouts returned directly to callers because it replaces the timeout cause.
+var errStreamLimit = errors.New("stream duration limit")
+
+// A nil cause keeps context.DeadlineExceeded, matching context.WithTimeout.
+func ctxWithTimeout(
+	ctx context.Context,
+	d time.Duration,
+	cause error,
+) (context.Context, context.CancelFunc) {
 	if d > 0 {
-		return context.WithTimeout(ctx, d)
+		return context.WithTimeoutCause(ctx, d, cause)
 	}
 	return context.WithCancel(ctx)
 }

--- a/internal/protocol/httpx/stream_sse.go
+++ b/internal/protocol/httpx/stream_sse.go
@@ -70,13 +70,13 @@ func sseLimitsFor(sse restfile.SSEOptions, opts Options) sseLimits {
 
 func (l sseLimits) sessionBytes() bytesize.Budget {
 	// Keep room for a full event and the summary event that follows it.
-	return bytesize.Of(max(int64(DefaultSSESessionBytes), 2*l.event))
+	return bytesize.Of(max(int64(DefaultSSESessionBytes), bytesize.Add(l.event, l.event)))
 }
 
 func (l sseLimits) lineBudget(read int64) int {
 	budget := l.line
 	if l.stream > 0 {
-		budget = min(budget, l.stream-read+1)
+		budget = min(budget, bytesize.Add(l.stream-read, 1))
 	}
 	return int(budget)
 }

--- a/internal/protocol/httpx/stream_sse.go
+++ b/internal/protocol/httpx/stream_sse.go
@@ -108,6 +108,7 @@ type SSESummary struct {
 	Reason     string        `json:"reason"`
 	Dropped    int64         `json:"dropped,omitempty"`
 	Error      string        `json:"error,omitempty"`
+	ErrorClass diag.Class    `json:"errorClass,omitempty"`
 }
 
 type SSETranscript struct {
@@ -123,7 +124,10 @@ func (s SSESummary) Err() error {
 	case s.Reason == sseReasonCanceled:
 		return diag.New(diag.ClassCanceled, cmp.Or(s.Error, "sse stream canceled"))
 	case s.Reason == sseReasonErr, s.Error != "":
-		return diag.New(diag.ClassProtocol, cmp.Or(s.Error, "sse stream failed"))
+		return diag.New(
+			s.ErrorClass.KnownOr(diag.ClassProtocol),
+			cmp.Or(s.Error, "sse stream failed"),
+		)
 	default:
 		return nil
 	}
@@ -250,8 +254,13 @@ func CompleteSSE(handle *StreamHandle) (*Response, error) {
 		acc.summary.Duration = time.Since(handle.Meta.ConnectedAt)
 	}
 	state, serr := session.State()
-	if acc.summary.Error == "" && serr != nil {
-		acc.summary.Error = serr.Error()
+	if serr != nil {
+		if acc.summary.Error == "" {
+			acc.summary.Error = serr.Error()
+		}
+		if class := diag.ClassOf(serr); class.Known() {
+			acc.summary.ErrorClass = class
+		}
 	}
 	// The run already set a reason naming the limit it stopped at, so keep it.
 	// Only "eof" gives way, because a failed session contradicts it.
@@ -351,7 +360,7 @@ func (r *sseRun) loop(ctx context.Context) error {
 				r.stop(r.ended(ctx))
 				return nil
 			}
-			return diag.WrapAs(diag.ClassProtocol, err, "read sse stream")
+			return diag.Wrap(err, "read sse stream")
 		}
 
 		if trimmed := strings.TrimRight(line, "\r\n"); trimmed == "" {

--- a/internal/protocol/httpx/stream_sse.go
+++ b/internal/protocol/httpx/stream_sse.go
@@ -39,6 +39,7 @@ const (
 	sseReasonEventBytes = "limit:event_bytes"
 	sseReasonTotal      = "timeout:total"
 	sseReasonCanceled   = "context_canceled"
+	sseReasonDeadline   = "context_deadline"
 )
 
 const (
@@ -116,13 +117,20 @@ type SSETranscript struct {
 	Summary SSESummary `json:"summary"`
 }
 
-// Err reports the failure that ended the stream. Reaching a configured limit or
-// timeout is a normal ending and returns nil. A broken read, or a line or event
-// larger than its limit, is a failure.
+// Err reports an error when the stream fails, is canceled, or exceeds a caller
+// deadline. Configured stream limits are normal endings.
 func (s SSESummary) Err() error {
 	switch {
 	case s.Reason == sseReasonCanceled:
-		return diag.New(diag.ClassCanceled, cmp.Or(s.Error, "sse stream canceled"))
+		return diag.New(
+			s.ErrorClass.KnownOr(diag.ClassCanceled),
+			cmp.Or(s.Error, "sse stream canceled"),
+		)
+	case s.Reason == sseReasonDeadline:
+		return diag.New(
+			s.ErrorClass.KnownOr(diag.ClassTimeout),
+			cmp.Or(s.Error, "sse stream ran out of time"),
+		)
 	case s.Reason == sseReasonErr, s.Error != "":
 		return diag.New(
 			s.ErrorClass.KnownOr(diag.ClassProtocol),
@@ -144,7 +152,7 @@ func (c *Client) StartSSE(
 	}
 
 	streamOpts := req.SSE.Options
-	streamCtx, cancel := ctxWithTimeout(ctx, streamOpts.TotalTimeout)
+	streamCtx, cancel := ctxWithTimeout(ctx, streamOpts.TotalTimeout, errStreamLimit)
 
 	httpReq, effectiveOpts, err := c.prepareHTTPRequest(streamCtx, req, resolver, opts)
 	if err != nil {
@@ -414,8 +422,10 @@ func (r *sseRun) ended(ctx context.Context) string {
 	switch {
 	case r.idled.Load():
 		return sseReasonIdle
-	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+	case errors.Is(context.Cause(ctx), errStreamLimit):
 		return sseReasonTotal
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return sseReasonDeadline
 	default:
 		return sseReasonCanceled
 	}
@@ -468,8 +478,11 @@ func (r *sseRun) finish(ctx context.Context, err error) {
 	})
 
 	closeErr := r.failure
-	if closeErr == nil && ctx.Err() != nil && r.summary.Reason == sseReasonCanceled {
-		closeErr = ctx.Err()
+	if closeErr == nil && ctx.Err() != nil {
+		switch r.summary.Reason {
+		case sseReasonCanceled, sseReasonDeadline:
+			closeErr = context.Cause(ctx)
+		}
 	}
 	r.session.Close(closeErr)
 }

--- a/internal/protocol/httpx/stream_sse.go
+++ b/internal/protocol/httpx/stream_sse.go
@@ -249,12 +249,6 @@ func CompleteSSE(handle *StreamHandle) (*Response, error) {
 	} else {
 		acc.summary.Duration = time.Since(handle.Meta.ConnectedAt)
 	}
-	if acc.summary.ByteCount == 0 {
-		acc.summary.ByteCount = int64(stats.BytesTotal)
-	}
-	if acc.summary.EventCount == 0 {
-		acc.summary.EventCount = len(acc.events)
-	}
 	state, serr := session.State()
 	if acc.summary.Error == "" && serr != nil {
 		acc.summary.Error = serr.Error()
@@ -435,14 +429,15 @@ func (r *sseRun) flush() bool {
 	return true
 }
 
+// A failed run publishes its summary too, so the counts come from the run and
+// not from what the buffer kept.
 func (r *sseRun) finish(ctx context.Context, err error) {
-	if err != nil {
-		r.session.Close(err)
-		return
-	}
-
-	// The transport may report a cancelled read as EOF, so check the context.
-	if ctx.Err() != nil {
+	switch {
+	case err != nil:
+		r.failure = err
+		r.stop(sseReasonErr)
+	case ctx.Err() != nil:
+		// The transport may report a cancelled read as EOF, so check the context.
 		r.stop(r.ended(ctx))
 	}
 

--- a/internal/protocol/httpx/stream_sse_parser.go
+++ b/internal/protocol/httpx/stream_sse_parser.go
@@ -29,7 +29,7 @@ func (a *sseAccumulator) consume(evt *stream.Event) {
 	case stream.DirReceive:
 		data := string(evt.Payload)
 		item := SSEEvent{
-			Index:     len(a.events),
+			Index:     evt.SSE.Index,
 			ID:        evt.SSE.ID,
 			Event:     evt.SSE.Name,
 			Data:      data,
@@ -68,6 +68,7 @@ func publishSSEEvent(session *stream.Session, evt SSEEvent) {
 		Timestamp: evt.Timestamp,
 		Payload:   []byte(evt.Data),
 		SSE: stream.SSEMetadata{
+			Index:   evt.Index,
 			Name:    evt.Event,
 			ID:      evt.ID,
 			Comment: evt.Comment,

--- a/internal/protocol/httpx/stream_sse_test.go
+++ b/internal/protocol/httpx/stream_sse_test.go
@@ -3,9 +3,11 @@ package httpx
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -522,6 +524,9 @@ func TestSSEFailureSummaryCountsWhatTheRunRead(t *testing.T) {
 	if !strings.Contains(sum.Error, "retry directive") {
 		t.Fatalf("Error = %q, want the parser failure", sum.Error)
 	}
+	if sum.ErrorClass != diag.ClassProtocol {
+		t.Fatalf("ErrorClass = %q, want %q", sum.ErrorClass, diag.ClassProtocol)
+	}
 	if sum.EventCount != events {
 		t.Fatalf("EventCount = %d, want the %d events the run read", sum.EventCount, events)
 	}
@@ -563,5 +568,87 @@ func TestSSEStreamWithoutEventsCountsNothing(t *testing.T) {
 	}
 	if sum.EventCount != 0 || sum.ByteCount != 0 {
 		t.Fatalf("summary = %d events and %d bytes, want an empty stream", sum.EventCount, sum.ByteCount)
+	}
+}
+
+// sseBody serves one event and then fails, so the run ends on a read error.
+type sseBody struct {
+	data []byte
+	err  error
+}
+
+func (b *sseBody) Read(p []byte) (int, error) {
+	if len(b.data) == 0 {
+		return 0, b.err
+	}
+	n := copy(p, b.data)
+	b.data = b.data[n:]
+	return n, nil
+}
+
+func (b *sseBody) Close() error { return nil }
+
+func failingSSEClient(t *testing.T, err error) *Client {
+	t.Helper()
+	return newTestClientWithHTTPFactory(func(Options) (*http.Client, error) {
+		rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Proto:      "HTTP/1.1",
+				Header:     make(http.Header),
+				Body:       &sseBody{data: []byte("data: ping\n\n"), err: err},
+				Request:    req,
+			}
+			resp.Header.Set("Content-Type", "text/event-stream")
+			return resp, nil
+		})
+		return &http.Client{Transport: rt}, nil
+	})
+}
+
+func TestSSEReadFailureKeepsItsClass(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want diag.Class
+	}{
+		{
+			name: "the connection dropped",
+			err:  &net.OpError{Op: "read", Err: errors.New("connection reset by peer")},
+			want: diag.ClassNetwork,
+		},
+		{
+			name: "a read that names nothing",
+			err:  errors.New("the stream broke"),
+			want: diag.ClassProtocol,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &restfile.Request{
+				Method: "GET",
+				URL:    "https://example.com/events",
+				SSE:    &restfile.SSERequest{},
+			}
+			resp, err := failingSSEClient(t, tt.err).ExecuteSSE(t.Context(), req, nil, Options{})
+			if err != nil {
+				t.Fatalf("ExecuteSSE: %v", err)
+			}
+
+			transcript, err := DecodeSSETranscript(resp.Body)
+			if err != nil {
+				t.Fatalf("decode transcript: %v", err)
+			}
+			if transcript.Summary.Reason != sseReasonErr {
+				t.Fatalf("Reason = %q, want %q", transcript.Summary.Reason, sseReasonErr)
+			}
+			if len(transcript.Events) != 1 {
+				t.Fatalf("kept %d events, want the one read before the failure", len(transcript.Events))
+			}
+			if got := diag.ClassOf(transcript.Summary.Err()); got != tt.want {
+				t.Fatalf("Err() class = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/protocol/httpx/stream_sse_test.go
+++ b/internal/protocol/httpx/stream_sse_test.go
@@ -64,11 +64,17 @@ func TestSSERunReportsAnIdleTimeoutOnEveryExit(t *testing.T) {
 }
 
 func TestSSERunNamesWhatCancelledTheRead(t *testing.T) {
-	deadline, cancelDeadline := context.WithDeadline(
+	limit, cancelLimit := ctxWithTimeout(context.Background(), time.Nanosecond, errStreamLimit)
+	defer cancelLimit()
+	<-limit.Done()
+
+	caller, cancelCaller := context.WithDeadline(
 		context.Background(),
 		time.Now().Add(-time.Second),
 	)
-	defer cancelDeadline()
+	defer cancelCaller()
+	outlived, cancelOutlived := ctxWithTimeout(caller, time.Hour, errStreamLimit)
+	defer cancelOutlived()
 
 	stopped, stop := context.WithCancel(context.Background())
 	stop()
@@ -80,7 +86,9 @@ func TestSSERunNamesWhatCancelledTheRead(t *testing.T) {
 		want  string
 	}{
 		{name: "the idle watcher", ctx: stopped, idled: true, want: sseReasonIdle},
-		{name: "the total timeout", ctx: deadline, want: sseReasonTotal},
+		{name: "the duration the request asked for", ctx: limit, want: sseReasonTotal},
+		{name: "a deadline the caller set", ctx: caller, want: sseReasonDeadline},
+		{name: "a caller deadline inside a longer duration", ctx: outlived, want: sseReasonDeadline},
 		{name: "the caller gave up", ctx: stopped, want: sseReasonCanceled},
 	}
 
@@ -647,6 +655,83 @@ func TestSSEReadFailureKeepsItsClass(t *testing.T) {
 				t.Fatalf("kept %d events, want the one read before the failure", len(transcript.Events))
 			}
 			if got := diag.ClassOf(transcript.Summary.Err()); got != tt.want {
+				t.Fatalf("Err() class = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSETellsACallerDeadlineFromTheDurationLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		total    time.Duration
+		deadline time.Duration
+		reason   string
+		want     diag.Class
+	}{
+		{
+			name:   "the duration the request asked for",
+			total:  250 * time.Millisecond,
+			reason: sseReasonTotal,
+		},
+		{
+			name:     "a deadline the caller set",
+			deadline: 250 * time.Millisecond,
+			reason:   sseReasonDeadline,
+			want:     diag.ClassTimeout,
+		},
+		{
+			name:     "a caller deadline inside a longer duration",
+			total:    time.Minute,
+			deadline: 250 * time.Millisecond,
+			reason:   sseReasonDeadline,
+			want:     diag.ClassTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := sseServer(t, func(w http.ResponseWriter, flush func()) {
+				_, _ = w.Write([]byte("data: ping\n\n"))
+				flush()
+				<-t.Context().Done()
+			})
+
+			ctx := t.Context()
+			if tt.deadline > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.deadline)
+				defer cancel()
+			}
+
+			req := &restfile.Request{
+				Method: "GET",
+				URL:    srv.URL,
+				SSE:    &restfile.SSERequest{Options: restfile.SSEOptions{TotalTimeout: tt.total}},
+			}
+			resp, err := NewClient(nil).ExecuteSSE(ctx, req, nil, Options{})
+			if err != nil {
+				t.Fatalf("ExecuteSSE: %v", err)
+			}
+
+			transcript, err := DecodeSSETranscript(resp.Body)
+			if err != nil {
+				t.Fatalf("decode transcript: %v", err)
+			}
+			sum := transcript.Summary
+			if sum.Reason != tt.reason {
+				t.Fatalf("Reason = %q, want %q", sum.Reason, tt.reason)
+			}
+			if len(transcript.Events) != 1 {
+				t.Fatalf("kept %d events, want the one read before the stop", len(transcript.Events))
+			}
+			if tt.want == "" {
+				if err := sum.Err(); err != nil {
+					t.Fatalf("a reached duration limit ended as a failure: %v", err)
+				}
+				return
+			}
+			if got := diag.ClassOf(sum.Err()); got != tt.want {
 				t.Fatalf("Err() class = %q, want %q", got, tt.want)
 			}
 		})

--- a/internal/protocol/httpx/stream_sse_test.go
+++ b/internal/protocol/httpx/stream_sse_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -485,5 +486,82 @@ func TestSSESummaryErr(t *testing.T) {
 				t.Fatalf("Err() = %q, want %q", err, tt.summary.Error)
 			}
 		})
+	}
+}
+
+func TestSSEAcceptsTheLargestByteLimit(t *testing.T) {
+	srv := sseServer(t, func(w http.ResponseWriter, flush func()) {
+		_, _ = w.Write([]byte("data: hello\n\n"))
+		flush()
+	})
+
+	transcript := sseTranscript(t, srv.URL, restfile.SSEOptions{MaxBytes: math.MaxInt64})
+	if len(transcript.Events) != 1 || transcript.Events[0].Data != "hello" {
+		t.Fatalf("events = %+v, want the one event the server sent", transcript.Events)
+	}
+}
+
+func TestSSEFailureSummaryCountsWhatTheRunRead(t *testing.T) {
+	const events = 5
+
+	var raw strings.Builder
+	for i := range events {
+		_, _ = fmt.Fprintf(&raw, "data: event-%d\n\n", i)
+	}
+	raw.WriteString("retry: notanumber\n")
+
+	srv := sseServer(t, func(w http.ResponseWriter, flush func()) {
+		_, _ = w.Write([]byte(raw.String()))
+		flush()
+	})
+
+	sum := sseTranscript(t, srv.URL, restfile.SSEOptions{}).Summary
+	if sum.Reason != sseReasonErr {
+		t.Fatalf("Reason = %q, want %q", sum.Reason, sseReasonErr)
+	}
+	if !strings.Contains(sum.Error, "retry directive") {
+		t.Fatalf("Error = %q, want the parser failure", sum.Error)
+	}
+	if sum.EventCount != events {
+		t.Fatalf("EventCount = %d, want the %d events the run read", sum.EventCount, events)
+	}
+	if sum.ByteCount != int64(raw.Len()) {
+		t.Fatalf("ByteCount = %d, want the %d bytes the run read", sum.ByteCount, raw.Len())
+	}
+}
+
+func TestSSEEventsKeepTheirStreamIndex(t *testing.T) {
+	const sent = 1200
+
+	srv := sseServer(t, func(w http.ResponseWriter, flush func()) {
+		for i := range sent {
+			_, _ = fmt.Fprintf(w, "data: event-%d\n\n", i)
+		}
+		flush()
+	})
+
+	transcript := sseTranscript(t, srv.URL, restfile.SSEOptions{})
+	if transcript.Summary.EventCount != sent {
+		t.Fatalf("EventCount = %d, want every event read", transcript.Summary.EventCount)
+	}
+	if len(transcript.Events) >= sent {
+		t.Fatalf("kept %d events, want the buffer to have discarded some", len(transcript.Events))
+	}
+	for _, evt := range transcript.Events {
+		if want := fmt.Sprintf("event-%d", evt.Index); evt.Data != want {
+			t.Fatalf("event at index %d holds %q, want %q", evt.Index, evt.Data, want)
+		}
+	}
+}
+
+func TestSSEStreamWithoutEventsCountsNothing(t *testing.T) {
+	srv := sseServer(t, func(w http.ResponseWriter, flush func()) { flush() })
+
+	sum := sseTranscript(t, srv.URL, restfile.SSEOptions{}).Summary
+	if sum.Reason != sseReasonEOF {
+		t.Fatalf("Reason = %q, want %q", sum.Reason, sseReasonEOF)
+	}
+	if sum.EventCount != 0 || sum.ByteCount != 0 {
+		t.Fatalf("summary = %d events and %d bytes, want an empty stream", sum.EventCount, sum.ByteCount)
 	}
 }

--- a/internal/protocol/httpx/stream_ws.go
+++ b/internal/protocol/httpx/stream_ws.go
@@ -280,6 +280,9 @@ func (c *Client) CompleteWebSocket(
 	if handle == nil || handle.Session == nil || handle.Sender == nil {
 		return nil, diag.New(diag.ClassProtocol, "websocket session not available")
 	}
+	if req == nil || req.WebSocket == nil {
+		return nil, diag.New(diag.ClassProtocol, "websocket request missing")
+	}
 
 	session := handle.Session
 	listener := session.Subscribe()
@@ -305,12 +308,8 @@ func (c *Client) CompleteWebSocket(
 	if baseDir == "" {
 		baseDir = opts.BaseDir
 	}
-	closedByScript, err := c.runWSSteps(session, sender, req, baseDir, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	if !closedByScript {
+	// A session that already ended needs no close frame.
+	if !c.runWSSteps(session, sender, req, baseDir, opts) && session.Context().Err() == nil {
 		_ = sender.Close(
 			session.Context(),
 			websocket.StatusNormalClosure,

--- a/internal/protocol/httpx/stream_ws.go
+++ b/internal/protocol/httpx/stream_ws.go
@@ -69,6 +69,7 @@ type WebSocketSummary struct {
 	CloseCode     int           `json:"closeCode,omitempty"`
 	CloseReason   string        `json:"closeReason,omitempty"`
 	Dropped       int64         `json:"dropped,omitempty"`
+	ErrorClass    diag.Class    `json:"errorClass,omitempty"`
 }
 
 type WebSocketTranscript struct {
@@ -87,7 +88,7 @@ func (s WebSocketSummary) Err() error {
 		)
 	case wsClosedByError:
 		return diag.New(
-			diag.ClassProtocol,
+			s.ErrorClass.KnownOr(diag.ClassProtocol),
 			cmp.Or(s.CloseReason, "websocket stream failed"),
 		)
 	default:

--- a/internal/protocol/httpx/stream_ws.go
+++ b/internal/protocol/httpx/stream_ws.go
@@ -77,15 +77,20 @@ type WebSocketTranscript struct {
 	Summary WebSocketSummary `json:"summary"`
 }
 
-// Err reports the failure that ended the session. A close either side asked for
-// and a timeout are normal endings and return nil.
+// Err reports an error when the session fails, is canceled, or exceeds a caller
+// deadline. A close from either side and an idle timeout are normal endings.
 func (s WebSocketSummary) Err() error {
 	switch s.ClosedBy {
 	case wsClosedByCanceled:
 		return diag.New(
-			diag.ClassCanceled,
+			s.ErrorClass.KnownOr(diag.ClassCanceled),
 			cmp.Or(s.CloseReason, "websocket stream canceled"),
 		)
+	case wsClosedByTimeout:
+		if !s.ErrorClass.Known() {
+			return nil
+		}
+		return diag.New(s.ErrorClass, cmp.Or(s.CloseReason, "websocket stream ran out of time"))
 	case wsClosedByError:
 		return diag.New(
 			s.ErrorClass.KnownOr(diag.ClassProtocol),
@@ -138,7 +143,7 @@ func (c *Client) StartWebSocket(
 	}
 
 	wsOpts := req.WebSocket.Options
-	handshakeCtx, handshakeCancel := ctxWithTimeout(ctx, wsOpts.HandshakeTimeout)
+	handshakeCtx, handshakeCancel := ctxWithTimeout(ctx, wsOpts.HandshakeTimeout, nil)
 	defer handshakeCancel()
 
 	httpReq, effectiveOpts, err := c.prepareHTTPRequestWithOpts(

--- a/internal/protocol/httpx/stream_ws_accumulator.go
+++ b/internal/protocol/httpx/stream_ws_accumulator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strconv"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/stream"
 )
 
@@ -165,7 +166,16 @@ func applyWebSocketSummaryDefaults(sum *WebSocketSummary, state stream.State, st
 			sum.ClosedBy = wsClosedByClient
 		}
 	}
-	if sum.CloseReason != "" || stateErr == nil {
+	if stateErr == nil {
+		return
+	}
+	// Only a failure needs a class. The other endings are named by closedBy.
+	if sum.ClosedBy == wsClosedByError {
+		if class := diag.ClassOf(stateErr); class.Known() {
+			sum.ErrorClass = class
+		}
+	}
+	if sum.CloseReason != "" {
 		return
 	}
 	switch sum.ClosedBy {

--- a/internal/protocol/httpx/stream_ws_accumulator.go
+++ b/internal/protocol/httpx/stream_ws_accumulator.go
@@ -147,9 +147,8 @@ func directionToString(dir stream.Direction) string {
 	}
 }
 
-// applyWebSocketSummaryDefaults fills in who ended a session when the events did
-// not say. A timeout and a canceled run get their own names because neither one
-// is a failure.
+// applyWebSocketSummaryDefaults fills fields not set by terminal events. Idle
+// timeouts have no error class, while caller deadlines do.
 func applyWebSocketSummaryDefaults(sum *WebSocketSummary, state stream.State, stateErr error) {
 	if sum == nil {
 		return
@@ -169,17 +168,13 @@ func applyWebSocketSummaryDefaults(sum *WebSocketSummary, state stream.State, st
 	if stateErr == nil {
 		return
 	}
-	// Only a failure needs a class. The other endings are named by closedBy.
-	if sum.ClosedBy == wsClosedByError {
+	switch sum.ClosedBy {
+	case wsClosedByCanceled, wsClosedByTimeout, wsClosedByError:
 		if class := diag.ClassOf(stateErr); class.Known() {
 			sum.ErrorClass = class
 		}
-	}
-	if sum.CloseReason != "" {
-		return
-	}
-	switch sum.ClosedBy {
-	case wsClosedByCanceled, wsClosedByTimeout, wsClosedByError:
-		sum.CloseReason = stateErr.Error()
+		if sum.CloseReason == "" {
+			sum.CloseReason = stateErr.Error()
+		}
 	}
 }

--- a/internal/protocol/httpx/stream_ws_runtime.go
+++ b/internal/protocol/httpx/stream_ws_runtime.go
@@ -196,7 +196,7 @@ func (rt *wsRuntime) readLoop() {
 			} else {
 				rt.closeTerminalNow(
 					nil,
-					diag.WrapAs(diag.ClassProtocol, err, "read websocket message"),
+					diag.Wrap(err, "read websocket message"),
 				)
 			}
 			return
@@ -335,7 +335,7 @@ func (rt *wsRuntime) performWrite(msg wsOutbound) error {
 		if err := rt.writeAndPublish(func() error {
 			return rt.conn.Write(ctx, msg.msgType, msg.payload)
 		}, evt); err != nil {
-			return diag.WrapAs(diag.ClassProtocol, err, "send websocket frame")
+			return diag.Wrap(err, "send websocket frame")
 		}
 		return nil
 	case wsOutboundPing:
@@ -365,7 +365,7 @@ func (rt *wsRuntime) performWrite(msg wsOutbound) error {
 		if err := rt.writeAndPublish(func() error {
 			return wsWriteControl(rt.conn, ctx, wsOpcodePing, payload)
 		}, evt); err != nil {
-			return diag.WrapAs(diag.ClassProtocol, err, "send websocket ping")
+			return diag.Wrap(err, "send websocket ping")
 		}
 		return nil
 	case wsOutboundPong:
@@ -396,7 +396,7 @@ func (rt *wsRuntime) performWrite(msg wsOutbound) error {
 		if err := rt.writeAndPublish(func() error {
 			return wsWriteControl(rt.conn, ctx, wsOpcodePong, payload)
 		}, evt); err != nil {
-			return diag.WrapAs(diag.ClassProtocol, err, "send websocket pong")
+			return diag.Wrap(err, "send websocket pong")
 		}
 		return nil
 	case wsOutboundClose:
@@ -428,7 +428,7 @@ func (rt *wsRuntime) performWrite(msg wsOutbound) error {
 		if err := rt.writeAndPublish(func() error {
 			return rt.conn.Close(msg.code, msg.reason)
 		}, evt); err != nil {
-			return diag.WrapAs(diag.ClassProtocol, err, "close websocket")
+			return diag.Wrap(err, "close websocket")
 		}
 		rt.closeTerminalNow(nil, nil)
 		return nil
@@ -451,7 +451,7 @@ func (rt *wsRuntime) shutdown() {
 		if err := rt.conn.Close(websocket.StatusNormalClosure, ""); err != nil &&
 			!errors.Is(err, net.ErrClosed) && !errors.Is(err, context.Canceled) {
 			rt.session.Close(
-				diag.WrapAs(diag.ClassProtocol, err, "close websocket connection"),
+				diag.Wrap(err, "close websocket connection"),
 			)
 		}
 	})

--- a/internal/protocol/httpx/stream_ws_sender.go
+++ b/internal/protocol/httpx/stream_ws_sender.go
@@ -22,6 +22,15 @@ func (s *WebSocketSender) touch() {
 	s.runtime.touchActivity()
 }
 
+// fail ends the session with err and stops publishing, so a close frame from
+// the peer cannot replace the real reason the run stopped.
+func (s *WebSocketSender) fail(err error) {
+	if s == nil || s.runtime == nil {
+		return
+	}
+	s.runtime.closeTerminalNow(nil, err)
+}
+
 // Multiple contexts race here: per-message timeout, session lifetime, and write
 // completion. Nested selects give priority to results that are already available.
 func (s *WebSocketSender) enqueue(msg wsOutbound) (err error) {

--- a/internal/protocol/httpx/stream_ws_steps.go
+++ b/internal/protocol/httpx/stream_ws_steps.go
@@ -1,6 +1,7 @@
 package httpx
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"strings"
@@ -25,17 +26,16 @@ func wsRecvWindow(opts restfile.WebSocketOptions) time.Duration {
 	return win
 }
 
+// runWSSteps reports whether a step closed the connection. A step that fails
+// ends the session with its error instead of returning it, so the caller can
+// still build the transcript.
 func (c *Client) runWSSteps(
 	session *stream.Session,
 	sender *WebSocketSender,
 	req *restfile.Request,
 	baseDir string,
 	opts Options,
-) (bool, error) {
-	if req == nil || req.WebSocket == nil {
-		return false, diag.New(diag.ClassProtocol, "websocket request missing")
-	}
-
+) bool {
 	wsReq := req.WebSocket
 	ctx := session.Context()
 	recvWindow := wsRecvWindow(wsReq.Options)
@@ -45,83 +45,68 @@ func (c *Client) runWSSteps(
 	for idx, step := range wsReq.Steps {
 		sender.touch()
 
-		if err := ensureSessionAlive(session); err != nil {
-			return false, err
+		if ctx.Err() != nil {
+			return closedByScript
 		}
 
 		label := fmt.Sprintf("%d:%s", idx+1, string(step.Type))
 		meta := map[string]string{wsMetaStep: label}
+
+		var err error
 		switch step.Type {
 		case restfile.WebSocketStepSendText:
 			meta[wsMetaType] = "text"
-			if err := sender.SendText(ctx, step.Value, meta); err != nil {
-				session.Cancel()
-				return false, err
-			}
-			waitForWindow(ctx, recvWindow)
+			err = sender.SendText(ctx, step.Value, meta)
 		case restfile.WebSocketStepSendJSON:
-			payload := strings.TrimSpace(step.Value)
-			if payload == "" {
-				payload = "{}"
-			}
 			meta[wsMetaType] = "json"
-			if err := sender.SendJSON(ctx, payload, meta); err != nil {
-				session.Cancel()
-				return false, err
-			}
-			waitForWindow(ctx, recvWindow)
+			err = sender.SendJSON(ctx, cmp.Or(strings.TrimSpace(step.Value), "{}"), meta)
 		case restfile.WebSocketStepSendBase64:
 			meta[wsMetaType] = "binary"
-			if err := sender.SendBase64(ctx, step.Value, meta); err != nil {
-				session.Cancel()
-				return false, err
-			}
-			waitForWindow(ctx, recvWindow)
+			err = sender.SendBase64(ctx, step.Value, meta)
 		case restfile.WebSocketStepSendFile:
-			data, _, readErr := c.readFile(lookup, step.File, "websocket payload file")
-			if readErr != nil {
-				session.Cancel()
-				return false, readErr
-			}
 			meta[wsMetaType] = "binary"
-			if err := sender.SendBinary(ctx, data, meta); err != nil {
-				session.Cancel()
-				return false, err
+			var data []byte
+			data, _, err = c.readFile(lookup, step.File, "websocket payload file")
+			if err == nil {
+				err = sender.SendBinary(ctx, data, meta)
 			}
-			waitForWindow(ctx, recvWindow)
 		case restfile.WebSocketStepPing:
 			meta[wsMetaType] = "ping"
-			if err := sender.Ping(ctx, step.Value, meta); err != nil {
-				session.Cancel()
-				return false, err
-			}
-			waitForWindow(ctx, recvWindow)
+			err = sender.Ping(ctx, step.Value, meta)
 		case restfile.WebSocketStepPong:
-			if err := sender.Pong(ctx, step.Value, meta); err != nil {
-				session.Cancel()
-				return false, err
-			}
-			waitForWindow(ctx, recvWindow)
+			err = sender.Pong(ctx, step.Value, meta)
 		case restfile.WebSocketStepWait:
-			if err := waitForDuration(ctx, step.Duration); err != nil {
-				session.Cancel()
-				return false, err
-			}
+			err = waitForDuration(ctx, step.Duration)
 		case restfile.WebSocketStepClose:
 			meta[wsMetaType] = "close"
-			code := websocket.StatusNormalClosure
-			if step.Code != 0 {
-				code = websocket.StatusCode(step.Code)
+			code := cmp.Or(websocket.StatusCode(step.Code), websocket.StatusNormalClosure)
+			err = sender.Close(ctx, code, step.Reason, meta)
+			closedByScript = err == nil
+		}
+
+		if err != nil {
+			if ctx.Err() == nil {
+				// The session is still open, so the step itself failed.
+				sender.fail(diag.WrapAs(diag.ClassProtocol, err, "websocket step "+label))
 			}
-			if err := sender.Close(ctx, code, step.Reason, meta); err != nil {
-				session.Cancel()
-				return false, err
-			}
-			closedByScript = true
+			return closedByScript
+		}
+
+		if wsStepSettles(step.Type) {
+			waitForWindow(ctx, recvWindow)
 		}
 	}
 
-	return closedByScript, nil
+	return closedByScript
+}
+
+// A step that sent a frame pauses for the answer. Wait and close have their own timing.
+func wsStepSettles(step restfile.WebSocketStepType) bool {
+	switch step {
+	case restfile.WebSocketStepWait, restfile.WebSocketStepClose:
+		return false
+	}
+	return true
 }
 
 func waitForWindow(ctx context.Context, d time.Duration) {
@@ -143,17 +128,4 @@ func waitForDuration(ctx context.Context, d time.Duration) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-}
-
-func ensureSessionAlive(session *stream.Session) error {
-	if session == nil {
-		return diag.New(diag.ClassProtocol, "websocket session missing")
-	}
-	if err := session.Context().Err(); err != nil {
-		if sessErr := session.Err(); sessErr != nil {
-			return sessErr
-		}
-		return diag.WrapAs(diag.ClassProtocol, err, "websocket session closed")
-	}
-	return nil
 }

--- a/internal/protocol/httpx/stream_ws_steps.go
+++ b/internal/protocol/httpx/stream_ws_steps.go
@@ -87,7 +87,7 @@ func (c *Client) runWSSteps(
 		if err != nil {
 			if ctx.Err() == nil {
 				// The session is still open, so the step itself failed.
-				sender.fail(diag.WrapAs(diag.ClassProtocol, err, "websocket step "+label))
+				sender.fail(diag.Wrap(err, "websocket step "+label))
 			}
 			return closedByScript
 		}

--- a/internal/protocol/httpx/stream_ws_test.go
+++ b/internal/protocol/httpx/stream_ws_test.go
@@ -1079,3 +1079,102 @@ func TestStreamSummaryErrFallsBackToProtocol(t *testing.T) {
 		})
 	}
 }
+
+func TestWebSocketTellsACallerDeadlineFromTheIdleLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		idle     time.Duration
+		deadline time.Duration
+		want     diag.Class
+	}{
+		{name: "the idle limit", idle: 200 * time.Millisecond},
+		{name: "a deadline the caller set", deadline: 300 * time.Millisecond, want: diag.ClassTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, cleanup := startSilentWebSocketServer(t)
+			defer cleanup()
+
+			ctx := t.Context()
+			if tt.deadline > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.deadline)
+				defer cancel()
+			}
+
+			req := &restfile.Request{
+				Method: http.MethodGet,
+				URL:    strings.Replace(server.URL, "http", "ws", 1) + "/ws",
+				WebSocket: &restfile.WebSocketRequest{
+					Options: restfile.WebSocketOptions{IdleTimeout: tt.idle},
+					Steps: []restfile.WebSocketStep{
+						{Type: restfile.WebSocketStepWait, Duration: 10 * time.Second},
+					},
+				},
+			}
+
+			resp, err := NewClient(nil).ExecuteWebSocket(ctx, req, nil, Options{})
+			if err != nil {
+				t.Fatalf("ExecuteWebSocket: %v", err)
+			}
+
+			sum := wsTranscript(t, resp).Summary
+			if sum.ClosedBy != wsClosedByTimeout {
+				t.Fatalf("closedBy = %q, want %q", sum.ClosedBy, wsClosedByTimeout)
+			}
+			if sum.ErrorClass != tt.want {
+				t.Fatalf("errorClass = %q, want %q", sum.ErrorClass, tt.want)
+			}
+			if tt.want == "" {
+				if err := sum.Err(); err != nil {
+					t.Fatalf("a reached idle limit ended as a failure: %v", err)
+				}
+				return
+			}
+			if got := diag.ClassOf(sum.Err()); got != tt.want {
+				t.Fatalf("Err() class = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartWebSocketHandshakeTimeoutIsATimeout(t *testing.T) {
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	// Keep accepted connections open until the client reaches its deadline.
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "ws://" + ln.Addr().String() + "/ws",
+		WebSocket: &restfile.WebSocketRequest{
+			Options: restfile.WebSocketOptions{HandshakeTimeout: 200 * time.Millisecond},
+		},
+	}
+
+	_, _, err = NewClient(nil).StartWebSocket(t.Context(), req, nil, Options{})
+	if err == nil {
+		t.Fatal("StartWebSocket = nil, want the handshake to run out of time")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want a deadline the caller can recognise", err)
+	}
+	if !slices.Contains(diag.Classes(err), diag.ClassTimeout) {
+		t.Fatalf("classes = %v, want %s", diag.Classes(err), diag.ClassTimeout)
+	}
+	if strings.Contains(err.Error(), errStreamLimit.Error()) {
+		t.Fatalf("error = %q, want no internal cause in the message", err)
+	}
+}

--- a/internal/protocol/httpx/stream_ws_test.go
+++ b/internal/protocol/httpx/stream_ws_test.go
@@ -924,8 +924,16 @@ func TestCompleteWebSocketReportsAStepFailureInTheSummary(t *testing.T) {
 		!strings.Contains(transcript.Summary.CloseReason, "websocket payload file") {
 		t.Fatalf("closeReason = %q, want the step and why it failed", transcript.Summary.CloseReason)
 	}
-	if err := transcript.Summary.Err(); err == nil {
+	// A payload Resterm could not read is a filesystem failure, not a protocol one.
+	if transcript.Summary.ErrorClass != diag.ClassFilesystem {
+		t.Fatalf("errorClass = %q, want %q", transcript.Summary.ErrorClass, diag.ClassFilesystem)
+	}
+	err = transcript.Summary.Err()
+	if err == nil {
 		t.Fatal("Err() = nil, want the failure to fail the request")
+	}
+	if !slices.Contains(diag.Classes(err), diag.ClassFilesystem) {
+		t.Fatalf("Err() classes = %v, want %s", diag.Classes(err), diag.ClassFilesystem)
 	}
 	if !wsSent(transcript, "hello") {
 		t.Fatalf("the transcript lost the frames sent before the failure: %+v", transcript.Events)
@@ -965,5 +973,109 @@ func TestCompleteWebSocketNamesACancelledRunAndKeepsTheTranscript(t *testing.T) 
 	}
 	if !wsSent(transcript, "hello") {
 		t.Fatalf("the transcript lost the frames sent before the cancel: %+v", transcript.Events)
+	}
+}
+
+func TestWebSocketStepFailureKeepsItsClass(t *testing.T) {
+	server, cleanup := startEchoWebSocketServer(t)
+	defer cleanup()
+
+	tests := []struct {
+		name string
+		step restfile.WebSocketStep
+		want diag.Class
+	}{
+		{
+			name: "unreadable payload file",
+			step: restfile.WebSocketStep{
+				Type: restfile.WebSocketStepSendFile,
+				File: "no-such-payload.bin",
+			},
+			want: diag.ClassFilesystem,
+		},
+		{
+			name: "payload that is not base64",
+			step: restfile.WebSocketStep{
+				Type:  restfile.WebSocketStepSendBase64,
+				Value: "not base64 at all",
+			},
+			want: diag.ClassProtocol,
+		},
+		{
+			name: "payload that is not json",
+			step: restfile.WebSocketStep{
+				Type:  restfile.WebSocketStepSendJSON,
+				Value: "{oops",
+			},
+			want: diag.ClassProtocol,
+		},
+		{
+			name: "control frame over its payload limit",
+			step: restfile.WebSocketStep{
+				Type:  restfile.WebSocketStepPing,
+				Value: strings.Repeat("A", websocketControlMaxPayload+1),
+			},
+			want: diag.ClassProtocol,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &restfile.Request{
+				Method: http.MethodGet,
+				URL:    strings.Replace(server.URL, "http", "ws", 1) + "/ws",
+				WebSocket: &restfile.WebSocketRequest{
+					Steps: []restfile.WebSocketStep{tt.step},
+				},
+			}
+
+			resp, err := NewClient(nil).ExecuteWebSocket(
+				t.Context(),
+				req,
+				nil,
+				Options{BaseDir: t.TempDir()},
+			)
+			if err != nil {
+				t.Fatalf("a failed step returned before the transcript was built: %v", err)
+			}
+
+			sum := wsTranscript(t, resp).Summary
+			if sum.ClosedBy != wsClosedByError {
+				t.Fatalf("closedBy = %q, want %q", sum.ClosedBy, wsClosedByError)
+			}
+			if sum.ErrorClass != tt.want {
+				t.Fatalf("errorClass = %q, want %q", sum.ErrorClass, tt.want)
+			}
+			if got := diag.Classes(sum.Err()); !slices.Contains(got, tt.want) {
+				t.Fatalf("Err() classes = %v, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// A transcript another build wrote can name a class this one does not have.
+func TestStreamSummaryErrFallsBackToProtocol(t *testing.T) {
+	tests := []struct {
+		name  string
+		class diag.Class
+		want  diag.Class
+	}{
+		{name: "no class", want: diag.ClassProtocol},
+		{name: "unknown class", class: "wormhole", want: diag.ClassProtocol},
+		{name: "unclassified", class: diag.ClassUnknown, want: diag.ClassProtocol},
+		{name: "a class this build knows", class: diag.ClassNetwork, want: diag.ClassNetwork},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := WebSocketSummary{ClosedBy: wsClosedByError, ErrorClass: tt.class}
+			if got := diag.ClassOf(ws.Err()); got != tt.want {
+				t.Fatalf("websocket Err() class = %q, want %q", got, tt.want)
+			}
+			sse := SSESummary{Reason: sseReasonErr, ErrorClass: tt.class}
+			if got := diag.ClassOf(sse.Err()); got != tt.want {
+				t.Fatalf("sse Err() class = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/protocol/httpx/stream_ws_test.go
+++ b/internal/protocol/httpx/stream_ws_test.go
@@ -41,12 +41,11 @@ func startEchoWebSocketServer(t *testing.T) (*httptest.Server, func()) {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
 			if err != nil {
-				t.Fatalf("websocket accept failed: %v", err)
+				return
 			}
+			// A hijacked connection outlives Server.Close, so the handler must not touch t.
 			defer func() {
-				if err := conn.Close(websocket.StatusNormalClosure, "bye"); err != nil {
-					t.Logf("close websocket: %v", err)
-				}
+				_ = conn.Close(websocket.StatusNormalClosure, "bye")
 			}()
 
 			ctx := r.Context()
@@ -84,12 +83,11 @@ func startSilentWebSocketServer(t *testing.T) (*httptest.Server, func()) {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
 			if err != nil {
-				t.Fatalf("websocket accept failed: %v", err)
+				return
 			}
+			// A hijacked connection outlives Server.Close, so the handler must not touch t.
 			defer func() {
-				if err := conn.Close(websocket.StatusNormalClosure, "bye"); err != nil {
-					t.Logf("close websocket: %v", err)
-				}
+				_ = conn.Close(websocket.StatusNormalClosure, "bye")
 			}()
 			<-r.Context().Done()
 		}),
@@ -817,5 +815,155 @@ loop:
 	case <-session.Done():
 	case <-time.After(2 * time.Second):
 		t.Fatal("session did not terminate after close")
+	}
+}
+
+func startClosingWebSocketServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := httptest.NewUnstartedServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+			if err != nil {
+				return
+			}
+			typ, data, err := conn.Read(r.Context())
+			if err != nil {
+				return
+			}
+			if err := conn.Write(r.Context(), typ, data); err != nil {
+				return
+			}
+			_ = conn.Close(websocket.StatusGoingAway, "server going away")
+		}),
+	)
+	srv.Listener = ln
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func wsTranscript(t *testing.T, resp *Response) WebSocketTranscript {
+	t.Helper()
+	if resp == nil {
+		t.Fatal("no response to read a transcript from")
+	}
+	transcript, err := DecodeWebSocketTranscript(resp.Body)
+	if err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+	return *transcript
+}
+
+func wsSent(transcript WebSocketTranscript, text string) bool {
+	return slices.ContainsFunc(transcript.Events, func(evt WebSocketEvent) bool {
+		return evt.Direction == "send" && evt.Text == text
+	})
+}
+
+func TestCompleteWebSocketKeepsTheTranscriptWhenTheServerClosesMidScript(t *testing.T) {
+	server := startClosingWebSocketServer(t)
+
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    strings.Replace(server.URL, "http", "ws", 1) + "/ws",
+		WebSocket: &restfile.WebSocketRequest{
+			Steps: []restfile.WebSocketStep{
+				{Type: restfile.WebSocketStepSendText, Value: "hello"},
+				{Type: restfile.WebSocketStepWait, Duration: 5 * time.Second},
+				{Type: restfile.WebSocketStepSendText, Value: "never sent"},
+			},
+		},
+	}
+
+	resp, err := NewClient(nil).ExecuteWebSocket(t.Context(), req, nil, Options{})
+	if err != nil {
+		t.Fatalf("a server closing mid-script failed the request: %v", err)
+	}
+
+	transcript := wsTranscript(t, resp)
+	if err := transcript.Summary.Err(); err != nil {
+		t.Fatalf("a normal server close ended as a stream failure: %v", err)
+	}
+	if transcript.Summary.ClosedBy != wsClosedByServer {
+		t.Fatalf("closedBy = %q, want %q", transcript.Summary.ClosedBy, wsClosedByServer)
+	}
+	if !wsSent(transcript, "hello") {
+		t.Fatalf("the transcript lost the frames sent before the close: %+v", transcript.Events)
+	}
+}
+
+func TestCompleteWebSocketReportsAStepFailureInTheSummary(t *testing.T) {
+	server, cleanup := startEchoWebSocketServer(t)
+	defer cleanup()
+
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    strings.Replace(server.URL, "http", "ws", 1) + "/ws",
+		WebSocket: &restfile.WebSocketRequest{
+			Steps: []restfile.WebSocketStep{
+				{Type: restfile.WebSocketStepSendText, Value: "hello"},
+				{Type: restfile.WebSocketStepSendFile, File: "no-such-payload.bin"},
+			},
+		},
+	}
+
+	resp, err := NewClient(nil).ExecuteWebSocket(t.Context(), req, nil, Options{BaseDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("a failed step returned before the transcript was built: %v", err)
+	}
+
+	transcript := wsTranscript(t, resp)
+	if transcript.Summary.ClosedBy != wsClosedByError {
+		t.Fatalf("closedBy = %q, want %q", transcript.Summary.ClosedBy, wsClosedByError)
+	}
+	if !strings.Contains(transcript.Summary.CloseReason, "step 2:send_file") ||
+		!strings.Contains(transcript.Summary.CloseReason, "websocket payload file") {
+		t.Fatalf("closeReason = %q, want the step and why it failed", transcript.Summary.CloseReason)
+	}
+	if err := transcript.Summary.Err(); err == nil {
+		t.Fatal("Err() = nil, want the failure to fail the request")
+	}
+	if !wsSent(transcript, "hello") {
+		t.Fatalf("the transcript lost the frames sent before the failure: %+v", transcript.Events)
+	}
+}
+
+func TestCompleteWebSocketNamesACancelledRunAndKeepsTheTranscript(t *testing.T) {
+	server, cleanup := startEchoWebSocketServer(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    strings.Replace(server.URL, "http", "ws", 1) + "/ws",
+		WebSocket: &restfile.WebSocketRequest{
+			Steps: []restfile.WebSocketStep{
+				{Type: restfile.WebSocketStepSendText, Value: "hello"},
+				{Type: restfile.WebSocketStepWait, Duration: 5 * time.Second},
+			},
+		},
+	}
+
+	time.AfterFunc(300*time.Millisecond, cancel)
+	resp, err := NewClient(nil).ExecuteWebSocket(ctx, req, nil, Options{})
+	if err != nil {
+		t.Fatalf("a cancelled run returned before the transcript was built: %v", err)
+	}
+
+	transcript := wsTranscript(t, resp)
+	if transcript.Summary.ClosedBy != wsClosedByCanceled {
+		t.Fatalf("closedBy = %q, want %q", transcript.Summary.ClosedBy, wsClosedByCanceled)
+	}
+	if !slices.Contains(diag.Classes(transcript.Summary.Err()), diag.ClassCanceled) {
+		t.Fatalf("Err() = %v, want a cancelled run", transcript.Summary.Err())
+	}
+	if !wsSent(transcript, "hello") {
+		t.Fatalf("the transcript lost the frames sent before the cancel: %+v", transcript.Events)
 	}
 }

--- a/internal/runner/report_fmt_test.go
+++ b/internal/runner/report_fmt_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"errors"
 	"net"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/history"
 	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/runx/fail"
 	"github.com/unkn0wn-root/resterm/internal/scripts"
 	"google.golang.org/grpc/codes"
@@ -320,6 +322,16 @@ func TestStreamFailureKeepsItsExitCode(t *testing.T) {
 			code: runfail.CodeProtocol,
 			exit: runfail.ExitProtocol,
 		},
+		{
+			name: "a deadline the caller set",
+			sum: httpx.WebSocketSummary{
+				ClosedBy:    "timeout",
+				CloseReason: "context deadline exceeded",
+				ErrorClass:  diag.ClassTimeout,
+			},
+			code: runfail.CodeTimeout,
+			exit: runfail.ExitTimeout,
+		},
 	}
 
 	for _, tt := range tests {
@@ -334,5 +346,51 @@ func TestStreamFailureKeepsItsExitCode(t *testing.T) {
 				t.Fatalf("source = %q, want %q", got.Source, "stream")
 			}
 		})
+	}
+}
+
+func TestWebSocketHandshakeTimeoutExitCode(t *testing.T) {
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	req := &restfile.Request{
+		Method: http.MethodGet,
+		URL:    "ws://" + ln.Addr().String() + "/ws",
+		WebSocket: &restfile.WebSocketRequest{
+			Options: restfile.WebSocketOptions{HandshakeTimeout: 200 * time.Millisecond},
+		},
+	}
+	_, _, err = httpx.NewClient(nil).StartWebSocket(t.Context(), req, nil, httpx.Options{})
+
+	got := resultFailure(Result{Err: err})
+	if got.Code != runfail.CodeTimeout || got.ExitCode != runfail.ExitTimeout {
+		t.Fatalf("failure = %s/%d, want %s/%d",
+			got.Code, got.ExitCode, runfail.CodeTimeout, runfail.ExitTimeout)
+	}
+}
+
+func TestReachedStreamLimitIsNotAFailure(t *testing.T) {
+	sums := []httpx.WebSocketSummary{
+		{ClosedBy: "timeout", CloseReason: "idle timeout after 5s"},
+		{ClosedBy: "server", CloseReason: "bye"},
+		{ClosedBy: "client"},
+	}
+
+	for _, sum := range sums {
+		if err := sum.Err(); err != nil {
+			t.Fatalf("closedBy %q ended as a failure: %v", sum.ClosedBy, err)
+		}
 	}
 }

--- a/internal/runner/report_fmt_test.go
+++ b/internal/runner/report_fmt_test.go
@@ -274,3 +274,65 @@ func TestFormatStreamCarriesTheFailure(t *testing.T) {
 		t.Fatalf("Error = %q, want a complete transcript to report none", plain.Error)
 	}
 }
+
+// A stream carries its failure as text, so the class it recorded is what sets
+// the reported failure and the exit code.
+func TestStreamFailureKeepsItsExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		sum  httpx.WebSocketSummary
+		code runfail.Code
+		exit int
+	}{
+		{
+			name: "unreadable payload file",
+			sum: httpx.WebSocketSummary{
+				ClosedBy:    "error",
+				CloseReason: "websocket step 2:send_file: open payload.bin: no such file",
+				ErrorClass:  diag.ClassFilesystem,
+			},
+			code: runfail.CodeFilesystem,
+			exit: runfail.ExitFilesystem,
+		},
+		{
+			name: "broken frame",
+			sum: httpx.WebSocketSummary{
+				ClosedBy:    "error",
+				CloseReason: "read websocket message: bad frame",
+				ErrorClass:  diag.ClassProtocol,
+			},
+			code: runfail.CodeProtocol,
+			exit: runfail.ExitProtocol,
+		},
+		{
+			name: "connection dropped",
+			sum: httpx.WebSocketSummary{
+				ClosedBy:    "error",
+				CloseReason: "read websocket message: connection reset by peer",
+				ErrorClass:  diag.ClassNetwork,
+			},
+			code: runfail.CodeNetwork,
+			exit: runfail.ExitNetwork,
+		},
+		{
+			name: "a transcript with no class",
+			sum:  httpx.WebSocketSummary{ClosedBy: "error", CloseReason: "something broke"},
+			code: runfail.CodeProtocol,
+			exit: runfail.ExitProtocol,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Result{Stream: &StreamInfo{Kind: "websocket", Err: tt.sum.Err()}}
+
+			got := resultFailure(res)
+			if got.Code != tt.code || got.ExitCode != tt.exit {
+				t.Fatalf("failure = %s/%d, want %s/%d", got.Code, got.ExitCode, tt.code, tt.exit)
+			}
+			if got.Source != "stream" {
+				t.Fatalf("source = %q, want %q", got.Source, "stream")
+			}
+		})
+	}
+}

--- a/internal/stream/event.go
+++ b/internal/stream/event.go
@@ -58,6 +58,7 @@ func (e *Event) Size() int64 {
 }
 
 type SSEMetadata struct {
+	Index   int
 	Name    string
 	ID      string
 	Comment string


### PR DESCRIPTION
This PR hardens stream failure handling, URL origin checks, and byte-limit arithmetic.

### Changes

- Preserve partial SSE and WebSocket transcripts when a stream fails. Events and frames collected before the failure remain available to the UI, scripts, history, and headless reports.
- Preserve the original failure class through stream transcripts. For example, a missing `@ws send-file` payload reports filesystem with detailed exit code 25, instead of protocol/26.
- Distinguish configured stream limits from caller deadlines. Idle and duration limits remain normal endings, while expired caller deadlines report timeout/20.
- Include stream errors in headless reports and expose the optional errorClass summary field.
- Format IPv6 origins with brackets and escaped zone identifiers.
- Compare IPv6 zone identifiers exactly, preventing redirects between differently cased interface zones from being treated as the same origin.
- Use saturating byte-size arithmetic so limits near math.MaxInt64 cannot wrap into negative values.

Existing request syntax is unchanged. Stream summaries gain the optional errorClass field, and headless stream reports gain Error.