### PR TITLE
RST-347: Improve comment highlighting and header

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2516,7 +2516,7 @@ The segmented bottom bar uses `[status_bar]` for section backgrounds and text co
 Setting `editor_metadata.directive_default` recolours every built-in directive (`@name`, `@tag`, etc.) that still uses the inherited default. Specify entries inside `[editor_metadata.directive_colors]` only when you need a directive to diverge from that default.
 
 Set `editor_metadata.request_line` to recolour the full request line (`POST https://…`). If you omit it, Resterm falls back to the directive default.
-Use `editor_metadata.request_separator` for the `###` section dividers and `editor_metadata.comment_marker` for the `#` / `//` prefixes at the start of comment lines.
+Use `editor_metadata.request_separator` for the `###` section dividers. `editor_metadata.comment_marker` colours ordinary `#`, `//`, `--`, and `/* … */` comments. Directive names and values keep their metadata colours. Comment markers inside multipart bodies, mock responses, and script blocks are treated as data and are not coloured.
 
 `styles.stream_*` keys control the transcript viewer (events, timestamps, direction badges). `styles.stream_console_*` tweak the interactive WebSocket console (prompt, status line, input field).
 

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -34,30 +34,12 @@ type strictAliasState struct {
 	conflict bool
 }
 
-type exprScanner struct {
-	s   string
-	i   int
+type quoteScan struct {
 	q   byte
 	esc bool
 }
 
-func newExprScanner(s string) *exprScanner {
-	return &exprScanner{s: s}
-}
-
-func (sc *exprScanner) done() bool {
-	return sc.i >= len(sc.s)
-}
-
-func (sc *exprScanner) ch() byte {
-	return sc.s[sc.i]
-}
-
-func (sc *exprScanner) advance(n int) {
-	sc.i += n
-}
-
-func (sc *exprScanner) inQuoted(ch byte) bool {
+func (sc *quoteScan) inQuoted(ch byte) bool {
 	if sc.q == 0 {
 		return false
 	}
@@ -75,12 +57,34 @@ func (sc *exprScanner) inQuoted(ch byte) bool {
 	return true
 }
 
-func (sc *exprScanner) openQuote(ch byte) bool {
+func (sc *quoteScan) openQuote(ch byte) bool {
 	if !isQuote(ch) {
 		return false
 	}
 	sc.q = ch
 	return true
+}
+
+type exprScanner struct {
+	quoteScan
+	s string
+	i int
+}
+
+func newExprScanner(s string) *exprScanner {
+	return &exprScanner{s: s}
+}
+
+func (sc *exprScanner) done() bool {
+	return sc.i >= len(sc.s)
+}
+
+func (sc *exprScanner) ch() byte {
+	return sc.s[sc.i]
+}
+
+func (sc *exprScanner) advance(n int) {
+	sc.i += n
 }
 
 func HasUnquotedTemplateMarker(ex string) bool {
@@ -109,6 +113,76 @@ type templateScan struct {
 	rem  string // the text left once the closed markers are cut out
 	has  bool   // a marker closed
 	open bool   // the last marker never closed
+}
+
+type TemplateState uint8
+
+const (
+	TemplateNone TemplateState = iota
+	TemplateClosed
+	TemplateOpen
+)
+
+type TemplateScanner struct {
+	quoteScan
+	pendingOpen  bool
+	pendingClose bool
+	open         bool
+	closed       bool
+}
+
+func (s *TemplateScanner) Feed(src string) {
+	for i := range len(src) {
+		s.feedByte(src[i])
+	}
+}
+
+func (s *TemplateScanner) State() TemplateState {
+	if s.open {
+		return TemplateOpen
+	}
+	if s.closed {
+		return TemplateClosed
+	}
+	return TemplateNone
+}
+
+func (s *TemplateScanner) feedByte(ch byte) {
+	if s.open {
+		s.feedMarkerByte(ch)
+		return
+	}
+	if s.inQuoted(ch) {
+		return
+	}
+	// Clear a pending "{" before a quote starts.
+	if s.pendingOpen {
+		s.pendingOpen = false
+		if ch == '{' {
+			s.open = true
+			return
+		}
+	}
+	if s.openQuote(ch) {
+		return
+	}
+	if ch == '{' {
+		s.pendingOpen = true
+	}
+}
+
+func (s *TemplateScanner) feedMarkerByte(ch byte) {
+	if s.pendingClose {
+		s.pendingClose = false
+		if ch == '}' {
+			s.open = false
+			s.closed = true
+			return
+		}
+	}
+	if ch == '}' {
+		s.pendingClose = true
+	}
 }
 
 // scanTemplates ignores markers inside quoted RTS strings.

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -105,6 +105,41 @@ func TestOpenMarker(t *testing.T) {
 	}
 }
 
+func TestTemplateScannerMatchesBatchScanAtEveryChunkBoundary(t *testing.T) {
+	inputs := []string{
+		`response.json.token`,
+		`Bearer {{token}}`,
+		`Bearer {{token`,
+		`{{a}} and {{b`,
+		`contains(response.text(), "{{token")`,
+		"contains(\"escaped\\\n{{token}}\")",
+		"{{\n response.status\n}}",
+		`{{a}"{{b}}"{{c}}`,
+	}
+
+	for _, input := range inputs {
+		for cut := range len(input) + 1 {
+			var scanner TemplateScanner
+			scanner.Feed(input[:cut])
+			scanner.Feed(input[cut:])
+			if got, want := scanner.State(), templateState(input); got != want {
+				t.Fatalf("chunks [%q, %q] have state %d, whole read gives %d", input[:cut], input[cut:], got, want)
+			}
+		}
+	}
+}
+
+func templateState(input string) TemplateState {
+	scan := scanTemplates(input)
+	if scan.open {
+		return TemplateOpen
+	}
+	if scan.has {
+		return TemplateClosed
+	}
+	return TemplateNone
+}
+
 func TestMixedTemplateRTSCall(t *testing.T) {
 	if !MixedTemplateRTSCall(`contains({{name}}, "x")`) {
 		t.Fatalf("expected mixed template+call form to be detected")

--- a/internal/directive/lexer.go
+++ b/internal/directive/lexer.go
@@ -25,18 +25,32 @@ type lexer struct {
 	pos     int
 	escapes bool
 
-	tok     strings.Builder
+	tok   strings.Builder
+	begun bool
+	start int
+	field fieldScan
+}
+
+type fieldScan struct {
+	written bool
 	last    rune
 	quote   rune
 	escaped bool
-	begun   bool
-	start   int
 	// closers holds the brackets still waiting to be matched, outermost first.
 	closers  []rune
 	inString bool
 	strEsc   bool
 	state    nameState
 }
+
+type fieldStep uint8
+
+const (
+	fieldSkip fieldStep = iota
+	fieldKeep
+	fieldEscaped
+	fieldEnd
+)
 
 // nameState tracks how much of the token still reads as a name, which is what
 // tells an argument list from a value that merely holds a parenthesis.
@@ -73,44 +87,21 @@ func (l *lexer) next() (token, bool) {
 			l.begun = true
 			l.start = base + i
 		}
-		switch {
-		case len(l.closers) > 0:
-			l.group(r)
-		case l.escaped:
-			l.escaped = false
-			// Anything else inside quotes keeps the backslash it was typed with,
-			// so paths do not get mangled.
-			if l.quote != 0 && r != l.quote && r != '\\' {
-				l.write('\\')
-			}
-			l.write(r)
-		case l.escapes && r == '\\':
-			l.escaped = true
-		case l.quote != 0:
-			if r == l.quote {
-				l.quote = 0
-				break
-			}
-			l.write(r)
-		case l.opens(r):
-			l.write(r)
-			l.push(r)
-		case (r == '"' || r == '\'') && l.startsValue():
-			l.quote = r
-		case unicode.IsSpace(r):
-			if l.tok.Len() > 0 {
-				l.pos = base + i + utf8.RuneLen(r)
-				return token{val: l.tok.String(), start: l.start, end: base + i}, true
-			}
-		default:
-			l.name(r)
-			l.write(r)
+		switch l.field.feed(r, l.escapes) {
+		case fieldEscaped:
+			l.tok.WriteRune('\\')
+			l.tok.WriteRune(r)
+		case fieldKeep:
+			l.tok.WriteRune(r)
+		case fieldEnd:
+			l.pos = base + i + utf8.RuneLen(r)
+			return token{val: l.tok.String(), start: l.start, end: base + i}, true
 		}
 	}
 
 	l.pos = len(l.src)
-	if l.escaped {
-		l.write('\\')
+	if l.field.escaped {
+		l.tok.WriteRune('\\')
 	}
 	if l.tok.Len() == 0 {
 		return token{}, false
@@ -120,69 +111,125 @@ func (l *lexer) next() (token, bool) {
 
 func (l *lexer) reset() {
 	l.tok.Reset()
-	l.last = 0
-	l.quote = 0
-	l.escaped = false
 	l.begun = false
-	l.closers = l.closers[:0]
-	l.inString = false
-	l.strEsc = false
-	l.state = inKey
+	l.field.reset()
 }
 
-func (l *lexer) write(r rune) {
-	l.tok.WriteRune(r)
-	l.last = r
+func (f *fieldScan) feed(r rune, escapes bool) fieldStep {
+	switch {
+	case len(f.closers) > 0:
+		f.group(r)
+		return fieldKeep
+	case f.escaped:
+		f.escaped = false
+		// Preserve backslashes that do not escape the quote or another backslash.
+		if f.quote != 0 && r != f.quote && r != '\\' {
+			f.write('\\')
+			f.write(r)
+			return fieldEscaped
+		}
+		f.write(r)
+		return fieldKeep
+	case escapes && r == '\\':
+		f.escaped = true
+		return fieldSkip
+	case f.quote != 0:
+		if r == f.quote {
+			f.quote = 0
+			return fieldSkip
+		}
+		f.write(r)
+		return fieldKeep
+	case f.opens(r):
+		f.write(r)
+		f.push(r)
+		return fieldKeep
+	case (r == '"' || r == '\'') && f.startsValue():
+		f.quote = r
+		return fieldSkip
+	case unicode.IsSpace(r):
+		if f.written {
+			return fieldEnd
+		}
+		return fieldSkip
+	default:
+		f.name(r)
+		f.write(r)
+		return fieldKeep
+	}
+}
+
+func (f *fieldScan) reset() {
+	f.written = false
+	f.last = 0
+	f.quote = 0
+	f.escaped = false
+	f.closers = f.closers[:0]
+	f.inString = false
+	f.strEsc = false
+	f.state = inKey
+}
+
+func (f *fieldScan) write(r rune) {
+	f.written = true
+	f.last = r
+}
+
+func (f *fieldScan) closer() rune {
+	if n := len(f.closers); n > 0 {
+		return f.closers[n-1]
+	}
+	return f.quote
 }
 
 // A value opens a group when a bracket follows the equals sign, or when an
 // argument list follows a name: headers={"a":"b"} and latency=random(1s,2s).
-func (l *lexer) opens(r rune) bool {
+func (f *fieldScan) opens(r rune) bool {
 	switch r {
 	case '[', '{':
-		return l.last == '='
+		return f.last == '='
 	case '(':
-		return l.state == inName && l.last != '='
+		return f.state == inName && f.last != '='
 	}
 	return false
 }
 
-func (l *lexer) name(r rune) {
+func (f *fieldScan) name(r rune) {
 	switch {
-	case l.state == inKey:
-		if r == '=' && l.tok.Len() > 0 {
-			l.state = inName
+	case f.state == inKey:
+		if r == '=' && f.written {
+			f.state = inName
 		}
-	case l.state == inName && !IsKeyRune(r):
-		l.state = inText
+	case f.state == inName && !IsKeyRune(r):
+		f.state = inText
 	}
 }
 
 // A quote groups a value when it opens the token or follows the equals sign.
-func (l *lexer) startsValue() bool {
-	return l.tok.Len() == 0 || l.last == '='
+func (f *fieldScan) startsValue() bool {
+	return !f.written || f.last == '='
 }
 
 // Delimiters inside JSON strings are ordinary characters. Outside strings we
 // track nesting, but leave mismatched ones for the value parser to reject.
-func (l *lexer) group(r rune) {
-	l.write(r)
+func (f *fieldScan) group(r rune) {
+	f.write(r)
 	switch {
-	case l.inString:
+	case f.inString:
 		switch {
-		case l.strEsc:
-			l.strEsc = false
+		case f.strEsc:
+			f.strEsc = false
 		case r == '\\':
-			l.strEsc = true
+			f.strEsc = true
 		case r == '"':
-			l.inString = false
+			f.inString = false
 		}
 	case r == '"':
-		l.inString = true
+		f.inString = true
 	case isOpener(r):
-		l.push(r)
+		f.push(r)
 	default:
-		l.pop(r)
+		f.pop(r)
 	}
 }
 
@@ -190,19 +237,19 @@ func isOpener(r rune) bool {
 	return r == '[' || r == '{' || r == '('
 }
 
-func (l *lexer) push(r rune) {
+func (f *fieldScan) push(r rune) {
 	switch r {
 	case '[':
-		l.closers = append(l.closers, ']')
+		f.closers = append(f.closers, ']')
 	case '{':
-		l.closers = append(l.closers, '}')
+		f.closers = append(f.closers, '}')
 	case '(':
-		l.closers = append(l.closers, ')')
+		f.closers = append(f.closers, ')')
 	}
 }
 
-func (l *lexer) pop(r rune) {
-	if n := len(l.closers); n > 0 && l.closers[n-1] == r {
-		l.closers = l.closers[:n-1]
+func (f *fieldScan) pop(r rune) {
+	if n := len(f.closers); n > 0 && f.closers[n-1] == r {
+		f.closers = f.closers[:n-1]
 	}
 }

--- a/internal/directive/option.go
+++ b/internal/directive/option.go
@@ -59,14 +59,7 @@ func OptionsOpen(input string) rune {
 	lex := &lexer{src: input, escapes: true}
 	var closer rune
 	for _, ok := lex.next(); ok; _, ok = lex.next() {
-		switch {
-		case len(lex.closers) > 0:
-			closer = lex.closers[len(lex.closers)-1]
-		case lex.quote != 0:
-			closer = lex.quote
-		default:
-			closer = 0
-		}
+		closer = lex.field.closer()
 	}
 	return closer
 }

--- a/internal/directive/option_scan.go
+++ b/internal/directive/option_scan.go
@@ -1,0 +1,37 @@
+package directive
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+type OptionsScanner struct {
+	field fieldScan
+	tail  string
+}
+
+func (s *OptionsScanner) Feed(src string) {
+	if s.tail != "" {
+		src = s.tail + src
+		s.tail = ""
+	}
+
+	for len(src) > 0 {
+		if !utf8.FullRuneInString(src) {
+			s.tail = strings.Clone(src)
+			return
+		}
+		r, size := utf8.DecodeRuneInString(src)
+		if s.field.feed(r, true) == fieldEnd {
+			s.field.reset()
+		}
+		src = src[size:]
+	}
+}
+
+func (s *OptionsScanner) Closer() rune {
+	if !s.field.written && !s.field.escaped && s.tail == "" {
+		return 0
+	}
+	return s.field.closer()
+}

--- a/internal/directive/option_test.go
+++ b/internal/directive/option_test.go
@@ -548,6 +548,31 @@ func TestOptionsOpen(t *testing.T) {
 	}
 }
 
+func TestOptionsScannerMatchesOptionsOpenAtEveryChunkBoundary(t *testing.T) {
+	inputs := []string{
+		`json={"a":{"b":[1, 2]}} regex="^v[0-9]+$"`,
+		`json={"a":"\\\"}"}`,
+		`regex="first\nsecond"`,
+		"one=true\u2003json={\"a\": 1}",
+		`latency=random(1s, 2s)`,
+		`json={ headers={"X":"y"}`,
+		`regex="unfinished\\`,
+		`json={"a": 1}	"`,
+		"\"\xe2\x80",
+	}
+
+	for _, input := range inputs {
+		for cut := range len(input) + 1 {
+			var scan OptionsScanner
+			scan.Feed(input[:cut])
+			scan.Feed(input[cut:])
+			if got, want := scan.Closer(), OptionsOpen(input); got != want {
+				t.Fatalf("chunks [%q, %q] closed with %q, whole read gives %q", input[:cut], input[cut:], got, want)
+			}
+		}
+	}
+}
+
 // Options only ever fill through put, so tests see what a directive would store.
 func testOptions(vals map[string]string) Options {
 	opts := newOptions(len(vals))

--- a/internal/engine/headless/repeat_test.go
+++ b/internal/engine/headless/repeat_test.go
@@ -77,7 +77,13 @@ GET https://example.com/jobs/123
 			History:     history,
 		})
 		t.Cleanup(func() { _ = eng.Close() })
-		if seed, err := eng.ExecuteRequestContext(t.Context(), doc, doc.Requests[0], testSelection("")); err != nil || seed.Err != nil {
+		if seed, err := eng.ExecuteRequestContext(
+			t.Context(),
+			doc,
+			doc.Requests[0],
+			testSelection(""),
+		); err != nil ||
+			seed.Err != nil {
 			t.Fatalf("seed request = err %v, result error %v", err, seed.Err)
 		}
 		result, err := eng.ExecuteRequestContext(t.Context(), doc, doc.Requests[1], testSelection(""))
@@ -119,7 +125,10 @@ func TestExecuteRequestRejectsNonBooleanPollPredicate(t *testing.T) {
 			}, nil
 		})}, nil
 	})
-	doc := parser.Parse("jobs.http", []byte("# @poll timeout=1s until=response.json().status\nGET https://example.com/jobs/123\n"))
+	doc := parser.Parse(
+		"jobs.http",
+		[]byte("# @poll timeout=1s until=response.json().status\nGET https://example.com/jobs/123\n"),
+	)
 	if err := parser.Check(doc); err != nil {
 		t.Fatalf("parse request: %v", err)
 	}

--- a/internal/parser/comment.go
+++ b/internal/parser/comment.go
@@ -12,38 +12,26 @@ func (b *documentBuilder) handleComment(no, baseCol int, text string) {
 }
 
 func (b *documentBuilder) handleBlockComment(ln line) bool {
-	if b.inBlock {
-		content, closed := parseBlockCommentLine(ln.text)
-		if content != "" {
-			b.handleComment(ln.no, 0, content)
-		}
-		b.appendLine(ln.raw)
-		if closed {
-			b.inBlock = false
-		}
-		return true
+	opening := !b.inBlock
+	if opening && !ln.isBlockCommentStart() {
+		return false
 	}
 
-	if ln.isBlockCommentStart() {
-		content, closed := cutBlockCommentStart(ln.text)
-		if content != "" {
-			b.handleComment(ln.no, 0, content)
-		}
-		b.appendLine(ln.raw)
-		if !closed {
-			b.inBlock = true
-		}
-		return true
+	c, closed := ln.blockComment(opening)
+	if c.text != "" {
+		b.handleComment(ln.no, 0, c.text)
 	}
-	return false
+	b.appendLine(ln.raw)
+	b.inBlock = !closed
+	return true
 }
 
 func (b *documentBuilder) handleCommentLine(ln line) bool {
-	text, col, ok := ln.comment()
+	c, ok := ln.comment()
 	if !ok {
 		return false
 	}
-	b.handleComment(ln.no, col, text)
+	b.handleComment(ln.no, c.col(), c.text)
 	b.appendLine(ln.raw)
 	return true
 }

--- a/internal/parser/continuation.go
+++ b/internal/parser/continuation.go
@@ -51,6 +51,7 @@ type directiveReadKind uint8
 
 const (
 	directiveReadNone directiveReadKind = iota
+	directiveReadMark                   // Bare @ typed before a directive name.
 	directiveReadStarted
 	directiveReadContinued
 	directiveReadCompleted
@@ -112,6 +113,9 @@ func (r *directiveReader) read(no, col int, text string) directiveReadResult {
 		return r.readNew(no, col, call, cut)
 	}
 	if !parsed {
+		if text == "@" {
+			return directiveReadResult{kind: directiveReadMark}
+		}
 		return directiveReadResult{}
 	}
 	return r.readNew(no, col, call, nil)

--- a/internal/parser/continuation.go
+++ b/internal/parser/continuation.go
@@ -12,53 +12,167 @@ import (
 type openDirective struct {
 	d      parsedDirective
 	closer string
+	args   strings.Builder
+	state  continuationState
 }
 
-func (b *documentBuilder) readDirective(no, col int, text string) (parsedDirective, bool) {
-	call, ok := directive.Parse(text)
-	if b.open != nil {
-		// A known directive ends the current one instead of becoming its argument.
-		if !ok || !call.Name.Known() {
-			return b.growDirective(no, col, text)
+func (o *openDirective) write(text string) {
+	o.args.WriteString(text)
+	o.state.feed(text)
+}
+
+func (o *openDirective) add(col int, text string) {
+	padding := max(col-1, 0)
+	if padding == 0 {
+		switch o.d.Name.Continuation() {
+		case directive.ContinueExpr, directive.ContinueCapture:
+			// Expression columns include one byte for the missing comment marker.
+			padding = 1
 		}
-		b.failOpenDirective()
 	}
-	if !ok {
+	o.write("\n")
+	if padding > 0 {
+		o.write(strings.Repeat(" ", padding))
+	}
+	o.write(text)
+}
+
+func (o *openDirective) collect() string {
+	o.d.Args = o.args.String()
+	return o.d.Args
+}
+
+// Parsing and editor highlighting share this reader for multiline directives.
+type directiveReader struct {
+	open *openDirective
+}
+
+type directiveReadKind uint8
+
+const (
+	directiveReadNone directiveReadKind = iota
+	directiveReadStarted
+	directiveReadContinued
+	directiveReadCompleted
+	directiveReadContinuationCompleted
+)
+
+type directiveReadResult struct {
+	kind      directiveReadKind
+	directive parsedDirective
+	owner     directive.Name
+	cut       *openDirective
+}
+
+func (r directiveReadResult) completed() (parsedDirective, bool) {
+	switch r.kind {
+	case directiveReadCompleted, directiveReadContinuationCompleted:
+		return r.directive, true
+	default:
 		return parsedDirective{}, false
 	}
+}
 
+func (r *directiveReader) pending() (directive.Name, bool) {
+	if r.open == nil {
+		return "", false
+	}
+	return r.open.d.Name, true
+}
+
+func (r *directiveReader) abandon() *openDirective {
+	o := r.open
+	if o == nil {
+		return nil
+	}
+	r.open = nil
+	if closer := openCloser(o.d.Name, o.collect()); closer != "" {
+		o.closer = closer
+	}
+	return o
+}
+
+func (r *directiveReader) read(no, col int, text string) directiveReadResult {
+	call, parsed := directive.Parse(text)
+	if r.open != nil {
+		// A known directive ends the unfinished directive.
+		if !parsed || !call.Name.Known() {
+			owner := r.open.d.Name
+			d, done := r.grow(no, col, text)
+			if done {
+				return directiveReadResult{
+					kind:      directiveReadContinuationCompleted,
+					directive: d,
+					owner:     owner,
+				}
+			}
+			return directiveReadResult{kind: directiveReadContinued, owner: owner}
+		}
+		cut := r.abandon()
+		return r.readNew(no, col, call, cut)
+	}
+	if !parsed {
+		return directiveReadResult{}
+	}
+	return r.readNew(no, col, call, nil)
+}
+
+func (r *directiveReader) readNew(no, col int, call directive.Call, cut *openDirective) directiveReadResult {
 	d := parsedDirective{Call: call, lines: restfile.LineRange{Start: no, End: no}}
 	if col > 0 {
 		d.argCol = col + call.ArgOffset
 	}
 	if closer := openCloser(d.Name, d.Args); closer != "" {
-		b.open = &openDirective{d: d, closer: closer}
-		return parsedDirective{}, false
-	}
-	return d, true
-}
-
-func (b *documentBuilder) growDirective(no, col int, text string) (parsedDirective, bool) {
-	o := b.open
-	o.d.lines.End = no
-	// Preserve newlines and indentation so diagnostics keep their source positions.
-	padding := max(col-1, 0)
-	if padding == 0 {
-		switch o.d.Name.Continuation() {
-		case directive.ContinueExpr, directive.ContinueCapture:
-			// The writer replaces one leading padding byte with its "#" marker.
-			// These grammars ignore that whitespace, so keep their model stable.
-			padding = 1
+		o := &openDirective{d: d, closer: closer}
+		o.args.WriteString(d.Args)
+		o.state = newContinuationState(d.Name, d.Args)
+		r.open = o
+		return directiveReadResult{
+			kind:  directiveReadStarted,
+			owner: d.Name,
+			cut:   cut,
 		}
 	}
-	o.d.Args += "\n" + strings.Repeat(" ", padding) + text
+	return directiveReadResult{
+		kind:      directiveReadCompleted,
+		directive: d,
+		owner:     d.Name,
+		cut:       cut,
+	}
+}
 
-	if closer := openCloser(o.d.Name, o.d.Args); closer != "" {
-		o.closer = closer
+func (r *directiveReader) grow(no, col int, text string) (parsedDirective, bool) {
+	o := r.open
+	o.d.lines.End = no
+	o.add(col, text)
+
+	if !o.state.mayComplete() {
 		return parsedDirective{}, false
 	}
-	b.open = nil
+	if closer := openCloser(o.d.Name, o.collect()); closer != "" {
+		o.closer = closer
+		// The full parse found more input to collect, so rebuild the scan state.
+		o.state = newContinuationState(o.d.Name, o.d.Args)
+		return parsedDirective{}, false
+	}
+	r.open = nil
 	return o.d, true
+}
+
+// Only comments can continue an argument. A separator always ends it.
+func (r *directiveReader) close(ln line, inBlock bool) *openDirective {
+	if r.open == nil || inBlock || (!ln.isSeparator() && ln.isComment()) {
+		return nil
+	}
+	return r.abandon()
+}
+
+func (b *documentBuilder) readDirective(no, col int, text string) (parsedDirective, bool) {
+	result := b.reader.read(no, col, text)
+	if result.cut != nil {
+		b.failOpenDirective(result.cut)
+	}
+	return result.completed()
 }
 
 func openCloser(name directive.Name, args string) string {
@@ -96,7 +210,7 @@ func captureCloser(expr string) string {
 func argExpr(name directive.Name, args string) string {
 	switch name {
 	case directive.Assert:
-		expr, _ := splitAssert(args)
+		expr, _, _ := splitAssert(args)
 		return expr
 	case directive.Capture:
 		_, _, expr := cutCapture(args)
@@ -120,13 +234,10 @@ func argExpr(name directive.Name, args string) string {
 	}
 }
 
-// An argument continues while comment lines follow it. Every line of a block
-// comment carries one, and a ### separator ends the directive wherever it sits.
 func (b *documentBuilder) closeOpenDirective(ln line) {
-	if b.open == nil || b.inBlock || (!ln.isSeparator() && ln.isComment()) {
-		return
+	if cut := b.reader.close(ln, b.inBlock); cut != nil {
+		b.failOpenDirective(cut)
 	}
-	b.failOpenDirective()
 }
 
 func (b *documentBuilder) flushOpenLines() {
@@ -137,9 +248,7 @@ func (b *documentBuilder) flushOpenLines() {
 	}
 }
 
-func (b *documentBuilder) failOpenDirective() {
-	o := b.open
-	b.open = nil
+func (b *documentBuilder) failOpenDirective(o *openDirective) {
 	b.openLines = nil
 	err := &directive.UnclosedError{Directive: o.d.Spelling, Closer: o.closer}
 	if b.mock != nil {

--- a/internal/parser/continuation_scan.go
+++ b/internal/parser/continuation_scan.go
@@ -1,0 +1,254 @@
+package parser
+
+import (
+	"github.com/unkn0wn-root/resterm/internal/capture"
+	"github.com/unkn0wn-root/resterm/internal/directive"
+	"github.com/unkn0wn-root/resterm/internal/rts"
+)
+
+type expressionCutMode uint8
+
+const (
+	expressionCutNone expressionCutMode = iota
+	expressionCutAssert
+	expressionCutBranch
+	expressionCutForEach
+)
+
+type expressionCutAction uint8
+
+const (
+	expressionCutContinue expressionCutAction = iota
+	expressionCutRestart
+	expressionCutStop
+)
+
+type optionStartScanner struct {
+	key       int
+	invalid   bool
+	skipLogic byte
+}
+
+func (s *optionStartScanner) feed(ch, next byte) bool {
+	if s.skipLogic != 0 {
+		if ch == s.skipLogic {
+			s.skipLogic = 0
+			return false
+		}
+		s.skipLogic = 0
+	}
+
+	if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' {
+		s.key = 0
+		s.invalid = false
+		return false
+	}
+	if ch == '&' || ch == '|' {
+		if next == ch {
+			s.invalid = true
+			s.skipLogic = ch
+			return false
+		}
+		// Mask treats a lone ampersand or pipe as a field boundary.
+		s.key = 0
+		s.invalid = false
+		return false
+	}
+	if s.invalid {
+		return false
+	}
+	if directive.IsKeyRune(rune(ch)) {
+		s.key++
+		return false
+	}
+	if ch == '=' && s.key > 0 {
+		if next == '=' {
+			s.invalid = true
+			return false
+		}
+		return true
+	}
+	s.invalid = true
+	return false
+}
+
+type expressionCutScanner struct {
+	mode    expressionCutMode
+	stopped bool
+	inSeen  bool
+	last    byte
+	window  [4]byte
+	windowN int
+	option  optionStartScanner
+}
+
+func (s *expressionCutScanner) feed(ch, next byte) expressionCutAction {
+	if s.stopped {
+		return expressionCutStop
+	}
+
+	switch s.mode {
+	case expressionCutAssert:
+		cut := s.last == '=' && ch == '>'
+		s.last = ch
+		if cut {
+			s.stopped = true
+			return expressionCutStop
+		}
+	case expressionCutBranch:
+		if s.option.feed(ch, next) {
+			s.stopped = true
+			return expressionCutStop
+		}
+	case expressionCutForEach:
+		s.push(ch)
+		switch {
+		case s.hasSuffix(" as "):
+			s.stopped = true
+			return expressionCutStop
+		case !s.inSeen && s.hasSuffix(" in "):
+			s.inSeen = true
+			s.windowN = 0
+			return expressionCutRestart
+		}
+	}
+	return expressionCutContinue
+}
+
+func (s *expressionCutScanner) push(ch byte) {
+	if s.windowN < len(s.window) {
+		s.window[s.windowN] = ch
+		s.windowN++
+		return
+	}
+	copy(s.window[:], s.window[1:])
+	s.window[len(s.window)-1] = ch
+}
+
+func (s *expressionCutScanner) hasSuffix(text string) bool {
+	if s.windowN < len(text) {
+		return false
+	}
+	start := s.windowN - len(text)
+	return string(s.window[start:s.windowN]) == text
+}
+
+type expressionContinuation struct {
+	groups rts.GroupScanner
+	cut    expressionCutScanner
+}
+
+func newExpressionContinuation(name directive.Name, args string) expressionContinuation {
+	var scan expressionContinuation
+	switch name {
+	case directive.Assert:
+		scan.cut.mode = expressionCutAssert
+		expr, _, cut := splitAssert(args)
+		scan.start(expr, cut)
+	case directive.If, directive.Elif, directive.Case:
+		scan.cut.mode = expressionCutBranch
+		expr, opts := cutBranch(args)
+		scan.start(expr, opts != "")
+	case directive.ForEach:
+		scan.cut.mode = expressionCutForEach
+		expr, _, form := cutForEach(args)
+		scan.cut.inSeen = form == forEachIn
+		scan.start(expr, form == forEachAs)
+	default:
+		scan.groups.Feed(argExpr(name, args))
+	}
+	return scan
+}
+
+func (s *expressionContinuation) start(expr string, cut bool) {
+	if cut {
+		s.groups.Feed(expr)
+		s.cut.stopped = true
+		return
+	}
+	s.feed(expr)
+}
+
+func (s *expressionContinuation) feed(src string) {
+	for i := range len(src) {
+		var next byte
+		if i+1 < len(src) {
+			next = src[i+1]
+		}
+		top, ok := s.groups.ScanByte(src[i])
+		if !ok {
+			continue
+		}
+		switch s.cut.feed(top, next) {
+		case expressionCutRestart:
+			s.groups = rts.GroupScanner{}
+		case expressionCutStop:
+			return
+		}
+	}
+}
+
+type captureContinuation struct {
+	groups    rts.GroupScanner
+	templates capture.TemplateScanner
+}
+
+func (s *captureContinuation) feed(src string) {
+	s.groups.Feed(src)
+	s.templates.Feed(src)
+}
+
+func (s *captureContinuation) mayComplete() bool {
+	switch s.templates.State() {
+	case capture.TemplateOpen:
+		return false
+	case capture.TemplateClosed:
+		return true
+	default:
+		return s.groups.Closer() == 0
+	}
+}
+
+type continuationState struct {
+	mode    directive.Continuation
+	options directive.OptionsScanner
+	expr    expressionContinuation
+	capture captureContinuation
+}
+
+func newContinuationState(name directive.Name, args string) continuationState {
+	state := continuationState{mode: name.Continuation()}
+	switch state.mode {
+	case directive.ContinueOptions:
+		state.options.Feed(args)
+	case directive.ContinueExpr:
+		state.expr = newExpressionContinuation(name, args)
+	case directive.ContinueCapture:
+		state.capture.feed(argExpr(name, args))
+	}
+	return state
+}
+
+func (s *continuationState) feed(src string) {
+	switch s.mode {
+	case directive.ContinueOptions:
+		s.options.Feed(src)
+	case directive.ContinueExpr:
+		s.expr.feed(src)
+	case directive.ContinueCapture:
+		s.capture.feed(src)
+	}
+}
+
+func (s *continuationState) mayComplete() bool {
+	switch s.mode {
+	case directive.ContinueOptions:
+		return s.options.Closer() == 0
+	case directive.ContinueExpr:
+		return s.expr.groups.Closer() == 0
+	case directive.ContinueCapture:
+		return s.capture.mayComplete()
+	default:
+		return true
+	}
+}

--- a/internal/parser/continuation_test.go
+++ b/internal/parser/continuation_test.go
@@ -256,7 +256,9 @@ GET https://example.com/
 
 func TestParseBlockCommentOptionContinuationKeepsZeroPadding(t *testing.T) {
 	b := &documentBuilder{}
-	if _, ok := b.readDirective(1, 0, `@match regex="first`); ok || b.open == nil {
+	_, complete := b.readDirective(1, 0, `@match regex="first`)
+	_, pending := b.reader.pending()
+	if complete || !pending {
 		t.Fatal("expected the quoted option to remain open")
 	}
 
@@ -295,6 +297,16 @@ GET https://example.com/
 	}
 	if cap.Line != 5 || cap.Col != 26 {
 		t.Fatalf("capture position = %d:%d, want 5:26", cap.Line, cap.Col)
+	}
+}
+
+func TestParseContinuationKeepsAnEscapedRTSLineEndingInsideAString(t *testing.T) {
+	req := parseOneRequest(t, "# @when contains(\n#   \"x\\\n#   \")\nGET https://example.com/\n")
+	if req.Metadata.When == nil {
+		t.Fatal("multiline @when was not applied")
+	}
+	if got, want := req.Metadata.When.Expression, "contains(\n    \"x\\\n    \")"; got != want {
+		t.Fatalf("expression = %q, want %q", got, want)
 	}
 }
 

--- a/internal/parser/directive.go
+++ b/internal/parser/directive.go
@@ -217,7 +217,7 @@ func parseForEachSpec(rest string, line int) (*restfile.ForEachSpec, error) {
 	switch {
 	case expr == "" && name == "":
 		return nil, fmt.Errorf("@for-each expression missing")
-	case form == "":
+	case form == forEachNone:
 		return nil, fmt.Errorf("@for-each must use 'as' or 'in'")
 	case expr == "" || name == "":
 		return nil, fmt.Errorf("@for-each requires %s", form)
@@ -228,18 +228,36 @@ func parseForEachSpec(rest string, line int) (*restfile.ForEachSpec, error) {
 	return &restfile.ForEachSpec{Expression: expr, Var: name, Line: line, Col: 1}, nil
 }
 
+type forEachForm uint8
+
+const (
+	forEachNone forEachForm = iota
+	forEachAs
+	forEachIn
+)
+
+func (f forEachForm) String() string {
+	switch f {
+	case forEachAs:
+		return "'<expr> as <name>'"
+	case forEachIn:
+		return "'<name> in <expr>'"
+	}
+	return ""
+}
+
 // cutForEach ignores keywords inside strings, comments, and nested groups.
 // The as form is read from the right so the expression may contain the keyword.
-func cutForEach(rest string) (expr, name, form string) {
+func cutForEach(rest string) (expr, name string, form forEachForm) {
 	rest = strings.TrimSpace(rest)
 	mask := rts.Mask(rest)
 	if i := strings.LastIndex(mask, " as "); i >= 0 {
-		return strings.TrimSpace(rest[:i]), strings.TrimSpace(rest[i+4:]), "'<expr> as <name>'"
+		return strings.TrimSpace(rest[:i]), strings.TrimSpace(rest[i+4:]), forEachAs
 	}
 	if i := strings.Index(mask, " in "); i >= 0 {
-		return strings.TrimSpace(rest[i+4:]), strings.TrimSpace(rest[:i]), "'<name> in <expr>'"
+		return strings.TrimSpace(rest[i+4:]), strings.TrimSpace(rest[:i]), forEachIn
 	}
-	return rest, "", ""
+	return rest, "", forEachNone
 }
 
 type authDirective struct {

--- a/internal/parser/document.go
+++ b/internal/parser/document.go
@@ -21,7 +21,7 @@ type documentBuilder struct {
 	request              *requestBuilder
 	mock                 *mockBuilder
 	workflow             *workflowBuilder
-	open                 *openDirective
+	reader               directiveReader
 	openLines            []string
 	pendingTitle         string
 	file                 fileScope
@@ -228,7 +228,7 @@ func (b *documentBuilder) appendLine(raw string) {
 		b.request.originalLines = append(b.request.originalLines, raw)
 		return
 	}
-	if b.open != nil {
+	if _, open := b.reader.pending(); open {
 		b.openLines = append(b.openLines, raw)
 	}
 }
@@ -276,8 +276,8 @@ func (b *documentBuilder) flushWorkflow(line int) {
 }
 
 func (b *documentBuilder) finish() {
-	if b.open != nil {
-		b.failOpenDirective()
+	if cut := b.reader.abandon(); cut != nil {
+		b.failOpenDirective(cut)
 	}
 	b.flushMock()
 	b.flushRequest(0)

--- a/internal/parser/line.go
+++ b/internal/parser/line.go
@@ -8,14 +8,37 @@ import (
 
 // line stores the raw text, a trimmed form for matching, and its line ending.
 type line struct {
-	no   int // 1-based
-	raw  string
-	text string
-	eol  string
+	no     int // 1-based
+	raw    string
+	text   string
+	eol    string
+	indent int
 }
 
 func makeLine(no int, raw, term string) line {
-	return line{no: no, raw: raw, text: strings.TrimSpace(raw), eol: term}
+	body := str.TrimLeft(raw)
+	return line{
+		no:     no,
+		raw:    raw,
+		text:   str.TrimRight(body),
+		eol:    term,
+		indent: len(raw) - len(body),
+	}
+}
+
+type commentText struct {
+	text  string
+	start int
+	end   int
+}
+
+func (c commentText) col() int {
+	return c.start + 1
+}
+
+func (ln line) span(text string, off int) commentText {
+	start := ln.indent + off
+	return commentText{text: text, start: start, end: start + len(text)}
 }
 
 func (ln line) isSeparator() bool {
@@ -35,17 +58,16 @@ func (ln line) isComment() bool {
 	return ok
 }
 
-func (ln line) comment() (string, int, bool) {
-	text, col, ok := stripComment(ln.text)
+func (ln line) comment() (commentText, bool) {
+	text, off, ok := stripComment(ln.text)
 	if !ok {
-		return "", 0, false
+		return commentText{}, false
 	}
-	return text, strings.Index(ln.raw, ln.text) + col, true
+	return ln.span(text, off), true
 }
 
 // stripComment strips a leading //, # or -- marker. It returns the comment
-// text, the 1-based column of that text inside the input and whether the
-// input was a comment at all.
+// text and its byte offset.
 func stripComment(text string) (string, int, bool) {
 	var n int
 	switch {
@@ -58,30 +80,29 @@ func stripComment(text string) (string, int, bool) {
 	default:
 		return "", 0, false
 	}
-	body := text[n:]
-	lead := len(body) - len(strings.TrimLeft(body, " \t"))
-	return strings.TrimSpace(body), n + lead + 1, true
+	body := str.TrimLeft(text[n:])
+	return str.TrimRight(body), len(text) - len(body), true
 }
 
-// cutBlockCommentStart strips the opening "/*" and parses the remainder as a
-// block comment line.
-func cutBlockCommentStart(text string) (string, bool) {
-	return parseBlockCommentLine(strings.TrimPrefix(text, "/*"))
-}
-
-func parseBlockCommentLine(text string) (string, bool) {
-	working := text
-	closed := false
-	if idx := strings.Index(working, "*/"); idx >= 0 {
-		closed = true
-		working = working[:idx]
+func (ln line) blockComment(opening bool) (c commentText, closed bool) {
+	body := ln.text
+	off := 0
+	if opening {
+		rest := strings.TrimPrefix(body, "/*")
+		off, body = len(body)-len(rest), rest
+	}
+	if end := strings.Index(body, "*/"); end >= 0 {
+		body, closed = body[:end], true
 	}
 
-	working = strings.TrimSpace(working)
-	for strings.HasPrefix(working, "*") {
-		working = strings.TrimSpace(strings.TrimPrefix(working, "*"))
+	text := str.TrimLeft(body)
+	off += len(body) - len(text)
+	for strings.HasPrefix(text, "*") {
+		rest := str.TrimLeft(text[1:])
+		off += len(text) - len(rest)
+		text = rest
 	}
-	return working, closed
+	return ln.span(str.TrimRight(text), off), closed
 }
 
 func (ln line) isScriptBlockStart() bool {

--- a/internal/parser/metadata.go
+++ b/internal/parser/metadata.go
@@ -311,7 +311,7 @@ func cutCapture(rest string) (scope, name, expr string) {
 }
 
 func (b *documentBuilder) parseAssertDirective(rest string, line, col int) (restfile.AssertSpec, bool) {
-	expr, msg := splitAssert(rest)
+	expr, msg, _ := splitAssert(rest)
 	if expr == "" {
 		return restfile.AssertSpec{}, false
 	}
@@ -324,13 +324,13 @@ func (b *documentBuilder) parseAssertDirective(rest string, line, col int) (rest
 }
 
 // splitAssert ignores arrows inside strings, comments, and nested groups.
-func splitAssert(text string) (expr, msg string) {
+func splitAssert(text string) (expr, msg string, cut bool) {
 	s := strings.TrimSpace(text)
 	i := strings.Index(rts.Mask(s), "=>")
 	if i < 0 {
-		return s, ""
+		return s, "", false
 	}
-	return strings.TrimSpace(s[:i]), directive.TrimQuotes(strings.TrimSpace(s[i+2:]))
+	return strings.TrimSpace(s[:i]), directive.TrimQuotes(strings.TrimSpace(s[i+2:])), true
 }
 
 func (b *documentBuilder) lintRequestCaptures(req *restfile.Request) {

--- a/internal/parser/mock.go
+++ b/internal/parser/mock.go
@@ -203,8 +203,8 @@ func (m *mockBuilder) parsePreamble(b *documentBuilder, ln line) {
 	if ln.text == "" {
 		return
 	}
-	if text, col, ok := ln.comment(); ok {
-		if d, ok := b.readDirective(ln.no, col, text); ok {
+	if c, ok := ln.comment(); ok {
+		if d, ok := b.readDirective(ln.no, c.col(), c.text); ok {
 			m.declare(b, d)
 		}
 		return

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -410,7 +410,7 @@ func TestParseDirectiveExpressionColumns(t *testing.T) {
 }
 
 func TestSplitAssertEscapes(t *testing.T) {
-	expr, msg := splitAssert(`contains(body, "a=>b") => "ok"`)
+	expr, msg, _ := splitAssert(`contains(body, "a=>b") => "ok"`)
 	if expr != `contains(body, "a=>b")` {
 		t.Fatalf("unexpected expr: %q", expr)
 	}
@@ -418,7 +418,7 @@ func TestSplitAssertEscapes(t *testing.T) {
 		t.Fatalf("unexpected msg: %q", msg)
 	}
 
-	expr, msg = splitAssert(`contains(body, "a\"=>b") => "ok"`)
+	expr, msg, _ = splitAssert(`contains(body, "a\"=>b") => "ok"`)
 	if expr != `contains(body, "a\"=>b")` {
 		t.Fatalf("unexpected escaped expr: %q", expr)
 	}

--- a/internal/parser/repeat_test.go
+++ b/internal/parser/repeat_test.go
@@ -46,7 +46,8 @@ GET https://example.com/jobs/123
 	if retry.When == nil || retry.When.Expression != "response.statusCode in [429, 502, 503]" {
 		t.Fatalf("@retry-when = %+v", retry.When)
 	}
-	if retry.Backoff.Initial != 100*time.Millisecond || retry.Backoff.Max != 2*time.Second || retry.Backoff.JitterPercent != 20 {
+	if retry.Backoff.Initial != 100*time.Millisecond || retry.Backoff.Max != 2*time.Second ||
+		retry.Backoff.JitterPercent != 20 {
 		t.Fatalf("@retry-backoff = %+v", retry.Backoff)
 	}
 }
@@ -78,18 +79,58 @@ func TestParseRepeatPolicyErrors(t *testing.T) {
 		want string
 	}{
 		{name: "poll missing until", src: "# @poll every=1s\nGET https://example.com\n", want: "requires until="},
-		{name: "zero interval", src: "# @poll every=0 timeout=1s until=true\nGET https://example.com\n", want: "positive duration"},
-		{name: "retry missing count", src: "# @retry enabled=true\nGET https://example.com\n", want: "count is required"},
+		{
+			name: "zero interval",
+			src:  "# @poll every=0 timeout=1s until=true\nGET https://example.com\n",
+			want: "positive duration",
+		},
+		{
+			name: "retry missing count",
+			src:  "# @retry enabled=true\nGET https://example.com\n",
+			want: "count is required",
+		},
 		{name: "retry zero", src: "# @retry count=0\nGET https://example.com\n", want: "greater than zero"},
 		{name: "orphan condition", src: "# @retry-when true\nGET https://example.com\n", want: "requires @retry"},
-		{name: "orphan backoff", src: "# @retry-backoff exponential(1ms, 1s)\nGET https://example.com\n", want: "requires @retry"},
-		{name: "bad backoff bound", src: "# @retry count=1\n# @retry-backoff exponential(2s, 1s)\nGET https://example.com\n", want: "maximum must be at least"},
-		{name: "bad jitter", src: "# @retry count=1\n# @retry-backoff exponential(1ms, 1s) jitter=101%\nGET https://example.com\n", want: "between 0% and 100%"},
-		{name: "non-finite jitter", src: "# @retry count=1\n# @retry-backoff exponential(1ms, 1s) jitter=NaN%\nGET https://example.com\n", want: "between 0% and 100%"},
-		{name: "profile conflict", src: "# @profile count=2\n# @retry count=1\nGET https://example.com\n", want: "cannot be combined with @profile"},
-		{name: "grpc unsupported", src: "# @poll until=true\nGRPC example.Service/Call\n{}\n", want: "not supported for gRPC"},
-		{name: "sse unsupported", src: "# @sse\n# @retry count=1\nGET https://example.com/events\n", want: "not supported for SSE"},
-		{name: "websocket unsupported", src: "# @websocket\n# @poll until=true\nGET wss://example.com/events\n", want: "not supported for WebSocket"},
+		{
+			name: "orphan backoff",
+			src:  "# @retry-backoff exponential(1ms, 1s)\nGET https://example.com\n",
+			want: "requires @retry",
+		},
+		{
+			name: "bad backoff bound",
+			src:  "# @retry count=1\n# @retry-backoff exponential(2s, 1s)\nGET https://example.com\n",
+			want: "maximum must be at least",
+		},
+		{
+			name: "bad jitter",
+			src:  "# @retry count=1\n# @retry-backoff exponential(1ms, 1s) jitter=101%\nGET https://example.com\n",
+			want: "between 0% and 100%",
+		},
+		{
+			name: "non-finite jitter",
+			src:  "# @retry count=1\n# @retry-backoff exponential(1ms, 1s) jitter=NaN%\nGET https://example.com\n",
+			want: "between 0% and 100%",
+		},
+		{
+			name: "profile conflict",
+			src:  "# @profile count=2\n# @retry count=1\nGET https://example.com\n",
+			want: "cannot be combined with @profile",
+		},
+		{
+			name: "grpc unsupported",
+			src:  "# @poll until=true\nGRPC example.Service/Call\n{}\n",
+			want: "not supported for gRPC",
+		},
+		{
+			name: "sse unsupported",
+			src:  "# @sse\n# @retry count=1\nGET https://example.com/events\n",
+			want: "not supported for SSE",
+		},
+		{
+			name: "websocket unsupported",
+			src:  "# @websocket\n# @poll until=true\nGET wss://example.com/events\n",
+			want: "not supported for WebSocket",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/parser/source_syntax.go
+++ b/internal/parser/source_syntax.go
@@ -315,6 +315,8 @@ func (s *sourceScan) commentLine(ln line, c commentText) (SourceLine, directive.
 		return sourceComment(ln, c, SourceLineDirective, argKind(result.owner)), result.directive.Call, true
 	case directiveReadContinuationCompleted:
 		return sourceComment(ln, c, SourceLineDirectiveValue, argKind(result.owner)), result.directive.Call, true
+	case directiveReadMark:
+		return sourceComment(ln, c, SourceLineDirective, directive.ArgNone), directive.Call{}, false
 	default:
 		return sourceComment(ln, c, SourceLineComment, 0), directive.Call{}, false
 	}

--- a/internal/parser/source_syntax.go
+++ b/internal/parser/source_syntax.go
@@ -40,10 +40,6 @@ func (k SourceLineKind) String() string {
 	}
 }
 
-func (k SourceLineKind) hasContent() bool {
-	return k == SourceLineComment || k == SourceLineDirective || k == SourceLineDirectiveValue
-}
-
 // ContentStart and ContentEnd are rune offsets for comment text without its marker or spaces.
 type SourceLine struct {
 	Kind         SourceLineKind

--- a/internal/parser/source_syntax.go
+++ b/internal/parser/source_syntax.go
@@ -1,0 +1,468 @@
+package parser
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+	grpcbuilder "github.com/unkn0wn-root/resterm/internal/parser/builder/grpc"
+	httpbuilder "github.com/unkn0wn-root/resterm/internal/parser/builder/http"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+type SourceLineKind uint8
+
+const (
+	SourceLineCode SourceLineKind = iota
+	SourceLineComment
+	SourceLineDirective
+	SourceLineDirectiveValue
+	SourceLineRequestSeparator
+	SourceLineLiteral
+)
+
+func (k SourceLineKind) String() string {
+	switch k {
+	case SourceLineCode:
+		return "code"
+	case SourceLineComment:
+		return "comment"
+	case SourceLineDirective:
+		return "directive"
+	case SourceLineDirectiveValue:
+		return "directive value"
+	case SourceLineRequestSeparator:
+		return "request separator"
+	case SourceLineLiteral:
+		return "literal"
+	default:
+		return "unknown"
+	}
+}
+
+func (k SourceLineKind) hasContent() bool {
+	return k == SourceLineComment || k == SourceLineDirective || k == SourceLineDirectiveValue
+}
+
+// ContentStart and ContentEnd are rune offsets for comment text without its marker or spaces.
+type SourceLine struct {
+	Kind         SourceLineKind
+	Args         directive.ArgKind
+	ContentStart int
+	ContentEnd   int
+}
+
+func (l SourceLine) ContentRange(n int) (start, end int, ok bool) {
+	start, end = min(l.ContentStart, n), min(l.ContentEnd, n)
+	return start, end, start < end
+}
+
+// SourceSyntax uses the parser's context rules to classify each line.
+type SourceSyntax struct {
+	lines   []SourceLine
+	effects map[directiveKey]directiveEffect
+}
+
+// A trailing newline creates an empty final line to match the editor.
+func (s *SourceSyntax) Classify(source string) {
+	count := strings.Count(source, "\n") + 1
+	if cap(s.lines) < count {
+		s.lines = make([]SourceLine, count)
+	}
+	s.lines = s.lines[:count]
+
+	// Reuse directive results across edits, but cap the cache.
+	if s.effects == nil || len(s.effects) > maxDirectiveEffects {
+		s.effects = make(map[directiveKey]directiveEffect)
+	}
+
+	scan := sourceScan{effects: s.effects}
+	i := 0
+	for raw := range strings.SplitSeq(source, "\n") {
+		s.lines[i] = scan.classify(makeLine(i+1, strings.TrimSuffix(raw, "\r"), ""))
+		i++
+	}
+}
+
+func (s *SourceSyntax) Len() int {
+	return len(s.lines)
+}
+
+func (s *SourceSyntax) Line(i int) SourceLine {
+	if i < 0 || i >= len(s.lines) {
+		return SourceLine{}
+	}
+	return s.lines[i]
+}
+
+type sourceScan struct {
+	inBlock  bool
+	inScript bool
+	workflow bool
+	request  requestScan
+	mock     mockScan
+	reader   directiveReader
+	effects  map[directiveKey]directiveEffect
+}
+
+type directiveKey struct {
+	name       directive.Name
+	spelling   directive.Name
+	args       string
+	inWorkflow bool
+}
+
+// clone prevents the cache from retaining the source buffer.
+func (k directiveKey) clone() directiveKey {
+	k.name = directive.Name(strings.Clone(string(k.name)))
+	k.spelling = directive.Name(strings.Clone(string(k.spelling)))
+	k.args = strings.Clone(k.args)
+	return k
+}
+
+type directiveEffect struct {
+	opensRequest   bool
+	startsWorkflow bool
+	startsMock     bool
+	mockSequence   bool
+}
+
+const maxDirectiveEffects = 4096
+
+type requestScan struct {
+	open        bool
+	hasMethod   bool
+	headersDone bool
+	contentType string
+	multipart   *multipartSpan
+}
+
+type mockScan struct {
+	active    bool
+	sequence  bool
+	hasStatus bool
+}
+
+// Keep this order in sync with documentBuilder.processLine.
+func (s *sourceScan) classify(ln line) SourceLine {
+	s.reader.close(ln, s.inBlock)
+
+	switch {
+	case s.mock.active:
+		return s.mockLine(ln)
+	case s.inBlock:
+		return s.blockCommentLine(ln, false)
+	case s.inScript:
+		return s.scriptBlockLine(ln)
+	}
+
+	if ln.isScriptBlockStart() {
+		s.openRequest()
+		s.inScript = true
+		return SourceLine{Kind: SourceLineLiteral}
+	}
+
+	if ln.isSeparator() {
+		s.endSection()
+		return SourceLine{Kind: SourceLineRequestSeparator}
+	}
+
+	if s.multipartBodyLine(ln) {
+		return SourceLine{Kind: SourceLineLiteral}
+	}
+
+	if ln.isBlockCommentStart() {
+		return s.blockCommentLine(ln, true)
+	}
+
+	if c, ok := ln.comment(); ok {
+		syntax, call, ok := s.commentLine(ln, c)
+		if ok {
+			s.applyDirective(call)
+		}
+		return syntax
+	}
+
+	if ln.hasScriptMarker() {
+		s.openRequest()
+		return SourceLine{}
+	}
+
+	if s.variableLine(ln) {
+		return SourceLine{}
+	}
+
+	if ln.text == "" {
+		s.endHeaders()
+		return SourceLine{}
+	}
+
+	if s.request.hasMethod && s.request.headersDone {
+		return SourceLine{Kind: SourceLineLiteral}
+	}
+
+	switch readMethodLine(ln.raw) {
+	case methodLineOpens:
+		s.openMethodLine()
+		return SourceLine{}
+	case methodLineRejected:
+		return SourceLine{}
+	}
+
+	if s.request.hasMethod {
+		s.observeHeader(ln.raw)
+		return SourceLine{}
+	}
+
+	s.openRequest()
+	return SourceLine{}
+}
+
+func (s *sourceScan) blockCommentLine(ln line, opening bool) SourceLine {
+	c, closed := ln.blockComment(opening)
+	s.inBlock = !closed
+	if c.text == "" {
+		return sourceComment(ln, c, SourceLineComment, 0)
+	}
+
+	syntax, call, ok := s.commentLine(ln, c)
+	if ok {
+		s.applyDirective(call)
+	}
+	return syntax
+}
+
+func (s *sourceScan) scriptBlockLine(ln line) SourceLine {
+	switch {
+	case ln.isScriptBlockEnd():
+		s.inScript = false
+	case ln.isSeparator():
+		s.endSection()
+		return SourceLine{Kind: SourceLineRequestSeparator}
+	}
+	return SourceLine{Kind: SourceLineLiteral}
+}
+
+func (s *sourceScan) mockLine(ln line) SourceLine {
+	if ln.isSeparator() {
+		s.endSection()
+		return SourceLine{Kind: SourceLineRequestSeparator}
+	}
+
+	if s.mock.sequence && s.mock.hasStatus && restfile.IsMockSequenceDelimiter(ln.text) {
+		s.mock.hasStatus = false
+		return SourceLine{Kind: SourceLineLiteral}
+	}
+
+	if !s.mock.hasStatus {
+		return s.mockPreambleLine(ln)
+	}
+
+	return SourceLine{Kind: SourceLineLiteral}
+}
+
+func (s *sourceScan) mockPreambleLine(ln line) SourceLine {
+	if ln.text == "" {
+		return SourceLine{}
+	}
+	// Preamble directives are classified but do not change surrounding state.
+	if c, ok := ln.comment(); ok {
+		syntax, _, _ := s.commentLine(ln, c)
+		return syntax
+	}
+	if status, recognized, err := parseMockStatusLine(ln.text); recognized && err == nil && status != 0 {
+		s.mock.hasStatus = true
+	}
+	return SourceLine{Kind: SourceLineLiteral}
+}
+
+func (s *sourceScan) multipartBodyLine(ln line) bool {
+	m := s.request.multipart
+	return ln.text != "" && m != nil && m.bodyLine(ln.text)
+}
+
+// An unscoped variable uses request scope inside a request and file scope elsewhere.
+func (s *sourceScan) variableLine(ln line) bool {
+	matches := variableLineRe.FindStringSubmatch(ln.text)
+	if matches == nil {
+		return false
+	}
+
+	scope, _, ok := directive.ParseSecretScope(matches[1])
+	if !ok {
+		scope = directive.ScopeFile
+		if s.request.open {
+			scope = directive.ScopeRequest
+		}
+	}
+	if scope == directive.ScopeRequest {
+		s.openRequest()
+	}
+	return true
+}
+
+func (s *sourceScan) observeHeader(raw string) {
+	name, value, ok := strings.Cut(raw, ":")
+	if ok && strings.EqualFold(strings.TrimSpace(name), "Content-Type") {
+		s.request.contentType = strings.TrimSpace(value)
+	}
+}
+
+func (s *sourceScan) commentLine(ln line, c commentText) (SourceLine, directive.Call, bool) {
+	result := s.reader.read(ln.no, c.col(), c.text)
+	switch result.kind {
+	case directiveReadStarted:
+		return sourceComment(ln, c, SourceLineDirective, argKind(result.owner)), directive.Call{}, false
+	case directiveReadContinued:
+		return sourceComment(ln, c, SourceLineDirectiveValue, argKind(result.owner)), directive.Call{}, false
+	case directiveReadCompleted:
+		return sourceComment(ln, c, SourceLineDirective, argKind(result.owner)), result.directive.Call, true
+	case directiveReadContinuationCompleted:
+		return sourceComment(ln, c, SourceLineDirectiveValue, argKind(result.owner)), result.directive.Call, true
+	default:
+		return sourceComment(ln, c, SourceLineComment, 0), directive.Call{}, false
+	}
+}
+
+func argKind(name directive.Name) directive.ArgKind {
+	spec, ok := directive.Lookup(name)
+	if !ok {
+		return directive.ArgToken
+	}
+	return spec.Args
+}
+
+func (s *sourceScan) applyDirective(call directive.Call) {
+	// @workflow can close an open request; other directives cannot.
+	if call.Name == directive.Workflow {
+		if s.effectOf(call, false).startsWorkflow {
+			s.request = requestScan{}
+			s.workflow = true
+		}
+		return
+	}
+
+	if s.request.open {
+		return
+	}
+
+	effect := s.effectOf(call, s.workflow)
+	switch {
+	case effect.startsMock:
+		s.mock = mockScan{active: true, sequence: effect.mockSequence}
+	case effect.opensRequest:
+		s.openRequest()
+	}
+}
+
+func (s *sourceScan) effectOf(call directive.Call, inWorkflow bool) directiveEffect {
+	if !call.Name.Known() {
+		return directiveEffect{}
+	}
+
+	if strings.Contains(call.Args, "\n") {
+		return probeEffect(call, inWorkflow)
+	}
+
+	key := directiveKey{
+		name:       call.Name,
+		spelling:   call.Spelling,
+		args:       call.Args,
+		inWorkflow: inWorkflow,
+	}
+	if effect, ok := s.effects[key]; ok {
+		return effect
+	}
+
+	effect := probeEffect(call, inWorkflow)
+	s.effects[key.clone()] = effect
+	return effect
+}
+
+// Run directives through the parser so classification follows the same rules.
+func probeEffect(call directive.Call, inWorkflow bool) directiveEffect {
+	probe := documentBuilder{doc: &restfile.Document{}}
+	if inWorkflow {
+		probe.workflow = newWorkflowBuilder(1, "probe")
+	}
+	probe.routeDirective(parsedDirective{
+		Call:  call,
+		lines: restfile.LineRange{Start: 1, End: 1},
+	})
+
+	effect := directiveEffect{
+		opensRequest:   probe.inRequest,
+		startsWorkflow: !inWorkflow && probe.workflow != nil,
+		startsMock:     probe.mock != nil,
+	}
+	if effect.startsMock {
+		effect.mockSequence = probe.mock.sequence != ""
+	}
+	return effect
+}
+
+func (s *sourceScan) openRequest() {
+	s.request.open = true
+	s.workflow = false
+}
+
+func (s *sourceScan) openMethodLine() {
+	s.openRequest()
+	s.request.hasMethod = true
+	s.request.headersDone = false
+	s.request.contentType = ""
+	s.request.multipart = nil
+}
+
+func (s *sourceScan) endHeaders() {
+	if !s.request.hasMethod || s.request.headersDone {
+		return
+	}
+	s.request.headersDone = true
+	if restfile.IsMultipartMime(s.request.contentType) {
+		s.request.multipart = newMultipartSpan(s.request.contentType)
+	}
+}
+
+// Keep cached directive results between sections.
+func (s *sourceScan) endSection() {
+	*s = sourceScan{effects: s.effects}
+}
+
+type methodLineKind uint8
+
+const (
+	notMethodLine methodLineKind = iota
+	methodLineOpens
+	methodLineRejected
+)
+
+// Match handleMethodLine, including request lines that are rejected.
+func readMethodLine(raw string) methodLineKind {
+	if grpcbuilder.IsMethodLine(raw) {
+		return methodLineOpens
+	}
+
+	_, ok, err := httpbuilder.ParseMethodLine(raw)
+	if !ok && err == nil {
+		_, ok, err = httpbuilder.ParseWebSocketURLLine(raw)
+	}
+	switch {
+	case err != nil:
+		return methodLineRejected
+	case ok:
+		return methodLineOpens
+	default:
+		return notMethodLine
+	}
+}
+
+func sourceComment(ln line, c commentText, kind SourceLineKind, args directive.ArgKind) SourceLine {
+	start := utf8.RuneCountInString(ln.raw[:c.start])
+	return SourceLine{
+		Kind:         kind,
+		Args:         args,
+		ContentStart: start,
+		ContentEnd:   start + utf8.RuneCountInString(ln.raw[c.start:c.end]),
+	}
+}

--- a/internal/parser/source_syntax_test.go
+++ b/internal/parser/source_syntax_test.go
@@ -1,0 +1,230 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+)
+
+func TestSourceSyntaxComments(t *testing.T) {
+	lines := []string{
+		"\t# ✅ hash comment",
+		"  // slash comment",
+		"-- dash comment",
+		"## @if this stays prose",
+		"/**",
+		" * block prose",
+		" * @name Blocked",
+		" **/",
+		"### named request",
+		"GET https://example.test",
+	}
+
+	got := classifySource(strings.Join(lines, "\r\n"))
+	assertSourceKinds(t, got, []SourceLineKind{
+		SourceLineComment,
+		SourceLineComment,
+		SourceLineComment,
+		SourceLineComment,
+		SourceLineComment,
+		SourceLineComment,
+		SourceLineDirective,
+		SourceLineComment,
+		SourceLineRequestSeparator,
+		SourceLineCode,
+	})
+
+	for no, want := range []string{
+		"✅ hash comment",
+		"slash comment",
+		"dash comment",
+		"# @if this stays prose",
+		"",
+		"block prose",
+		"@name Blocked",
+		"",
+	} {
+		if text := sourceContent(lines[no], got[no]); text != want {
+			t.Fatalf("line %d content = %q, want %q", no+1, text, want)
+		}
+	}
+}
+
+func TestSourceSyntaxMultilineDirectives(t *testing.T) {
+	source := strings.Join([]string{
+		"# @assert (",
+		"# true",
+		"# )",
+		"# ordinary prose",
+		"# @match json={",
+		`# "a": 1`,
+		"# }",
+		"# @mock method=GET path=/health",
+		"HTTP/1.1 200 OK",
+		"",
+		"# response body",
+	}, "\n")
+
+	got := classifySource(source)
+	assertSourceKinds(t, got, []SourceLineKind{
+		SourceLineDirective,
+		SourceLineDirectiveValue,
+		SourceLineDirectiveValue,
+		SourceLineComment,
+		SourceLineDirective,
+		SourceLineDirectiveValue,
+		SourceLineDirectiveValue,
+		SourceLineDirective,
+		SourceLineCode,
+		SourceLineCode,
+		SourceLineComment,
+	})
+
+	for _, no := range []int{0, 1, 2} {
+		if got[no].Args != directive.ArgText {
+			t.Fatalf("line %d args = %d, want text", no+1, got[no].Args)
+		}
+	}
+	for _, no := range []int{4, 5, 6} {
+		if got[no].Args != directive.ArgOptions {
+			t.Fatalf("line %d args = %d, want options", no+1, got[no].Args)
+		}
+	}
+	if mocks := Parse("complete.http", []byte(source)).Mocks; len(mocks) != 0 {
+		t.Fatalf("parser created %d mocks after a request-opening assertion, want none", len(mocks))
+	}
+}
+
+func TestSourceSyntaxKeepsLiteralContentUnclassified(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		line   int
+	}{
+		{
+			name: "multipart body",
+			source: strings.Join([]string{
+				"POST https://example.test/upload",
+				"Content-Type: multipart/form-data; boundary=B",
+				"",
+				"--B",
+				"Content-Disposition: form-data; name=script",
+				"",
+				"# literal body",
+				"--B--",
+			}, "\n"),
+			line: 6,
+		},
+		{
+			name:   "mock response body",
+			source: "# @mock method=GET path=/health\nHTTP/1.1 200 OK\n\n# literal body",
+			line:   3,
+		},
+		{
+			name:   "script block",
+			source: "# @script test\n> {%\n// JavaScript comment\n> %}",
+			line:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifySource(tt.source)[tt.line].Kind; got != SourceLineLiteral {
+				t.Fatalf("line kind = %v, want literal", got)
+			}
+		})
+	}
+}
+
+func TestSourceSyntaxReuseAndBounds(t *testing.T) {
+	var syntax SourceSyntax
+	syntax.Classify("// one\n// two\n// three")
+	syntax.Classify("GET https://example.test\n")
+
+	if syntax.Len() != 2 {
+		t.Fatalf("classified %d lines, want 2", syntax.Len())
+	}
+	for _, no := range []int{0, 1, 7} {
+		if kind := syntax.Line(no).Kind; kind != SourceLineCode {
+			t.Fatalf("line %d kind = %v, want code", no+1, kind)
+		}
+	}
+
+	line := SourceLine{Kind: SourceLineComment, ContentStart: 2, ContentEnd: 40}
+	start, end, ok := line.ContentRange(6)
+	if !ok || start != 2 || end != 6 {
+		t.Fatalf("ContentRange(6) = (%d, %d, %v), want (2, 6, true)", start, end, ok)
+	}
+}
+
+func TestSourceSyntaxMockAgreesWithParser(t *testing.T) {
+	prefixes := []string{
+		"",
+		"GET https://example.test",
+		"@request value = 1",
+		"# @assert sum(",
+		"# @workflow flow\n# @step login using=Login",
+	}
+	for _, spec := range directive.Specs() {
+		prefixes = append(prefixes, "# "+spec.Name.Tag(), "# "+spec.Name.Tag()+" value")
+	}
+
+	for no, prefix := range prefixes {
+		source := prefix
+		if source != "" {
+			source += "\n"
+		}
+		source += "# @mock method=GET path=/health\nHTTP/1.1 200 OK\n\n# body marker\n"
+
+		body := strings.Count(source, "\n") - 1
+		got := classifySource(source)[body].Kind
+		mocked := len(Parse("agree.http", []byte(source)).Mocks) == 1
+		if (got == SourceLineLiteral) != mocked {
+			t.Fatalf("case %d: body kind = %v, parser found mock = %v", no, got, mocked)
+		}
+	}
+}
+
+func TestArgKindComesFromCatalog(t *testing.T) {
+	for name, want := range map[directive.Name]directive.ArgKind{
+		"nolog":       directive.ArgNone,
+		"settings":    directive.ArgOptions,
+		"grpc-method": directive.ArgToken,
+	} {
+		if got := argKind(name); got != want {
+			t.Fatalf("argKind(%q) = %d, want %d", name, got, want)
+		}
+	}
+}
+
+func classifySource(source string) []SourceLine {
+	var syntax SourceSyntax
+	syntax.Classify(source)
+	out := make([]SourceLine, syntax.Len())
+	for no := range out {
+		out[no] = syntax.Line(no)
+	}
+	return out
+}
+
+func assertSourceKinds(t *testing.T, got []SourceLine, want []SourceLineKind) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("classified %d lines, want %d", len(got), len(want))
+	}
+	for no := range want {
+		if got[no].Kind != want[no] {
+			t.Fatalf("line %d kind = %v, want %v", no+1, got[no].Kind, want[no])
+		}
+	}
+}
+
+func sourceContent(line string, syntax SourceLine) string {
+	runes := []rune(line)
+	start, end, ok := syntax.ContentRange(len(runes))
+	if !ok {
+		return ""
+	}
+	return string(runes[start:end])
+}

--- a/internal/parser/source_syntax_test.go
+++ b/internal/parser/source_syntax_test.go
@@ -96,6 +96,84 @@ func TestSourceSyntaxMultilineDirectives(t *testing.T) {
 	}
 }
 
+func TestSourceSyntaxMarksADirectiveBeingTyped(t *testing.T) {
+	tests := []struct {
+		name   string
+		source []string
+		line   int
+		want   SourceLineKind
+	}{
+		{
+			name:   "file scope",
+			source: []string{"# @"},
+			want:   SourceLineDirective,
+		},
+		{
+			name:   "separator instead of a name",
+			source: []string{"# @:"},
+			want:   SourceLineComment,
+		},
+		{
+			name:   "separator before a name",
+			source: []string{"# @:x"},
+			want:   SourceLineComment,
+		},
+		{
+			name:   "block comment",
+			source: []string{"/**", " * @", " */"},
+			line:   1,
+			want:   SourceLineDirective,
+		},
+		{
+			name:   "mock preamble",
+			source: []string{"# @mock method=GET path=/health", "# @", "HTTP/1.1 200 OK"},
+			line:   1,
+			want:   SourceLineDirective,
+		},
+		{
+			name:   "line an argument runs on",
+			source: []string{"# @assert sum(", "# @"},
+			line:   1,
+			want:   SourceLineDirectiveValue,
+		},
+		{
+			name:   "script block",
+			source: []string{"# @script test", "> {%", "# @", "> %}"},
+			line:   2,
+			want:   SourceLineLiteral,
+		},
+		{
+			name:   "mock response body",
+			source: []string{"# @mock method=GET path=/health", "HTTP/1.1 200 OK", "", "# @"},
+			line:   3,
+			want:   SourceLineLiteral,
+		},
+		{
+			name: "multipart part",
+			source: []string{
+				"POST https://example.test",
+				"Content-Type: multipart/form-data; boundary=B",
+				"",
+				"--B",
+				"",
+				"# @",
+				"--B--",
+			},
+			line: 5,
+			want: SourceLineLiteral,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifySource(strings.Join(tt.source, "\n"))[tt.line]
+			if got.Kind != tt.want {
+				t.Fatalf("line %d kind = %v, want %v", tt.line+1, got.Kind, tt.want)
+			}
+		})
+	}
+}
+
 func TestSourceSyntaxKeepsLiteralContentUnclassified(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/rts/group.go
+++ b/internal/rts/group.go
@@ -52,18 +52,177 @@ func OpenGroup(src string) (closer rune) {
 		case LBRACE:
 			open = append(open, '}')
 		case RPAREN:
-			open = closeGroup(open, ')')
+			open = popGroup(open, ')')
 		case RBRACK:
-			open = closeGroup(open, ']')
+			open = popGroup(open, ']')
 		case RBRACE:
-			open = closeGroup(open, '}')
+			open = popGroup(open, '}')
 		}
 	}
 }
 
-func closeGroup(open []rune, closer rune) []rune {
+func popGroup(open []rune, closer rune) []rune {
 	if n := len(open); n > 0 && open[n-1] == closer {
 		return open[:n-1]
 	}
 	return open
+}
+
+type groupScanMode uint8
+
+const (
+	groupScanCode groupScanMode = iota
+	groupScanString
+	groupScanComment
+)
+
+type GroupScanner struct {
+	// open follows OpenGroup, while depth follows Mask. Mismatched closers affect only depth.
+	open    []rune
+	depth   int
+	mode    groupScanMode
+	quote   byte
+	escaped bool
+	skipLF  bool
+	stopped bool
+}
+
+func (g *GroupScanner) Closer() rune {
+	if len(g.open) == 0 {
+		return 0
+	}
+	return g.open[len(g.open)-1]
+}
+
+func (g *GroupScanner) Feed(src string) {
+	for i := range len(src) {
+		g.ScanByte(src[i])
+	}
+}
+
+// ScanByte returns bytes visible at the top level, using spaces for hidden text.
+// Nested bytes return ok=false. NUL ends the scan and CRLF counts as one newline.
+func (g *GroupScanner) ScanByte(ch byte) (top byte, ok bool) {
+	if g.stopped {
+		return 0, false
+	}
+	if ch == 0 {
+		if g.mode == groupScanString && g.escaped {
+			g.escaped = false
+			return 0, false
+		}
+		g.stopped = true
+		return 0, false
+	}
+	if g.skipLF {
+		g.skipLF = false
+		if ch == '\n' {
+			return 0, false
+		}
+	}
+
+	switch g.mode {
+	case groupScanString:
+		return g.stringByte(ch)
+	case groupScanComment:
+		return g.commentByte(ch)
+	default:
+		return g.codeByte(ch)
+	}
+}
+
+func (g *GroupScanner) codeByte(ch byte) (byte, bool) {
+	switch ch {
+	case '\n', '\r':
+		return g.endLine(ch)
+	case '#':
+		g.mode = groupScanComment
+		return g.hiddenTopLevel()
+	case '"', '\'':
+		g.mode = groupScanString
+		g.quote = ch
+		return g.hiddenTopLevel()
+	case '(':
+		return g.openGroup(ch, ')')
+	case '[':
+		return g.openGroup(ch, ']')
+	case '{':
+		return g.openGroup(ch, '}')
+	case ')', ']', '}':
+		return g.closeGroup(ch)
+	}
+	if g.depth != 0 {
+		return 0, false
+	}
+	if isTopLevelTokenByte(ch) {
+		return ch, true
+	}
+	return ' ', true
+}
+
+func (g *GroupScanner) commentByte(ch byte) (byte, bool) {
+	if ch != '\n' && ch != '\r' {
+		return 0, false
+	}
+	return g.endLine(ch)
+}
+
+func (g *GroupScanner) stringByte(ch byte) (byte, bool) {
+	if g.escaped {
+		g.escaped = false
+		if ch == '\r' {
+			g.skipLF = true
+		}
+		return 0, false
+	}
+	switch ch {
+	case '\n', '\r':
+		return g.endLine(ch)
+	case '\\':
+		g.escaped = true
+	case g.quote:
+		g.mode = groupScanCode
+		g.quote = 0
+	}
+	return 0, false
+}
+
+// An unterminated string ends with its line, the way the lexer reads it.
+func (g *GroupScanner) endLine(ch byte) (byte, bool) {
+	g.mode = groupScanCode
+	g.quote = 0
+	if ch == '\r' {
+		g.skipLF = true
+	}
+	return g.hiddenTopLevel()
+}
+
+func (g *GroupScanner) hiddenTopLevel() (byte, bool) {
+	if g.depth == 0 {
+		return ' ', true
+	}
+	return 0, false
+}
+
+func (g *GroupScanner) openGroup(ch byte, closer rune) (byte, bool) {
+	top := g.depth == 0
+	g.depth++
+	g.open = append(g.open, closer)
+	return ch, top
+}
+
+func (g *GroupScanner) closeGroup(ch byte) (byte, bool) {
+	if g.depth > 0 {
+		g.depth--
+	}
+	g.open = popGroup(g.open, rune(ch))
+	return ch, g.depth == 0
+}
+
+func isTopLevelTokenByte(ch byte) bool {
+	switch ch {
+	case ',', '.', ';', ':', '?', '+', '-', '*', '/', '%', '=', '!', '&', '|', '<', '>':
+		return true
+	}
+	return isIdent(ch) || isSpace(ch)
 }

--- a/internal/rts/group_test.go
+++ b/internal/rts/group_test.go
@@ -75,3 +75,35 @@ func TestMask(t *testing.T) {
 		})
 	}
 }
+
+func TestGroupScannerMatchesOpenGroup(t *testing.T) {
+	sources := []string{
+		"sum(1, 2)",
+		"contains(\"x\\\n)\")",
+		"contains(\"x\\\r\n)\")",
+		"contains(\"x\n)\")",
+		"call(\n # ) ignored\n)",
+		"[a mismatched) still open",
+		"call(\x00) ignored",
+		"(\"\\\x00\")",
+	}
+
+	for _, src := range sources {
+		for cut := range len(src) + 1 {
+			var scan GroupScanner
+			scan.Feed(src[:cut])
+			scan.Feed(src[cut:])
+			if got, want := scan.Closer(), OpenGroup(src); got != want {
+				t.Fatalf("chunks [%q, %q] closed with %q, whole read gives %q", src[:cut], src[cut:], got, want)
+			}
+		}
+
+		var scan GroupScanner
+		for i := range len(src) {
+			scan.Feed(src[i : i+1])
+		}
+		if got, want := scan.Closer(), OpenGroup(src); got != want {
+			t.Fatalf("byte chunks over %q closed with %q, whole read gives %q", src, got, want)
+		}
+	}
+}

--- a/internal/scripts/guard_test.go
+++ b/internal/scripts/guard_test.go
@@ -92,8 +92,7 @@ func TestPreRequestStopsAtTheScriptTimeout(t *testing.T) {
 }
 
 func TestGuardReleasesItsWatcher(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	before := runtime.NumGoroutine()
 	runner := NewRunner(nil)

--- a/internal/ui/editor_metadata_highlighter.go
+++ b/internal/ui/editor_metadata_highlighter.go
@@ -11,19 +11,10 @@ import (
 
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/intellisense"
+	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/theme"
 	"github.com/unkn0wn-root/resterm/internal/ui/textarea"
 )
-
-// An unknown name still paints a token value. The zero Spec.Args is ArgNone,
-// which would hide the value, so the fallback has to be spelled out.
-func directiveArgKind(name directive.Name) directive.ArgKind {
-	spec, ok := directive.Lookup(name)
-	if !ok {
-		return directive.ArgToken
-	}
-	return spec.Args
-}
 
 // stylePainter fills styles lazily so a line with nothing painted returns nil.
 type stylePainter struct {
@@ -58,6 +49,7 @@ type metadataRuneStyler struct {
 	requestLineEnabled  bool
 	requestSepStyle     lipgloss.Style
 	requestSepEnabled   bool
+	syntax              parser.SourceSyntax
 	cache               map[int]lineCache
 }
 
@@ -68,7 +60,7 @@ type lineCache struct {
 	styles   []lipgloss.Style
 }
 
-func newMetadataRuneStyler(p theme.EditorMetadataPalette) textarea.RuneStyler {
+func newMetadataRuneStyler(p theme.EditorMetadataPalette) *metadataRuneStyler {
 	s := &metadataRuneStyler{
 		palette:         p,
 		directiveStyles: make(map[string]lipgloss.Style),
@@ -121,6 +113,11 @@ func selectEditorRuneStyler(path string, palette theme.EditorMetadataPalette) te
 	return newMetadataRuneStyler(palette)
 }
 
+func (s *metadataRuneStyler) SetSource(source string) {
+	s.syntax.Classify(source)
+	clear(s.cache)
+}
+
 func (s *metadataRuneStyler) StylesForLine(line []rune, idx int) []lipgloss.Style {
 	if len(line) == 0 {
 		delete(s.cache, idx)
@@ -133,72 +130,107 @@ func (s *metadataRuneStyler) StylesForLine(line []rune, idx int) []lipgloss.Styl
 		return cached.styles
 	}
 
-	styles := s.computeStyles(line)
+	styles := s.computeStyles(line, s.syntax.Line(idx))
 	s.cache[idx] = lineCache{hash: lineHash, length: len(line), computed: true, styles: styles}
 	return styles
 }
 
-func (s *metadataRuneStyler) computeStyles(line []rune) []lipgloss.Style {
-	i := skipSpace(line, 0)
-	if i >= len(line) {
+func (s *metadataRuneStyler) computeStyles(line []rune, syntax parser.SourceLine) []lipgloss.Style {
+	start := skipSpace(line, 0)
+	if start >= len(line) {
 		return nil
 	}
 
-	if styles := s.requestLineStyles(line, i); styles != nil {
-		return styles
-	}
-
-	if styles := s.requestSeparatorStyles(line, i); styles != nil {
-		return styles
-	}
-
-	markerStart := i
-	markerLen := commentMarkerLength(line, i)
-	if markerLen == 0 {
+	switch syntax.Kind {
+	case parser.SourceLineCode:
+		return s.requestLineStyles(line, start)
+	case parser.SourceLineComment:
+		return s.proseStyles(line, start)
+	case parser.SourceLineDirective:
+		return s.directiveLineStyles(line, start, syntax)
+	case parser.SourceLineDirectiveValue:
+		return s.directiveValueStyles(line, start, syntax)
+	case parser.SourceLineRequestSeparator:
+		return s.separatorStyles(line, start)
+	default:
 		return nil
 	}
+}
 
-	directiveStart := skipSpace(line, markerStart+markerLen)
-	if directiveStart >= len(line) || line[directiveStart] != '@' {
+func (s *metadataRuneStyler) proseStyles(line []rune, start int) []lipgloss.Style {
+	if !s.commentEnabled {
 		return nil
 	}
+	return fillFrom(line, start, s.commentStyle)
+}
 
+func (s *metadataRuneStyler) directiveLineStyles(
+	line []rune,
+	start int,
+	syntax parser.SourceLine,
+) []lipgloss.Style {
 	p := &stylePainter{n: len(line)}
+	nameStart, end, ok := syntax.ContentRange(len(line))
 	if s.commentEnabled {
-		p.paint(markerStart, markerStart+markerLen, s.commentStyle)
+		p.paint(start, nameStart, s.commentStyle)
 	}
-
-	directiveEnd := directiveStart + 1
-	for directiveEnd < len(line) && isDirectiveRune(line[directiveEnd]) {
-		directiveEnd++
-	}
-	directiveKey := strings.ToLower(string(line[directiveStart+1 : directiveEnd]))
-
-	if dirStyle, ok := s.directiveStyle(directiveKey); ok {
-		p.paint(directiveStart, directiveEnd, dirStyle)
-	}
-
-	valueStart := skipArgSep(line, directiveEnd)
-	if valueStart >= len(line) {
+	if !ok {
 		return p.styles
 	}
 
-	switch directiveArgKind(directive.Name(directiveKey)) {
+	nameEnd := nameStart + 1
+	for nameEnd < end && isDirectiveRune(line[nameEnd]) {
+		nameEnd++
+	}
+	if style, ok := s.directiveStyle(strings.ToLower(string(line[nameStart+1 : nameEnd]))); ok {
+		p.paint(nameStart, nameEnd, style)
+	}
+
+	s.paintArgument(p, line, syntax.Args, skipArgSep(line, nameEnd, end), end)
+	return p.styles
+}
+
+func (s *metadataRuneStyler) directiveValueStyles(
+	line []rune,
+	start int,
+	syntax parser.SourceLine,
+) []lipgloss.Style {
+	p := &stylePainter{n: len(line)}
+	valueStart, end, ok := syntax.ContentRange(len(line))
+	if s.commentEnabled {
+		p.paint(start, valueStart, s.commentStyle)
+	}
+	if ok {
+		s.paintArgument(p, line, syntax.Args, valueStart, end)
+	}
+	return p.styles
+}
+
+func (s *metadataRuneStyler) paintArgument(
+	p *stylePainter,
+	line []rune,
+	args directive.ArgKind,
+	start, end int,
+) {
+	if start >= end {
+		return
+	}
+
+	switch args {
 	case directive.ArgNone:
 	case directive.ArgSetting:
-		s.applySettingStyles(p, line, valueStart)
+		s.applySettingStyles(p, line, start, end)
 	case directive.ArgOptions:
-		s.applyOptionStyles(p, line, valueStart)
+		s.applyOptionStyles(p, line, start, end)
 	case directive.ArgText:
 		if s.valueEnabled {
-			p.paint(valueStart, len(line), s.valueStyle)
+			p.paint(start, end, s.valueStyle)
 		}
 	case directive.ArgToken:
 		if s.valueEnabled {
-			p.paint(valueStart, readToken(line, valueStart), s.valueStyle)
+			p.paint(start, readToken(line, start, end), s.valueStyle)
 		}
 	}
-	return p.styles
 }
 
 func (s *metadataRuneStyler) directiveStyle(key string) (lipgloss.Style, bool) {
@@ -220,16 +252,19 @@ func (s *metadataRuneStyler) directiveStyle(key string) (lipgloss.Style, bool) {
 	return style, true
 }
 
-func (s *metadataRuneStyler) applySettingStyles(p *stylePainter, line []rune, start int) {
+func (s *metadataRuneStyler) applySettingStyles(
+	p *stylePainter,
+	line []rune,
+	start, end int,
+) {
 	if !s.settingKeyEnabled && !s.settingValueEnabled {
 		return
 	}
 
-	// The @settings spelling. putSetting reads it with ParseOptions, so it gets
-	// painted the way @settings is.
-	tokEnd := readToken(line, start)
+	// @setting also accepts the @settings key=value form.
+	tokEnd := readToken(line, start, end)
 	if slices.Contains(line[start:tokEnd], '=') {
-		s.applyOptionStyles(p, line, start)
+		s.applyOptionStyles(p, line, start, end)
 		return
 	}
 
@@ -241,20 +276,24 @@ func (s *metadataRuneStyler) applySettingStyles(p *stylePainter, line []rune, st
 		p.paint(start, keyEnd, s.settingKeyStyle)
 	}
 	if s.settingValueEnabled {
-		p.paint(skipSpace(line, tokEnd), len(line), s.settingValueStyle)
+		p.paint(skipSpaceTo(line, tokEnd, end), end, s.settingValueStyle)
 	}
 }
 
-func (s *metadataRuneStyler) applyOptionStyles(p *stylePainter, line []rune, start int) {
+func (s *metadataRuneStyler) applyOptionStyles(
+	p *stylePainter,
+	line []rune,
+	start, end int,
+) {
 	if s.valueEnabled {
-		p.paint(start, len(line), s.valueStyle)
+		p.paint(start, end, s.valueStyle)
 	}
 	if !s.settingKeyEnabled && !s.settingValueEnabled {
 		return
 	}
 
 	// Spans are byte offsets in rest. The cursor turns them into rune indexes.
-	rest := string(line[start:])
+	rest := string(line[start:end])
 	b, r := 0, start
 	runeAt := func(off int) int {
 		for b < off {
@@ -289,40 +328,32 @@ func hashRunes(runes []rune) uint64 {
 }
 
 func (s *metadataRuneStyler) requestLineStyles(line []rune, start int) []lipgloss.Style {
-	if !s.requestLineEnabled {
+	if !s.requestLineEnabled || !isRequestLine(line, start) {
 		return nil
 	}
-
-	if !isRequestLine(line, start) {
-		return nil
-	}
-
-	styles := make([]lipgloss.Style, len(line))
-	for idx := start; idx < len(line); idx++ {
-		styles[idx] = s.requestLineStyle
-	}
-	return styles
+	return fillFrom(line, start, s.requestLineStyle)
 }
 
-func (s *metadataRuneStyler) requestSeparatorStyles(line []rune, start int) []lipgloss.Style {
+func (s *metadataRuneStyler) separatorStyles(line []rune, start int) []lipgloss.Style {
 	if !s.requestSepEnabled {
 		return nil
 	}
+	return fillFrom(line, start, s.requestSepStyle)
+}
 
-	if !hasRequestSeparatorPrefix(line, start) {
-		return nil
-	}
-
-	styles := make([]lipgloss.Style, len(line))
-	for idx := start; idx < len(line); idx++ {
-		styles[idx] = s.requestSepStyle
-	}
-	return styles
+func fillFrom(line []rune, start int, style lipgloss.Style) []lipgloss.Style {
+	p := stylePainter{n: len(line)}
+	p.paint(start, len(line), style)
+	return p.styles
 }
 
 func skipSpace(line []rune, start int) int {
+	return skipSpaceTo(line, start, len(line))
+}
+
+func skipSpaceTo(line []rune, start, end int) int {
 	i := start
-	for i < len(line) && unicode.IsSpace(line[i]) {
+	for i < end && unicode.IsSpace(line[i]) {
 		i++
 	}
 	return i
@@ -330,45 +361,21 @@ func skipSpace(line []rune, start int) int {
 
 // The colon in "@name: value" separates, it is not part of the value, so the
 // styling starts past it.
-func skipArgSep(line []rune, start int) int {
+func skipArgSep(line []rune, start, end int) int {
 	i := start
-	for i < len(line) && directive.IsArgSep(line[i]) {
+	for i < end && directive.IsArgSep(line[i]) {
 		i++
 	}
 	return i
-}
-
-func hasRequestSeparatorPrefix(line []rune, start int) bool {
-	if len(line)-start < 3 {
-		return false
-	}
-	if string(line[start:start+3]) != "###" {
-		return false
-	}
-	if len(line) == start+3 {
-		return true
-	}
-	return unicode.IsSpace(line[start+3])
-}
-
-func commentMarkerLength(line []rune, idx int) int {
-	switch {
-	case line[idx] == '#':
-		return 1
-	case line[idx] == '/' && idx+1 < len(line) && line[idx+1] == '/':
-		return 2
-	default:
-		return 0
-	}
 }
 
 func isDirectiveRune(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.'
 }
 
-func readToken(line []rune, start int) int {
+func readToken(line []rune, start, end int) int {
 	i := start
-	for i < len(line) && !unicode.IsSpace(line[i]) {
+	for i < end && !unicode.IsSpace(line[i]) {
 		i++
 	}
 	return i
@@ -379,7 +386,7 @@ func isRequestLine(line []rune, start int) bool {
 		return false
 	}
 
-	end := readToken(line, start)
+	end := readToken(line, start, len(line))
 	if end <= start {
 		return false
 	}

--- a/internal/ui/editor_metadata_highlighter_test.go
+++ b/internal/ui/editor_metadata_highlighter_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/theme"
 )
 
@@ -15,8 +14,7 @@ func TestMetadataRuneStylerNameDirective(t *testing.T) {
 	palette := theme.DefaultTheme().EditorMetadata
 	styler := newMetadataRuneStyler(palette)
 
-	line := []rune("# @name getUser")
-	styles := styler.StylesForLine(line, 0)
+	styles := styleLine(styler, "# @name getUser")
 	if styles == nil {
 		t.Fatalf("expected styles for metadata line")
 	}
@@ -44,6 +42,91 @@ func TestMetadataRuneStylerNameDirective(t *testing.T) {
 	}
 }
 
+func TestMetadataRuneStylerDimsOrdinaryComments(t *testing.T) {
+	palette := theme.DefaultTheme().EditorMetadata
+	line := "-- ordinary comment"
+	styles := styleLine(newMetadataRuneStyler(palette), line)
+	assertMetadataTokenColor(t, styles, line, line, palette.CommentMarker)
+}
+
+func TestMetadataRuneStylerKeepsDirectiveEmphasisInsideComments(t *testing.T) {
+	palette := theme.DefaultTheme().EditorMetadata
+	styler := newMetadataRuneStyler(palette)
+	source := strings.Join([]string{
+		"/**",
+		" * @name Blocked",
+		" */",
+	}, "\n")
+	styler.SetSource(source)
+
+	line := " * @name Blocked"
+	styles := styler.StylesForLine([]rune(line), 1)
+	assertMetadataTokenColor(t, styles, line, "*", palette.CommentMarker)
+	assertMetadataTokenColor(t, styles, line, "@name", palette.DirectiveColors["name"])
+	assertMetadataTokenColor(t, styles, line, "Blocked", palette.Value)
+	if !styles[strings.Index(line, "@name")].GetBold() {
+		t.Fatal("expected block-comment directive to remain bold")
+	}
+}
+
+func TestMetadataRuneStylerKeepsDirectiveArgumentsUndimmed(t *testing.T) {
+	palette := theme.DefaultTheme().EditorMetadata
+	styler := newMetadataRuneStyler(palette)
+
+	line := "# @auth request bearer request-token-{{$uuid}}"
+	styles := styleLine(styler, line)
+
+	assertMetadataTokenColor(t, styles, line, "#", palette.CommentMarker)
+	assertMetadataTokenColor(t, styles, line, "@auth", palette.DirectiveColors["auth"])
+	assertMetadataTokenColor(t, styles, line, "request", palette.Value)
+	assertMetadataTokenNotColor(t, styles, line, "bearer request-token-{{$uuid}}", palette.CommentMarker)
+}
+
+func TestMetadataRuneStylerColoursEveryLineOfAnArgument(t *testing.T) {
+	palette := theme.DefaultTheme().EditorMetadata
+	styler := newMetadataRuneStyler(palette)
+	lines := []string{
+		"# @assert (",
+		"#   response.statusCode == 200",
+		`# ) => "echo endpoint did not return the query arguments"`,
+		"# ordinary prose",
+	}
+	styler.SetSource(strings.Join(lines, "\n"))
+
+	for no, line := range lines[:3] {
+		styles := styler.StylesForLine([]rune(line), no)
+		if styles == nil {
+			t.Fatalf("line %d has no styles", no+1)
+		}
+		assertMetadataTokenColor(t, styles, line, "#", palette.CommentMarker)
+		text := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "#"))
+		if no == 0 {
+			text = "("
+		}
+		assertMetadataTokenColor(t, styles, line, text, palette.Value)
+	}
+
+	prose := lines[3]
+	styles := styler.StylesForLine([]rune(prose), 3)
+	assertMetadataTokenColor(t, styles, prose, "ordinary prose", palette.CommentMarker)
+}
+
+func TestMetadataRuneStylerSourceChangeInvalidatesContext(t *testing.T) {
+	palette := theme.DefaultTheme().EditorMetadata
+	styler := newMetadataRuneStyler(palette)
+	line := []rune("same text")
+
+	styler.SetSource("/*\nsame text\n*/")
+	if styles := styler.StylesForLine(line, 1); styles == nil {
+		t.Fatal("expected text inside block comment to be styled")
+	}
+
+	styler.SetSource("GET https://example.test\nsame text\nbody")
+	if styles := styler.StylesForLine(line, 1); styles != nil {
+		t.Fatalf("unchanged text kept stale block-comment style: %+v", styles)
+	}
+}
+
 // The colon in "@name: value" is a separator, so it must not be styled as part
 // of the value. Parse accepts both spellings and the editor has to agree.
 func TestMetadataRuneStylerColonSeparator(t *testing.T) {
@@ -68,7 +151,7 @@ func TestMetadataRuneStylerColonSeparator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			styler := newMetadataRuneStyler(palette)
-			styles := styler.StylesForLine([]rune(tt.line), 0)
+			styles := styleLine(styler, tt.line)
 			if styles == nil {
 				t.Fatalf("expected styles for %q", tt.line)
 			}
@@ -85,32 +168,12 @@ func TestMetadataRuneStylerColonSeparator(t *testing.T) {
 	}
 }
 
-func TestDirectiveArgumentKindsComeFromCatalog(t *testing.T) {
-	tests := map[string]directive.ArgKind{
-		"name":      directive.ArgToken,
-		"desc":      directive.ArgText,
-		"nolog":     directive.ArgNone,
-		"setting":   directive.ArgSetting,
-		"settings":  directive.ArgOptions,
-		"timeout":   directive.ArgToken,
-		"websocket": directive.ArgOptions,
-	}
-	for name, want := range tests {
-		if got := directiveArgKind(directive.Name(name)); got != want {
-			t.Fatalf("directiveArgKind(%q) = %d, want %d", name, got, want)
-		}
-	}
-	if got := directiveArgKind("grpc-method"); got != directive.ArgToken {
-		t.Fatalf("unknown directive kind = %d, want the ArgToken fallback", got)
-	}
-}
-
 func TestMetadataRuneStylerSettingDirective(t *testing.T) {
 	palette := theme.DefaultTheme().EditorMetadata
 	styler := newMetadataRuneStyler(palette)
 
-	line := []rune("# @setting timeout 5s")
-	styles := styler.StylesForLine(line, 0)
+	line := "# @setting timeout 5s"
+	styles := styleLine(styler, line)
 	if styles == nil {
 		t.Fatalf("expected styles for metadata line")
 	}
@@ -154,7 +217,7 @@ func TestMetadataRuneStylerSettingEqualsDirective(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			styles := styler.StylesForLine([]rune(tt.line), 0)
+			styles := styleLine(styler, tt.line)
 			assertMetadataTokenColor(t, styles, tt.line, "timeout", palette.SettingKey)
 			assertMetadataTokenNotColor(t, styles, tt.line, "=", palette.SettingKey)
 			if tt.value != "" {
@@ -211,7 +274,7 @@ func TestMetadataRuneStylerOptionDirectives(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			styles := styler.StylesForLine([]rune(tt.line), 0)
+			styles := styleLine(styler, tt.line)
 			for _, key := range tt.keys {
 				assertMetadataTokenColor(t, styles, tt.line, key, palette.SettingKey)
 			}
@@ -230,7 +293,7 @@ func TestMetadataRuneStylerSettingKeyIsNotBold(t *testing.T) {
 	styler := newMetadataRuneStyler(palette)
 
 	line := "# @mock method=POST path=/accounts name=flagged"
-	styles := styler.StylesForLine([]rune(line), 0)
+	styles := styleLine(styler, line)
 	for _, key := range []string{"method", "path", "name"} {
 		start, end := metadataTokenRange(t, styles, line, key)
 		for i := start; i < end; i++ {
@@ -248,7 +311,7 @@ func TestMetadataRuneStylerTimeoutUsesGenericValue(t *testing.T) {
 	}
 
 	line := "# @timeout 5s"
-	styles := newMetadataRuneStyler(palette).StylesForLine([]rune(line), 0)
+	styles := styleLine(newMetadataRuneStyler(palette), line)
 	assertMetadataTokenColor(t, styles, line, "5s", palette.Value)
 }
 
@@ -261,8 +324,7 @@ func TestMetadataRuneStylerRequestLines(t *testing.T) {
 	}
 	expected := lipgloss.NewStyle().Foreground(color).Bold(true).Render("P")
 
-	httpLine := []rune("POST https://api.example.com")
-	styles := styler.StylesForLine(httpLine, 0)
+	styles := styleLine(styler, "POST https://api.example.com")
 	if styles == nil {
 		t.Fatalf("expected styles for HTTP request line")
 	}
@@ -270,8 +332,7 @@ func TestMetadataRuneStylerRequestLines(t *testing.T) {
 		t.Fatalf("HTTP request style mismatch:\nwant %q\n got %q", expected, got)
 	}
 
-	grpcLine := []rune("GRPC localhost:50051")
-	styles = styler.StylesForLine(grpcLine, 0)
+	styles = styleLine(styler, "GRPC localhost:50051")
 	if styles == nil {
 		t.Fatalf("expected styles for gRPC request line")
 	}
@@ -284,8 +345,7 @@ func TestMetadataRuneStylerRequestLines(t *testing.T) {
 		t.Fatalf("gRPC request style mismatch:\nwant %q\n got %q", expected, got)
 	}
 
-	wsLine := []rune("WS wss://stream.example.com")
-	styles = styler.StylesForLine(wsLine, 0)
+	styles = styleLine(styler, "WS wss://stream.example.com")
 	if styles == nil {
 		t.Fatalf("expected styles for WebSocket request line")
 	}
@@ -345,8 +405,7 @@ func TestMetadataRuneStylerRequestSeparator(t *testing.T) {
 		t.Fatal("expected request separator color in palette")
 	}
 
-	line := []rune("### graphql list items")
-	styles := styler.StylesForLine(line, 0)
+	styles := styleLine(styler, "### graphql list items")
 	if styles == nil {
 		t.Fatalf("expected styles for request separator")
 	}
@@ -367,8 +426,7 @@ func TestMetadataRuneStylerRequestSeparator(t *testing.T) {
 		t.Fatalf("request separator text not styled uniformly:\nwant %q\n got %q", want, got)
 	}
 
-	lineNoSpace := []rune("###")
-	styles = styler.StylesForLine(lineNoSpace, 0)
+	styles = styleLine(styler, "###")
 	if styles == nil {
 		t.Fatalf("expected styles for compact request separator")
 	}
@@ -384,4 +442,9 @@ func TestMetadataRuneStylerRequestSeparator(t *testing.T) {
 			got,
 		)
 	}
+}
+
+func styleLine(styler *metadataRuneStyler, line string) []lipgloss.Style {
+	styler.SetSource(line)
+	return styler.StylesForLine([]rune(line), 0)
 }

--- a/internal/ui/editor_metadata_highlighter_test.go
+++ b/internal/ui/editor_metadata_highlighter_test.go
@@ -7,8 +7,15 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/unkn0wn-root/resterm/internal/intellisense"
+	"github.com/unkn0wn-root/resterm/internal/parser"
 	"github.com/unkn0wn-root/resterm/internal/theme"
 )
+
+type completionLines []string
+
+func (l completionLines) LineCount() int         { return len(l) }
+func (l completionLines) LineRunes(i int) []rune { return []rune(l[i]) }
 
 func TestMetadataRuneStylerNameDirective(t *testing.T) {
 	palette := theme.DefaultTheme().EditorMetadata
@@ -109,6 +116,35 @@ func TestMetadataRuneStylerColoursEveryLineOfAnArgument(t *testing.T) {
 	prose := lines[3]
 	styles := styler.StylesForLine([]rune(prose), 3)
 	assertMetadataTokenColor(t, styles, prose, "ordinary prose", palette.CommentMarker)
+}
+
+func TestDirectiveMarkMatchesCompletion(t *testing.T) {
+	lines := completionLines{"# @", "# @:", "# @:x", "# @::", "# ordinary prose", "#"}
+
+	var syntax parser.SourceSyntax
+	syntax.Classify(strings.Join(lines, "\n"))
+
+	for no, line := range lines {
+		ctx, ok := intellisense.Analyze(lines, no, len([]rune(line)))
+		opens := ok && ctx.Kind == intellisense.KindDirective
+		coloured := syntax.Line(no).Kind == parser.SourceLineDirective
+		if opens != coloured {
+			t.Fatalf("%q: completion opens = %v, editor colours a directive = %v", line, opens, coloured)
+		}
+	}
+}
+
+func TestMetadataRuneStylerColoursADirectiveMarkBeingTyped(t *testing.T) {
+	palette := theme.DefaultTheme().EditorMetadata
+	styler := newMetadataRuneStyler(palette)
+
+	line := "# @"
+	styles := styleLine(styler, line)
+	if styles == nil {
+		t.Fatal("a directive being typed has no styles")
+	}
+	assertMetadataTokenColor(t, styles, line, "#", palette.CommentMarker)
+	assertMetadataTokenColor(t, styles, line, "@", palette.DirectiveDefault)
 }
 
 func TestMetadataRuneStylerSourceChangeInvalidatesContext(t *testing.T) {

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -110,6 +110,11 @@ type requestEditor struct {
 	scope             intellisense.Scope
 }
 
+type sourceStyler interface {
+	textarea.RuneStyler
+	SetSource(source string)
+}
+
 const editorUndoLimit = 64
 
 type editorSnapshot struct {
@@ -241,8 +246,18 @@ func (e requestEditor) Revision() uint64 {
 	return e.revision
 }
 
-func (e *requestEditor) noteContentChanged() {
+func (e *requestEditor) noteContentChanged(value string) {
 	e.revision++
+	if styler, ok := e.RuneStyler().(sourceStyler); ok {
+		styler.SetSource(value)
+	}
+}
+
+func (e *requestEditor) SetRuneStyler(styler textarea.RuneStyler) {
+	e.Model.SetRuneStyler(styler)
+	if source, ok := styler.(sourceStyler); ok {
+		source.SetSource(e.Value())
+	}
 }
 
 func (e *requestEditor) SetValue(value string) {
@@ -250,8 +265,9 @@ func (e *requestEditor) SetValue(value string) {
 		return
 	}
 
-	e.noteContentChanged()
 	e.Model.SetValue(value)
+	// Classify the normalized text stored by the textarea.
+	e.noteContentChanged(e.Value())
 }
 
 func (e *requestEditor) SetMotionsEnabled(enabled bool) {
@@ -707,8 +723,8 @@ func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 	if !isKey {
 		var innerCmd tea.Cmd
 		e.Model, innerCmd = e.Model.Update(msg)
-		if e.Value() != beforeValue && e.revision == beforeRevision {
-			e.noteContentChanged()
+		if value := e.Value(); value != beforeValue && e.revision == beforeRevision {
+			e.noteContentChanged(value)
 		}
 		return e, innerCmd
 	}
@@ -916,8 +932,8 @@ func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 		}
 		var innerCmd tea.Cmd
 		e.Model, innerCmd = e.Model.Update(transformed)
-		if e.Value() != beforeValue && e.revision == beforeRevision {
-			e.noteContentChanged()
+		if value := e.Value(); value != beforeValue && e.revision == beforeRevision {
+			e.noteContentChanged(value)
 		}
 		if innerCmd != nil {
 			cmds = append(cmds, innerCmd)

--- a/internal/ui/editor_state_test.go
+++ b/internal/ui/editor_state_test.go
@@ -8,9 +8,22 @@ import (
 
 	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/unkn0wn-root/resterm/internal/intellisense"
 	"github.com/unkn0wn-root/resterm/internal/parser"
 )
+
+type sourceRecordingRuneStyler struct {
+	source string
+}
+
+func (s *sourceRecordingRuneStyler) SetSource(source string) {
+	s.source = source
+}
+
+func (s *sourceRecordingRuneStyler) StylesForLine([]rune, int) []lipgloss.Style {
+	return nil
+}
 
 func newTestEditor(content string) requestEditor {
 	editor := newRequestEditor()
@@ -89,6 +102,36 @@ func TestRequestEditorSetValueNoopsWhenUnchanged(t *testing.T) {
 	}
 	if got := editor.Revision(); got != beforeRevision {
 		t.Fatalf("expected revision to remain %d, got %d", beforeRevision, got)
+	}
+}
+
+func TestRequestEditorKeepsSourceAwareRuneStylerInSync(t *testing.T) {
+	editor := newTestEditor("alpha")
+	styler := &sourceRecordingRuneStyler{}
+	editor.SetRuneStyler(styler)
+	if styler.source != "alpha" {
+		t.Fatalf("source after installing styler = %q, want alpha", styler.source)
+	}
+
+	editor.SetValue("beta")
+	if styler.source != "beta" {
+		t.Fatalf("source after SetValue = %q, want beta", styler.source)
+	}
+
+	editor.SetMotionsEnabled(false)
+	editor.moveCursorTo(0, len([]rune(editor.Value())))
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'!'}})
+	if styler.source != "beta!" {
+		t.Fatalf("source after typing = %q, want beta!", styler.source)
+	}
+
+	input := "\t# @name tabbed\rother"
+	editor.SetValue(input)
+	if editor.Value() == input {
+		t.Fatal("expected the textarea to rewrite the input")
+	}
+	if styler.source != editor.Value() {
+		t.Fatalf("styler source = %q, editor holds %q", styler.source, editor.Value())
 	}
 }
 

--- a/internal/ui/header_layout.go
+++ b/internal/ui/header_layout.go
@@ -33,11 +33,13 @@ const headerValueFloor = 8
 // everything before it is an alternative wording that says the same thing in
 // less room. The fitter shrinks cells one step at a time, spending every lossless
 // rendering before it truncates anything and truncating before it drops a cell.
+// separator is the glue drawn before this segment, so a cell that needs unusual
+// glue keeps it whichever neighbour survives.
 type headerSegment struct {
-	text           []string
-	lossy          int
-	priority       int
-	separatorAfter string
+	text      []string
+	lossy     int
+	priority  int
+	separator string
 }
 
 func headerContentWidth(total int, style lipgloss.Style) int {
@@ -162,8 +164,8 @@ func fitHeaderSegments(segs []headerSegment, sep string, sepW, limit int) (strin
 	for i, seg := range segs {
 		widths[i] = headerSegmentWidths(seg.text)
 		separatorWidths[i] = sepW
-		if seg.separatorAfter != "" {
-			separatorWidths[i] = lipgloss.Width(seg.separatorAfter)
+		if seg.separator != "" {
+			separatorWidths[i] = lipgloss.Width(seg.separator)
 		}
 	}
 
@@ -252,7 +254,7 @@ func headerLineWidth(widths [][]int, separatorWidths, keep, levels []int) int {
 	total := 0
 	for n, i := range keep {
 		if n > 0 {
-			total += separatorWidths[keep[n-1]]
+			total += separatorWidths[i]
 		}
 		total += widths[i][levels[i]]
 	}
@@ -263,7 +265,7 @@ func joinHeaderSegments(segs []headerSegment, keep, levels []int, sep string) st
 	parts := make([]string, 0, 2*len(keep))
 	for n, i := range keep {
 		if n > 0 {
-			separator := segs[keep[n-1]].separatorAfter
+			separator := segs[i].separator
 			if separator == "" {
 				separator = sep
 			}

--- a/internal/ui/header_layout_test.go
+++ b/internal/ui/header_layout_test.go
@@ -149,7 +149,7 @@ func TestBuildHeaderLineLeftOnly(t *testing.T) {
 
 func TestFitHeaderSegmentsUsesSegmentSeparatorWidth(t *testing.T) {
 	segs := headerTextSegments("A", "BB")
-	segs[0].separatorAfter = " || "
+	segs[1].separator = " || "
 
 	line, width := fitHeaderSegments(segs, " ", 1, 6)
 	if got := ansi.Strip(line); got != "A" {
@@ -162,7 +162,7 @@ func TestFitHeaderSegmentsUsesSegmentSeparatorWidth(t *testing.T) {
 
 func TestBuildHeaderLineUsesGroupSeparatorWithoutTrailingDivider(t *testing.T) {
 	segs := headerTextSegments("BRAND", "ENV", "WORKSPACE")
-	segs[0].separatorAfter = headerGroupSep
+	segs[1].separator = headerGroupSep
 
 	line := buildHeaderLine(
 		segs,

--- a/internal/ui/header_render_test.go
+++ b/internal/ui/header_render_test.go
@@ -66,6 +66,7 @@ func TestHeaderRendersLayout(t *testing.T) {
 		headerBrandName + headerGroupSep + iconHeaderEnv,
 		iconHeaderEnv + " " + labelHeaderEnv + " default  " + iconHeaderWorkspace + " " +
 			labelHeaderWorkspace,
+		iconHeaderRequests + " " + labelHeaderRequests + " 0 " + iconHeaderActive + " GET create-user",
 		"201 · " + latLabel,
 	} {
 		if !strings.Contains(lines[0], want) {

--- a/internal/ui/header_render_test.go
+++ b/internal/ui/header_render_test.go
@@ -94,17 +94,39 @@ func TestHeaderDropsHelpBeforeLatency(t *testing.T) {
 	t.Fatal("expected Help to be hidden at a narrow width")
 }
 
-func TestHeaderShowsNoSelectedRequest(t *testing.T) {
-	model := headerTestModel(t, 160)
-	model.activeRequestTitle = ""
-
-	if view := ansi.Strip(model.renderHeader()); !strings.Contains(view, iconHeaderActive+" none selected") {
-		t.Fatalf("header does not show that no request is selected:\n%s", view)
+func TestHeaderOmitsActiveRequestWhenNoneSelected(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []requestListItem
+		count string
+	}{
+		{name: "no requests", count: "0"},
+		{name: "requests without a selection", items: make([]requestListItem, 17), count: "17"},
 	}
 
-	model.width = 70
-	if view := ansi.Strip(model.renderHeader()); !strings.Contains(view, iconHeaderActive+" none") {
-		t.Fatalf("narrow header does not use the short empty value:\n%s", view)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := headerTestModel(t, 160)
+			model.currentRequest = nil
+			model.activeRequestTitle = ""
+			model.requestItems = tt.items
+			model.testResults = []scripts.TestResult{{Name: "passed", Passed: true}}
+
+			for _, width := range []int{160, 70} {
+				model.width = width
+				view := ansi.Strip(model.renderHeader())
+				if strings.Contains(view, iconHeaderActive) {
+					t.Fatalf("width %d header contains an active-request cell:\n%s", width, view)
+				}
+				if width == 160 {
+					want := iconHeaderRequests + " " + labelHeaderRequests + " " + tt.count +
+						headerCellSep + iconTestPass
+					if !strings.Contains(view, want) {
+						t.Fatalf("header does not join request count to the following cell with %q:\n%s", want, view)
+					}
+				}
+			}
+		})
 	}
 }
 
@@ -146,18 +168,28 @@ func TestHeaderKeepsThemeBackground(t *testing.T) {
 
 func TestHeaderFitsSupportedWidths(t *testing.T) {
 	model := headerTestModel(t, 200)
+	activeRequests := []string{"GET create-user", ""}
 	statuses := []headerTransportStatus{
 		{},
 		{label: "ResourceExhausted", level: statusWarn},
 	}
 
-	for _, status := range statuses {
-		model.headerTransport = status
-		for width := 3; width <= 200; width++ {
-			model.width = width
-			for _, line := range strings.Split(model.renderHeader(), "\n") {
-				if got := lipgloss.Width(line); got > width {
-					t.Fatalf("status %q width %d rendered %d cells", status.label, width, got)
+	for _, activeRequest := range activeRequests {
+		model.activeRequestTitle = activeRequest
+		for _, status := range statuses {
+			model.headerTransport = status
+			for width := 3; width <= 200; width++ {
+				model.width = width
+				for _, line := range strings.Split(model.renderHeader(), "\n") {
+					if got := lipgloss.Width(line); got > width {
+						t.Fatalf(
+							"active request %q status %q width %d rendered %d cells",
+							activeRequest,
+							status.label,
+							width,
+							got,
+						)
+					}
 				}
 			}
 		}

--- a/internal/ui/header_render_test.go
+++ b/internal/ui/header_render_test.go
@@ -199,7 +199,7 @@ func TestHeaderFitsSupportedWidths(t *testing.T) {
 			model.headerTransport = status
 			for width := 3; width <= 200; width++ {
 				model.width = width
-				for _, line := range strings.Split(model.renderHeader(), "\n") {
+				for line := range strings.SplitSeq(model.renderHeader(), "\n") {
 					if got := lipgloss.Width(line); got > width {
 						t.Fatalf(
 							"active request %q status %q width %d rendered %d cells",

--- a/internal/ui/header_render_test.go
+++ b/internal/ui/header_render_test.go
@@ -45,7 +45,7 @@ func TestHeaderRendersLayout(t *testing.T) {
 	for _, want := range []string{
 		headerBrandName,
 		iconHeaderEnv + " " + labelHeaderEnv + " default",
-		iconHeaderWorkspace + " acme-api",
+		iconHeaderWorkspace + " " + labelHeaderWorkspace + " acme-api",
 		iconHeaderRequests + " " + labelHeaderRequests,
 		iconHeaderActive + " GET create-user",
 		"✗ 1 fail",
@@ -64,7 +64,8 @@ func TestHeaderRendersLayout(t *testing.T) {
 	}
 	for _, want := range []string{
 		headerBrandName + headerGroupSep + iconHeaderEnv,
-		iconHeaderEnv + " " + labelHeaderEnv + " default  " + iconHeaderWorkspace,
+		iconHeaderEnv + " " + labelHeaderEnv + " default  " + iconHeaderWorkspace + " " +
+			labelHeaderWorkspace,
 		"201 · " + latLabel,
 	} {
 		if !strings.Contains(lines[0], want) {
@@ -92,6 +93,23 @@ func TestHeaderDropsHelpBeforeLatency(t *testing.T) {
 		return
 	}
 	t.Fatal("expected Help to be hidden at a narrow width")
+}
+
+func TestHeaderCompactsWorkspaceLabelBeforeDroppingWorkspace(t *testing.T) {
+	model := headerTestModel(t, 160)
+
+	for width := 159; width >= 30; width-- {
+		model.width = width
+		view := ansi.Strip(model.renderHeader())
+		if strings.Contains(view, labelHeaderWorkspace) {
+			continue
+		}
+		if !strings.Contains(view, iconHeaderWorkspace+" acme-api") {
+			t.Fatalf("workspace label and value disappeared together at width %d:\n%s", width, view)
+		}
+		return
+	}
+	t.Fatal("expected the workspace label to be hidden at a narrow width")
 }
 
 func TestHeaderOmitsActiveRequestWhenNoneSelected(t *testing.T) {

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -1913,15 +1913,18 @@ func renderCommandKeycap(
 	return content
 }
 
-// headerCell is a header segment before rendering. values carries the same
-// information from longest to shortest.
+// headerCell is a header segment before rendering. labels and values each carry
+// the same information from longest to shortest, so a cell can give up words
+// before it gives up characters. A labels list ending in "" drops the label
+// entirely and leaves the icon to stand for it. separator is the glue drawn
+// before the cell, so it survives whichever neighbour the fitter keeps.
 type headerCell struct {
-	icon         string
-	label        string
-	compactLabel bool
-	values       []string
-	style        lipgloss.Style
-	priority     int
+	icon      string
+	labels    []string
+	values    []string
+	style     lipgloss.Style
+	priority  int
+	separator string
 }
 
 // Each style includes the header background because ANSI resets clear it.
@@ -1995,26 +1998,38 @@ func (s headerStyles) forTests(status testStatus) lipgloss.Style {
 	return s.fail
 }
 
-func (s headerStyles) cell(c headerCell, value string) string {
+func (s headerStyles) cell(c headerCell, label, value string) string {
 	prefix := s.icon.Render(c.icon)
-	if c.label != "" {
-		prefix += s.label.Render(" " + c.label)
+	if label != "" {
+		prefix += s.label.Render(" " + label)
 	}
 	return prefix + s.label.Render(" ") + c.style.Render(value)
 }
 
+// cellVariants renders a cell widest first: every label wording against the
+// widest value, then the shortest label against each narrower value. Both lists
+// must run widest to narrowest, since the fitter needs each step to save room.
 func (s headerStyles) cellVariants(c headerCell, limit int) ([]string, int) {
 	values, lossy := headerCellVariants(c.values, limit)
-	text := make([]string, 0, len(values)+1)
-	if c.compactLabel && c.label != "" {
-		text = append(text, s.cell(c, values[0]))
-		c.label = ""
-		if lossy > 0 {
-			lossy++
-		}
+	labels := c.labels
+	if len(labels) == 0 {
+		labels = []string{""}
+	}
+
+	short := labels[len(labels)-1]
+	text := make([]string, 0, len(labels)-1+len(values))
+	for _, label := range labels[:len(labels)-1] {
+		text = append(text, s.cell(c, label, values[0]))
 	}
 	for _, value := range values {
-		text = append(text, s.cell(c, value))
+		text = append(text, s.cell(c, short, value))
+	}
+
+	// Shorter label wordings say the same thing, so truncation still starts at
+	// the same value, just further down the list. A lossy of 0 stays 0: values[0]
+	// is already truncated, so every label wording of it is too.
+	if lossy > 0 {
+		lossy += len(labels) - 1
 	}
 	return text, lossy
 }
@@ -2032,23 +2047,23 @@ func (m *Model) renderHeader() string {
 	styles := m.headerStyles()
 	cells := []headerCell{
 		{
-			icon:     iconHeaderEnv,
-			label:    labelHeaderEnv,
-			values:   m.headerEnvVariants(),
-			style:    styles.value,
-			priority: headerPriorityEnv,
+			icon:      iconHeaderEnv,
+			labels:    []string{labelHeaderEnv},
+			values:    m.headerEnvVariants(),
+			style:     styles.value,
+			priority:  headerPriorityEnv,
+			separator: styles.group,
 		},
 		{
-			icon:         iconHeaderWorkspace,
-			label:        labelHeaderWorkspace,
-			compactLabel: true,
-			values:       []string{workspace},
-			style:        styles.value,
-			priority:     headerPriorityWorkspace,
+			icon:     iconHeaderWorkspace,
+			labels:   []string{labelHeaderWorkspace, ""},
+			values:   []string{workspace},
+			style:    styles.value,
+			priority: headerPriorityWorkspace,
 		},
 		{
 			icon:     iconHeaderRequests,
-			label:    labelHeaderRequests,
+			labels:   []string{labelHeaderRequests},
 			values:   []string{strconv.Itoa(len(m.requestItems))},
 			style:    styles.value,
 			priority: headerPriorityRequests,
@@ -2073,16 +2088,16 @@ func (m *Model) renderHeader() string {
 
 	segments := make([]headerSegment, 0, len(cells)+1)
 	segments = append(segments, headerSegment{
-		text:           []string{styles.brand.Render(headerBrandName)},
-		priority:       headerPriorityBrand,
-		separatorAfter: styles.group,
+		text:     []string{styles.brand.Render(headerBrandName)},
+		priority: headerPriorityBrand,
 	})
 	for _, cell := range cells {
 		text, lossy := styles.cellVariants(cell, limit)
 		segments = append(segments, headerSegment{
-			text:     text,
-			lossy:    lossy,
-			priority: cell.priority,
+			text:      text,
+			lossy:     lossy,
+			priority:  cell.priority,
+			separator: cell.separator,
 		})
 	}
 
@@ -2109,10 +2124,11 @@ func headerRule(st lipgloss.Style, width int) string {
 
 func (m *Model) headerActiveCell(styles headerStyles, request string) headerCell {
 	cell := headerCell{
-		icon:     iconHeaderActive,
-		values:   []string{request},
-		style:    styles.value,
-		priority: headerPriorityActive,
+		icon:      iconHeaderActive,
+		values:    []string{request},
+		style:     styles.value,
+		priority:  headerPriorityActive,
+		separator: styles.fill.Render(" "),
 	}
 	if m.currentRequest != nil {
 		cell.style = cell.style.Foreground(methodColor(m.theme, m.currentRequest.Method))

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -46,12 +46,13 @@ const (
 )
 
 const (
-	iconHeaderWorkspace = "▣"
-	iconHeaderEnv       = "⬢"
-	iconHeaderRequests  = "⇄"
-	iconHeaderActive    = "›"
-	labelHeaderEnv      = "env"
-	labelHeaderRequests = "req"
+	iconHeaderWorkspace  = "▣"
+	iconHeaderEnv        = "⬢"
+	iconHeaderRequests   = "⇄"
+	iconHeaderActive     = "›"
+	labelHeaderEnv       = "env"
+	labelHeaderRequests  = "req"
+	labelHeaderWorkspace = "workspace"
 )
 
 type testStatus string
@@ -1915,11 +1916,12 @@ func renderCommandKeycap(
 // headerCell is a header segment before rendering. values carries the same
 // information from longest to shortest.
 type headerCell struct {
-	icon     string
-	label    string
-	values   []string
-	style    lipgloss.Style
-	priority int
+	icon         string
+	label        string
+	compactLabel bool
+	values       []string
+	style        lipgloss.Style
+	priority     int
 }
 
 // Each style includes the header background because ANSI resets clear it.
@@ -2001,6 +2003,22 @@ func (s headerStyles) cell(c headerCell, value string) string {
 	return prefix + s.label.Render(" ") + c.style.Render(value)
 }
 
+func (s headerStyles) cellVariants(c headerCell, limit int) ([]string, int) {
+	values, lossy := headerCellVariants(c.values, limit)
+	text := make([]string, 0, len(values)+1)
+	if c.compactLabel && c.label != "" {
+		text = append(text, s.cell(c, values[0]))
+		c.label = ""
+		if lossy > 0 {
+			lossy++
+		}
+	}
+	for _, value := range values {
+		text = append(text, s.cell(c, value))
+	}
+	return text, lossy
+}
+
 func (m *Model) renderHeader() string {
 	workspace := filepath.Base(m.ws.root)
 	if workspace == "" {
@@ -2021,10 +2039,12 @@ func (m *Model) renderHeader() string {
 			priority: headerPriorityEnv,
 		},
 		{
-			icon:     iconHeaderWorkspace,
-			values:   []string{workspace},
-			style:    styles.value,
-			priority: headerPriorityWorkspace,
+			icon:         iconHeaderWorkspace,
+			label:        labelHeaderWorkspace,
+			compactLabel: true,
+			values:       []string{workspace},
+			style:        styles.value,
+			priority:     headerPriorityWorkspace,
 		},
 		{
 			icon:     iconHeaderRequests,
@@ -2058,11 +2078,7 @@ func (m *Model) renderHeader() string {
 		separatorAfter: styles.group,
 	})
 	for _, cell := range cells {
-		values, lossy := headerCellVariants(cell.values, limit)
-		text := make([]string, 0, len(values))
-		for _, value := range values {
-			text = append(text, styles.cell(cell, value))
-		}
+		text, lossy := styles.cellVariants(cell, limit)
 		segments = append(segments, headerSegment{
 			text:     text,
 			lossy:    lossy,

--- a/internal/ui/model_render.go
+++ b/internal/ui/model_render.go
@@ -49,7 +49,7 @@ const (
 	iconHeaderWorkspace = "▣"
 	iconHeaderEnv       = "⬢"
 	iconHeaderRequests  = "⇄"
-	iconHeaderActive    = "◨"
+	iconHeaderActive    = "›"
 	labelHeaderEnv      = "env"
 	labelHeaderRequests = "req"
 )
@@ -2033,7 +2033,9 @@ func (m *Model) renderHeader() string {
 			style:    styles.value,
 			priority: headerPriorityRequests,
 		},
-		m.headerActiveCell(styles, request),
+	}
+	if request != "" {
+		cells = append(cells, m.headerActiveCell(styles, request))
 	}
 
 	if summary, status, ok := m.headerTestStatus(); ok {
@@ -2090,15 +2092,12 @@ func headerRule(st lipgloss.Style, width int) string {
 }
 
 func (m *Model) headerActiveCell(styles headerStyles, request string) headerCell {
-	cell := headerCell{icon: iconHeaderActive, priority: headerPriorityActive}
-	if request == "" {
-		cell.values = []string{"none selected", "none"}
-		cell.style = styles.label
-		return cell
+	cell := headerCell{
+		icon:     iconHeaderActive,
+		values:   []string{request},
+		style:    styles.value,
+		priority: headerPriorityActive,
 	}
-
-	cell.values = []string{request}
-	cell.style = styles.value
 	if m.currentRequest != nil {
 		cell.style = cell.style.Foreground(methodColor(m.theme, m.currentRequest.Method))
 	}

--- a/internal/ui/model_render_test.go
+++ b/internal/ui/model_render_test.go
@@ -1885,11 +1885,11 @@ func TestUnfocusedSplitResponseColumnKeepsPrettyContentReadable(t *testing.T) {
 func framedLineWith(view, needle string) string {
 	for line := range strings.SplitSeq(view, "\n") {
 		plain := ansi.Strip(line)
-		idx := strings.Index(plain, needle)
-		if idx < 0 {
+		before, after, ok := strings.Cut(plain, needle)
+		if !ok {
 			continue
 		}
-		if strings.Contains(plain[:idx], "│") && strings.Contains(plain[idx+len(needle):], "│") {
+		if strings.Contains(before, "│") && strings.Contains(after, "│") {
 			return line
 		}
 	}


### PR DESCRIPTION
This PR makes editor highlighting understand where text appears instead of relying only on line prefixes.

- Correctly highlights `#, //, --`, and block comments.
- Preserves directive and value highlighting across multiple lines.
- Avoids highlighting comment-like content inside multipart bodies, mock responses, and script blocks.
- Improves header labels, separators, and request-state display.
- Adds tests and more efficient incremental syntax scanning.

Request execution behavior is unchanged.