### PR TITLE
RST-349: cli flags in any order

### DIFF
--- a/cmd/resterm/collection.go
+++ b/cmd/resterm/collection.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -65,27 +64,21 @@ func runCollectionExport(args []string) error {
 	fs.BoolVar(&force, "force", false, "Overwrite existing output directory")
 
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("collection export: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf(
-			"collection export: unexpected args: %s",
-			strings.Join(fs.Args(), " "),
-		)
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
 
-	workspace = str.Trim(workspace)
 	if workspace == "" {
 		return errors.New("collection export: --workspace is required")
 	}
-	out = str.Trim(out)
 	if out == "" {
 		return errors.New("collection export: --out is required")
 	}
-	name = str.Trim(name)
 
 	res, err := collection.ExportBundle(collection.ExportOptions{
 		Workspace: workspace,
@@ -129,23 +122,18 @@ func runCollectionImport(args []string) error {
 	fs.BoolVar(&dry, "dry-run", false, "Plan import without writing files")
 
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("collection import: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf(
-			"collection import: unexpected args: %s",
-			strings.Join(fs.Args(), " "),
-		)
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
 
-	in = str.Trim(in)
 	if in == "" {
 		return errors.New("collection import: --in is required")
 	}
-	workspace = str.Trim(workspace)
 	if workspace == "" {
 		return errors.New("collection import: --workspace is required")
 	}
@@ -196,23 +184,18 @@ func runCollectionPack(args []string) error {
 	fs.BoolVar(&force, "force", false, "Overwrite existing archive file")
 
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("collection pack: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf(
-			"collection pack: unexpected args: %s",
-			strings.Join(fs.Args(), " "),
-		)
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
 
-	in = str.Trim(in)
 	if in == "" {
 		return errors.New("collection pack: --in is required")
 	}
-	out = str.Trim(out)
 	if out == "" {
 		return errors.New("collection pack: --out is required")
 	}
@@ -248,23 +231,18 @@ func runCollectionUnpack(args []string) error {
 	fs.BoolVar(&force, "force", false, "Overwrite existing output directory")
 
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("collection unpack: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf(
-			"collection unpack: unexpected args: %s",
-			strings.Join(fs.Args(), " "),
-		)
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
 
-	in = str.Trim(in)
 	if in == "" {
 		return errors.New("collection unpack: --in is required")
 	}
-	out = str.Trim(out)
 	if out == "" {
 		return errors.New("collection unpack: --out is required")
 	}

--- a/cmd/resterm/history.go
+++ b/cmd/resterm/history.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -64,15 +63,14 @@ func runHistoryExport(args []string) error {
 	var out string
 	fs.StringVar(&out, "out", "", "Output JSON file path")
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("history export: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf("history export: unexpected args: %s", strings.Join(fs.Args(), " "))
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
-	out = str.Trim(out)
 	if out == "" {
 		return errors.New("history export: --out is required")
 	}
@@ -98,15 +96,14 @@ func runHistoryImport(args []string) error {
 	var in string
 	fs.StringVar(&in, "in", "", "Input JSON file path")
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("history import: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf("history import: unexpected args: %s", strings.Join(fs.Args(), " "))
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
-	in = str.Trim(in)
 	if in == "" {
 		return errors.New("history import: --in is required")
 	}
@@ -132,15 +129,14 @@ func runHistoryBackup(args []string) error {
 	var out string
 	fs.StringVar(&out, "out", "", "Output SQLite backup file path")
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("history backup: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf("history backup: unexpected args: %s", strings.Join(fs.Args(), " "))
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
-	out = str.Trim(out)
 	if out == "" {
 		return errors.New("history backup: --out is required")
 	}
@@ -163,13 +159,13 @@ func runHistoryBackup(args []string) error {
 func runHistoryStats(args []string) error {
 	fs := cli.NewSubcommandFlagSet("resterm", "history stats", os.Stderr)
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("history stats: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf("history stats: unexpected args: %s", strings.Join(fs.Args(), " "))
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
 
 	s, err := openHistoryStore(true)
@@ -204,13 +200,13 @@ func runHistoryStats(args []string) error {
 func runHistoryCompact(args []string) error {
 	fs := cli.NewSubcommandFlagSet("resterm", "history compact", os.Stderr)
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("history compact: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf("history compact: unexpected args: %s", strings.Join(fs.Args(), " "))
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
 
 	s, err := openHistoryStore(true)
@@ -249,13 +245,13 @@ func runHistoryCheck(args []string) error {
 	var full bool
 	fs.BoolVar(&full, "full", false, "Use full integrity check")
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return fmt.Errorf("history check: %w", err)
 	}
-	if len(fs.Args()) > 0 {
-		return fmt.Errorf("history check: unexpected args: %s", strings.Join(fs.Args(), " "))
+	if err := fs.UnexpectedArgs(); err != nil {
+		return err
 	}
 
 	s, err := openHistoryStore(true)

--- a/cmd/resterm/init.go
+++ b/cmd/resterm/init.go
@@ -76,7 +76,7 @@ func (c *initCmd) run() error {
 		return initcmd.Run(initcmd.Opt{List: true, Out: os.Stdout})
 	}
 	if len(extra) > 0 {
-		if c.dir == initcmd.DefaultDir && len(extra) == 1 {
+		if !c.fs.WasSet("dir") && len(extra) == 1 {
 			c.dir = extra[0]
 		} else {
 			return fmt.Errorf("init: unexpected args: %s", strings.Join(extra, " "))

--- a/cmd/resterm/init.go
+++ b/cmd/resterm/init.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -28,7 +27,7 @@ func handleInitSubcommand(args []string) (bool, error) {
 func runInit(args []string) error {
 	c := newInitCmd()
 	if err := c.parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return err
@@ -37,7 +36,7 @@ func runInit(args []string) error {
 }
 
 type initCmd struct {
-	fs    *flag.FlagSet
+	fs    *cli.FlagSet
 	dir   string
 	tpl   string
 	force bool

--- a/cmd/resterm/init_test.go
+++ b/cmd/resterm/init_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunInitTakesDirFromFlagOrPositional(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "positional", args: []string{"target"}},
+		{name: "flag", args: []string{"--dir", "target"}},
+		{name: "flag after positional", args: []string{"--template", "minimal", "target"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			if _, _, err := captureRunIO(t, func() error { return runInit(test.args) }); err != nil {
+				t.Fatalf("runInit(%q): %v", test.args, err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, "target", "requests.http")); err != nil {
+				t.Fatalf("runInit(%q) did not write into target: %v", test.args, err)
+			}
+		})
+	}
+}
+
+// A --dir given alongside a positional directory is ambiguous, whatever value
+// the flag carries.
+func TestRunInitRejectsDirFlagWithPositional(t *testing.T) {
+	for _, args := range [][]string{
+		{"--dir", ".", "target"},
+		{"--dir", " . ", "target"},
+		{"--dir", "other", "target"},
+		{"target", "--dir", "."},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			_, _, err := captureRunIO(t, func() error { return runInit(args) })
+			if err == nil {
+				t.Fatalf("runInit(%q) = nil, want an ambiguity error", args)
+			}
+		})
+	}
+}

--- a/cmd/resterm/main.go
+++ b/cmd/resterm/main.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -86,90 +85,56 @@ func run(a []string) error {
 
 	exec := cli.NewExecFlags()
 	fs := cli.NewFlagSet("resterm")
-	cli.StringVarAliases(fs, &filePath, "", "Path to .http/.rest file to open", "file", "f")
+	fs.StringVarAliases(&filePath, "", "Path to .http/.rest file to open", "file", "f")
 	exec.Bind(fs)
-	cli.BoolVarAliases(fs, &showVersion, false, "Show resterm version", "version", "v")
-	cli.BoolVarAliases(
-		fs,
-		&checkUpdate,
-		false,
-		"Check for newer releases and exit",
-		"check-update",
-		"c",
-	)
-	cli.BoolVarAliases(
-		fs,
-		&doUpdate,
-		false,
-		"Download and install the latest release, if available",
-		"update",
-		"u",
-	)
-	cli.StringVarAliases(
-		fs,
-		&curlSrc,
-		"",
-		"Curl command or file path to convert",
-		"from-curl",
-		"fc",
-	)
-	cli.StringVarAliases(
-		fs,
+	fs.BoolVarAliases(&showVersion, false, "Show resterm version", "version", "v")
+	fs.BoolVarAliases(&checkUpdate, false, "Check for newer releases and exit", "check-update", "c")
+	fs.BoolVarAliases(&doUpdate, false, "Download and install the latest release, if available", "update", "u")
+	fs.StringVarAliases(&curlSrc, "", "Curl command or file path to convert", "from-curl", "fc")
+	fs.StringVarAliases(
 		&openapiSpec,
 		"",
 		"Path or URL (http/https) to an OpenAPI specification to convert",
 		"from-openapi",
 		"fo",
 	)
-	cli.StringVarAliases(
-		fs,
-		&httpOut,
-		"",
-		"Destination path for generated .http file",
-		"http-out",
-		"o",
-	)
-	cli.StringVarAliases(
-		fs,
+	fs.StringVarAliases(&httpOut, "", "Destination path for generated .http file", "http-out", "o")
+	fs.StringVarAliases(
 		&openapiBase,
 		openapi.DefaultBaseURLVariable,
 		"Variable name for the generated base URL",
 		"openapi-base-var",
 		"ob",
 	)
-	cli.BoolVarAliases(
-		fs,
+	fs.BoolVarAliases(
 		&openapiResolveRefs,
 		false,
 		"Resolve external $ref references during OpenAPI import",
 		"openapi-resolve-refs",
 		"or",
 	)
-	cli.BoolVarAliases(
-		fs,
+	fs.BoolVarAliases(
 		&openapiIncludeDeprecated,
 		false,
 		"Include deprecated operations when generating requests",
 		"openapi-include-deprecated",
 		"od",
 	)
-	cli.IntVarAliases(
-		fs,
+	fs.IntVarAliases(
 		&openapiServerIndex,
 		0,
 		"Preferred server index (0-based) from the spec to use as the base URL",
 		"openapi-server-index",
 		"os",
 	)
-	cli.StringVarAliases(
-		fs,
+	fs.StringVarAliases(
 		&openapiMode,
 		string(openapi.GenerationRequests),
 		"OpenAPI output mode: requests, mocks, or both",
 		"openapi-mode",
 	)
 	if err := fs.Parse(a); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			printMainUsage(os.Stderr, fs)
 			return nil
 		}
@@ -438,7 +403,7 @@ func run(a []string) error {
 	return nil
 }
 
-func printMainUsage(w io.Writer, fs *flag.FlagSet) {
+func printMainUsage(w io.Writer, fs *cli.FlagSet) {
 	if _, err := fmt.Fprintf(w, "Usage: %s [flags] [file]\n\n", fs.Name()); err != nil {
 		return
 	}

--- a/cmd/resterm/mock.go
+++ b/cmd/resterm/mock.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -108,49 +107,38 @@ func mockUsageError(err error) error {
 func runMockServe(args []string) error {
 	fs := cli.NewFlagSet("mock")
 	cfg := defaultMockConfig()
-	cli.StringVarAliases(fs, &cfg.addr, cfg.addr, "Listen address", "addr", "a")
-	cli.StringListVarAliases(
-		fs,
+	fs.StringVarAliases(&cfg.addr, cfg.addr, "Listen address", "addr", "a")
+	fs.StringListVarAliases(
 		&cfg.sources,
 		"Serve only these request files (repeatable, comma lists allowed)",
 		"source",
 		"s",
 	)
-	cli.StringVarAliases(fs, &cfg.cors, cfg.cors, "CORS policy: auto, off, *, or comma-separated origins", "cors")
-	cli.StringVarAliases(
-		fs,
-		&cfg.tlsCert,
-		"",
-		"Serve HTTPS using this PEM certificate (requires --tls-key)",
-		"tls-cert",
-	)
-	cli.StringVarAliases(fs, &cfg.tlsKey, "", "PEM private key for --tls-cert", "tls-key")
-	cli.BoolVarAliases(fs, &cfg.recursive, false, "Scan workspace recursively", "recursive", "r")
-	cli.BoolVarAliases(fs, &cfg.watch, true, "Reload changed sources and fixtures", "watch", "w")
-	cli.BoolVarAliases(fs, &cfg.quiet, false, "Suppress per-request access summaries", "quiet", "q")
-	cli.IntVarAliases(
-		fs,
+	fs.StringVarAliases(&cfg.cors, cfg.cors, "CORS policy: auto, off, *, or comma-separated origins", "cors")
+	fs.StringVarAliases(&cfg.tlsCert, "", "Serve HTTPS using this PEM certificate (requires --tls-key)", "tls-cert")
+	fs.StringVarAliases(&cfg.tlsKey, "", "PEM private key for --tls-cert", "tls-key")
+	fs.BoolVarAliases(&cfg.recursive, false, "Scan workspace recursively", "recursive", "r")
+	fs.BoolVarAliases(&cfg.watch, true, "Reload changed sources and fixtures", "watch", "w")
+	fs.BoolVarAliases(&cfg.quiet, false, "Suppress per-request access summaries", "quiet", "q")
+	fs.IntVarAliases(
 		&cfg.sequenceKeyLimit,
 		cfg.sequenceKeyLimit,
 		"Maximum distinct keys retained by each sequence",
 		"sequence-key-limit",
 	)
-	cli.IntVarAliases(
-		fs,
+	fs.IntVarAliases(
 		&cfg.journalEntries,
 		cfg.journalEntries,
 		"Maximum requests retained for verification",
 		"journal-entries",
 	)
-	cli.StringVarAliases(
-		fs,
+	fs.StringVarAliases(
 		&cfg.journalBytes,
 		cfg.journalBytes,
 		"Maximum memory retained by the request journal",
 		"journal-bytes",
 	)
-	cli.StringVarAliases(
-		fs,
+	fs.StringVarAliases(
 		&cfg.journalBodyLimit,
 		cfg.journalBodyLimit,
 		"Maximum body bytes retained per request",
@@ -166,7 +154,7 @@ func runMockServe(args []string) error {
 		}
 	}
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return mockUsageError(err)
@@ -322,7 +310,7 @@ func closeMockServer(server *mock.Server) error {
 	return nil
 }
 
-func printMockUsage(w io.Writer, fs *flag.FlagSet) {
+func printMockUsage(w io.Writer, fs *cli.FlagSet) {
 	_, _ = fmt.Fprintln(w, "Usage: resterm mock [flags] [file|dir]")
 	_, _ = fmt.Fprintln(w, "       resterm mock reset [flags] [sequence]")
 	_, _ = fmt.Fprintln(w, "       resterm mock clear [flags]")

--- a/cmd/resterm/mock_control.go
+++ b/cmd/resterm/mock_control.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -25,10 +24,10 @@ type mockControlConfig struct {
 	insecure bool
 }
 
-func (c *mockControlConfig) bind(fs *flag.FlagSet) {
-	cli.StringVarAliases(fs, &c.url, defaultMockURL, "Mock server URL", "url", "u")
-	cli.DurationVarAliases(fs, &c.timeout, 5*time.Second, "Control request timeout", "timeout", "t")
-	cli.BoolVarAliases(fs, &c.insecure, false, "Skip HTTPS certificate verification", "insecure", "k")
+func (c *mockControlConfig) bind(fs *cli.FlagSet) {
+	fs.StringVarAliases(&c.url, defaultMockURL, "Mock server URL", "url", "u")
+	fs.DurationVarAliases(&c.timeout, 5*time.Second, "Control request timeout", "timeout", "t")
+	fs.BoolVarAliases(&c.insecure, false, "Skip HTTPS certificate verification", "insecure", "k")
 }
 
 func (c mockControlConfig) client() (*mock.Client, error) {
@@ -47,7 +46,7 @@ func controlSetup(
 	cmd string,
 	args []string,
 	errOut io.Writer,
-	extra func(*flag.FlagSet),
+	extra func(*cli.FlagSet),
 ) (client *mock.Client, pos []string, done bool, err error) {
 	fs := cli.NewSubcommandFlagSet("resterm", cmd, errOut)
 	var cfg mockControlConfig
@@ -56,7 +55,7 @@ func controlSetup(
 		extra(fs)
 	}
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil, nil, true, nil
 		}
 		return nil, nil, false, mockUsageError(err)
@@ -120,10 +119,9 @@ func runMockClear(args []string, out, errOut io.Writer) error {
 func runMockVerify(args []string, out, errOut io.Writer) error {
 	var recursive bool
 	var sources []string
-	client, pos, done, err := controlSetup("mock verify", args, errOut, func(fs *flag.FlagSet) {
-		cli.BoolVarAliases(fs, &recursive, false, "Scan workspace recursively", "recursive", "r")
-		cli.StringListVarAliases(
-			fs,
+	client, pos, done, err := controlSetup("mock verify", args, errOut, func(fs *cli.FlagSet) {
+		fs.BoolVarAliases(&recursive, false, "Scan workspace recursively", "recursive", "r")
+		fs.StringListVarAliases(
 			&sources,
 			"Verify only these request files (repeatable, comma lists allowed)",
 			"source",

--- a/cmd/resterm/run.go
+++ b/cmd/resterm/run.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -51,7 +50,7 @@ func runRun(args []string) error {
 
 	cmd := newRunCmd()
 	if err := cmd.parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return nil
 		}
 		return runExit(err, runExitCodeUsage)
@@ -98,7 +97,7 @@ func isRunUsageError(err error) bool {
 }
 
 type runCmd struct {
-	fs *flag.FlagSet
+	fs *cli.FlagSet
 
 	exec cli.ExecFlags
 
@@ -155,114 +154,29 @@ func newRunCmd() *runCmd {
 
 func (c *runCmd) bind() {
 	c.exec.Bind(c.fs)
-	cli.StringVarAliases(c.fs, &c.request, "", "Run a named request", "request", "r")
-	cli.StringVarAliases(c.fs, &c.workflow, "", "Run a named workflow", "workflow", "W")
-	cli.StringVarAliases(c.fs, &c.tag, "", "Run requests matching a tag", "tag", "g")
-	cli.BoolVarAliases(c.fs, &c.all, false, "Run all requests in the file", "all", "a")
-	cli.IntVarAliases(
-		c.fs,
-		&c.line,
-		0,
-		"Run the request or workflow at a specific line",
-		"line",
-		"l",
-	)
-	cli.StringVarAliases(
-		c.fs,
-		&c.format,
-		c.format,
-		"Output format: auto, text, json, junit, pretty, raw",
-		"format",
-		"f",
-	)
-	cli.StringVarAliases(
-		c.fs,
-		&c.exitCodeMode,
-		c.exitCodeMode,
-		"Exit code mode: detailed or summary",
-		"exit-code-mode",
-		"m",
-	)
-	cli.StringVarAliases(
-		c.fs,
-		&c.color,
-		c.color,
-		"Color for pretty output: auto, always, never",
-		"color",
-		"c",
-	)
-	cli.BoolVarAliases(
-		c.fs,
-		&c.body,
-		false,
-		"Print only the response body for a single request result",
-		"body",
-		"b",
-	)
-	cli.BoolVarAliases(
-		c.fs,
-		&c.headers,
-		false,
-		"Include request and response headers in output",
-		"headers",
-		"H",
-	)
-	cli.BoolVarAliases(
-		c.fs,
-		&c.profile,
-		false,
-		"Force profile mode for the selected request",
-		"profile",
-		"p",
-	)
-	cli.BoolVarAliases(
-		c.fs,
-		&c.failFast,
-		false,
-		"Stop after the first failed result",
-		"fail-fast",
-		"ff",
-	)
-	cli.StringVarAliases(
-		c.fs,
-		&c.artifactDir,
-		"",
-		"Directory to write run artifacts",
-		"artifact-dir",
-		"A",
-	)
-	cli.StringVarAliases(
-		c.fs,
-		&c.stateDir,
-		"",
-		"Directory for persisted run state",
-		"state-dir",
-		"s",
-	)
-	cli.BoolVarAliases(
-		c.fs,
+	c.fs.StringVarAliases(&c.request, "", "Run a named request", "request", "r")
+	c.fs.StringVarAliases(&c.workflow, "", "Run a named workflow", "workflow", "W")
+	c.fs.StringVarAliases(&c.tag, "", "Run requests matching a tag", "tag", "g")
+	c.fs.BoolVarAliases(&c.all, false, "Run all requests in the file", "all", "a")
+	c.fs.IntVarAliases(&c.line, 0, "Run the request or workflow at a specific line", "line", "l")
+	c.fs.StringVarAliases(&c.format, c.format, "Output format: auto, text, json, junit, pretty, raw", "format", "f")
+	c.fs.StringVarAliases(&c.exitCodeMode, c.exitCodeMode, "Exit code mode: detailed or summary", "exit-code-mode", "m")
+	c.fs.StringVarAliases(&c.color, c.color, "Color for pretty output: auto, always, never", "color", "c")
+	c.fs.BoolVarAliases(&c.body, false, "Print only the response body for a single request result", "body", "b")
+	c.fs.BoolVarAliases(&c.headers, false, "Include request and response headers in output", "headers", "H")
+	c.fs.BoolVarAliases(&c.profile, false, "Force profile mode for the selected request", "profile", "p")
+	c.fs.BoolVarAliases(&c.failFast, false, "Stop after the first failed result", "fail-fast", "ff")
+	c.fs.StringVarAliases(&c.artifactDir, "", "Directory to write run artifacts", "artifact-dir", "A")
+	c.fs.StringVarAliases(&c.stateDir, "", "Directory for persisted run state", "state-dir", "s")
+	c.fs.BoolVarAliases(
 		&c.persistGlobals,
 		false,
 		"Persist captured globals between invocations",
 		"persist-globals",
 		"G",
 	)
-	cli.BoolVarAliases(
-		c.fs,
-		&c.persistAuth,
-		false,
-		"Persist cached auth state between invocations",
-		"persist-auth",
-		"P",
-	)
-	cli.BoolVarAliases(
-		c.fs,
-		&c.history,
-		false,
-		"Persist run history to the state directory",
-		"history",
-		"y",
-	)
+	c.fs.BoolVarAliases(&c.persistAuth, false, "Persist cached auth state between invocations", "persist-auth", "P")
+	c.fs.BoolVarAliases(&c.history, false, "Persist run history to the state directory", "history", "y")
 }
 
 func (c *runCmd) parse(args []string) error {
@@ -722,10 +636,7 @@ func runExit(err error, code int) error {
 	return cli.ExitErr{Err: fmt.Errorf("run: %w", err), Code: code}
 }
 
-func printRunUsage(w io.Writer, fs *flag.FlagSet) {
-	if w == nil || fs == nil {
-		return
-	}
+func printRunUsage(w io.Writer, fs *cli.FlagSet) {
 	if _, err := fmt.Fprintf(w, "Usage: resterm run [flags] <file|->\n\n"); err != nil {
 		return
 	}

--- a/cmd/resterm/run_test.go
+++ b/cmd/resterm/run_test.go
@@ -188,6 +188,43 @@ func TestRunCmdShortAliases(t *testing.T) {
 	}
 }
 
+func TestRunCmdAllowsFlagsAfterSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantPath string
+		wantReq  string
+	}{
+		{
+			name:     "file path",
+			args:     []string{"requests.http", "-r", "createPost"},
+			wantPath: "requests.http",
+			wantReq:  "createPost",
+		},
+		{
+			name:     "stdin",
+			args:     []string{"-", "--request", "health"},
+			wantPath: "-",
+			wantReq:  "health",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := newRunCmd()
+			if err := cmd.parse(test.args); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if cmd.request != test.wantReq {
+				t.Errorf("request = %q, want %q", cmd.request, test.wantReq)
+			}
+			if got := cmd.fs.Args(); len(got) != 1 || got[0] != test.wantPath {
+				t.Errorf("args = %q, want [%q]", got, test.wantPath)
+			}
+		})
+	}
+}
+
 func TestRunDispatchesRunSubcommand(t *testing.T) {
 	stdout, stderr, err := captureRunIO(t, func() error {
 		return run([]string{"run", "-h"})

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,10 @@ Use this guide for command-line behavior. For request syntax, directives, workfl
 | `resterm --from-openapi ...` | Generate `.http` collections from OpenAPI documents. |
 | `resterm --check-update`, `resterm --update`, `resterm --version` | Inspect or update the installed binary. |
 
+## Argument Order
+
+Flags and positional arguments may be interspersed, so `resterm run requests.http --request createPost` and `resterm run --request createPost requests.http` are the same command. Everything after a `--` terminator is treated as a positional argument, which is how you pass a file whose name starts with a dash.
+
 ## Shared Execution Flags
 
 These flags are shared by `resterm` and `resterm run` when request execution is involved.
@@ -78,6 +82,7 @@ resterm run [flags] <file|->
 
 - Pass a file path to execute a request document from disk.
 - Pass `-` to read the request file from stdin.
+- Flags may appear before or after the file argument. See [Argument Order](#argument-order).
 
 ### Selecting What To Run
 
@@ -365,7 +370,7 @@ resterm mock verify payments.http
 resterm mock verify --recursive .
 ```
 
-The operations connect to `http://127.0.0.1:8080` by default. Each accepts `--url`, `--timeout`, and `--insecure`, and `verify` also accepts `--recursive`. Put flags before the optional sequence or source argument, for example:
+The operations connect to `http://127.0.0.1:8080` by default. Each accepts `--url`, `--timeout`, and `--insecure`, and `verify` also accepts `--recursive`. Flags may go on either side of the optional sequence or source argument, for example:
 
 ```bash
 resterm mock reset --url http://127.0.0.1:9090 polling

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -373,8 +373,8 @@ resterm mock verify --recursive .
 The operations connect to `http://127.0.0.1:8080` by default. Each accepts `--url`, `--timeout`, and `--insecure`, and `verify` also accepts `--recursive`. Flags may go on either side of the optional sequence or source argument, for example:
 
 ```bash
-resterm mock reset --url http://127.0.0.1:9090 polling
-resterm mock verify --url https://localhost:9443 --insecure payments.http
+resterm mock reset polling --url http://127.0.0.1:9090
+resterm mock verify payments.http --url https://localhost:9443 --insecure
 ```
 
 The URL must contain only the `http` or `https` scheme and host. Operational commands intentionally do not support proxy base paths. Source files or directories named `reset`, `clear`, or `verify` should be passed with an explicit path such as `./reset` so they are not interpreted as operations.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -98,7 +98,7 @@ Both templates add `resterm.env.json` to `.gitignore` so secrets stay out of ver
 
 | Flag | Description |
 | --- | --- |
-| `-dir <path>` | Target directory. You can also pass the path as a positional argument. |
+| `-dir <path>` | Target directory. You can also pass the path as a positional argument, but not both. |
 | `-template <name>` | Template to use (`standard` or `minimal`). |
 | `-force` | Overwrite existing files instead of aborting. |
 | `-dry-run` | Print actions without writing anything. |

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"maps"
 	"os"
@@ -60,95 +59,62 @@ func NewExecFlags() ExecFlags {
 	}
 }
 
-func (f *ExecFlags) Bind(fs *flag.FlagSet) {
-	if fs == nil || f == nil {
-		return
-	}
-	StringVarAliases(fs, &f.EnvName, "", "Environment name to use", "env", "e")
+func (f *ExecFlags) Bind(fs *FlagSet) {
+	fs.StringVarAliases(&f.EnvName, "", "Environment name to use", "env", "e")
 	fs.Var(&f.EnvGroups, "env-group", "Select a grouped environment as group=profile (repeatable)")
-	StringVarAliases(fs, &f.EnvFile, "", "Path to environment file", "env-file", "E")
-	StringVarAliases(
-		fs,
-		&f.Workspace,
-		"",
-		"Workspace directory to scan for request files",
-		"workspace",
-		"w",
-	)
-	DurationVarAliases(fs, &f.Timeout, f.Timeout, "Request timeout", "timeout", "t")
-	BoolVarAliases(fs, &f.Insecure, false, "Skip TLS certificate verification", "insecure", "k")
-	BoolVarAliases(fs, &f.Follow, f.Follow, "Follow redirects", "follow", "L")
-	IntVarAliases(
-		fs,
+	fs.StringVarAliases(&f.EnvFile, "", "Path to environment file", "env-file", "E")
+	fs.StringVarAliases(&f.Workspace, "", "Workspace directory to scan for request files", "workspace", "w")
+	fs.DurationVarAliases(&f.Timeout, f.Timeout, "Request timeout", "timeout", "t")
+	fs.BoolVarAliases(&f.Insecure, false, "Skip TLS certificate verification", "insecure", "k")
+	fs.BoolVarAliases(&f.Follow, f.Follow, "Follow redirects", "follow", "L")
+	fs.IntVarAliases(
 		&f.MaxRedirects,
 		f.MaxRedirects,
 		"Redirects to follow before giving up (0 follows none)",
 		"max-redirects",
 	)
-	StringVarAliases(fs, &f.ProxyURL, "", "HTTP proxy URL", "proxy", "x")
-	StringVarAliases(
-		fs,
+	fs.StringVarAliases(&f.ProxyURL, "", "HTTP proxy URL", "proxy", "x")
+	fs.StringVarAliases(
 		&f.MaxResponseSize,
 		"",
 		"Response body limit such as 100mb, or none to read without a limit",
 		"max-response-size",
 	)
-	BoolVarAliases(
-		fs,
-		&f.Recursive,
-		false,
-		"Recursively scan workspace for request files",
-		"recursive",
-		"R",
-	)
+	fs.BoolVarAliases(&f.Recursive, false, "Recursively scan workspace for request files", "recursive", "R")
 	f.BindTelemetryFlags(fs)
-	StringVarAliases(
-		fs,
+	fs.StringVarAliases(
 		&f.CompareTargetsRaw,
 		"",
 		"Default environments or profiles for manual compare runs (comma separated)",
 		"compare",
 		"C",
 	)
-	StringVarAliases(
-		fs,
+	fs.StringVarAliases(
 		&f.CompareBaseline,
 		"",
 		"Baseline environment when --compare is used (defaults to first target)",
 		"compare-base",
 		"B",
 	)
-	StringVarAliases(
-		fs,
-		&f.CompareGroup,
-		"",
-		"Environment group varied by --compare",
-		"compare-group",
-	)
+	fs.StringVarAliases(&f.CompareGroup, "", "Environment group varied by --compare", "compare-group")
 }
 
-func (f *ExecFlags) BindTelemetryFlags(fs *flag.FlagSet) {
-	if fs == nil || f == nil {
-		return
-	}
-	StringVarAliases(
-		fs,
+func (f *ExecFlags) BindTelemetryFlags(fs *FlagSet) {
+	fs.StringVarAliases(
 		&f.telemetry.Endpoint,
 		f.telemetry.Endpoint,
 		"OTLP collector endpoint used when @trace is enabled",
 		"trace-otel-endpoint",
 		"toe",
 	)
-	BoolVarAliases(
-		fs,
+	fs.BoolVarAliases(
 		&f.telemetry.Insecure,
 		f.telemetry.Insecure,
 		"Disable TLS for OTLP trace export",
 		"trace-otel-insecure",
 		"toi",
 	)
-	StringVarAliases(
-		fs,
+	fs.StringVarAliases(
 		&f.telemetry.ServiceName,
 		f.telemetry.ServiceName,
 		"Override service.name resource attribute for exported spans",

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -10,6 +11,16 @@ import (
 )
 
 const aliasUsagePrefix = "Alias for --"
+
+// ErrHelp is returned when Parse sees -h or --help.
+var ErrHelp = flag.ErrHelp
+
+// FlagSet accepts flags before or after positional arguments.
+// String flags are trimmed.
+type FlagSet struct {
+	*flag.FlagSet
+	args []string
+}
 
 type stringValue struct {
 	dst *string
@@ -43,13 +54,13 @@ func (v stringListValue) Set(s string) error {
 	return nil
 }
 
-func NewFlagSet(name string) *flag.FlagSet {
-	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+func NewFlagSet(name string) *FlagSet {
+	fs := &FlagSet{FlagSet: flag.NewFlagSet(name, flag.ContinueOnError)}
 	fs.SetOutput(io.Discard)
 	return fs
 }
 
-func NewSubcommandFlagSet(app, name string, w io.Writer) *flag.FlagSet {
+func NewSubcommandFlagSet(app, name string, w io.Writer) *FlagSet {
 	fs := NewFlagSet(name)
 	fs.Usage = func() {
 		PrintFlagSetUsage(w, app, fs)
@@ -57,50 +68,115 @@ func NewSubcommandFlagSet(app, name string, w io.Writer) *flag.FlagSet {
 	return fs
 }
 
-func StringVar(fs *flag.FlagSet, dst *string, name, value, usage string) {
+// Parse accepts flags before or after positional arguments until "--".
+func (f *FlagSet) Parse(args []string) error {
+	flags, positional := f.split(args)
+	f.args = positional
+	return f.FlagSet.Parse(flags)
+}
+
+// Args returns the positional arguments in their original order.
+func (f *FlagSet) Args() []string {
+	return f.args
+}
+
+func (f *FlagSet) Arg(i int) string {
+	if i < 0 || i >= len(f.args) {
+		return ""
+	}
+	return f.args[i]
+}
+
+func (f *FlagSet) NArg() int {
+	return len(f.args)
+}
+
+// UnexpectedArgs returns an error if the command received positional arguments.
+func (f *FlagSet) UnexpectedArgs() error {
+	if len(f.args) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s: unexpected args: %s", f.Name(), strings.Join(f.args, " "))
+}
+
+func (f *FlagSet) split(args []string) (flags, positional []string) {
+	flags = make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return flags, append(positional, args[i+1:]...)
+		}
+
+		name, inline, ok := flagArg(arg)
+		if !ok {
+			positional = append(positional, arg)
+			continue
+		}
+
+		flags = append(flags, arg)
+		if inline || i+1 >= len(args) {
+			continue
+		}
+		// A non-boolean flag consumes the next argument, even if it starts with "-".
+		if def := f.Lookup(name); def != nil && !isBoolFlag(def.Value) {
+			i++
+			flags = append(flags, args[i])
+		}
+	}
+	return flags, positional
+}
+
+func flagArg(arg string) (name string, inline, ok bool) {
+	if len(arg) < 2 || arg[0] != '-' {
+		return "", false, false
+	}
+
+	name = strings.TrimPrefix(arg[1:], "-")
+	name, _, inline = strings.Cut(name, "=")
+	return name, inline, true
+}
+
+func isBoolFlag(value flag.Value) bool {
+	b, ok := value.(interface{ IsBoolFlag() bool })
+	return ok && b.IsBoolFlag()
+}
+
+func (f *FlagSet) StringVar(dst *string, name, value, usage string) {
 	*dst = str.Trim(value)
-	fs.Var(stringValue{dst: dst}, name, usage)
+	f.Var(stringValue{dst: dst}, name, usage)
 }
 
-func StringVarAliases(fs *flag.FlagSet, dst *string, value, usage string, names ...string) {
+func (f *FlagSet) StringVarAliases(dst *string, value, usage string, names ...string) {
 	registerAliases(names, usage, func(name, usage string) {
-		StringVar(fs, dst, name, value, usage)
+		f.StringVar(dst, name, value, usage)
 	})
 }
 
-func StringListVarAliases(fs *flag.FlagSet, dst *[]string, usage string, names ...string) {
+func (f *FlagSet) StringListVarAliases(dst *[]string, usage string, names ...string) {
 	registerAliases(names, usage, func(name, usage string) {
-		fs.Var(stringListValue{dst: dst}, name, usage)
+		f.Var(stringListValue{dst: dst}, name, usage)
 	})
 }
 
-func BoolVarAliases(fs *flag.FlagSet, dst *bool, value bool, usage string, names ...string) {
+func (f *FlagSet) BoolVarAliases(dst *bool, value bool, usage string, names ...string) {
 	registerAliases(names, usage, func(name, usage string) {
-		fs.BoolVar(dst, name, value, usage)
+		f.BoolVar(dst, name, value, usage)
 	})
 }
 
-func IntVarAliases(fs *flag.FlagSet, dst *int, value int, usage string, names ...string) {
+func (f *FlagSet) IntVarAliases(dst *int, value int, usage string, names ...string) {
 	registerAliases(names, usage, func(name, usage string) {
-		fs.IntVar(dst, name, value, usage)
+		f.IntVar(dst, name, value, usage)
 	})
 }
 
-func DurationVarAliases(
-	fs *flag.FlagSet,
-	dst *time.Duration,
-	value time.Duration,
-	usage string,
-	names ...string,
-) {
+func (f *FlagSet) DurationVarAliases(dst *time.Duration, value time.Duration, usage string, names ...string) {
 	registerAliases(names, usage, func(name, usage string) {
-		fs.DurationVar(dst, name, value, usage)
+		f.DurationVar(dst, name, value, usage)
 	})
 }
 
-// registerAliases binds names[0] as the canonical flag and every later name
-// as an alias; the alias usage string is what PrintFlagDefaults folds back
-// into the canonical flag's row.
+// The first name is shown in help. Later names are marked as aliases so help can combine them.
 func registerAliases(names []string, usage string, bind func(name, usage string)) {
 	for i, name := range names {
 		flagUsage := usage

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -99,6 +99,22 @@ func (f *FlagSet) UnexpectedArgs() error {
 	return fmt.Errorf("%s: unexpected args: %s", f.Name(), strings.Join(f.args, " "))
 }
 
+// WasSet reports whether the flag, or one of its aliases, appeared in the
+// arguments, even when its value is the same as the default.
+func (f *FlagSet) WasSet(name string) bool {
+	set := false
+	f.Visit(func(fl *flag.Flag) {
+		if fl.Name == name {
+			set = true
+			return
+		}
+		if target, ok := aliasTarget(fl.Usage); ok && target == name {
+			set = true
+		}
+	})
+	return set
+}
+
 func (f *FlagSet) split(args []string) (flags, positional []string) {
 	flags = make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {

--- a/internal/cli/flag_help.go
+++ b/internal/cli/flag_help.go
@@ -25,13 +25,13 @@ const (
 // MaxTextWidth caps wrapped CLI text output at a readable line length.
 const MaxTextWidth = 100
 
-func PrintFlagSetUsage(w io.Writer, app string, fs *flag.FlagSet) {
+func PrintFlagSetUsage(w io.Writer, app string, fs *FlagSet) {
 	_, _ = fmt.Fprintf(w, "Usage: %s %s [flags]\n\n", app, fs.Name())
 	_, _ = fmt.Fprintln(w, "Flags:")
 	PrintFlagDefaults(w, fs)
 }
 
-func PrintFlagDefaults(w io.Writer, fs *flag.FlagSet) {
+func PrintFlagDefaults(w io.Writer, fs *FlagSet) {
 	rows := collectRows(fs)
 	lay := newLayout(rows, DetectWidth(w))
 	for _, row := range rows {
@@ -44,7 +44,7 @@ type flagRow struct {
 	help  string // description, including any "(default ...)" suffix
 }
 
-func collectRows(fs *flag.FlagSet) []flagRow {
+func collectRows(fs *FlagSet) []flagRow {
 	canonical, aliases := splitAliases(fs)
 
 	names := make([]string, 0, len(canonical))
@@ -72,7 +72,7 @@ func collectRows(fs *flag.FlagSet) []flagRow {
 	return rows
 }
 
-func splitAliases(fs *flag.FlagSet) (canonical map[string]*flag.Flag, aliases map[string][]string) {
+func splitAliases(fs *FlagSet) (canonical map[string]*flag.Flag, aliases map[string][]string) {
 	canonical = map[string]*flag.Flag{}
 	aliases = map[string][]string{}
 	fs.VisitAll(func(f *flag.Flag) {

--- a/internal/cli/flag_test.go
+++ b/internal/cli/flag_test.go
@@ -170,6 +170,39 @@ func TestUnexpectedArgs(t *testing.T) {
 	}
 }
 
+func TestWasSet(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "absent", args: []string{"requests.http"}, want: false},
+		{name: "long name", args: []string{"--request", "health"}, want: true},
+		{name: "short alias", args: []string{"-r", "health"}, want: true},
+		{name: "inline value", args: []string{"--request=health"}, want: true},
+		{name: "after a positional", args: []string{"requests.http", "-r", "health"}, want: true},
+		{name: "value equal to the default", args: []string{"--request", "auto"}, want: true},
+		{name: "another flag only", args: []string{"-a"}, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := NewFlagSet("test")
+			var request string
+			var all bool
+			fs.StringVarAliases(&request, "auto", "request", "request", "r")
+			fs.BoolVarAliases(&all, false, "all", "all", "a")
+
+			if err := fs.Parse(test.args); err != nil {
+				t.Fatalf("Parse(%q): %v", test.args, err)
+			}
+			if got := fs.WasSet("request"); got != test.want {
+				t.Errorf("WasSet(\"request\") = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestStringVarTrimsDefaultAndParsedValue(t *testing.T) {
 	fs := NewFlagSet("trim")
 	var got string

--- a/internal/cli/flag_test.go
+++ b/internal/cli/flag_test.go
@@ -1,16 +1,179 @@
 package cli
 
 import (
+	"errors"
+	"io"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/mattn/go-runewidth"
 )
 
+func TestFlagSetParsesInterspersedArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantRequest string
+		wantTags    []string
+		wantArgs    []string
+		wantAll     bool
+	}{
+		{
+			name:        "flags before positional",
+			args:        []string{"-request", "createPost", "requests.http"},
+			wantRequest: "createPost",
+			wantArgs:    []string{"requests.http"},
+		},
+		{
+			name:        "flags after positional",
+			args:        []string{"requests.http", "-r", "createPost"},
+			wantRequest: "createPost",
+			wantArgs:    []string{"requests.http"},
+		},
+		{
+			name:        "inline flag after positional",
+			args:        []string{"requests.http", "--request=createPost"},
+			wantRequest: "createPost",
+			wantArgs:    []string{"requests.http"},
+		},
+		{
+			name:        "stdin before flag",
+			args:        []string{"-", "--request", "health"},
+			wantRequest: "health",
+			wantArgs:    []string{"-"},
+		},
+		{
+			name:        "flag value starts with dash",
+			args:        []string{"requests.http", "--request", "-internal"},
+			wantRequest: "-internal",
+			wantArgs:    []string{"requests.http"},
+		},
+		{
+			name:     "repeated and boolean flags preserve order",
+			args:     []string{"first", "--tag", "one", "middle", "-a", "--tag=two", "last"},
+			wantTags: []string{"one", "two"},
+			wantArgs: []string{"first", "middle", "last"},
+			wantAll:  true,
+		},
+		{
+			name:     "terminator keeps remaining args positional",
+			args:     []string{"requests.http", "-a", "--", "--request", "ignored"},
+			wantArgs: []string{"requests.http", "--request", "ignored"},
+			wantAll:  true,
+		},
+		{
+			name:        "terminator is consumed as a flag value",
+			args:        []string{"requests.http", "--request", "--", "-a"},
+			wantRequest: "--",
+			wantArgs:    []string{"requests.http"},
+			wantAll:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := NewFlagSet("test")
+			var request string
+			var tags []string
+			var all bool
+			fs.StringVarAliases(&request, "", "request", "request", "r")
+			fs.StringListVarAliases(&tags, "tag", "tag", "g")
+			fs.BoolVarAliases(&all, false, "all", "all", "a")
+
+			if err := fs.Parse(test.args); err != nil {
+				t.Fatalf("Parse(%q): %v", test.args, err)
+			}
+			if request != test.wantRequest {
+				t.Errorf("request = %q, want %q", request, test.wantRequest)
+			}
+			if !slices.Equal(tags, test.wantTags) {
+				t.Errorf("tags = %q, want %q", tags, test.wantTags)
+			}
+			if all != test.wantAll {
+				t.Errorf("all = %t, want %t", all, test.wantAll)
+			}
+			if got := fs.Args(); !slices.Equal(got, test.wantArgs) {
+				t.Errorf("Args() = %q, want %q", got, test.wantArgs)
+			}
+			if got := fs.NArg(); got != len(test.wantArgs) {
+				t.Errorf("NArg() = %d, want %d", got, len(test.wantArgs))
+			}
+			for i, want := range test.wantArgs {
+				if got := fs.Arg(i); got != want {
+					t.Errorf("Arg(%d) = %q, want %q", i, got, want)
+				}
+			}
+			if got := fs.Arg(len(test.wantArgs)); got != "" {
+				t.Errorf("Arg(%d) = %q, want empty string", len(test.wantArgs), got)
+			}
+		})
+	}
+}
+
+func TestFlagSetReportsErrorsAfterPositionalArgs(t *testing.T) {
+	t.Run("help", func(t *testing.T) {
+		fs := NewFlagSet("test")
+		if err := fs.Parse([]string{"requests.http", "--help"}); !errors.Is(err, ErrHelp) {
+			t.Fatalf("Parse() error = %v, want help error", err)
+		}
+	})
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "unknown flag",
+			args: []string{"requests.http", "--unknown"},
+			want: "flag provided but not defined",
+		},
+		{
+			name: "missing value",
+			args: []string{"requests.http", "--request"},
+			want: "needs an argument",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs := NewFlagSet("test")
+			var request string
+			fs.StringVar(&request, "request", "", "request")
+
+			err := fs.Parse(test.args)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Parse(%q) error = %v, want %q", test.args, err, test.want)
+			}
+		})
+	}
+}
+
+func TestUnexpectedArgs(t *testing.T) {
+	fs := NewSubcommandFlagSet("resterm", "history export", io.Discard)
+	var out string
+	fs.StringVar(&out, "out", "", "output")
+
+	if err := fs.Parse([]string{"--out", "dump.json"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if err := fs.UnexpectedArgs(); err != nil {
+		t.Fatalf("UnexpectedArgs() = %v, want nil", err)
+	}
+
+	if err := fs.Parse([]string{"--out", "dump.json", "extra", "args"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	err := fs.UnexpectedArgs()
+	if err == nil || err.Error() != "history export: unexpected args: extra args" {
+		t.Fatalf("UnexpectedArgs() = %v, want the command name and both args", err)
+	}
+}
+
 func TestStringVarTrimsDefaultAndParsedValue(t *testing.T) {
 	fs := NewFlagSet("trim")
 	var got string
-	StringVar(fs, &got, "name", "  dev  ", "name")
+	fs.StringVar(&got, "name", "  dev  ", "name")
 	if got != "dev" {
 		t.Fatalf("default value = %q, want %q", got, "dev")
 	}
@@ -26,7 +189,7 @@ func TestStringVarTrimsDefaultAndParsedValue(t *testing.T) {
 func TestStringVarSupportsAliasBinding(t *testing.T) {
 	fs := NewFlagSet("trim")
 	var got string
-	StringVarAliases(fs, &got, "", "request", "request", "r")
+	fs.StringVarAliases(&got, "", "request", "request", "r")
 
 	if err := fs.Parse([]string{"-r", "  sample  "}); err != nil {
 		t.Fatalf("parse: %v", err)
@@ -40,8 +203,8 @@ func TestPrintFlagDefaultsCombinesAliases(t *testing.T) {
 	fs := NewFlagSet("help")
 	var env string
 	var recursive bool
-	StringVarAliases(fs, &env, "", "Environment name to use", "env", "e")
-	BoolVarAliases(fs, &recursive, false, "Recursively scan workspace", "recursive", "R")
+	fs.StringVarAliases(&env, "", "Environment name to use", "env", "e")
+	fs.BoolVarAliases(&recursive, false, "Recursively scan workspace", "recursive", "R")
 
 	var out strings.Builder
 	PrintFlagDefaults(&out, fs)
@@ -67,8 +230,8 @@ func TestPrintFlagDefaultsShowsLiteralStringDefaults(t *testing.T) {
 	var code string
 	var disabled string
 	var retries int
-	StringVar(fs, &code, "code", "0", "Status code")
-	StringVar(fs, &disabled, "disabled", "false", "Disabled marker")
+	fs.StringVar(&code, "code", "0", "Status code")
+	fs.StringVar(&disabled, "disabled", "false", "Disabled marker")
 	fs.IntVar(&retries, "retries", 0, "Retry count")
 
 	var out strings.Builder
@@ -97,8 +260,7 @@ func TestPrintFlagDefaultsUsesAvailableColumns(t *testing.T) {
 
 	fs := NewFlagSet("help")
 	var endpoint string
-	StringVarAliases(
-		fs,
+	fs.StringVarAliases(
 		&endpoint,
 		"",
 		"OTLP collector endpoint used when @trace is enabled",
@@ -121,8 +283,7 @@ func TestPrintFlagDefaultsWrapsWithinAvailableColumns(t *testing.T) {
 
 	fs := NewFlagSet("help")
 	var endpoint string
-	StringVarAliases(
-		fs,
+	fs.StringVarAliases(
 		&endpoint,
 		"",
 		"OTLP collector endpoint used when @trace is enabled",

--- a/internal/ui/model_mock_args.go
+++ b/internal/ui/model_mock_args.go
@@ -2,9 +2,7 @@ package ui
 
 import (
 	"errors"
-	"flag"
 	"fmt"
-	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/cli"
 	"github.com/unkn0wn-root/resterm/internal/files"
@@ -39,20 +37,13 @@ func parseMockStartArgs(args []string) (mockStartArgs, error) {
 	var out mockStartArgs
 	fs := newMockStartFlagSet(&out)
 
-	// flag stops parsing at the first non-flag argument, so lift a leading
-	// address out of the way first.
-	var pos []string
-	for len(args) > 0 && !strings.HasPrefix(args[0], "-") {
-		pos = append(pos, args[0])
-		args = args[1:]
-	}
 	if err := fs.Parse(args); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, cli.ErrHelp) {
 			return out, errMockArgsUsage
 		}
 		return out, err
 	}
-	for _, arg := range append(pos, fs.Args()...) {
+	for _, arg := range fs.Args() {
 		if err := out.setAddr(arg); err != nil {
 			return out, err
 		}
@@ -63,18 +54,12 @@ func parseMockStartArgs(args []string) (mockStartArgs, error) {
 	return out, nil
 }
 
-func newMockStartFlagSet(out *mockStartArgs) *flag.FlagSet {
+func newMockStartFlagSet(out *mockStartArgs) *cli.FlagSet {
 	fs := cli.NewFlagSet("mock start")
-	cli.StringVarAliases(fs, &out.addr, "", "Listen address", "addr", "a")
-	cli.StringListVarAliases(
-		fs,
-		&out.sources,
-		"Serve only these request files",
-		mockSourceFlagName,
-		mockSourceFlagAlias,
-	)
-	cli.BoolVarAliases(fs, &out.recursive, false, "Scan the workspace recursively", "recursive", "r")
-	cli.BoolVarAliases(fs, &out.all, false, "Serve the whole workspace", "all")
+	fs.StringVarAliases(&out.addr, "", "Listen address", "addr", "a")
+	fs.StringListVarAliases(&out.sources, "Serve only these request files", mockSourceFlagName, mockSourceFlagAlias)
+	fs.BoolVarAliases(&out.recursive, false, "Scan the workspace recursively", "recursive", "r")
+	fs.BoolVarAliases(&out.all, false, "Serve the whole workspace", "all")
 	return fs
 }
 


### PR DESCRIPTION
Flags and positional arguments may now be interspersed on every command, so `resterm run requests.http -r createPost` works.