### PR TITLE
RST-351: chained editor completions and file path suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,14 @@
 </h1>
 
 <p align="center">
-  <em>A terminal-native API client and workbench for REST, GraphQL, gRPC, WebSocket and SSE.</em>
+  <em>A terminal API client for REST, GraphQL, gRPC, WebSocket and SSE.</em>
 </p>
 
 <p align="center">
   <img src="_media/resterm_base.png" alt="Screenshot of Resterm TUI base" width="720" />
 </p>
 
-Resterm is an _API-as-code_ workbench - or, in more familiar terms, an API client - built around plain `.http` and `.rest` files that you can diff, review and version. It combines interactive request editing with declarative workflows, assertions, mock servers, tracing, profiling and headless automation. Everything stays on your machine. No accounts, no cloud sync, no telemetry.
-
-If you are looking for a Postman-style client centered on GUI collections, Resterm is probably _not_ for you, but give it a try anyway!
+Resterm stores API requests in plain `.http` and `.rest` files that you can diff, review and track in version control. Edit and send requests in the terminal, or run them from scripts and CI. Request files support workflows, assertions, mock servers, tracing and profiling. No accounts, cloud sync or telemetry.
 
 > [!NOTE]
 > Resterm is now v1! See the [v1.0.0 release notes](https://github.com/unkn0wn-root/resterm/releases/tag/v1.0.0) for new features and breaking changes.
@@ -86,11 +84,11 @@ Quick links: [Screenshots](#screenshot-tour), [Quick Start](#quick-start), [Requ
 
 ## Why Resterm
 
-- **HTTP, GraphQL, gRPC, WebSocket and SSE** out of the box.
-- **Automation lives in the request files:** conditions (`@when`, `@if`/`@elif`/`@else`, `@for-each`), multi-step workflows (`@workflow` / `@step`), captures, variables and assertions (`@capture`, `@var`, `@assert`).
+- **HTTP, GraphQL, gRPC, WebSocket and SSE** support.
+- **Automation in request files:** conditions (`@when`, `@if`/`@elif`/`@else`, `@for-each`), multi-step workflows (`@workflow` / `@step`), captures, variables and assertions (`@capture`, `@var`, `@assert`).
 - **RestermScript**, a small expression language built for Resterm, with JavaScript hooks when you want them.
-- **Vim-style controls** with contextual bottom bar hints, searchable offline help, `K` help under the cursor, `/` search and commands like `:w`, `:q`, `:help` and `:docs`.
-- **Built-in auth and tunneling:** OAuth 2.0 (client credentials, password, auth code with PKCE), auth backed by your existing CLIs, SSH tunnels and Kubernetes port-forwards. No extra tools needed.
+- **Vim-style controls** with shortcut hints, searchable offline help, `K` help under the cursor, `/` search and commands like `:w`, `:q`, `:help` and `:docs`.
+- **Auth and tunneling:** OAuth 2.0 (client credentials, password, authorization code with PKCE), auth through existing CLIs, SSH tunnels and Kubernetes port-forwards.
 - **CLI runner:** `resterm run` for scripted runs and CI, with JSON and JUnit output.
 - **Mock servers** declared next to the requests they mimic, with matching rules, sequences, call verification and hot reload.
 - **Timeline tracing, profiling and compare runs** across environments.
@@ -105,7 +103,7 @@ Quick links: [Screenshots](#screenshot-tour), [Quick Start](#quick-start), [Requ
    brew install resterm
    ```
 
-2. Bootstrap a workspace.
+2. Create a workspace.
 
    ```bash
    mkdir my-api && cd my-api
@@ -114,7 +112,7 @@ Quick links: [Screenshots](#screenshot-tour), [Quick Start](#quick-start), [Requ
 
    `resterm init` gives you a small project that works without an internet connection. The generated `requests.http` includes local mock scenarios and a few requests that build on each other. They cover assertions, bearer auth, JSON matching, `json-rules`, and `@for-each`.
 
-3. Start it and send your first request.
+3. Open Resterm and send your first request.
 
    ```bash
    resterm
@@ -142,11 +140,11 @@ Content-Type: application/json
 {"name":"{{= name }}"}
 ```
 
-Settings before the first request apply to the whole file, `###` separates requests, and directives can repeat, limit or validate a request. More examples here: [`_examples/`](_examples/).
+Settings before the first request apply to the whole file. `###` separates requests, and directives can repeat, limit or validate a request. More examples: [`_examples/`](_examples/).
 
 ## CLI
 
-`resterm run` executes `.http` / `.rest` files without opening the TUI, which is what CI runs.
+Use `resterm run` to execute `.http` / `.rest` files from scripts or CI without opening the TUI.
 
 ```bash
 resterm run --request CreateUser requests.http
@@ -235,13 +233,13 @@ The scripts detect your architecture, download the latest release and install th
 **Linux / macOS**
 
 ```bash
-# Detect latest tag
+# Find the latest release tag
 LATEST_TAG=$(curl -fsSL https://api.github.com/repos/unkn0wn-root/resterm/releases/latest | jq -r .tag_name)
 
 # Download the matching binary (Darwin/Linux + amd64/arm64)
 curl -fL -o resterm "https://github.com/unkn0wn-root/resterm/releases/download/${LATEST_TAG}/resterm_$(uname -s)_$(uname -m)"
 
-# Make it executable and move it onto your PATH
+# Install on PATH
 chmod +x resterm
 sudo install -m 0755 resterm /usr/local/bin/resterm
 ```
@@ -252,7 +250,7 @@ sudo install -m 0755 resterm /usr/local/bin/resterm
 $latest = Invoke-RestMethod https://api.github.com/repos/unkn0wn-root/resterm/releases/latest
 $asset  = $latest.assets | Where-Object { $_.name -like 'resterm_Windows_*' } | Select-Object -First 1
 Invoke-WebRequest -Uri $asset.browser_download_url -OutFile resterm.exe
-# Optionally relocate to a directory on PATH, e.g.:
+# Optionally move to a directory on PATH:
 Move-Item resterm.exe "$env:USERPROFILE\bin\resterm.exe"
 ```
 
@@ -273,8 +271,8 @@ The first command reports whether a newer release is available. The second downl
 
 ## Configuration
 
-- Environments are JSON files (`resterm.env.json`) discovered in the request directory, workspace root or CWD. A file can define named environments or independent groups, for example api, app, and credentials, that combine into one environment. Dotenv files (`.env`, `.env.*`) are opt-in via `--env-file` and are single-workspace. See [grouped environments](./docs/resterm.md#grouped-environments) and the runnable sample in `_examples/grouped/`.
-- Config is stored per OS and can be overridden with `RESTERM_CONFIG_DIR`:
+- Resterm looks for environment files (`resterm.env.json`) in the request directory, workspace root or current working directory. A file can define named environments or groups, such as api, app and credentials, that combine into one environment. Use `--env-file` to load dotenv files (`.env`, `.env.*`) for the current workspace. See [grouped environments](./docs/resterm.md#grouped-environments) and the example in `_examples/grouped/`.
+- Configuration is stored in the directory below. Set `RESTERM_CONFIG_DIR` to use another location:
   - macOS: `~/Library/Application Support/resterm`
   - Windows: `%APPDATA%\resterm`
   - Linux/Unix: `~/.config/resterm`
@@ -288,7 +286,7 @@ You can define mock responses in the same `.http` files as your requests.
 - Delay responses by a fixed amount, or give every request a different delay with `random`, `normal`, or `jitter`.
 - Build responses from path, query, header and body values, with generators for dynamic data.
 - Verify call counts with `@expect` or inspect received traffic from RestermScript.
-- Hot reload source files and fixtures, with optional TLS.
+- Reload source files and fixtures when they change. TLS is optional.
 
 Two scenarios on one route:
 
@@ -320,13 +318,13 @@ More in the [Mock Servers reference](docs/resterm.md#mock-servers), the [`rester
 
 ## Headless
 
-The [`headless`](./headless) package is the public Go API for the same engine that powers the TUI and CLI. Use it to run requests, workflows, assertions, compare runs and profiles from your own Go code or CI.
+The [`headless`](./headless) package is the public Go API for the engine used by the TUI and CLI. Use it to run requests, workflows, assertions, compare runs and profiles from your own Go code or CI.
 
 If you would rather not build a runner yourself, there is [resterm-runner](https://github.com/unkn0wn-root/resterm-runner).
 
 ## Collections
 
-Export a workspace as a Git-friendly bundle and import it into another one. Bundles carry a `manifest.json` with checksums, so imports verify file integrity first. Environment values are exported as `REPLACE_ME` placeholders, so secrets never leave your machine.
+Export a workspace as a bundle you can track in Git and import into another workspace. Each bundle includes a `manifest.json` with checksums that are verified during import. Environment values are replaced with `REPLACE_ME` placeholders.
 
 ```bash
 resterm collection export --workspace ./my-api --out ./shared/my-api-bundle
@@ -337,7 +335,7 @@ Add `--dry-run` to preview an import and `--force` to overwrite existing files. 
 
 ## Curl import
 
-Paste a curl command into the editor and press `Ctrl+Enter` to turn it into a structured request. Resterm understands the common flags, merges repeated data segments and keeps multipart uploads intact. Shell prefixes like `sudo` or `$` are ignored. The CLI does the same conversion with `--from-curl`.
+Paste a curl command into the editor and press `Ctrl+Enter` to convert it to a request. Resterm supports common flags, combines repeated data arguments and preserves multipart uploads. Shell prefixes like `sudo` or `$` are ignored. The CLI supports the same conversion with `--from-curl`.
 
 This:
 
@@ -363,7 +361,7 @@ Docs: [inline requests](./docs/resterm.md#inline-requests) and [import examples]
 
 ## RestermScript
 
-RestermScript (RTS) is a small expression language built for Resterm. It targets the request format, workflows and directives directly, which keeps scripts short and predictable. JavaScript hooks remain available when you need more.
+RestermScript (RTS) is an expression language for requests, workflows and directives. JavaScript hooks are also available.
 
 Quick example (RTS module + request):
 
@@ -389,7 +387,7 @@ Full reference: [`docs/restermscript.md`](docs/restermscript.md).
 
 ### OAuth 2.0
 
-Use `@auth oauth2` to acquire and inject tokens. Tokens are cached per environment and refreshed when possible. The client credentials grant is the default. The password grant and authorization code with PKCE are also supported:
+Use `@auth oauth2` to fetch tokens and add them to requests. Tokens are cached per environment and refreshed when possible. The client credentials grant is the default. The password grant and authorization code with PKCE are also supported:
 
 ```http
 ### Service status
@@ -511,11 +509,11 @@ Define an SSH profile before the requests that use it, then select it with `use=
 GET http://10.0.0.10/v1/health
 ```
 
-Profiles can be file-wide or workspace-wide, and one-off inline tunnels are also supported. Example: [`_examples/ssh.http`](_examples/ssh.http). See the [SSH documentation](./docs/resterm.md#ssh-tunnels).
+Profiles can apply to a file or workspace. You can also define a tunnel directly on a request. Example: [`_examples/ssh.http`](_examples/ssh.http). See the [SSH documentation](./docs/resterm.md#ssh-tunnels).
 
 ### Kubernetes port-forwards
 
-`@k8s` opens a managed port-forward to a pod, service, deployment or statefulset:
+`@k8s` opens a port-forward to a pod, service, deployment or statefulset:
 
 ```http
 ### Service health

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -199,39 +199,61 @@ The bottom command bar adapts to the focused pane, editor mode, and response tab
 
 ### Editor completions (IntelliSense)
 
-While the editor is in insert mode, Resterm suggests completions based on where the
-caret sits. Everything is computed locally from the open file and the active
-environment - there are no network calls while you type.
+In insert mode, Resterm suggests completions at the caret using the open file and
+active environment. It makes no network calls while you type.
 
 | Context | What completes |
 | --- | --- |
 | Start of a request line | HTTP methods plus `WS` / `WSS` / `GRPC` |
 | Start of a request URL | Schemes: `http://`, `https://`, `ws://`, `wss://` |
-| Line-leading `@` (with or without a comment marker) | Metadata directives and their options (e.g. `@auth bearer`, `@k8s target=`) |
+| `@` at the start of a line, with or without a comment marker | Directives, option keys, and values such as booleans, OAuth grants, HTTP/TLS modes, and workflow failure modes |
 | Header section (after the request line, before the blank line) | Header names, then values for well-known headers such as `Content-Type` |
 | Inside `{{ ... }}` | Variables in scope (file/global/request, `@const`, current-environment keys) and dynamic builtins (`$uuid`, `$timestamp`, ...) |
-| `@compare` arguments | Environment names |
+| `@compare` arguments | Environment names or profiles from the selected group; baseline suggestions use the targets already chosen |
 | `use=` on `@apply` / `@ssh` / `@k8s` | Matching `@patch` / `@ssh` / `@k8s` profile names |
+| `using=` / `run=` on workflow steps and branches | Named requests from the current document |
+| File paths | Files and directories for `@use`, descriptors, GraphQL/JSON inputs, TLS/SSH/Kubernetes options, request bodies, and script or body includes |
 
-Popup keys: `Up` / `Down` (or `Ctrl+P` / `Ctrl+N`) navigate, `Right` or `?` opens the
-details preview (`Ctrl+L` toggles it), `Left` / `Esc` closes the preview, `Enter` or
-`Tab` accepts, and `Esc` dismisses the popup. Styling is controlled by the
-`editor_hint_*` theme keys.
+Press `Ctrl+N` to show all completions valid at the caret. If there are none, it does
+nothing. In editor insert mode this key always controls completion, regardless of
+the New Request binding. Outside editor insert mode, the configured New Request
+shortcut applies.
 
-When a directive completion starts with bare `@`, accepting it adds the canonical
-`# ` comment marker automatically. For example, completing `@na` produces `# @name `.
-The marker is added only on acceptance, so in-place variables such as `@name = value`
-remain unchanged when you keep typing.
+In the popup, `Up` / `Down` or `Ctrl+P` / `Ctrl+N` selects an item. `Right` or `?`
+opens the details preview, `Ctrl+L` toggles it, and `Left` or `Esc` closes it.
+`Enter` or `Tab` accepts an item. `Esc` dismisses the popup when the preview is
+closed. Use the `editor_hint_*` theme keys to style the popup.
+
+After you accept a completion, the popup shows what can follow it. For example,
+`@auth` opens auth modes, `oauth2` opens its options, and `grant=` opens grant values.
+Headers open value suggestions, and directories open their contents. Options that
+can appear only once disappear after use, along with their aliases, such as `base=`
+and `baseline=`. You can repeat `@apply use=`, but profiles already selected are
+omitted.
+
+File suggestions use the request file's directory, or the workspace for temporary
+documents. They are filtered by file type where needed: `.rts` for `@use`, GraphQL
+for `@query`, JSON for `@variables`, and script files for script includes. Directory
+listings are cached while browsing. In directives that split arguments on spaces,
+paths with spaces are quoted. File references that use the rest of the line stay
+unquoted. Only SSH and Kubernetes path options expand `~` to the home directory.
+
+Accepting a directive typed without a comment marker adds `# ` automatically. For
+example, completing `@na` produces `# @name `. The marker is added only when you
+accept a suggestion, so you can still type variables such as `@name = value`.
 
 Many suggestions insert an example value, such as `@setting timeout=5s` or `@mock
 latency=random(100ms,500ms)`. Accepting one leaves the example selected, so the next
-keystroke replaces it. To keep the example instead, press `Tab`. The caret moves to the
-end of the insert, past the closing parenthesis when the example is a call. `Left` and
-`Right` also keep the example, putting the caret at its start or its end.
+keystroke replaces it. Press `Tab` to keep the example and move past the inserted
+text, including any closing parenthesis. `Left` and `Right` also keep the example
+and move to the start or end of the selected text.
 
-Completion is deliberately offline: it does not introspect a live gRPC server
-(reflection/descriptors) or a GraphQL schema to complete service, method, or field
-names.
+Dynamic helpers with call examples insert the call and select only its arguments.
+Variable completion adds any missing closing braces, so completing `{{ho`, `{{ho}`,
+and `{{ho}}` with `host` produces `{{host}}` in each case.
+
+Completion does not use gRPC reflection, descriptors, or GraphQL schemas to suggest
+service, method, or field names.
 
 ### Custom bindings
 

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -207,7 +207,7 @@ environment - there are no network calls while you type.
 | --- | --- |
 | Start of a request line | HTTP methods plus `WS` / `WSS` / `GRPC` |
 | Start of a request URL | Schemes: `http://`, `https://`, `ws://`, `wss://` |
-| `@` on a comment line | Metadata directives and their options (e.g. `@auth bearer`, `@k8s target=`) |
+| Line-leading `@` (with or without a comment marker) | Metadata directives and their options (e.g. `@auth bearer`, `@k8s target=`) |
 | Header section (after the request line, before the blank line) | Header names, then values for well-known headers such as `Content-Type` |
 | Inside `{{ ... }}` | Variables in scope (file/global/request, `@const`, current-environment keys) and dynamic builtins (`$uuid`, `$timestamp`, ...) |
 | `@compare` arguments | Environment names |
@@ -217,6 +217,11 @@ Popup keys: `Up` / `Down` (or `Ctrl+P` / `Ctrl+N`) navigate, `Right` or `?` open
 details preview (`Ctrl+L` toggles it), `Left` / `Esc` closes the preview, `Enter` or
 `Tab` accepts, and `Esc` dismisses the popup. Styling is controlled by the
 `editor_hint_*` theme keys.
+
+When a directive completion starts with bare `@`, accepting it adds the canonical
+`# ` comment marker automatically. For example, completing `@na` produces `# @name `.
+The marker is added only on acceptance, so in-place variables such as `@name = value`
+remain unchanged when you keep typing.
 
 Many suggestions insert an example value, such as `@setting timeout=5s` or `@mock
 latency=random(100ms,500ms)`. Accepting one leaves the example selected, so the next

--- a/internal/directive/field_test.go
+++ b/internal/directive/field_test.go
@@ -1,0 +1,47 @@
+package directive
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestScanFieldsKeepsValuesWithTheirSource(t *testing.T) {
+	const input = `"Dév One" using=Create\ User json={"name": "ø"} latency=normal(1s, 2s) key="C:\tmp\file"`
+	want := []struct {
+		raw, value string
+		option     bool
+	}{
+		{`"Dév One"`, "Dév One", false},
+		{`using=Create\`, `using=Create\`, true},
+		{`User`, "User", false},
+		{`json={"name": "ø"}`, `json={"name": "ø"}`, true},
+		{`latency=normal(1s, 2s)`, `latency=normal(1s, 2s)`, true},
+		{`key="C:\tmp\file"`, `key=C:\tmp\file`, true},
+	}
+	fields := slices.Collect(ScanFields(input))
+	if len(fields) != len(want) {
+		t.Fatalf("fields = %+v, want %d", fields, len(want))
+	}
+	for i, field := range fields {
+		if raw := input[field.Start:field.End]; raw != want[i].raw || field.Value != want[i].value {
+			t.Errorf("field %d: source %q, value %q; want %+v", i, raw, field.Value, want[i])
+		}
+		if got := field.Eq >= 0; got != want[i].option {
+			t.Errorf("field %d: option = %v", i, got)
+		}
+	}
+}
+
+func TestScanFieldsCanStopAndRestart(t *testing.T) {
+	fields := ScanFields(`first=1 second="unfinished`)
+	for field := range fields {
+		if field.Value != "first=1" {
+			t.Fatalf("first field = %+v", field)
+		}
+		break
+	}
+	all := slices.Collect(fields)
+	if len(all) != 2 || all[1].Value != "second=unfinished" {
+		t.Fatalf("restarted fields = %+v", all)
+	}
+}

--- a/internal/directive/name.go
+++ b/internal/directive/name.go
@@ -1,5 +1,8 @@
 package directive
 
+// CommentPrefix is the canonical prefix for a directive comment.
+const CommentPrefix = "# "
+
 // Name is the lowercase spelling without the leading @.
 type Name string
 
@@ -83,7 +86,7 @@ func (n Name) Tag() string {
 }
 
 func (n Name) Comment() string {
-	return "# " + n.Tag()
+	return CommentPrefix + n.Tag()
 }
 
 // Unknown names pass through so each parser can decide whether they are valid.

--- a/internal/directive/option.go
+++ b/internal/directive/option.go
@@ -400,22 +400,45 @@ type FieldSpan struct {
 	Start, End, Eq int
 }
 
+// Field pairs a decoded option field with its byte offsets in the source.
+type Field struct {
+	FieldSpan
+	Value string
+}
+
+// ScanFields yields the values returned by Fields with their source byte offsets.
+// It accepts incomplete quotes, JSON, and calls, and preserves bare backslashes.
+func ScanFields(input string) iter.Seq[Field] {
+	return scanFields(input, false)
+}
+
+func scanFields(input string, escapes bool) iter.Seq[Field] {
+	return func(yield func(Field) bool) {
+		lex := &lexer{src: input, escapes: escapes}
+		for {
+			tok, ok := lex.next()
+			if !ok {
+				return
+			}
+			eq := optionEq(input[tok.start:tok.end])
+			if eq >= 0 {
+				eq += tok.start
+			}
+			if !yield(Field{FieldSpan: FieldSpan{Start: tok.start, End: tok.end, Eq: eq}, Value: tok.val}) {
+				return
+			}
+		}
+	}
+}
+
 // FieldSpans reports where each field sits, scanning the way ParseOptions does,
 // so a span never splits a quoted or bracketed value.
 func FieldSpans(input string) []FieldSpan {
-	lex := &lexer{src: input, escapes: true}
 	var spans []FieldSpan
-	for {
-		tok, ok := lex.next()
-		if !ok {
-			return spans
-		}
-		eq := optionEq(input[tok.start:tok.end])
-		if eq >= 0 {
-			eq += tok.start
-		}
-		spans = append(spans, FieldSpan{Start: tok.start, End: tok.end, Eq: eq})
+	for field := range scanFields(input, true) {
+		spans = append(spans, field.FieldSpan)
 	}
+	return spans
 }
 
 // A name, then an equals sign typed outside quotes, then the value. This has to

--- a/internal/files/kind.go
+++ b/internal/files/kind.go
@@ -79,22 +79,6 @@ func IsRequest(path string) bool {
 	return requestExt[fileExt(path)] == KindRequest
 }
 
-func IsRTS(path string) bool {
-	return requestExt[fileExt(path)] == KindScript
-}
-
-func IsGraphQL(path string) bool {
-	return dataExt[fileExt(path)] == KindGraphQL
-}
-
-func IsJSON(path string) bool {
-	return dataExt[fileExt(path)] == KindJSON
-}
-
-func IsJavaScript(path string) bool {
-	return dataExt[fileExt(path)] == KindJavaScript
-}
-
 func IsWorkspace(path string) bool {
 	_, ok := ClassifyWorkspace(path)
 	return ok
@@ -115,6 +99,16 @@ func ClassifyWorkspace(path string) (Kind, bool) {
 	}
 	if vars.IsEnvFileName(path) {
 		return KindEnv, true
+	}
+	kind, ok := dataExt[ext]
+	return kind, ok
+}
+
+// classifyExt uses only the extension, so environment JSON files also count as JSON.
+func classifyExt(path string) (Kind, bool) {
+	ext := fileExt(path)
+	if kind, ok := requestExt[ext]; ok {
+		return kind, true
 	}
 	kind, ok := dataExt[ext]
 	return kind, ok

--- a/internal/files/path_filter.go
+++ b/internal/files/path_filter.go
@@ -10,12 +10,13 @@ type pathFilterKind uint8
 const (
 	pathFilterNone pathFilterKind = iota
 	pathFilterAny
-	pathFilterRequest
+	pathFilterKinds
 	pathFilterWorkspace
 )
 
 type PathFilter struct {
 	kind    pathFilterKind
+	kinds   uint // bitmask of Kind values
 	envFile string
 }
 
@@ -26,8 +27,17 @@ func AnyPathFilter() PathFilter {
 	return PathFilter{kind: pathFilterAny}
 }
 
+// KindPathFilter accepts files with an extension matching any of the given kinds.
+func KindPathFilter(kinds ...Kind) PathFilter {
+	f := PathFilter{kind: pathFilterKinds}
+	for _, k := range kinds {
+		f.kinds |= 1 << k
+	}
+	return f
+}
+
 func RequestPathFilter() PathFilter {
-	return PathFilter{kind: pathFilterRequest}
+	return KindPathFilter(KindRequest)
 }
 
 func WorkspacePathFilter(envFile string) PathFilter {
@@ -38,8 +48,9 @@ func (f PathFilter) Accept(path string) bool {
 	switch f.kind {
 	case pathFilterAny:
 		return true
-	case pathFilterRequest:
-		return IsRequest(path)
+	case pathFilterKinds:
+		kind, ok := classifyExt(path)
+		return ok && f.kinds&(1<<kind) != 0
 	case pathFilterWorkspace:
 		return IsWorkspace(path) || vars.IsDotEnvPath(path) || util.SameFile(path, f.envFile)
 	default: // pathFilterNone

--- a/internal/files/path_filter_test.go
+++ b/internal/files/path_filter_test.go
@@ -28,6 +28,10 @@ func TestPathFilter(t *testing.T) {
 		{"workspace accepts dotenv", WorkspacePathFilter(env), filepath.Join(dir, ".env.local"), true},
 		{"workspace accepts active env", WorkspacePathFilter(env), env, true},
 		{"workspace rejects unrelated", WorkspacePathFilter(env), filepath.Join(dir, "notes.txt"), false},
+		{"rts rejects javascript", KindPathFilter(KindScript), filepath.Join(dir, "helpers.js"), false},
+		{"script accepts rts", KindPathFilter(KindScript, KindJavaScript), filepath.Join(dir, "pre.rts"), true},
+		{"script accepts javascript", KindPathFilter(KindScript, KindJavaScript), filepath.Join(dir, "pre.mjs"), true},
+		{"script rejects text", KindPathFilter(KindScript, KindJavaScript), filepath.Join(dir, "pre.txt"), false},
 	}
 
 	for _, tt := range tests {

--- a/internal/intellisense/argument_items.go
+++ b/internal/intellisense/argument_items.go
@@ -1,0 +1,78 @@
+package intellisense
+
+import "cmp"
+
+func (a argument) label(key string) string {
+	switch a.form {
+	case formOption:
+		return key + "="
+	case formBudget:
+		return key + "<="
+	default:
+		return key
+	}
+}
+
+func (a argument) lead(key string) string {
+	if a.form == formWord {
+		return key + " "
+	}
+	return a.label(key)
+}
+
+func (a argument) items() []Item {
+	items := a.itemsNamed(a.key)
+	for _, alias := range a.aliases {
+		items = append(items, a.itemsNamed(alias)...)
+	}
+	return items
+}
+
+func (a argument) itemsNamed(key string) []Item {
+	if len(a.examples) == 0 {
+		return []Item{a.itemNamed(key, argExample{})}
+	}
+	items := make([]Item, len(a.examples))
+	for i, example := range a.examples {
+		items[i] = a.itemNamed(key, example)
+	}
+	return items
+}
+
+func (a argument) itemNamed(key string, example argExample) Item {
+	it := Item{Label: a.label(key), Summary: cmp.Or(example.summary, a.summary), Placeholder: example.placeholder}
+	if key != a.key {
+		it.Summary = "Alias for " + a.key
+	}
+	switch {
+	case example.text == "" && a.takesValue():
+		it.Continue = true
+		if a.form != formWord {
+			it.Insert = it.Label
+			it = it.WithoutTrailingSpace()
+		}
+	case example.text == "":
+		it.Continue = a.chain
+	case example.call != "" && a.form == formWord:
+		// The call already includes the argument name.
+		it.Insert = example.text
+	default:
+		if example.call != "" {
+			it.Label += example.call
+		}
+		it.Insert = a.lead(key) + example.text
+	}
+	return it
+}
+
+func (a argument) exampleItems() []Item {
+	var items []Item
+	for _, example := range a.examples {
+		items = append(items, Item{
+			Label:       example.text,
+			Summary:     cmp.Or(example.summary, a.summary),
+			Placeholder: example.placeholder,
+		})
+	}
+	return items
+}

--- a/internal/intellisense/argument_scan.go
+++ b/internal/intellisense/argument_scan.go
@@ -1,0 +1,111 @@
+package intellisense
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+)
+
+// field holds a decoded argument and its rune offsets in the source.
+type field struct {
+	start, end int
+	form       argForm
+	eq         int // rune offset of '=', or -1 for a positional field
+	text       string
+}
+
+func (f field) key() string {
+	name, _, _ := strings.Cut(f.text, "=")
+	return strings.TrimSuffix(name, "<")
+}
+
+func scanFields(text []rune) []field {
+	src := string(text)
+	at := func(b int) int { return utf8.RuneCountInString(src[:b]) }
+	var out []field
+	for token := range directive.ScanFields(src) {
+		f := field{start: at(token.Start), end: at(token.End), eq: -1, text: token.Value}
+		if token.Eq >= 0 {
+			f.form, f.eq = formOption, at(token.Eq)
+		} else if eq := budgetEq(src[token.Start:token.End]); eq >= 0 {
+			f.form, f.eq = formBudget, at(token.Start+eq)
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// budgetEq returns the byte offset of '=' in "key<=value", or -1 for other fields.
+func budgetEq(raw string) int {
+	key, _, ok := strings.Cut(raw, "<=")
+	if !ok || key == "" || strings.ContainsFunc(key, func(r rune) bool { return !directive.IsKeyRune(r) }) {
+		return -1
+	}
+	return len(key) + 1
+}
+
+type slot struct {
+	arg   *argument
+	value bool // the field holds the argument's value rather than its name
+}
+
+type scan struct {
+	slots []slot
+	open  *argument // argument waiting for a value in the next field
+	taken bool      // the directive's positional value is present
+}
+
+func (a args) read(fields []field) scan {
+	out := scan{slots: make([]slot, len(fields))}
+	for i, f := range fields {
+		switch {
+		case out.open != nil:
+			out.slots[i] = slot{arg: out.open, value: true}
+			out.open = nil
+		case f.eq >= 0:
+			if arg := a.findOption(f.key(), f.form); arg != nil {
+				out.slots[i] = slot{arg: arg, value: true}
+			}
+		default:
+			if arg := a.findWord(f.text); arg != nil {
+				out.slots[i] = slot{arg: arg}
+				if arg.takesValue() && !arg.loadsLine() {
+					out.open = arg
+				}
+				continue
+			}
+			if a.value != nil && !a.value.loadsLine() && (!out.taken || a.value.repeat) {
+				out.slots[i] = slot{arg: a.value, value: true}
+				out.taken = true
+			}
+		}
+	}
+	return out
+}
+
+// loadValue finds a path that uses the rest of the line and its starting rune offset.
+func (a args) loadValue(fields []field, text []rune) (*argument, int, bool) {
+	if a.value != nil && a.value.loadsLine() {
+		start, ok := loadStart(text, 0, a.value.value.path.form)
+		return a.value, start, ok
+	}
+	for _, f := range fields {
+		arg := a.findWord(f.text)
+		if arg == nil || !arg.loadsLine() {
+			continue
+		}
+		start, ok := loadStart(text, f.end, arg.value.path.form)
+		// Start value completion only after the caret leaves the argument name.
+		return arg, max(start, f.end+1), ok
+	}
+	return nil, 0, false
+}
+
+func loadStart(text []rune, from int, form pathForm) (int, bool) {
+	i := skipSpace(text, from)
+	if i < len(text) && text[i] == '<' {
+		return skipSpace(text, i+1), true
+	}
+	return i, form != pathLoadOnly
+}

--- a/internal/intellisense/arguments.go
+++ b/internal/intellisense/arguments.go
@@ -1,0 +1,230 @@
+package intellisense
+
+import (
+	"slices"
+	"strings"
+)
+
+type argForm uint8
+
+const (
+	formWord   argForm = iota // bare word, followed by a value if required
+	formOption                // key=value
+	formBudget                // key<=value, the @trace latency budgets
+)
+
+type pathForm uint8
+
+const (
+	// pathWord is one argument, quoted if it contains spaces.
+	pathWord pathForm = iota
+	// pathLoad uses the rest of the line, with an optional "<" marker.
+	pathLoad
+	// pathLoadOnly requires "<"; without it, the value is inline content.
+	pathLoadOnly
+)
+
+type valueKind uint8
+
+const (
+	valueNone   valueKind = iota // a bare flag with no value
+	valueText                    // free-form, so only the registered example is offered
+	valueChoice                  // one of a fixed set
+	valueNames                   // names supplied by the current workspace scope
+	valuePath
+)
+
+type nameSource func(Context, Scope) ([]string, string)
+
+type pathSpec struct {
+	kind PathKind
+	form pathForm
+	list bool
+	home bool // expand a leading "~"
+}
+
+type value struct {
+	kind    valueKind
+	choices []string
+	names   nameSource
+	path    pathSpec
+}
+
+// argument describes an option, a bare word, or a directive's positional value.
+type argument struct {
+	key     string
+	aliases []string
+	summary string
+	form    argForm
+	value   value
+
+	repeat bool
+	chain  bool // accepting the word opens suggestions for the next argument
+
+	examples []argExample
+}
+
+type argExample struct {
+	text        string
+	placeholder string // text selected for replacement when the example is inserted
+	summary     string // overrides the argument's description
+	call        string
+}
+
+type args struct {
+	// value is positional, such as the module path in @use.
+	value *argument
+	named []argument
+	// single allows one setting per line, as "key value" or "key=value".
+	single bool
+	// extraItems adds shortcuts that use the same filtering as other suggestions.
+	extraItems func(Context, Scope) []Item
+}
+
+func (a args) empty() bool {
+	return a.value == nil && len(a.named) == 0 && a.extraItems == nil
+}
+
+func (a args) find(pred func(argument) bool) *argument {
+	if i := slices.IndexFunc(a.named, pred); i >= 0 {
+		return &a.named[i]
+	}
+	return nil
+}
+
+func (a args) findOption(key string, form argForm) *argument {
+	return a.find(func(arg argument) bool {
+		return arg.form == form && arg.matches(key)
+	})
+}
+
+// findWord also accepts option names for directives that allow "key value".
+func (a args) findWord(text string) *argument {
+	return a.find(func(arg argument) bool {
+		return arg.form != formBudget && (arg.form == formWord || a.single) && arg.matches(text)
+	})
+}
+
+func (a argument) matches(key string) bool {
+	if strings.EqualFold(a.key, key) {
+		return true
+	}
+	return slices.ContainsFunc(a.aliases, func(alias string) bool {
+		return strings.EqualFold(alias, key)
+	})
+}
+
+func (a argument) takesValue() bool {
+	return a.value.kind != valueNone
+}
+
+func (a argument) loadsLine() bool {
+	return a.value.kind == valuePath && a.value.path.form != pathWord
+}
+
+func word(key, summary string) argument {
+	return argument{key: key, summary: summary, form: formWord}
+}
+
+func opt(key, summary, example string) argument {
+	return argument{
+		key:      key,
+		summary:  summary,
+		form:     formOption,
+		value:    value{kind: valueText},
+		examples: []argExample{plainExample(example)},
+	}
+}
+
+func optValue(key, summary string, v value) argument {
+	return argument{key: key, summary: summary, form: formOption, value: v}
+}
+
+func choice(key, summary string, choices ...string) argument {
+	return optValue(key, summary, value{kind: valueChoice, choices: choices})
+}
+
+func flag(key, summary string) argument {
+	return choice(key, summary, "true", "false")
+}
+
+// toggle uses "key true" or "key false" instead of "key=value".
+func toggle(key, summary string) argument {
+	a := flag(key, summary)
+	a.form = formWord
+	return a
+}
+
+func filePath(key, summary string, kind PathKind, form pathForm) argument {
+	return optValue(key, summary, pathValue(kind, form))
+}
+
+func budget(key, summary, example string) argument {
+	a := opt(key, summary, example)
+	a.form = formBudget
+	return a
+}
+
+func directiveValue(a argument) *argument {
+	a.form = formWord
+	return &a
+}
+
+func (a argument) alias(names ...string) argument {
+	a.aliases = append(a.aliases, names...)
+	return a
+}
+
+func (a argument) withExample(text string) argument {
+	a.examples = []argExample{plainExample(text)}
+	return a
+}
+
+// withOption selects only the option value, as in "@auth command argv=[...]".
+func (a argument) withOption(option string) argument {
+	a.examples = []argExample{{text: option, placeholder: optionValue(option)}}
+	return a
+}
+
+func (a argument) call(usage string) argument {
+	name, argv := cutCall(usage)
+	a.examples = []argExample{{text: usage, placeholder: argv, call: name}}
+	return a
+}
+
+func (a argument) chains() argument {
+	a.chain = true
+	return a
+}
+
+func (a argument) repeats() argument {
+	a.repeat = true
+	return a
+}
+
+func (a argument) home() argument {
+	a.value.path.home = true
+	return a
+}
+
+func (a argument) list() argument {
+	a.value.path.list = true
+	return a
+}
+
+func (a argument) takes(v value) argument {
+	a.value = v
+	return a
+}
+
+func plainExample(text string) argExample {
+	return argExample{text: text, placeholder: text}
+}
+
+func namesValue(source nameSource) value {
+	return value{kind: valueNames, names: source}
+}
+
+func pathValue(kind PathKind, form pathForm) value {
+	return value{kind: valuePath, path: pathSpec{kind: kind, form: form}}
+}

--- a/internal/intellisense/arguments_test.go
+++ b/internal/intellisense/arguments_test.go
@@ -1,0 +1,342 @@
+package intellisense
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+)
+
+func analyzeLine(t *testing.T, line string) Context {
+	t.Helper()
+	ctx, ok := Analyze(testLines{line}, 0, len([]rune(line)))
+	if !ok {
+		t.Fatalf("Analyze(%q) returned no context", line)
+	}
+	return ctx
+}
+
+func labels(items []Item) []string {
+	out := make([]string, len(items))
+	for i, item := range items {
+		out[i] = item.Label
+	}
+	return out
+}
+
+func TestAnalyzeArgumentValues(t *testing.T) {
+	tests := []struct {
+		line  string
+		key   string
+		query string
+		kind  valueKind
+		span  [2]int
+	}{
+		{
+			line:  "# @settings http-insecure=Tr",
+			key:   "http-insecure",
+			query: "Tr",
+			kind:  valueChoice,
+			span:  [2]int{26, 28},
+		},
+		{
+			line:  "# @setting http-version 2",
+			key:   "http-version",
+			query: "2",
+			kind:  valueChoice,
+			span:  [2]int{24, 25},
+		},
+		{
+			line:  "# @settings http-root-ca=certs/ø",
+			key:   "http-root-cas",
+			query: "certs/ø",
+			kind:  valuePath,
+			span:  [2]int{25, 32},
+		},
+		{
+			line:  `# @compare "Dév One" base="Dé`,
+			key:   "base",
+			query: "Dé",
+			kind:  valueNames,
+			span:  [2]int{26, 29},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			ctx := analyzeLine(t, tt.line)
+			if ctx.arg == nil {
+				t.Fatalf("context completes no value: %+v", ctx)
+			}
+			if got := argKey(ctx); got != tt.key {
+				t.Fatalf("argument = %q, want %q", got, tt.key)
+			}
+			if ctx.Query != tt.query {
+				t.Fatalf("query = %q, want %q", ctx.Query, tt.query)
+			}
+			if ctx.arg.value.kind != tt.kind {
+				t.Fatalf("value kind = %d, want %d", ctx.arg.value.kind, tt.kind)
+			}
+			if got := [2]int{ctx.Start, ctx.End}; got != tt.span {
+				t.Fatalf("replacement span = %v, want %v", got, tt.span)
+			}
+		})
+	}
+}
+
+func TestArgumentValueSuggestions(t *testing.T) {
+	tests := []struct {
+		line string
+		want []string
+	}{
+		{"# @settings http-insecure=", []string{"true", "false"}},
+		{"# @settings http-version=", []string{"1.1", "2"}},
+		{"# @body expand ", []string{"true", "false"}},
+		{"# @graphql ", []string{"true", "false"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			got := labels(suggest(tt.line, Scope{}))
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("values = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSingleSettingLineEndsAtItsValue(t *testing.T) {
+	for _, line := range []string{
+		"# @setting http-version 2 ",
+		"# @setting insecure=true ",
+		"# @body expand true ",
+		"# @graphql true ",
+	} {
+		if items := suggest(line, Scope{}); len(items) != 0 {
+			t.Fatalf("%q carries one setting yet still offers %q", line, labels(items))
+		}
+	}
+	if items := suggest("# @settings insecure=true ", Scope{}); len(items) == 0 {
+		t.Fatal("@settings should keep offering the options it has not been given")
+	}
+}
+
+func TestCompletedArgumentsAndAliasesAreFiltered(t *testing.T) {
+	items := suggest("# @settings insecure=true ", Scope{})
+	if slices.Contains(labels(items), "insecure=") {
+		t.Fatalf("completed option was offered again: %v", items)
+	}
+
+	items = suggest("# @compare dev prod baseline=dev ", Scope{Environments: []string{"dev", "prod", "qa"}})
+	for _, alias := range []string{"base=", "baseline=", "primary=", "ref="} {
+		if slices.Contains(labels(items), alias) {
+			t.Fatalf("completed alias family %q was offered: %v", alias, items)
+		}
+	}
+}
+
+func TestCompareSuggestionsRespectSelectedTargets(t *testing.T) {
+	flat := Scope{Environments: []string{"dev", "prod", "qa"}}
+	for _, line := range []string{"# @compare base=", "# @compare baseline="} {
+		if got := labels(suggest(line, flat)); !slices.Equal(got, flat.Environments) {
+			t.Fatalf("%q baseline choices = %q, want %q", line, got, flat.Environments)
+		}
+	}
+	if got := labels(suggest("# @compare dev prod base=", flat)); !slices.Equal(got, []string{"dev", "prod"}) {
+		t.Fatalf("baseline choices = %q, want only selected targets", got)
+	}
+
+	scope := Scope{
+		EnvironmentGroups: map[string][]string{
+			"api west": {"dev west", "prod west"},
+			"app":      {"dev app"},
+		},
+	}
+
+	got := labels(suggest(`# @compare group="api west" `, scope))
+	if !slices.Contains(got, "dev west") || !slices.Contains(got, "prod west") || slices.Contains(got, "dev app") {
+		t.Fatalf("grouped compare choices = %q", got)
+	}
+	for _, label := range got {
+		if strings.HasPrefix(label, "group=") {
+			t.Errorf("selected group still offers %q", label)
+		}
+	}
+
+	got = labels(suggest(`# @compare "dev west" "prod west" base=`, scope))
+	if !slices.Equal(got, []string{"dev west", "prod west"}) {
+		t.Fatalf("baseline choices = %q", got)
+	}
+}
+
+func TestDynamicValuesRoundTripThroughTheParser(t *testing.T) {
+	scope := Scope{
+		RequestNames:      []string{"Create User"},
+		EnvironmentGroups: map[string][]string{"api west": {"dev west"}},
+		Profiles:          ProfileSet{Patch: []string{"json api"}},
+	}
+	lines := []string{
+		"# @step one using=",
+		"# @step one run=",
+		"# @compare group=",
+		"# @compare base=",
+		"# @apply use=",
+	}
+	for _, line := range lines {
+		items := suggest(line, scope)
+		if len(items) != 1 {
+			t.Fatalf("%q suggestions = %v, want one scoped name", line, items)
+		}
+		for _, item := range items {
+			if strings.ContainsAny(item.Label, `"\`) {
+				t.Fatalf("%q offered a quoted label %q", line, item.Label)
+			}
+			fields := directive.Fields(item.InsertText())
+			if len(fields) != 1 || fields[0] != item.Label {
+				t.Fatalf("%q inserts %q, which reads back as %q", line, item.InsertText(), fields)
+			}
+		}
+	}
+}
+
+func TestAnalyzeFilesystemContexts(t *testing.T) {
+	tests := []struct {
+		line      string
+		kind      PathKind
+		quote     bool
+		continues bool
+		home      bool
+		list      bool
+	}{
+		{line: "# @ssh key=~/.ssh/id", kind: PathAny, quote: true, continues: true, home: true},
+		{line: "# @k8s kubeconfig=~/.kube/config", kind: PathAny, quote: true, continues: true, home: true},
+		{line: "# @settings grpc-client-cert=certs/client.pem", kind: PathAny, quote: true, continues: true},
+		{line: "# @settings http-root-cas=a.pem,b", kind: PathAny, quote: true, continues: true, list: true},
+		{line: "# @setting http-client-key certs/k", kind: PathAny, quote: true},
+		{line: "# @use ./rts/help", kind: PathRTS, quote: true, continues: true},
+		{line: "# @grpc-descriptor ./proto/api", kind: PathAny},
+		{line: "# @ws send-file < fixtures/data", kind: PathAny},
+		{line: "# @query < queries/main", kind: PathGraphQL},
+		{line: "# @variables < data/vars", kind: PathJSON},
+		{line: "< payloads/body", kind: PathAny},
+		{line: "> < scripts/pre", kind: PathScript},
+		{line: "@ fixtures/part", kind: PathAny},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			ctx := analyzeLine(t, tt.line)
+			want := PathContext{
+				Kind:      tt.kind,
+				Quote:     tt.quote,
+				List:      tt.list,
+				Home:      tt.home,
+				Continues: tt.continues,
+			}
+			if ctx.Kind != KindPath || ctx.Path != want {
+				t.Fatalf("path context = %v %+v, want %+v", ctx.Kind, ctx.Path, want)
+			}
+			if ctx.Query == "" || strings.HasPrefix(ctx.Query, " ") {
+				t.Fatalf("path query = %q", ctx.Query)
+			}
+		})
+	}
+}
+
+func TestInlineArgumentsAreNotPaths(t *testing.T) {
+	for _, line := range []string{"# @query { user", "# @variables {\"id\""} {
+		if ctx := analyzeLine(t, line); ctx.Kind == KindPath {
+			t.Fatalf("%q was read as a path: %+v", line, ctx)
+		}
+	}
+	items := suggest("# @query ", Scope{})
+	if !slices.Contains(labels(items), "<") {
+		t.Fatalf("the file marker is missing from %v", items)
+	}
+}
+
+func TestVariableClosersAndHelperUsage(t *testing.T) {
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"{{ho", "host}}"},
+		{"{{ho}", "host}"},
+		{"{{ho}}", "host"},
+	}
+	for _, tt := range tests {
+		ctx, ok := Analyze(testLines{tt.line}, 0, 4)
+		if !ok {
+			t.Fatalf("Analyze(%q) returned no context", tt.line)
+		}
+		items := variableSource{}.Provide(ctx, Scope{Variables: []VarRef{{Name: "host"}}})
+		if len(items) != 1 || items[0].InsertText() != tt.want {
+			t.Fatalf("%q insert = %#v, want %q", tt.line, items, tt.want)
+		}
+	}
+
+	ctx, _ := Analyze(testLines{"{{$randomI"}, 0, len([]rune("{{$randomI")))
+	items := variableSource{}.Provide(ctx, Scope{})
+	for _, item := range items {
+		if item.Label != "$randomInt" {
+			continue
+		}
+		if item.InsertText() != "$randomInt(1, 100)}}" || item.Placeholder != "1, 100" {
+			t.Fatalf("helper item = %+v", item)
+		}
+		return
+	}
+	t.Fatal("$randomInt completion missing")
+}
+
+func TestCompletedTraceBudgetsAreFiltered(t *testing.T) {
+	for _, line := range []string{
+		"# @trace dns<=50ms total<=400ms ",
+		"# @trace dns<=50ms total=400ms ",
+	} {
+		items := labels(suggest(line, Scope{}))
+		for _, label := range []string{"dns<=", "total<=", "total="} {
+			if slices.Contains(items, label) {
+				t.Errorf("%q repeats %q: %v", line, label, items)
+			}
+		}
+		if !slices.Contains(items, "connect<=") {
+			t.Errorf("%q lost the remaining budgets: %v", line, items)
+		}
+	}
+	items := suggest("# @trace dns<=", Scope{})
+	if len(items) != 1 || items[0].InsertText() != "50ms" || items[0].Placeholder != "50ms" {
+		t.Fatalf("budget values = %+v", items)
+	}
+}
+
+func TestDirectiveArgumentContainingAtSign(t *testing.T) {
+	items := labels(suggest("# @auth oauth2 username=person@example.com grant=", Scope{}))
+	if !slices.Contains(items, "password") {
+		t.Fatalf("@ inside a value hid the directive: %v", items)
+	}
+}
+
+func TestBackslashDoesNotShiftLaterFields(t *testing.T) {
+	// A bare backslash is literal, so it must not escape the space between fields.
+	ctx := analyzeLine(t, `# @compare Dév\ One group=api base=On`)
+	if ctx.Query != "On" || argKey(ctx) != "base" {
+		t.Fatalf("caret context = %+v", ctx)
+	}
+	if !ctx.completed.holds(compareTarget, "One") || !ctx.completed.holds("group", "api") {
+		t.Fatalf("backslash shifted subsequent values: %+v", ctx.completed)
+	}
+	items := directiveSource{}.Provide(ctx, Scope{})
+	if len(items) != 1 || items[0].InsertText() != "One" {
+		t.Fatalf("baseline values = %+v", items)
+	}
+}
+
+func TestPathContextPreservesBackslashes(t *testing.T) {
+	const path = `C:\modules\help`
+	ctx := analyzeLine(t, "# @use "+path)
+	if ctx.Kind != KindPath || ctx.Query != path {
+		t.Fatalf("path context = %+v", ctx)
+	}
+}

--- a/internal/intellisense/catalog.go
+++ b/internal/intellisense/catalog.go
@@ -1,0 +1,31 @@
+package intellisense
+
+import "github.com/unkn0wn-root/resterm/internal/directive"
+
+// The catalog is read only after initialization. Contexts share its arguments.
+type argumentCatalog map[directive.Name]args
+
+var argTable = buildArgTable()
+
+func argsFor(name directive.Name) args {
+	return argTable[name.Canonical()]
+}
+
+func buildArgTable() argumentCatalog {
+	c := make(argumentCatalog)
+	addRequestArgs(c)
+	addExecutionArgs(c)
+	addTransportArgs(c)
+	c.add(compareArgs(), directive.Compare)
+	return c
+}
+
+func (c argumentCatalog) add(a args, names ...directive.Name) {
+	for _, name := range names {
+		name = name.Canonical()
+		if _, exists := c[name]; exists {
+			panic("duplicate completion arguments for " + name.Tag())
+		}
+		c[name] = a
+	}
+}

--- a/internal/intellisense/catalog_execution.go
+++ b/internal/intellisense/catalog_execution.go
@@ -1,0 +1,115 @@
+package intellisense
+
+import (
+	"net/http"
+
+	"github.com/unkn0wn-root/resterm/internal/delay"
+	"github.com/unkn0wn-root/resterm/internal/directive"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
+)
+
+func addExecutionArgs(c argumentCatalog) {
+	c.add(args{named: mockArgs()}, directive.Mock)
+	c.add(args{named: matchArgs}, directive.Match)
+	c.add(args{named: []argument{opt("calls", "Exact matching request count", "1")}}, directive.Expect)
+	c.add(args{named: profileArgs}, directive.Profile)
+	c.add(args{named: pollArgs}, directive.Poll)
+	c.add(args{named: []argument{opt("count", "Number of additional attempts", "4")}}, directive.Retry)
+	c.add(args{named: []argument{
+		word("exponential", "Starting and maximum retry delay").call("exponential(100ms, 2s)"),
+		opt("jitter", "Random delay percentage", "20%"),
+	}}, directive.RetryBackoff)
+	c.add(args{named: scriptArgs}, directive.Script)
+	c.add(args{named: []argument{word("pre-request", "Run RestermScript before the request")}}, directive.RTS)
+	c.add(args{
+		value: directiveValue(filePath("module", "RestermScript module", PathRTS, pathWord)),
+		named: []argument{word("as", "Bind the module to an alias")},
+	}, directive.Use)
+	c.add(args{named: traceArgs}, directive.Trace)
+
+	failure := choice("on-failure", "Failure behavior",
+		string(restfile.WorkflowOnFailureStop), string(restfile.WorkflowOnFailureContinue),
+	).alias("onfailure")
+	c.add(args{named: []argument{failure}}, directive.Workflow)
+	c.add(args{named: []argument{
+		failure, optValue("using", "Request to run", namesValue(requestNames)).alias("run"),
+	}}, directive.Step)
+	c.add(args{named: []argument{
+		optValue("run", "Request to run", namesValue(requestNames)).alias("using"),
+		opt("fail", "Fail workflow branch with message", `"message"`),
+	}}, directive.If, directive.Elif, directive.Else, directive.Case, directive.Default)
+}
+
+func requestNames(_ Context, sc Scope) ([]string, string) {
+	return sc.RequestNames, "request"
+}
+
+var matchArgs = []argument{
+	opt("query", "Query matcher rules as JSON", `{"key":"value"}`),
+	opt("headers", "Header matcher rules as JSON", `{"X-Key":"value"}`),
+	opt("json", "Literal JSON body subset", `{"key":"value"}`),
+	opt("json-rules", "JSON body matcher rules", `{"key":{"gt":1}}`),
+}
+
+func mockArgs() []argument {
+	latency := opt("latency", "Constant response latency", "250ms")
+	for _, d := range delay.Distributions() {
+		latency.examples = append(latency.examples, argExample{
+			text: d.Usage(), placeholder: d.Args, summary: d.Summary, call: d.Name,
+		})
+	}
+	return []argument{
+		choice("method", "HTTP method to match", httpMethods...),
+		opt("path", "Origin-form route path", "/resource"),
+		opt("name", "Scenario selector name", "success"),
+		opt("sequence", "Response sequence name", "polling"),
+		opt("sequence-key", "Per-key cursor source (path, query, header, or cookie)", "path.id"),
+		flag("default", "Use as the route fallback"),
+		latency,
+		flag("interpolate", "Expand response templates"),
+	}
+}
+
+var httpMethods = []string{
+	http.MethodGet,
+	http.MethodHead,
+	http.MethodPost,
+	http.MethodPut,
+	http.MethodPatch,
+	http.MethodDelete,
+	http.MethodConnect,
+	http.MethodOptions,
+	http.MethodTrace,
+}
+
+var profileArgs = []argument{
+	opt("count", "Number of measured runs", "10"),
+	opt("warmup", "Warmup runs (excluded from stats)", "2"),
+	opt("delay", "Delay between runs (e.g. 250ms)", "250ms"),
+}
+
+var pollArgs = []argument{
+	opt("every", "Time between polling requests", "500ms"),
+	opt("timeout", "Total time allowed for polling", "30s"),
+	opt("until", "Condition that stops polling (must be last)", `response.json().status == "completed"`),
+}
+
+var scriptArgs = []argument{
+	word("pre-request", "Run script before the request").chains(),
+	word("test", "Run script after the response").chains(),
+	choice("lang", "Script language", "rts", "js").alias("language"),
+}
+
+var traceArgs = []argument{
+	flag("enabled", "Toggle tracing"),
+	budget("total", "Set overall latency budget", "400ms"),
+	opt("total", "Set overall latency budget (alternate syntax)", "400ms"),
+	budget("dns", "Budget for DNS lookup", "50ms"),
+	budget("connect", "Budget for TCP connect", "120ms"),
+	budget("tls", "Budget for TLS handshake", "150ms"),
+	budget("request-headers", "Budget for sending request headers", "20ms"),
+	budget("request-body", "Budget for sending request body", "100ms"),
+	budget("ttfb", "Budget until first response byte", "200ms"),
+	budget("transfer", "Budget for response transfer", "250ms"),
+	opt("tolerance", "Allow extra shared tolerance", "25ms").alias("allowance"),
+}

--- a/internal/intellisense/catalog_request.go
+++ b/internal/intellisense/catalog_request.go
@@ -1,0 +1,142 @@
+package intellisense
+
+import (
+	"github.com/unkn0wn-root/resterm/internal/authcmd"
+	"github.com/unkn0wn-root/resterm/internal/directive"
+	httpversion "github.com/unkn0wn-root/resterm/internal/http/version"
+	"github.com/unkn0wn-root/resterm/internal/oauth"
+	"github.com/unkn0wn-root/resterm/internal/protocol/grpcx"
+	"github.com/unkn0wn-root/resterm/internal/tlsconfig"
+)
+
+func addRequestArgs(c argumentCatalog) {
+	c.add(args{named: authArgs}, directive.Auth)
+	c.add(args{named: patchArgs}, directive.Patch)
+	c.add(args{named: []argument{
+		optValue("use", "Reference a named patch profile", namesValue(func(_ Context, sc Scope) ([]string, string) {
+			return sc.Profiles.Patch, "apply profile"
+		})).repeats(),
+	}}, directive.Apply)
+	c.add(args{named: bodyArgs, single: true}, directive.Body)
+	c.add(args{named: settingArgs, single: true}, directive.Setting)
+	c.add(args{named: settingArgs}, directive.Settings)
+	c.add(
+		args{value: directiveValue(filePath("query", "GraphQL query file", PathGraphQL, pathLoadOnly))},
+		directive.Query,
+	)
+	c.add(
+		args{value: directiveValue(filePath("variables", "GraphQL variables file", PathJSON, pathLoadOnly))},
+		directive.Variables,
+	)
+	c.add(args{value: directiveValue(flag("enabled", "Toggle GraphQL")), single: true}, directive.GraphQL)
+}
+
+var authArgs = []argument{
+	word("request", "Make the auth directive explicitly request-scoped").withExample("bearer {{token}}"),
+	word("file", "Define auth inherited by later requests in this file").withExample("bearer {{token}}"),
+	word("global", "Define auth inherited across the workspace").withExample("bearer {{token}}"),
+	word("none", "Disable inherited auth for the current request"),
+	word("basic", "Basic auth with username and password").withExample("user pass"),
+	word("bearer", "Bearer token auth").withExample("{{token}}"),
+	word("apikey", "API key auth in header or query").withExample("header X-API-Key {{key}}"),
+	word("oauth2", "Built-in OAuth 2.0 token acquisition and caching").chains(),
+	word("command", "Run a CLI command and inject its token output").
+		withOption(`argv=["gh","auth","token"]`),
+	word("header", "API key placement in headers"),
+	word("query", "API key placement in query string"),
+	opt("token_url", "OAuth2 token endpoint URL", "https://auth.example.com/oauth/token"),
+	opt("auth_url", "OAuth2 authorization endpoint URL", "https://auth.example.com/authorize"),
+	opt("client_id", "OAuth2 client ID", "{{clientId}}"),
+	opt("client_secret", "OAuth2 client secret", "{{clientSecret}}"),
+	choice(
+		"grant",
+		"OAuth2 grant type",
+		oauth.GrantClientCredentials,
+		oauth.GrantPassword,
+		oauth.GrantAuthorizationCode,
+	),
+	opt("scope", "OAuth2 scope list", `"read write"`),
+	opt("audience", "OAuth2 audience", "https://api.example.com"),
+	opt("resource", "OAuth2 resource indicator", "https://graph.microsoft.com"),
+	choice("client_auth", "OAuth2 client credential transport", oauth.ClientAuthBasic, oauth.ClientAuthBody),
+	opt("username", "Password grant username", "{{user.email}}"),
+	opt("password", "Password grant password", "{{user.password}}"),
+	opt("cache_key", "Reuse cached auth state across requests", "myapi"),
+	opt("redirect_uri", "OAuth2 redirect URI", "http://127.0.0.1:8484/callback"),
+	opt("code_verifier", "PKCE code verifier", "{{pkce.verifier}}"),
+	choice(
+		"code_challenge_method",
+		"PKCE challenge method",
+		oauth.CodeChallengeS256,
+		oauth.CodeChallengePlain,
+	),
+	opt("state", "OAuth2 state value", "{{oauth.state}}"),
+	opt("header", "Override injected header name", "Authorization"),
+	opt("argv", "Command argv as JSON array", `["gh","auth","token"]`),
+	choice("format", "Command output format", string(authcmd.FormatText), string(authcmd.FormatJSON)),
+	opt("scheme", "Command auth header scheme", "Bearer"),
+	opt("token_path", "JSON path to token value", "access_token"),
+	opt("type_path", "JSON path to token type", "token_type"),
+	opt("expiry_path", "JSON path to absolute expiry", "expires_at"),
+	opt("expires_in_path", "JSON path to relative expiry seconds", "expires_in"),
+	opt("ttl", "Fallback command auth cache TTL", "10m"),
+	opt("timeout", "Command auth timeout", "5s"),
+}
+
+var patchArgs = []argument{
+	word("file", "Define a file-scoped reusable patch profile"),
+	word("global", "Define a workspace-global reusable patch profile"),
+}
+
+var bodyArgs = []argument{
+	toggle("expand", "Expand body templates").alias("expand-templates"),
+	toggle("inline", "Force an inline body").alias("raw"),
+}
+
+var settingArgs = []argument{
+	opt("base-url", "Base URL for relative HTTP requests", "https://api.example.com/v1/"),
+	opt("timeout", "Request timeout (e.g. 5s)", "5s"),
+	opt("proxy", "HTTP proxy URL", "http://proxy"),
+	flag("followredirects", "Follow redirects"),
+	flag("insecure", "Skip TLS verification (HTTP)"),
+	flag("no-cookies", "Disable cookies for this request"),
+	opt(
+		"forward-credentials-on-redirect",
+		"Origins a redirect may carry credentials to",
+		"https://cdn.example.com",
+	),
+	opt("max-redirects", "Redirects to follow (count or none)", "20"),
+	opt("max-response-size", "Response body limit (size or none)", "100mb"),
+	opt("sse-max-line-bytes", "Default SSE line limit for every request", "4mb"),
+	opt("sse-max-event-bytes", "Default SSE event limit for every request", "8mb"),
+	opt("ws-max-message-bytes", "Default WebSocket message limit for every request", "32kb"),
+	choice(
+		"http-version",
+		"HTTP protocol version",
+		httpversion.Format(httpversion.V11),
+		httpversion.Format(httpversion.V2),
+	),
+	flag("http-insecure", "Skip TLS verification (HTTP)"),
+	filePath("http-root-cas", "Extra HTTP root CAs", PathAny, pathWord).list().alias("http-root-ca"),
+	choice(
+		"http-root-mode",
+		"HTTP root CA mode",
+		string(tlsconfig.RootModeAppend),
+		string(tlsconfig.RootModeReplace),
+	),
+	filePath("http-client-cert", "HTTP client certificate", PathAny, pathWord),
+	filePath("http-client-key", "HTTP client key", PathAny, pathWord),
+	flag("grpc-insecure", "Skip TLS verification (gRPC)"),
+	filePath("grpc-root-cas", "Extra gRPC root CAs", PathAny, pathWord).list().alias("grpc-root-ca"),
+	choice(
+		"grpc-root-mode",
+		"gRPC root CA mode",
+		string(tlsconfig.RootModeAppend),
+		string(tlsconfig.RootModeReplace),
+	),
+	filePath("grpc-client-cert", "gRPC client certificate", PathAny, pathWord),
+	filePath("grpc-client-key", "gRPC client key", PathAny, pathWord),
+	opt("grpc-max-recv-size", "Max gRPC response size", "16MB"),
+	opt("grpc-max-send-size", "Max gRPC request size", "16MB"),
+	choice("grpc-compression", "gRPC request compression", grpcx.CompressionNames()...),
+}

--- a/internal/intellisense/catalog_test.go
+++ b/internal/intellisense/catalog_test.go
@@ -1,0 +1,28 @@
+package intellisense
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestArgumentCatalogHasUnambiguousNames(t *testing.T) {
+	for name, args := range argTable {
+		t.Run(name.String(), func(t *testing.T) {
+			type spelling struct {
+				key  string
+				form argForm
+			}
+			seen := make(map[spelling]bool)
+			for _, arg := range args.named {
+				names := append([]string{arg.key}, arg.aliases...)
+				for _, key := range names {
+					id := spelling{strings.ToLower(key), arg.form}
+					if key == "" || seen[id] {
+						t.Errorf("ambiguous argument %q with form %d", key, arg.form)
+					}
+					seen[id] = true
+				}
+			}
+		})
+	}
+}

--- a/internal/intellisense/catalog_transport.go
+++ b/internal/intellisense/catalog_transport.go
@@ -1,0 +1,89 @@
+package intellisense
+
+import "github.com/unkn0wn-root/resterm/internal/directive"
+
+func addTransportArgs(c argumentCatalog) {
+	c.add(args{named: sseArgs}, directive.SSE)
+	c.add(args{named: webSocketArgs}, directive.WebSocket)
+	c.add(args{named: wsArgs}, directive.WS)
+	c.add(args{named: sshArgs}, directive.SSH)
+	c.add(args{named: k8sArgs}, directive.K8s)
+	c.add(
+		args{value: directiveValue(filePath("descriptor", "Descriptor set file", PathAny, pathLoad))},
+		directive.GRPCDescriptor,
+	)
+	c.add(
+		args{value: directiveValue(flag("enabled", "Toggle gRPC reflection")), single: true},
+		directive.GRPCReflection,
+	)
+	c.add(args{value: directiveValue(flag("enabled", "Force plaintext gRPC")), single: true}, directive.GRPCPlaintext)
+}
+
+var sseArgs = []argument{
+	opt("timeout", "Total stream timeout", "30s").alias("duration"),
+	opt("idle", "Idle timeout between events", "10s").alias("idle-timeout"),
+	opt("max-events", "Stop after N events", "100"),
+	opt("max-bytes", "Stop after N bytes", "1mb").alias("limit-bytes"),
+	opt("max-line-bytes", "Largest SSE line to buffer", "1mb"),
+	opt("max-event-bytes", "Largest SSE event to buffer", "1mb"),
+	word("off", "Disable SSE for this request"),
+}
+
+var webSocketArgs = []argument{
+	opt("timeout", "Handshake deadline", "10s"),
+	opt("idle-timeout", "Idle timeout (resets on any activity)", "5s").alias("idle"),
+	opt("max-message-bytes", "Max inbound frame size", "1mb"),
+	opt("subprotocols", "Comma-separated subprotocols", "chat,json"),
+	flag("compression", "Toggle WebSocket compression"),
+}
+
+var wsArgs = []argument{
+	word("send", "Send a text frame"),
+	word("send-json", "Send a JSON frame"),
+	word("send-base64", "Send base64-decoded binary data"),
+	word("send-file", "Send file contents").takes(pathValue(PathAny, pathLoad)),
+	word("ping", "Send a ping frame"),
+	word("pong", "Send a pong frame"),
+	word("wait", "Wait for a duration or incoming message"),
+	word("close", "Close the connection with code and reason"),
+}
+
+var sshArgs = []argument{
+	opt("host", "Jump host (supports env:VAR and templates)", "env:SSH_HOST"),
+	opt("port", "Port (default 22)", "22"),
+	opt("user", "SSH user", "ops"),
+	opt("password", "Password auth", "env:SSH_PW").alias("pass"),
+	filePath("key", "Private key path", PathAny, pathWord).home(),
+	opt("passphrase", "Key passphrase", "env:SSH_KEY_PW"),
+	flag("agent", "Use the SSH agent"),
+	filePath("known_hosts", "Known hosts file", PathAny, pathWord).home().alias("known-hosts"),
+	flag("strict_hostkey", "Toggle host key checking").alias("strict-hostkey", "strict_host_key"),
+	flag("persist", "Keep the tunnel open"),
+	opt("timeout", "SSH dial timeout", "15s"),
+	opt("keepalive", "Server keepalive interval", "30s"),
+	opt("retries", "Retry count for tunnel attach", "2"),
+	optValue("use", "Reference a named SSH profile", namesValue(func(_ Context, sc Scope) ([]string, string) {
+		return sc.Profiles.SSH, "ssh profile"
+	})),
+}
+
+var k8sArgs = []argument{
+	opt("target", "Target ref (pod:/service:/deployment:/statefulset:)", "pod:api-server"),
+	opt("namespace", "Kubernetes namespace (default: default)", "default"),
+	opt("pod", "Pod name for port-forward target", "api-server"),
+	opt("service", "Service name for target pod selection", "api"),
+	opt("deployment", "Deployment name for target pod selection", "api"),
+	opt("statefulset", "StatefulSet name for target pod selection", "db"),
+	opt("port", "Remote port (number or named port)", "8080"),
+	opt("context", "Kubeconfig context override", "dev-cluster"),
+	filePath("kubeconfig", "Kubeconfig path override", PathAny, pathWord).home().alias("config"),
+	opt("container", "Container name in selected pod", "api"),
+	opt("local_port", "Local port to bind (optional)", "18080"),
+	opt("address", "Local bind address", "127.0.0.1"),
+	opt("pod_running_timeout", "Wait timeout for running pod", "20s"),
+	opt("retries", "Retry count for forward attach", "2"),
+	optValue("use", "Reference a named Kubernetes profile", namesValue(func(_ Context, sc Scope) ([]string, string) {
+		return sc.Profiles.K8s, "k8s profile"
+	})),
+	flag("persist", "Keep the forwarder open"),
+}

--- a/internal/intellisense/compare.go
+++ b/internal/intellisense/compare.go
@@ -1,0 +1,97 @@
+package intellisense
+
+import (
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+)
+
+// compareTarget is the internal key for positional environment names.
+const compareTarget = "target"
+
+func compareArgs() args {
+	return args{
+		value: directiveValue(optValue(compareTarget, "Environment to compare", namesValue(compareTargets)).repeats()),
+		named: []argument{
+			optValue(
+				"base",
+				"Set the baseline environment",
+				namesValue(compareBaseline),
+			).alias("baseline", "primary", "ref"),
+			optValue("group", "Select the environment group to vary", namesValue(compareGroups)),
+		},
+		extraItems: compareGroupItems,
+	}
+}
+
+func compareGroupItems(ctx Context, sc Scope) []Item {
+	if ctx.completed.has("group") {
+		return nil
+	}
+	var items []Item
+	for _, group := range groupNames(sc.EnvironmentGroups) {
+		items = append(items, Item{
+			Label:    "group=" + group,
+			Insert:   "group=" + directive.Quote(group),
+			Summary:  "environment group",
+			Continue: true,
+		})
+	}
+	return items
+}
+
+func compareGroups(_ Context, sc Scope) ([]string, string) {
+	return groupNames(sc.EnvironmentGroups), "environment group"
+}
+
+func compareBaseline(ctx Context, sc Scope) ([]string, string) {
+	if targets := ctx.completed[compareTarget]; len(targets) > 0 {
+		return targets, "environment profile"
+	}
+	return compareTargets(ctx, sc)
+}
+
+func compareTargets(ctx Context, sc Scope) ([]string, string) {
+	if len(sc.Environments) > 0 {
+		return sc.Environments, "environment"
+	}
+	return groupedProfiles(ctx, sc), "environment profile"
+}
+
+func groupedProfiles(ctx Context, sc Scope) []string {
+	if selected, ok := ctx.completed.last("group"); ok {
+		for group, profiles := range sc.EnvironmentGroups {
+			if strings.EqualFold(group, selected) {
+				return slices.Clone(profiles)
+			}
+		}
+	}
+	return groupProfiles(sc.EnvironmentGroups)
+}
+
+func groupNames(groups map[string][]string) []string {
+	return slices.SortedFunc(maps.Keys(groups), compareFold)
+}
+
+func groupProfiles(groups map[string][]string) []string {
+	seen := make(map[string]struct{})
+	var profiles []string
+	for _, group := range groupNames(groups) {
+		for _, profile := range groups[group] {
+			key := strings.ToLower(profile)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			profiles = append(profiles, profile)
+		}
+	}
+	slices.SortFunc(profiles, compareFold)
+	return profiles
+}
+
+func compareFold(a, b string) int {
+	return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+}

--- a/internal/intellisense/context.go
+++ b/internal/intellisense/context.go
@@ -1,6 +1,7 @@
 package intellisense
 
 import (
+	"slices"
 	"strings"
 	"unicode"
 
@@ -18,21 +19,73 @@ const (
 	KindHeaderName        // start of a header line
 	KindHeaderValue       // value after "Name:" on a header line
 	KindVariable          // identifier inside an open {{ ... }}
+	KindPath              // a filesystem path, in a directive or a body reference
 )
 
-type Context struct {
-	Kind          Kind
-	DirectiveName directive.Name // base key for KindDirectiveArg
-	HeaderName    string         // lowercased name for KindHeaderValue
-	ArgKey        string         // option key when completing a value, e.g. "use"
-	Query         string         // partial token being completed, lowercased
-	Start         int            // rune offset within the caret line where Query begins
+// PathKind identifies which file types to suggest.
+type PathKind uint8
 
-	needsCommentPrefix bool
+const (
+	PathNone PathKind = iota
+	PathAny
+	PathRTS
+	PathGraphQL
+	PathJSON
+	PathScript
+)
+
+// PathContext describes the syntax allowed for a path completion.
+type PathContext struct {
+	Kind      PathKind
+	Quote     bool   // quote paths that contain spaces
+	List      bool   // complete one entry in a list of paths
+	Home      bool   // expand a leading "~"
+	Continues bool   // more arguments may follow the path
+	Suffix    string // decoded value after the caret in a list
 }
 
-// Lines exposes the buffer's logical lines to Analyze - LineRunes(i) is the
-// 0-based line i (the same sequence as strings.Split(value, "\n")).
+type Context struct {
+	Kind  Kind
+	Query string // the partial token being completed
+	Start int    // first rune offset to replace on the current line
+	End   int    // rune offset after the text to replace
+	Path  PathContext
+
+	name      directive.Name
+	header    string    // lowercased header name for KindHeaderValue
+	arg       *argument // argument whose value is being completed
+	completed completed
+	closing   string // text that completes an unfinished template
+	call      bool   // the identifier is followed by an argument list
+	bare      bool   // the directive was typed without its comment marker
+}
+
+// completed stores values already on the line under each argument's canonical name.
+type completed map[string][]string
+
+func (c completed) add(key, value string) {
+	c[key] = append(c[key], value)
+}
+
+func (c completed) has(key string) bool {
+	return len(c[key]) > 0
+}
+
+func (c completed) holds(key, value string) bool {
+	return slices.ContainsFunc(c[key], func(v string) bool {
+		return strings.EqualFold(v, value)
+	})
+}
+
+func (c completed) last(key string) (string, bool) {
+	values := c[key]
+	if len(values) == 0 {
+		return "", false
+	}
+	return values[len(values)-1], true
+}
+
+// Lines exposes newline-separated buffer lines to Analyze. Line indexes start at zero.
 type Lines interface {
 	LineCount() int
 	LineRunes(i int) []rune
@@ -43,20 +96,18 @@ func Analyze(lines Lines, line, col int) (Context, bool) {
 		return Context{}, false
 	}
 	cur := lines.LineRunes(line)
-	if col < 0 {
-		col = 0
-	}
-	if col > len(cur) {
-		col = len(cur)
-	}
+	col = clamp(col, 0, len(cur))
 
 	if ctx, ok := analyzeVariable(cur, col); ok {
 		return ctx, true
 	}
 	if marker := commentPrefixLen(cur); marker >= 0 {
-		return analyzeDirective(cur, marker, col)
+		return analyzeDirective(cur, marker, col, false)
 	}
-	if ctx, ok := analyzeBareDirective(cur, col); ok {
+	if ctx, ok := analyzeDirective(cur, 0, col, true); ok {
+		return ctx, true
+	}
+	if ctx, ok := analyzeBodyPath(cur, col); ok {
 		return ctx, true
 	}
 	return analyzeRequest(lines, line, cur, col)
@@ -80,98 +131,60 @@ func analyzeVariable(cur []rune, col int) (Context, bool) {
 	for start > open && IsTokenRune(cur[start-1]) {
 		start--
 	}
-	return Context{
-		Kind:  KindVariable,
-		Query: strings.ToLower(string(cur[start:col])),
-		Start: start,
-	}, true
-}
+	end := col
+	for end < len(cur) && IsTokenRune(cur[end]) {
+		end++
+	}
+	ctx := Context{Kind: KindVariable, Query: string(cur[start:col]), Start: start, End: end}
 
-func analyzeDirective(cur []rune, marker, col int) (Context, bool) {
-	at := -1
-	for i := col - 1; i >= marker; i-- {
-		if cur[i] == '@' {
-			at = i
-			break
-		}
+	next := skipSpace(cur, end)
+	if next < len(cur) && cur[next] == '(' {
+		ctx.call = true
+		return ctx, true
 	}
-	if at < 0 {
-		return Context{}, false
-	}
-	// everything between the marker and '@' must be blank for this to be a
-	// directive anchor (e.g. "# @", "/* @"), not an '@' inside other text.
-	if strings.TrimSpace(string(cur[marker:at])) != "" {
-		return Context{}, false
-	}
-
-	ctx, ok := analyzeDirectiveArea(cur[at+1 : col])
-	if !ok {
-		return Context{}, false
-	}
-	// area offsets are relative to the rune after '@'.
-	if ctx.Kind == KindDirective {
-		ctx.Start = at
-	} else {
-		ctx.Start += at + 1
+	// Missing braces go after the whitespace, so the replacement covers it.
+	if closers := skipPartial(cur, next, "}}") - next; closers < 2 {
+		ctx.End = next
+		ctx.closing = string(cur[end:next]) + strings.Repeat("}", 2-closers)
 	}
 	return ctx, true
 }
 
-func analyzeBareDirective(cur []rune, col int) (Context, bool) {
-	at := leadingSpaceLen(cur)
-	if at >= col || cur[at] != '@' {
+// analyzeBodyPath handles body files ("< file"), script includes ("> < file"),
+// and inline body includes ("@ file").
+func analyzeBodyPath(cur []rune, col int) (Context, bool) {
+	start := leadingSpaceLen(cur)
+	if start >= len(cur) || col < start {
 		return Context{}, false
 	}
-
-	ctx, ok := analyzeDirectiveArea(cur[at+1 : col])
-	if !ok || ctx.Kind != KindDirective {
-		return Context{}, false
-	}
-	ctx.Start = at
-	ctx.needsCommentPrefix = true
-	return ctx, true
-}
-
-func analyzeDirectiveArea(area []rune) (Context, bool) {
-	if len(area) == 0 {
-		return Context{Kind: KindDirective}, true
-	}
-
-	// A colon ends the name the same way a space does. Parse takes both, so
-	// "@auth:bea" has to complete like "@auth bea".
-	sep := -1
-	for i, r := range area {
-		if directive.IsArgSep(r) {
-			sep = i
-			break
-		}
-		if !isQueryRune(r) {
+	kind := PathAny
+	switch cur[start] {
+	case '<', '@':
+		start++
+	case '>':
+		start = skipSpace(cur, start+1)
+		if start >= len(cur) || cur[start] != '<' {
 			return Context{}, false
 		}
-	}
-	if sep == -1 {
-		return Context{Kind: KindDirective, Query: strings.ToLower(string(area))}, true
-	}
-	if sep == 0 {
+		start++
+		kind = PathScript
+	default:
 		return Context{}, false
 	}
-
-	base := directive.Name(strings.ToLower(string(area[:sep])))
-
-	start, token, ok := splitToken(area, skipArgSep(area, sep))
-	if !ok {
+	if start < len(cur) && !unicode.IsSpace(cur[start]) {
 		return Context{}, false
 	}
-
-	ctx := Context{Kind: KindDirectiveArg, DirectiveName: base, Start: start}
-	if key, val, found := splitValueToken(token); found {
-		ctx.ArgKey = key
-		ctx.Query = strings.ToLower(val)
-		ctx.Start = start + (len(token) - len([]rune(val)))
-	} else {
-		ctx.Query = strings.ToLower(string(token))
+	start = skipSpace(cur, start)
+	if col < start {
+		return Context{}, false
 	}
-	return ctx, true
+	return Context{
+		Kind:  KindPath,
+		Query: string(cur[start:col]),
+		Start: start,
+		End:   len(cur),
+		Path:  PathContext{Kind: kind},
+	}, true
 }
 
 func analyzeRequest(lines Lines, line int, cur []rune, col int) (Context, bool) {
@@ -203,10 +216,7 @@ func analyzeRequest(lines Lines, line int, cur []rune, col int) (Context, bool) 
 }
 
 func requestLineContext(cur []rune, col int) (Context, bool) {
-	start := 0
-	for start < len(cur) && unicode.IsSpace(cur[start]) {
-		start++
-	}
+	start := skipSpace(cur, 0)
 	end := start
 	for end < len(cur) && !unicode.IsSpace(cur[end]) {
 		end++
@@ -218,71 +228,65 @@ func requestLineContext(cur []rune, col int) (Context, bool) {
 			return Context{}, false
 		}
 		for _, r := range cur[start:col] {
-			if !isMethodRune(r) {
+			if !unicode.IsLetter(r) {
 				return Context{}, false
 			}
 		}
-		return Context{Kind: KindMethod, Query: strings.ToLower(string(cur[start:col])), Start: start}, true
+		return Context{
+			Kind:  KindMethod,
+			Query: strings.ToLower(string(cur[start:col])),
+			Start: start,
+			End:   end,
+		}, true
 	}
 
 	// Second token: the URL scheme, while still typing scheme letters (before "://").
-	u := end
-	for u < len(cur) && unicode.IsSpace(cur[u]) {
-		u++
-	}
+	u := skipSpace(cur, end)
 	uEnd := u
-	for uEnd < len(cur) && !unicode.IsSpace(cur[uEnd]) {
+	for uEnd < len(cur) && unicode.IsLetter(cur[uEnd]) {
 		uEnd++
 	}
 	if col <= u || col > uEnd {
 		return Context{}, false
 	}
-	for _, r := range cur[u:col] {
-		if !unicode.IsLetter(r) {
-			return Context{}, false
-		}
-	}
-	return Context{Kind: KindScheme, Query: strings.ToLower(string(cur[u:col])), Start: u}, true
+	return Context{
+		Kind:  KindScheme,
+		Query: strings.ToLower(string(cur[u:col])),
+		Start: u,
+		End:   skipPartial(cur, uEnd, "://"),
+	}, true
 }
 
 func headerContext(cur []rune, col int) (Context, bool) {
-	colon := -1
-	for i, r := range cur {
-		if r == ':' {
-			colon = i
-			break
-		}
-	}
+	colon := slices.Index(cur, ':')
 
 	if colon < 0 || col <= colon {
-		start := 0
-		for start < len(cur) && unicode.IsSpace(cur[start]) {
-			start++
-		}
-		end := col
-		if colon >= 0 && colon < end {
-			end = colon
-		}
-		if end < start {
+		start := skipSpace(cur, 0)
+		if col < start {
 			return Context{}, false
+		}
+		end := len(cur)
+		if colon >= 0 {
+			end = colon + 1
 		}
 		return Context{
 			Kind:  KindHeaderName,
-			Query: strings.ToLower(strings.TrimSpace(string(cur[start:end]))),
+			Query: strings.ToLower(strings.TrimSpace(string(cur[start:col]))),
 			Start: start,
+			End:   end,
 		}, true
 	}
 
-	name := strings.ToLower(strings.TrimSpace(string(cur[:colon])))
 	start := colon + 1
 	for start < col && unicode.IsSpace(cur[start]) {
 		start++
 	}
 	return Context{
-		Kind:       KindHeaderValue,
-		HeaderName: name,
-		Query:      strings.ToLower(string(cur[start:col])),
-		Start:      start,
+		Kind:   KindHeaderValue,
+		header: strings.ToLower(strings.TrimSpace(string(cur[:colon]))),
+		Query:  strings.ToLower(string(cur[start:col])),
+		Start:  start,
+		End:    len(cur),
 	}, true
 }
 
@@ -300,11 +304,29 @@ func commentPrefixLen(cur []rune) int {
 }
 
 func leadingSpaceLen(cur []rune) int {
-	i := 0
+	return skipSpace(cur, 0)
+}
+
+func skipSpace(cur []rune, i int) int {
 	for i < len(cur) && unicode.IsSpace(cur[i]) {
 		i++
 	}
 	return i
+}
+
+// skipPartial consumes the matching prefix of want at i.
+func skipPartial(cur []rune, i int, want string) int {
+	for _, r := range want {
+		if i >= len(cur) || cur[i] != r {
+			break
+		}
+		i++
+	}
+	return i
+}
+
+func clamp(v, lo, hi int) int {
+	return min(max(v, lo), hi)
 }
 
 func looksLikeRequestLine(line string) bool {
@@ -321,54 +343,6 @@ func looksLikeRequestLine(line string) bool {
 	}
 	lower := strings.ToLower(t)
 	return strings.HasPrefix(lower, "ws://") || strings.HasPrefix(lower, "wss://")
-}
-
-func splitValueToken(token []rune) (key, value string, ok bool) {
-	for i, r := range token {
-		if r == '=' {
-			// only use= gets value completion. Other key=value tokens stay whole
-			// so their label still prefix-matches (e.g. enabled=true).
-			if k := strings.ToLower(string(token[:i])); k == "use" {
-				return k, string(token[i+1:]), true
-			}
-			return "", "", false
-		}
-		if !isQueryRune(r) {
-			return "", "", false
-		}
-	}
-	return "", "", false
-}
-
-func skipArgSep(area []rune, start int) int {
-	for start < len(area) {
-		if !directive.IsArgSep(area[start]) {
-			return start
-		}
-		start++
-	}
-	return len(area)
-}
-
-func splitToken(area []rune, start int) (int, []rune, bool) {
-	tokenStart := start
-	pos := start
-	for pos < len(area) {
-		r := area[pos]
-		if unicode.IsSpace(r) {
-			pos++
-			for pos < len(area) && unicode.IsSpace(area[pos]) {
-				pos++
-			}
-			tokenStart = pos
-			continue
-		}
-		if !isSubcommandRune(r) {
-			return 0, nil, false
-		}
-		pos++
-	}
-	return tokenStart, area[tokenStart:], true
 }
 
 func hasRunePrefix(s []rune, prefix string) bool {
@@ -391,22 +365,6 @@ func isQueryRune(r rune) bool {
 	return r == '-' || r == '_'
 }
 
-func isSubcommandRune(r rune) bool {
-	if isQueryRune(r) {
-		return true
-	}
-	switch r {
-	case '=', '<', '>', ',':
-		return true
-	default:
-		return false
-	}
-}
-
 func IsTokenRune(r rune) bool {
 	return isQueryRune(r) || r == '$' || r == '.'
-}
-
-func isMethodRune(r rune) bool {
-	return unicode.IsLetter(r)
 }

--- a/internal/intellisense/context.go
+++ b/internal/intellisense/context.go
@@ -11,7 +11,7 @@ type Kind int
 
 const (
 	KindNone         Kind = iota
-	KindDirective         // @directive name on a comment line
+	KindDirective         // @directive name, optionally before its comment prefix is inserted
 	KindDirectiveArg      // a sub-token of a directive (auth/k8s/trace/...)
 	KindMethod            // first token of a request line
 	KindScheme            // URL scheme after a request method
@@ -21,11 +21,14 @@ const (
 )
 
 type Context struct {
-	Kind      Kind
-	Directive string // base key (KindDirectiveArg) or header name (KindHeaderValue)
-	ArgKey    string // option key when completing a value, e.g. "use"
-	Query     string // partial token being completed, lowercased
-	Start     int    // rune offset within the caret line where Query begins
+	Kind          Kind
+	DirectiveName directive.Name // base key for KindDirectiveArg
+	HeaderName    string         // lowercased name for KindHeaderValue
+	ArgKey        string         // option key when completing a value, e.g. "use"
+	Query         string         // partial token being completed, lowercased
+	Start         int            // rune offset within the caret line where Query begins
+
+	needsCommentPrefix bool
 }
 
 // Lines exposes the buffer's logical lines to Analyze - LineRunes(i) is the
@@ -52,6 +55,9 @@ func Analyze(lines Lines, line, col int) (Context, bool) {
 	}
 	if marker := commentPrefixLen(cur); marker >= 0 {
 		return analyzeDirective(cur, marker, col)
+	}
+	if ctx, ok := analyzeBareDirective(cur, col); ok {
+		return ctx, true
 	}
 	return analyzeRequest(lines, line, cur, col)
 }
@@ -111,6 +117,21 @@ func analyzeDirective(cur []rune, marker, col int) (Context, bool) {
 	return ctx, true
 }
 
+func analyzeBareDirective(cur []rune, col int) (Context, bool) {
+	at := leadingSpaceLen(cur)
+	if at >= col || cur[at] != '@' {
+		return Context{}, false
+	}
+
+	ctx, ok := analyzeDirectiveArea(cur[at+1 : col])
+	if !ok || ctx.Kind != KindDirective {
+		return Context{}, false
+	}
+	ctx.Start = at
+	ctx.needsCommentPrefix = true
+	return ctx, true
+}
+
 func analyzeDirectiveArea(area []rune) (Context, bool) {
 	if len(area) == 0 {
 		return Context{Kind: KindDirective}, true
@@ -135,14 +156,14 @@ func analyzeDirectiveArea(area []rune) (Context, bool) {
 		return Context{}, false
 	}
 
-	base := strings.ToLower(string(area[:sep]))
+	base := directive.Name(strings.ToLower(string(area[:sep])))
 
 	start, token, ok := splitToken(area, skipArgSep(area, sep))
 	if !ok {
 		return Context{}, false
 	}
 
-	ctx := Context{Kind: KindDirectiveArg, Directive: base, Start: start}
+	ctx := Context{Kind: KindDirectiveArg, DirectiveName: base, Start: start}
 	if key, val, found := splitValueToken(token); found {
 		ctx.ArgKey = key
 		ctx.Query = strings.ToLower(val)
@@ -258,18 +279,15 @@ func headerContext(cur []rune, col int) (Context, bool) {
 		start++
 	}
 	return Context{
-		Kind:      KindHeaderValue,
-		Directive: name,
-		Query:     strings.ToLower(string(cur[start:col])),
-		Start:     start,
+		Kind:       KindHeaderValue,
+		HeaderName: name,
+		Query:      strings.ToLower(string(cur[start:col])),
+		Start:      start,
 	}, true
 }
 
 func commentPrefixLen(cur []rune) int {
-	i := 0
-	for i < len(cur) && unicode.IsSpace(cur[i]) {
-		i++
-	}
+	i := leadingSpaceLen(cur)
 	rest := cur[i:]
 	switch {
 	case hasRunePrefix(rest, "//"), hasRunePrefix(rest, "/*"), hasRunePrefix(rest, "--"):
@@ -279,6 +297,14 @@ func commentPrefixLen(cur []rune) int {
 	default:
 		return -1
 	}
+}
+
+func leadingSpaceLen(cur []rune) int {
+	i := 0
+	for i < len(cur) && unicode.IsSpace(cur[i]) {
+		i++
+	}
+	return i
 }
 
 func looksLikeRequestLine(line string) bool {

--- a/internal/intellisense/context_test.go
+++ b/internal/intellisense/context_test.go
@@ -1,6 +1,10 @@
 package intellisense
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+)
 
 type testLines []string
 
@@ -9,13 +13,15 @@ func (t testLines) LineRunes(i int) []rune { return []rune(t[i]) }
 
 func TestAnalyzeClassifiesContexts(t *testing.T) {
 	cases := []struct {
-		name      string
-		lines     []string
-		line, col int
-		wantKind  Kind
-		wantDir   string
-		wantArg   string
-		wantQuery string
+		name              string
+		lines             []string
+		line, col         int
+		wantKind          Kind
+		wantDir           directive.Name
+		wantHeader        string
+		wantArg           string
+		wantQuery         string
+		wantCommentPrefix bool
 	}{
 		{
 			name:     "directive name after comment marker",
@@ -30,6 +36,55 @@ func TestAnalyzeClassifiesContexts(t *testing.T) {
 			line:     0,
 			col:      3,
 			wantKind: KindDirective, wantQuery: "",
+		},
+		{
+			name:     "directive name without comment marker",
+			lines:    []string{"@na"},
+			line:     0,
+			col:      3,
+			wantKind: KindDirective, wantQuery: "na", wantCommentPrefix: true,
+		},
+		{
+			name:     "bare at sign without comment marker",
+			lines:    []string{"@"},
+			line:     0,
+			col:      1,
+			wantKind: KindDirective, wantQuery: "", wantCommentPrefix: true,
+		},
+		{
+			name:     "indented directive name without comment marker",
+			lines:    []string{"\t@au"},
+			line:     0,
+			col:      4,
+			wantKind: KindDirective, wantQuery: "au", wantCommentPrefix: true,
+		},
+		{
+			name:     "directive name without comment marker after body",
+			lines:    []string{"POST https://example.test", "", "@na"},
+			line:     2,
+			col:      3,
+			wantKind: KindDirective, wantQuery: "na", wantCommentPrefix: true,
+		},
+		{
+			name:     "embedded at sign is not a directive",
+			lines:    []string{"prefix @na"},
+			line:     0,
+			col:      10,
+			wantKind: KindNone,
+		},
+		{
+			name:     "bare directive stops at an argument separator",
+			lines:    []string{"@name "},
+			line:     0,
+			col:      6,
+			wantKind: KindNone,
+		},
+		{
+			name:     "in-place variable remains outside directive completion",
+			lines:    []string{"@name = value"},
+			line:     0,
+			col:      13,
+			wantKind: KindNone,
 		},
 		{
 			name:     "slash comment directive",
@@ -113,7 +168,7 @@ func TestAnalyzeClassifiesContexts(t *testing.T) {
 			lines:    []string{"GET https://x", "Content-Type: app"},
 			line:     1,
 			col:      17,
-			wantKind: KindHeaderValue, wantDir: "content-type", wantQuery: "app",
+			wantKind: KindHeaderValue, wantHeader: "content-type", wantQuery: "app",
 		},
 		{
 			name:     "no completion in body",
@@ -211,14 +266,24 @@ func TestAnalyzeClassifiesContexts(t *testing.T) {
 			if ctx.Kind != tc.wantKind {
 				t.Fatalf("kind = %d, want %d", ctx.Kind, tc.wantKind)
 			}
-			if ctx.Directive != tc.wantDir {
-				t.Fatalf("directive = %q, want %q", ctx.Directive, tc.wantDir)
+			if ctx.DirectiveName != tc.wantDir {
+				t.Fatalf("directive = %q, want %q", ctx.DirectiveName, tc.wantDir)
+			}
+			if ctx.HeaderName != tc.wantHeader {
+				t.Fatalf("header = %q, want %q", ctx.HeaderName, tc.wantHeader)
 			}
 			if ctx.ArgKey != tc.wantArg {
 				t.Fatalf("argKey = %q, want %q", ctx.ArgKey, tc.wantArg)
 			}
 			if ctx.Query != tc.wantQuery {
 				t.Fatalf("query = %q, want %q", ctx.Query, tc.wantQuery)
+			}
+			if ctx.needsCommentPrefix != tc.wantCommentPrefix {
+				t.Fatalf(
+					"needsCommentPrefix = %v, want %v",
+					ctx.needsCommentPrefix,
+					tc.wantCommentPrefix,
+				)
 			}
 		})
 	}
@@ -232,6 +297,16 @@ func TestAnalyzeStartMarksReplacementToken(t *testing.T) {
 	}
 	if ctx.Start != 2 {
 		t.Fatalf("directive start = %d, want 2", ctx.Start)
+	}
+
+	// The indentation is kept outside the replacement and the accepted item
+	// supplies the missing canonical comment prefix.
+	ctx, ok = Analyze(testLines{"\t@na"}, 0, 4)
+	if !ok || ctx.Kind != KindDirective || !ctx.needsCommentPrefix {
+		t.Fatalf("expected bare directive context, got %+v ok=%v", ctx, ok)
+	}
+	if ctx.Start != 1 {
+		t.Fatalf("bare directive start = %d, want 1", ctx.Start)
 	}
 
 	// Variable token starts right after the leading "{{".

--- a/internal/intellisense/context_test.go
+++ b/internal/intellisense/context_test.go
@@ -8,6 +8,13 @@ import (
 
 type testLines []string
 
+func argKey(ctx Context) string {
+	if ctx.arg == nil {
+		return ""
+	}
+	return ctx.arg.key
+}
+
 func (t testLines) LineCount() int         { return len(t) }
 func (t testLines) LineRunes(i int) []rune { return []rune(t[i]) }
 
@@ -266,24 +273,20 @@ func TestAnalyzeClassifiesContexts(t *testing.T) {
 			if ctx.Kind != tc.wantKind {
 				t.Fatalf("kind = %d, want %d", ctx.Kind, tc.wantKind)
 			}
-			if ctx.DirectiveName != tc.wantDir {
-				t.Fatalf("directive = %q, want %q", ctx.DirectiveName, tc.wantDir)
+			if ctx.name != tc.wantDir {
+				t.Fatalf("directive = %q, want %q", ctx.name, tc.wantDir)
 			}
-			if ctx.HeaderName != tc.wantHeader {
-				t.Fatalf("header = %q, want %q", ctx.HeaderName, tc.wantHeader)
+			if ctx.header != tc.wantHeader {
+				t.Fatalf("header = %q, want %q", ctx.header, tc.wantHeader)
 			}
-			if ctx.ArgKey != tc.wantArg {
-				t.Fatalf("argKey = %q, want %q", ctx.ArgKey, tc.wantArg)
+			if got := argKey(ctx); got != tc.wantArg {
+				t.Fatalf("argKey = %q, want %q", got, tc.wantArg)
 			}
 			if ctx.Query != tc.wantQuery {
 				t.Fatalf("query = %q, want %q", ctx.Query, tc.wantQuery)
 			}
-			if ctx.needsCommentPrefix != tc.wantCommentPrefix {
-				t.Fatalf(
-					"needsCommentPrefix = %v, want %v",
-					ctx.needsCommentPrefix,
-					tc.wantCommentPrefix,
-				)
+			if ctx.bare != tc.wantCommentPrefix {
+				t.Fatalf("bare directive = %v, want %v", ctx.bare, tc.wantCommentPrefix)
 			}
 		})
 	}
@@ -302,7 +305,7 @@ func TestAnalyzeStartMarksReplacementToken(t *testing.T) {
 	// The indentation is kept outside the replacement and the accepted item
 	// supplies the missing canonical comment prefix.
 	ctx, ok = Analyze(testLines{"\t@na"}, 0, 4)
-	if !ok || ctx.Kind != KindDirective || !ctx.needsCommentPrefix {
+	if !ok || ctx.Kind != KindDirective || !ctx.bare {
 		t.Fatalf("expected bare directive context, got %+v ok=%v", ctx, ok)
 	}
 	if ctx.Start != 1 {

--- a/internal/intellisense/directive_context.go
+++ b/internal/intellisense/directive_context.go
@@ -1,0 +1,227 @@
+package intellisense
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
+)
+
+// Bare directives complete only their names because "@name = value" defines a variable.
+func analyzeDirective(cur []rune, from, col int, bare bool) (Context, bool) {
+	at := skipSpace(cur, from)
+	if at >= col || cur[at] != '@' {
+		return Context{}, false
+	}
+
+	ctx, ok := analyzeDirectiveArea(cur[at+1:], col-at-1)
+	if !ok || (bare && ctx.Kind != KindDirective) {
+		return Context{}, false
+	}
+	// Convert offsets to the full line and include '@' when replacing the name.
+	ctx.Start += at + 1
+	ctx.End += at + 1
+	if ctx.Kind == KindDirective {
+		ctx.Start = at
+	}
+	ctx.bare = bare
+	return ctx, true
+}
+
+func analyzeDirectiveArea(area []rune, caret int) (Context, bool) {
+	caret = clamp(caret, 0, len(area))
+	if len(area) == 0 {
+		return Context{Kind: KindDirective}, true
+	}
+
+	// The parser accepts both "@auth:bea" and "@auth bea".
+	sep := -1
+	for i, r := range area {
+		if directive.IsArgSep(r) {
+			sep = i
+			break
+		}
+		if !isQueryRune(r) {
+			return Context{}, false
+		}
+	}
+	if sep == -1 || caret <= sep {
+		end := len(area)
+		if sep >= 0 {
+			end = sep
+		}
+		return Context{Kind: KindDirective, Query: string(area[:caret]), End: end}, true
+	}
+	if sep == 0 {
+		return Context{}, false
+	}
+
+	name := directive.Name(strings.ToLower(string(area[:sep]))).Canonical()
+	start := min(skipArgSep(area, sep), caret)
+	ctx := analyzeArguments(name, area[start:], caret-start)
+	ctx.Start += start
+	ctx.End += start
+	return ctx, true
+}
+
+func analyzeArguments(name directive.Name, text []rune, caret int) Context {
+	caret = clamp(caret, 0, len(text))
+	table := argsFor(name)
+	ctx := Context{
+		Kind:      KindDirectiveArg,
+		name:      name,
+		Start:     caret,
+		End:       caret,
+		completed: completed{},
+	}
+
+	fields := scanFields(text)
+	if arg, start, ok := table.loadValue(fields, text); ok && caret >= start {
+		ctx.Start, ctx.End = start, len(text)
+		ctx.Query = string(text[start:caret])
+		ctx.setValue(arg, table.single)
+		return ctx
+	}
+
+	read := table.read(fields)
+	cur := fieldAt(fields, caret)
+	for i, s := range read.slots {
+		if i != cur {
+			ctx.record(s, fields[i])
+		}
+	}
+
+	if cur < 0 {
+		switch {
+		case read.open != nil:
+			ctx.setValue(read.open, table.single)
+		case table.single && len(ctx.completed) > 0:
+			ctx.Kind = KindNone
+		case table.value != nil && !table.value.loadsLine() && !read.taken && !table.value.repeat:
+			ctx.setValue(table.value, table.single)
+		}
+		return ctx
+	}
+
+	s, f := read.slots[cur], fields[cur]
+	ctx.Start, ctx.End = f.start, f.end
+	ctx.Query = decodedPrefix(text[f.start:caret])
+	switch {
+	case f.eq >= 0 && caret > f.eq:
+		if s.arg == nil {
+			return Context{Kind: KindNone}
+		}
+		ctx.Start = f.eq + 1
+		ctx.Query = optionValue(ctx.Query)
+		ctx.setValue(s.arg, table.single)
+		if s.arg.repeat {
+			ctx.narrowToSegment(s.arg, text, caret)
+		}
+	case s.value && f.eq < 0:
+		ctx.setValue(s.arg, table.single)
+	}
+	if ctx.Kind == KindPath && ctx.Path.List {
+		ctx.Path.Suffix = strings.TrimPrefix(decodedPrefix(text[ctx.Start:ctx.End]), ctx.Query)
+	}
+	return ctx
+}
+
+// fieldAt returns the field index at the caret, or -1 between fields.
+func fieldAt(fields []field, caret int) int {
+	for i, f := range fields {
+		if caret >= f.start && caret <= f.end {
+			return i
+		}
+	}
+	return -1
+}
+
+func (ctx *Context) record(s slot, f field) {
+	if s.arg == nil {
+		return
+	}
+	switch {
+	case s.value && f.eq >= 0:
+		ctx.completed.add(s.arg.key, optionValue(f.text))
+	case s.value, !s.arg.takesValue():
+		ctx.completed.add(s.arg.key, f.text)
+	}
+}
+
+func (ctx *Context) setValue(arg *argument, single bool) {
+	ctx.arg = arg
+	if arg.value.kind != valuePath {
+		return
+	}
+	path := arg.value.path
+	ctx.Kind = KindPath
+	ctx.Path = PathContext{
+		Kind:      path.kind,
+		Quote:     path.form == pathWord,
+		List:      path.list,
+		Home:      path.home,
+		Continues: path.form == pathWord && !single,
+	}
+}
+
+// narrowToSegment completes only the list entry at the caret.
+// Entries repeat the key, as in "@apply use=one,use=two".
+func (ctx *Context) narrowToSegment(arg *argument, text []rune, caret int) {
+	start := ctx.Start
+	raw := string(text[start:ctx.End])
+	cursor := len(string(text[start:caret]))
+	offset := 0
+	for part := range strings.SplitSeq(raw, ",") {
+		end := offset + len(part)
+		valueAt, value := cutSegmentKey(arg, part)
+		if cursor < offset || cursor > end {
+			if v := directive.TrimQuotes(strings.TrimSpace(value)); v != "" {
+				ctx.completed.add(arg.key, v)
+			}
+			offset = end + 1
+			continue
+		}
+
+		from := offset + valueAt
+		if from > cursor {
+			// The caret is still in the repeated key, before its value begins.
+			from = offset
+			ctx.arg = nil
+		}
+		ctx.Start = start + utf8.RuneCountInString(raw[:from])
+		ctx.End = start + utf8.RuneCountInString(raw[:end])
+		ctx.Query = decodedPrefix(text[ctx.Start:caret])
+		offset = end + 1
+	}
+}
+
+// cutSegmentKey removes a repeated key and returns the value's byte offset and text.
+func cutSegmentKey(arg *argument, part string) (int, string) {
+	value := strings.TrimLeftFunc(part, unicode.IsSpace)
+	if key, rest, ok := strings.Cut(value, "="); ok && arg.matches(key) {
+		value = rest
+	}
+	return len(part) - len(value), value
+}
+
+func optionValue(text string) string {
+	_, value, _ := strings.Cut(text, "=")
+	return value
+}
+
+// Match the decoded prefix so quotes do not affect suggestion filtering.
+func decodedPrefix(raw []rune) string {
+	var value string
+	for field := range directive.ScanFields(string(raw)) {
+		value = field.Value
+	}
+	return value
+}
+
+func skipArgSep(area []rune, start int) int {
+	for start < len(area) && directive.IsArgSep(area[start]) {
+		start++
+	}
+	return start
+}

--- a/internal/intellisense/directives.go
+++ b/internal/intellisense/directives.go
@@ -1,12 +1,6 @@
 package intellisense
 
-import (
-	"slices"
-	"strings"
-
-	"github.com/unkn0wn-root/resterm/internal/delay"
-	"github.com/unkn0wn-root/resterm/internal/directive"
-)
+import "github.com/unkn0wn-root/resterm/internal/directive"
 
 var directives = directiveItems()
 
@@ -22,6 +16,7 @@ func directiveItems() []Item {
 			Label:           spec.Name.Tag(),
 			Aliases:         aliases,
 			Summary:         spec.Summary,
+			Continue:        !argsFor(spec.Name).empty(),
 			noTrailingSpace: spec.Args == directive.ArgNone,
 		}
 		if spec.Name == directive.RTS {
@@ -31,1055 +26,100 @@ func directiveItems() []Item {
 	return items
 }
 
-var mockArgs = mockItems()
-
-// The latency suggestions mirror the delay registry, so a new distribution
-// needs no second list here.
-func mockItems() []Item {
-	items := []Item{
-		{
-			Label:       "method=",
-			Summary:     "HTTP method to match",
-			Insert:      "method=GET",
-			Placeholder: "GET",
-		},
-		{
-			Label:       "path=",
-			Summary:     "Origin-form route path",
-			Insert:      "path=/resource",
-			Placeholder: "/resource",
-		},
-		{
-			Label:       "name=",
-			Summary:     "Scenario selector name",
-			Insert:      "name=success",
-			Placeholder: "success",
-		},
-		{
-			Label:       "sequence=",
-			Summary:     "Response sequence name",
-			Insert:      "sequence=polling",
-			Placeholder: "polling",
-		},
-		{
-			Label:       "sequence-key=",
-			Summary:     "Per-key cursor source (path, query, header, or cookie)",
-			Insert:      "sequence-key=path.id",
-			Placeholder: "path.id",
-		},
-		{Label: "default=true", Summary: "Use as the route fallback"},
-		{
-			Label:       "latency=",
-			Summary:     "Constant response latency",
-			Insert:      "latency=250ms",
-			Placeholder: "250ms",
-		},
-	}
-	for _, d := range delay.Distributions() {
-		items = append(items, Item{
-			Label:       "latency=" + d.Name,
-			Summary:     d.Summary,
-			Insert:      "latency=" + d.Usage(),
-			Placeholder: d.Args,
-		})
-	}
-	return append(items, Item{
-		Label:   "interpolate=false",
-		Summary: "Preserve response template syntax literally",
-	})
-}
-
-var scriptArgs = []Item{
-	{Label: "pre-request", Summary: "Run script before the request"},
-	{Label: "test", Summary: "Run script after the response"},
-	{Label: "lang=rts", Aliases: []string{"language=rts"}, Summary: "Use RestermScript (RST)"},
-	{Label: "lang=js", Aliases: []string{"language=js"}, Summary: "Use JavaScript (Goja)"},
-}
-
-var rtsArgs = []Item{
-	{Label: "pre-request", Summary: "Run RestermScript before the request"},
-}
-
-var workflowRunArgs = []Item{
-	{
-		Label:       "run=",
-		Summary:     "Run workflow step",
-		Insert:      "run=StepName",
-		Placeholder: "StepName",
-	},
-	{
-		Label:       "fail=",
-		Summary:     "Fail workflow branch with message",
-		Insert:      "fail=\"message\"",
-		Placeholder: "\"message\"",
-	},
-}
-
-var settingArgs = []Item{
-	{
-		Label:       "base-url=",
-		Summary:     "Base URL for relative HTTP requests",
-		Insert:      "base-url=https://api.example.com/v1/",
-		Placeholder: "https://api.example.com/v1/",
-	},
-	{
-		Label:       "timeout=",
-		Summary:     "Request timeout (e.g. 5s)",
-		Insert:      "timeout=5s",
-		Placeholder: "5s",
-	},
-	{
-		Label:       "proxy=",
-		Summary:     "HTTP proxy URL",
-		Insert:      "proxy=http://proxy",
-		Placeholder: "http://proxy",
-	},
-	{
-		Label:       "followredirects=",
-		Summary:     "Follow redirects (true/false)",
-		Insert:      "followredirects=false",
-		Placeholder: "false",
-	},
-	{
-		Label:       "insecure=",
-		Summary:     "Skip TLS verify (HTTP)",
-		Insert:      "insecure=true",
-		Placeholder: "true",
-	},
-	{
-		Label:       "no-cookies=",
-		Summary:     "Disable cookies for this request",
-		Insert:      "no-cookies=true",
-		Placeholder: "true",
-	},
-	{
-		Label:       "forward-credentials-on-redirect=",
-		Summary:     "Origins a redirect may carry credentials to",
-		Insert:      "forward-credentials-on-redirect=https://cdn.example.com",
-		Placeholder: "https://cdn.example.com",
-	},
-	{
-		Label:       "max-redirects=",
-		Summary:     "Redirects to follow (count or none)",
-		Insert:      "max-redirects=20",
-		Placeholder: "20",
-	},
-	{
-		Label:       "max-response-size=",
-		Summary:     "Response body limit (size or none)",
-		Insert:      "max-response-size=100mb",
-		Placeholder: "100mb",
-	},
-	{
-		Label:       "sse-max-line-bytes=",
-		Summary:     "Default SSE line limit for every request",
-		Insert:      "sse-max-line-bytes=4mb",
-		Placeholder: "4mb",
-	},
-	{
-		Label:       "sse-max-event-bytes=",
-		Summary:     "Default SSE event limit for every request",
-		Insert:      "sse-max-event-bytes=8mb",
-		Placeholder: "8mb",
-	},
-	{
-		Label:       "ws-max-message-bytes=",
-		Summary:     "Default WebSocket message limit for every request",
-		Insert:      "ws-max-message-bytes=32kb",
-		Placeholder: "32kb",
-	},
-	{
-		Label:       "http-version=",
-		Summary:     "HTTP protocol version (1.1|2)",
-		Insert:      "http-version=1.1",
-		Placeholder: "1.1",
-	},
-	{
-		Label:       "http-insecure=",
-		Summary:     "Skip TLS verify (HTTP)",
-		Insert:      "http-insecure=true",
-		Placeholder: "true",
-	},
-	{
-		Label:       "http-root-cas=",
-		Summary:     "Extra root CAs (comma/space separated)",
-		Insert:      "http-root-cas=ca.pem",
-		Placeholder: "ca.pem",
-	},
-	{
-		Label:       "http-root-mode=",
-		Summary:     "Root CA mode (append|replace)",
-		Insert:      "http-root-mode=append",
-		Placeholder: "append",
-	},
-	{
-		Label:       "http-client-cert=",
-		Summary:     "Client certificate path",
-		Insert:      "http-client-cert=cert.pem",
-		Placeholder: "cert.pem",
-	},
-	{
-		Label:       "http-client-key=",
-		Summary:     "Client key path",
-		Insert:      "http-client-key=key.pem",
-		Placeholder: "key.pem",
-	},
-	{
-		Label:       "grpc-insecure=",
-		Summary:     "Skip TLS verify (gRPC)",
-		Insert:      "grpc-insecure=true",
-		Placeholder: "true",
-	},
-	{
-		Label:       "grpc-root-cas=",
-		Summary:     "Extra gRPC root CAs",
-		Insert:      "grpc-root-cas=ca.pem",
-		Placeholder: "ca.pem",
-	},
-	{
-		Label:       "grpc-root-mode=",
-		Summary:     "gRPC root mode (append|replace)",
-		Insert:      "grpc-root-mode=append",
-		Placeholder: "append",
-	},
-	{
-		Label:       "grpc-client-cert=",
-		Summary:     "gRPC client cert path",
-		Insert:      "grpc-client-cert=cert.pem",
-		Placeholder: "cert.pem",
-	},
-	{
-		Label:       "grpc-client-key=",
-		Summary:     "gRPC client key path",
-		Insert:      "grpc-client-key=key.pem",
-		Placeholder: "key.pem",
-	},
-	{
-		Label:       "grpc-max-recv-size=",
-		Summary:     "Max gRPC response size",
-		Insert:      "grpc-max-recv-size=16MB",
-		Placeholder: "16MB",
-	},
-	{
-		Label:       "grpc-max-send-size=",
-		Summary:     "Max gRPC request size",
-		Insert:      "grpc-max-send-size=16MB",
-		Placeholder: "16MB",
-	},
-	{
-		Label:       "grpc-compression=",
-		Summary:     "gRPC request compression (gzip|none)",
-		Insert:      "grpc-compression=gzip",
-		Placeholder: "gzip",
-	},
-}
-
-// directiveArgs maps a directive base key to its option/sub-token suggestions.
-var directiveArgs = map[directive.Name][]Item{
-	directive.Mock: mockArgs,
-	directive.Match: {
-		{
-			Label:       "query=",
-			Summary:     "Query matcher rules as JSON",
-			Insert:      `query={"key":"value"}`,
-			Placeholder: `{"key":"value"}`,
-		},
-		{
-			Label:       "headers=",
-			Summary:     "Header matcher rules as JSON",
-			Insert:      `headers={"X-Key":"value"}`,
-			Placeholder: `{"X-Key":"value"}`,
-		},
-		{
-			Label:       "json=",
-			Summary:     "Literal JSON body subset",
-			Insert:      `json={"key":"value"}`,
-			Placeholder: `{"key":"value"}`,
-		},
-		{
-			Label:       "json-rules=",
-			Summary:     "JSON body matcher rules",
-			Insert:      `json-rules={"key":{"gt":1}}`,
-			Placeholder: `{"key":{"gt":1}}`,
-		},
-	},
-	directive.Expect: {
-		{
-			Label:       "calls=",
-			Summary:     "Exact matching request count",
-			Insert:      "calls=1",
-			Placeholder: "1",
-		},
-	},
-	directive.Auth: {
-		{
-			Label:       "request",
-			Summary:     "Make the auth directive explicitly request-scoped",
-			Insert:      "request bearer {{token}}",
-			Placeholder: "bearer {{token}}",
-		},
-		{
-			Label:       "file",
-			Summary:     "Define auth inherited by later requests in this file",
-			Insert:      "file bearer {{token}}",
-			Placeholder: "bearer {{token}}",
-		},
-		{
-			Label:       "global",
-			Summary:     "Define auth inherited across the workspace",
-			Insert:      "global bearer {{token}}",
-			Placeholder: "bearer {{token}}",
-		},
-		{Label: "none", Summary: "Disable inherited auth for the current request"},
-		{
-			Label:       "basic",
-			Summary:     "Basic auth with username and password",
-			Insert:      "basic user pass",
-			Placeholder: "user pass",
-		},
-		{
-			Label:       "bearer",
-			Summary:     "Bearer token auth",
-			Insert:      "bearer {{token}}",
-			Placeholder: "{{token}}",
-		},
-		{
-			Label:       "apikey",
-			Summary:     "API key auth in header or query",
-			Insert:      "apikey header X-API-Key {{key}}",
-			Placeholder: "header X-API-Key {{key}}",
-		},
-		{
-			Label:   "oauth2",
-			Summary: "Built-in OAuth 2.0 token acquisition and caching",
-		},
-		{
-			Label:       "command",
-			Summary:     "Run a CLI command and inject its token output",
-			Insert:      `command argv=["gh","auth","token"]`,
-			Placeholder: `["gh","auth","token"]`,
-		},
-		{Label: "header", Summary: "API key placement in headers"},
-		{Label: "query", Summary: "API key placement in query string"},
-		{
-			Label:       "token_url=",
-			Summary:     "OAuth2 token endpoint URL",
-			Insert:      "token_url=https://auth.example.com/oauth/token",
-			Placeholder: "https://auth.example.com/oauth/token",
-		},
-		{
-			Label:       "auth_url=",
-			Summary:     "OAuth2 authorization endpoint URL",
-			Insert:      "auth_url=https://auth.example.com/authorize",
-			Placeholder: "https://auth.example.com/authorize",
-		},
-		{
-			Label:       "client_id=",
-			Summary:     "OAuth2 client ID",
-			Insert:      "client_id={{clientId}}",
-			Placeholder: "{{clientId}}",
-		},
-		{
-			Label:       "client_secret=",
-			Summary:     "OAuth2 client secret",
-			Insert:      "client_secret={{clientSecret}}",
-			Placeholder: "{{clientSecret}}",
-		},
-		{
-			Label:       "grant=",
-			Summary:     "OAuth2 grant type",
-			Insert:      "grant=client_credentials",
-			Placeholder: "client_credentials",
-		},
-		{
-			Label:       "scope=",
-			Summary:     "OAuth2 scope list",
-			Insert:      `scope="read write"`,
-			Placeholder: `"read write"`,
-		},
-		{
-			Label:       "audience=",
-			Summary:     "OAuth2 audience",
-			Insert:      "audience=https://api.example.com",
-			Placeholder: "https://api.example.com",
-		},
-		{
-			Label:       "resource=",
-			Summary:     "OAuth2 resource indicator",
-			Insert:      "resource=https://graph.microsoft.com",
-			Placeholder: "https://graph.microsoft.com",
-		},
-		{
-			Label:       "client_auth=",
-			Summary:     "OAuth2 client credential transport",
-			Insert:      "client_auth=basic",
-			Placeholder: "basic",
-		},
-		{
-			Label:       "username=",
-			Summary:     "Password grant username",
-			Insert:      "username={{user.email}}",
-			Placeholder: "{{user.email}}",
-		},
-		{
-			Label:       "password=",
-			Summary:     "Password grant password",
-			Insert:      "password={{user.password}}",
-			Placeholder: "{{user.password}}",
-		},
-		{
-			Label:       "cache_key=",
-			Summary:     "Reuse cached auth state across requests",
-			Insert:      "cache_key=myapi",
-			Placeholder: "myapi",
-		},
-		{
-			Label:       "redirect_uri=",
-			Summary:     "OAuth2 redirect URI",
-			Insert:      "redirect_uri=http://127.0.0.1:8484/callback",
-			Placeholder: "http://127.0.0.1:8484/callback",
-		},
-		{
-			Label:       "code_verifier=",
-			Summary:     "PKCE code verifier",
-			Insert:      "code_verifier={{pkce.verifier}}",
-			Placeholder: "{{pkce.verifier}}",
-		},
-		{
-			Label:       "code_challenge_method=",
-			Summary:     "PKCE challenge method",
-			Insert:      "code_challenge_method=s256",
-			Placeholder: "s256",
-		},
-		{
-			Label:       "state=",
-			Summary:     "OAuth2 state value",
-			Insert:      "state={{oauth.state}}",
-			Placeholder: "{{oauth.state}}",
-		},
-		{
-			Label:       "header=",
-			Summary:     "Override injected header name",
-			Insert:      "header=Authorization",
-			Placeholder: "Authorization",
-		},
-		{
-			Label:       "argv=",
-			Summary:     "Command argv as JSON array",
-			Insert:      `argv=["gh","auth","token"]`,
-			Placeholder: `["gh","auth","token"]`,
-		},
-		{
-			Label:       "format=",
-			Summary:     "Command output format",
-			Insert:      "format=json",
-			Placeholder: "json",
-		},
-		{
-			Label:       "scheme=",
-			Summary:     "Command auth header scheme",
-			Insert:      "scheme=Bearer",
-			Placeholder: "Bearer",
-		},
-		{
-			Label:       "token_path=",
-			Summary:     "JSON path to token value",
-			Insert:      "token_path=access_token",
-			Placeholder: "access_token",
-		},
-		{
-			Label:       "type_path=",
-			Summary:     "JSON path to token type",
-			Insert:      "type_path=token_type",
-			Placeholder: "token_type",
-		},
-		{
-			Label:       "expiry_path=",
-			Summary:     "JSON path to absolute expiry",
-			Insert:      "expiry_path=expires_at",
-			Placeholder: "expires_at",
-		},
-		{
-			Label:       "expires_in_path=",
-			Summary:     "JSON path to relative expiry seconds",
-			Insert:      "expires_in_path=expires_in",
-			Placeholder: "expires_in",
-		},
-		{
-			Label:       "ttl=",
-			Summary:     "Fallback command auth cache TTL",
-			Insert:      "ttl=10m",
-			Placeholder: "10m",
-		},
-		{
-			Label:       "timeout=",
-			Summary:     "Command auth timeout",
-			Insert:      "timeout=5s",
-			Placeholder: "5s",
-		},
-	},
-	directive.Apply: {
-		{
-			Label:       "use=",
-			Summary:     "Reference a named patch profile",
-			Insert:      "use=jsonApi",
-			Placeholder: "jsonApi",
-		},
-	},
-	directive.Patch: {
-		{Label: "file", Summary: "Define a file-scoped reusable patch profile"},
-		{Label: "global", Summary: "Define a workspace-global reusable patch profile"},
-	},
-	directive.Body: {
-		{Label: "expand", Summary: "Expand templates before sending body (incl. gRPC files)"},
-		{Label: "expand-templates", Summary: "Synonym for expand (explicit form)"},
-	},
-	directive.Profile: {
-		{
-			Label:       "count=",
-			Summary:     "Number of measured runs",
-			Insert:      "count=10",
-			Placeholder: "10",
-		},
-		{
-			Label:       "warmup=",
-			Summary:     "Warmup runs (excluded from stats)",
-			Insert:      "warmup=2",
-			Placeholder: "2",
-		},
-		{
-			Label:       "delay=",
-			Summary:     "Delay between runs (e.g. 250ms)",
-			Insert:      "delay=250ms",
-			Placeholder: "250ms",
-		},
-	},
-	directive.Poll: {
-		{
-			Label:       "every=",
-			Summary:     "Time between polling requests",
-			Insert:      "every=500ms",
-			Placeholder: "500ms",
-		},
-		{
-			Label:       "timeout=",
-			Summary:     "Total time allowed for polling",
-			Insert:      "timeout=30s",
-			Placeholder: "30s",
-		},
-		{
-			Label:       "until=",
-			Summary:     "Condition that stops polling (must be last)",
-			Insert:      "until=response.json().status == \"completed\"",
-			Placeholder: "response.json().status == \"completed\"",
-		},
-	},
-	directive.Retry: {
-		{
-			Label:       "count=",
-			Summary:     "Number of additional attempts",
-			Insert:      "count=4",
-			Placeholder: "4",
-		},
-	},
-	directive.RetryBackoff: {
-		{
-			Label:       "exponential(",
-			Summary:     "Starting and maximum retry delay",
-			Insert:      "exponential(100ms, 2s)",
-			Placeholder: "100ms, 2s",
-		},
-		{
-			Label:       "jitter=",
-			Summary:     "Random delay percentage",
-			Insert:      "jitter=20%",
-			Placeholder: "20%",
-		},
-	},
-	directive.Script:  scriptArgs,
-	directive.RTS:     rtsArgs,
-	directive.If:      workflowRunArgs,
-	directive.Elif:    workflowRunArgs,
-	directive.Else:    workflowRunArgs,
-	directive.Case:    workflowRunArgs,
-	directive.Default: workflowRunArgs,
-	directive.Trace: {
-		{Label: "enabled=true", Summary: "Turn tracing on"},
-		{Label: "enabled=false", Summary: "Turn tracing off"},
-		{
-			Label:       "total<=",
-			Summary:     "Set overall latency budget",
-			Insert:      "total<=400ms",
-			Placeholder: "400ms",
-		},
-		{
-			Label:       "total=",
-			Summary:     "Set overall latency budget (alternate syntax)",
-			Insert:      "total=400ms",
-			Placeholder: "400ms",
-		},
-		{
-			Label:       "dns<=",
-			Summary:     "Budget for DNS lookup",
-			Insert:      "dns<=50ms",
-			Placeholder: "50ms",
-		},
-		{
-			Label:       "connect<=",
-			Summary:     "Budget for TCP connect",
-			Insert:      "connect<=120ms",
-			Placeholder: "120ms",
-		},
-		{
-			Label:       "tls<=",
-			Summary:     "Budget for TLS handshake",
-			Insert:      "tls<=150ms",
-			Placeholder: "150ms",
-		},
-		{
-			Label:       "request-headers<=",
-			Summary:     "Budget for sending request headers",
-			Insert:      "request-headers<=20ms",
-			Placeholder: "20ms",
-		},
-		{
-			Label:       "request-body<=",
-			Summary:     "Budget for sending request body",
-			Insert:      "request-body<=100ms",
-			Placeholder: "100ms",
-		},
-		{
-			Label:       "ttfb<=",
-			Summary:     "Budget until first response byte",
-			Insert:      "ttfb<=200ms",
-			Placeholder: "200ms",
-		},
-		{
-			Label:       "transfer<=",
-			Summary:     "Budget for response transfer",
-			Insert:      "transfer<=250ms",
-			Placeholder: "250ms",
-		},
-		{
-			Label:       "tolerance=",
-			Summary:     "Allow extra shared tolerance",
-			Insert:      "tolerance=25ms",
-			Placeholder: "25ms",
-		},
-		{
-			Label:       "allowance=",
-			Summary:     "Alias for tolerance",
-			Insert:      "allowance=25ms",
-			Placeholder: "25ms",
-		},
-	},
-	directive.SSE: {
-		{
-			Label:       "timeout=",
-			Summary:     "Total stream timeout",
-			Insert:      "timeout=30s",
-			Placeholder: "30s",
-		},
-		{
-			Label:       "duration=",
-			Summary:     "Total stream timeout (alias)",
-			Insert:      "duration=30s",
-			Placeholder: "30s",
-		},
-		{
-			Label:       "idle=",
-			Summary:     "Idle timeout between events",
-			Insert:      "idle=10s",
-			Placeholder: "10s",
-		},
-		{
-			Label:       "idle-timeout=",
-			Summary:     "Idle timeout (long form)",
-			Insert:      "idle-timeout=10s",
-			Placeholder: "10s",
-		},
-		{
-			Label:       "max-events=",
-			Summary:     "Stop after N events",
-			Insert:      "max-events=100",
-			Placeholder: "100",
-		},
-		{
-			Label:       "max-bytes=",
-			Summary:     "Stop after N bytes",
-			Insert:      "max-bytes=1mb",
-			Placeholder: "1mb",
-		},
-		{
-			Label:       "max-line-bytes=",
-			Summary:     "Largest SSE line to buffer",
-			Insert:      "max-line-bytes=1mb",
-			Placeholder: "1mb",
-		},
-		{
-			Label:       "max-event-bytes=",
-			Summary:     "Largest SSE event to buffer",
-			Insert:      "max-event-bytes=1mb",
-			Placeholder: "1mb",
-		},
-		{
-			Label:       "limit-bytes=",
-			Summary:     "Stop after N bytes (alias)",
-			Insert:      "limit-bytes=1mb",
-			Placeholder: "1mb",
-		},
-		{Label: "off", Summary: "Disable SSE for this request"},
-	},
-	directive.WebSocket: {
-		{
-			Label:       "timeout=",
-			Summary:     "Handshake deadline",
-			Insert:      "timeout=10s",
-			Placeholder: "10s",
-		},
-		{
-			Label:       "idle-timeout=",
-			Summary:     "Idle timeout (resets on any activity)",
-			Insert:      "idle-timeout=5s",
-			Placeholder: "5s",
-		},
-		{
-			Label:       "idle=",
-			Summary:     "Idle timeout (short form)",
-			Insert:      "idle=5s",
-			Placeholder: "5s",
-		},
-		{
-			Label:       "max-message-bytes=",
-			Summary:     "Max inbound frame size",
-			Insert:      "max-message-bytes=1mb",
-			Placeholder: "1mb",
-		},
-		{
-			Label:       "subprotocols=",
-			Summary:     "Comma-separated subprotocols",
-			Insert:      "subprotocols=chat,json",
-			Placeholder: "chat,json",
-		},
-		{
-			Label:       "compression=",
-			Summary:     "Enable/disable compression",
-			Insert:      "compression=true",
-			Placeholder: "true",
-		},
-	},
-	directive.WS: {
-		{Label: "send", Summary: "Send a text frame"},
-		{Label: "send-json", Summary: "Send a JSON frame"},
-		{Label: "send-base64", Summary: "Send base64-decoded binary data"},
-		{Label: "send-file", Summary: "Send file contents"},
-		{Label: "ping", Summary: "Send a ping frame"},
-		{Label: "pong", Summary: "Send a pong frame"},
-		{Label: "wait", Summary: "Wait for a duration or incoming message"},
-		{Label: "close", Summary: "Close the connection with code and reason"},
-	},
-	directive.Compare: {
-		{
-			Label:       "base=",
-			Summary:     "Set the baseline environment",
-			Insert:      "base=dev",
-			Placeholder: "dev",
-		},
-		{
-			Label:       "baseline=",
-			Summary:     "Alias for base",
-			Insert:      "baseline=prod",
-			Placeholder: "prod",
-		},
-		{
-			Label:       "group=",
-			Summary:     "Select the environment group to vary",
-			Insert:      "group=api",
-			Placeholder: "api",
-		},
-	},
-	directive.SSH: {
-		{
-			Label:       "host=",
-			Summary:     "Jump host (supports env:VAR and templates)",
-			Insert:      "host=env:SSH_HOST",
-			Placeholder: "env:SSH_HOST",
-		},
-		{Label: "port=", Summary: "Port (default 22)", Insert: "port=22", Placeholder: "22"},
-		{Label: "user=", Summary: "SSH user", Insert: "user=ops", Placeholder: "ops"},
-		{
-			Label:       "password=",
-			Summary:     "Password auth",
-			Insert:      "password=env:SSH_PW",
-			Placeholder: "env:SSH_PW",
-		},
-		{
-			Label:       "key=",
-			Summary:     "Private key path",
-			Insert:      "key=~/.ssh/id_ed25519",
-			Placeholder: "~/.ssh/id_ed25519",
-		},
-		{
-			Label:       "passphrase=",
-			Summary:     "Key passphrase",
-			Insert:      "passphrase=env:SSH_KEY_PW",
-			Placeholder: "env:SSH_KEY_PW",
-		},
-		{
-			Label:       "agent=",
-			Summary:     "Use SSH agent (default true)",
-			Insert:      "agent=false",
-			Placeholder: "false",
-		},
-		{
-			Label:       "known_hosts=",
-			Summary:     "Known hosts file",
-			Insert:      "known_hosts=~/.ssh/known_hosts",
-			Placeholder: "~/.ssh/known_hosts",
-		},
-		{
-			Label:       "strict_hostkey=",
-			Summary:     "Toggle host key checking",
-			Insert:      "strict_hostkey=false",
-			Placeholder: "false",
-		},
-		{Label: "persist", Summary: "Keep tunnel open (global/file scope only)"},
-		{
-			Label:       "timeout=",
-			Summary:     "SSH dial timeout",
-			Insert:      "timeout=15s",
-			Placeholder: "15s",
-		},
-		{
-			Label:       "keepalive=",
-			Summary:     "Server keepalive interval",
-			Insert:      "keepalive=30s",
-			Placeholder: "30s",
-		},
-		{
-			Label:       "retries=",
-			Summary:     "Retry count for tunnel attach",
-			Insert:      "retries=2",
-			Placeholder: "2",
-		},
-		{
-			Label:       "use=",
-			Summary:     "Reference named profile",
-			Insert:      "use=edge",
-			Placeholder: "edge",
-		},
-		{
-			Label:       "persist=",
-			Summary:     "Explicit persist toggle",
-			Insert:      "persist=true",
-			Placeholder: "true",
-		},
-	},
-	directive.K8s: {
-		{
-			Label:       "target=",
-			Summary:     "Target ref (pod:/service:/deployment:/statefulset:)",
-			Insert:      "target=pod:api-server",
-			Placeholder: "pod:api-server",
-		},
-		{
-			Label:       "namespace=",
-			Summary:     "Kubernetes namespace (default: default)",
-			Insert:      "namespace=default",
-			Placeholder: "default",
-		},
-		{
-			Label:       "pod=",
-			Summary:     "Pod name for port-forward target",
-			Insert:      "pod=api-server",
-			Placeholder: "api-server",
-		},
-		{
-			Label:       "service=",
-			Summary:     "Service name for target pod selection",
-			Insert:      "service=api",
-			Placeholder: "api",
-		},
-		{
-			Label:       "deployment=",
-			Summary:     "Deployment name for target pod selection",
-			Insert:      "deployment=api",
-			Placeholder: "api",
-		},
-		{
-			Label:       "statefulset=",
-			Summary:     "StatefulSet name for target pod selection",
-			Insert:      "statefulset=db",
-			Placeholder: "db",
-		},
-		{
-			Label:       "port=",
-			Summary:     "Remote port (number or named port)",
-			Insert:      "port=8080",
-			Placeholder: "8080",
-		},
-		{
-			Label:       "context=",
-			Summary:     "Kubeconfig context override",
-			Insert:      "context=dev-cluster",
-			Placeholder: "dev-cluster",
-		},
-		{
-			Label:       "kubeconfig=",
-			Summary:     "Kubeconfig path override",
-			Insert:      "kubeconfig=~/.kube/config",
-			Placeholder: "~/.kube/config",
-		},
-		{
-			Label:       "container=",
-			Summary:     "Container name in selected pod",
-			Insert:      "container=api",
-			Placeholder: "api",
-		},
-		{
-			Label:       "local_port=",
-			Summary:     "Local port to bind (optional)",
-			Insert:      "local_port=18080",
-			Placeholder: "18080",
-		},
-		{
-			Label:       "address=",
-			Summary:     "Local bind address",
-			Insert:      "address=127.0.0.1",
-			Placeholder: "127.0.0.1",
-		},
-		{
-			Label:       "pod_running_timeout=",
-			Summary:     "Wait timeout for running pod",
-			Insert:      "pod_running_timeout=20s",
-			Placeholder: "20s",
-		},
-		{
-			Label:       "retries=",
-			Summary:     "Retry count for forward attach",
-			Insert:      "retries=2",
-			Placeholder: "2",
-		},
-		{
-			Label:       "use=",
-			Summary:     "Reference named profile",
-			Insert:      "use=cluster-api",
-			Placeholder: "cluster-api",
-		},
-		{
-			Label:       "persist=",
-			Summary:     "Keep forwarder open (global/file scope)",
-			Insert:      "persist=true",
-			Placeholder: "true",
-		},
-	},
-	directive.Setting:  settingArgs,
-	directive.Settings: settingArgs,
-}
+// @query and @variables require "<" before a file path.
+var loadMarker = Item{Label: "<", Summary: "Load from a file", Continue: true}
 
 type directiveSource struct{}
 
 func (directiveSource) Provide(ctx Context, sc Scope) []Item {
 	switch ctx.Kind {
 	case KindDirective:
-		items := filter(directives, ctx.Query)
-		if ctx.needsCommentPrefix {
-			for i, item := range items {
-				items[i] = item.withInsertPrefix(directive.CommentPrefix)
-			}
-		}
-		return items
+		return directiveNameItems(ctx)
 	case KindDirectiveArg:
-		name := ctx.DirectiveName.Canonical()
-		if ctx.ArgKey == "use" {
-			return filter(profileItems(name, sc.Profiles), ctx.Query)
+		if ctx.arg != nil {
+			return valueItems(ctx.arg, ctx, sc)
 		}
-		if name == directive.Compare {
-			return compareItems(ctx, sc)
-		}
-		opts := directiveArgs[name]
-		if len(opts) == 0 {
-			return nil
-		}
-		return filter(opts, ctx.Query)
+		return argumentItems(ctx, sc)
 	default:
 		return nil
 	}
 }
 
-func compareItems(ctx Context, sc Scope) []Item {
-	if ctx.ArgKey == "group" {
-		return filter(environmentItems(groupNames(sc.EnvironmentGroups), "environment group"), ctx.Query)
+func directiveNameItems(ctx Context) []Item {
+	items := filter(directives, ctx.Query)
+	if !ctx.bare {
+		return items
 	}
-
-	profiles := groupProfiles(sc.EnvironmentGroups)
-	if ctx.ArgKey == "base" || ctx.ArgKey == "baseline" {
-		return filter(environmentItems(profiles, "environment profile"), ctx.Query)
+	for i, item := range items {
+		items[i] = item.withInsertPrefix(directive.CommentPrefix)
 	}
-
-	opts := directiveArgs[directive.Compare]
-	opts = slices.Concat(opts, environmentItems(sc.Environments, "environment"))
-	opts = slices.Concat(opts, environmentItems(profiles, "environment profile"))
-	for _, group := range groupNames(sc.EnvironmentGroups) {
-		opts = append(opts, Item{
-			Label:   "group=" + group,
-			Summary: "environment group",
-		})
-	}
-	return filter(opts, ctx.Query)
+	return items
 }
 
-func profileItems(name directive.Name, profiles ProfileSet) []Item {
-	var names []string
-	switch name {
-	case directive.Apply:
-		names = profiles.Patch
-	case directive.SSH:
-		names = profiles.SSH
-	case directive.K8s:
-		names = profiles.K8s
+func argumentItems(ctx Context, sc Scope) []Item {
+	table := argsFor(ctx.name)
+	if table.empty() {
+		return nil
 	}
-	out := make([]Item, len(names))
-	for i, n := range names {
-		out[i] = Item{Label: n, Summary: name.String() + " profile"}
+	items := make([]Item, 0, len(table.named)+1)
+	for i := range table.named {
+		arg := &table.named[i]
+		if !arg.repeat && ctx.completed.has(arg.key) {
+			continue
+		}
+		items = append(items, arg.items()...)
 	}
-	return out
-}
-
-func environmentItems(names []string, summary string) []Item {
-	out := make([]Item, len(names))
-	for i, n := range names {
-		out[i] = Item{Label: n, Summary: summary}
-	}
-	return out
-}
-
-func groupNames(groups map[string][]string) []string {
-	names := make([]string, 0, len(groups))
-	for name := range groups {
-		names = append(names, name)
-	}
-	slices.SortFunc(names, compareFold)
-	return names
-}
-
-func groupProfiles(groups map[string][]string) []string {
-	seen := make(map[string]struct{})
-	var profiles []string
-	for _, group := range groupNames(groups) {
-		for _, profile := range groups[group] {
-			key := strings.ToLower(profile)
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			profiles = append(profiles, profile)
+	if v := table.value; v != nil {
+		switch {
+		case v.value.kind == valuePath && v.value.path.form == pathLoadOnly:
+			items = append(items, loadMarker)
+		case v.value.kind != valuePath && (v.repeat || !ctx.completed.has(v.key)):
+			items = append(items, valueItems(v, ctx, sc)...)
 		}
 	}
-	slices.SortFunc(profiles, compareFold)
-	return profiles
+	if table.extraItems != nil {
+		items = append(items, table.extraItems(ctx, sc)...)
+	}
+	return filter(items, ctx.Query)
 }
 
-func compareFold(a, b string) int {
-	return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+func valueItems(arg *argument, ctx Context, sc Scope) []Item {
+	var items []Item
+	// The editor handles KindPath by reading the filesystem.
+	switch arg.value.kind {
+	case valueChoice:
+		items = labeledItems(arg.value.choices, "value")
+	case valueText:
+		items = arg.exampleItems()
+	case valueNames:
+		items = labeledItems(arg.value.names(ctx, sc))
+	}
+
+	single := argsFor(ctx.name).single
+	out := make([]Item, 0, len(items))
+	for _, item := range filter(items, ctx.Query) {
+		if ctx.completed.holds(arg.key, item.Label) {
+			continue
+		}
+		if arg.value.kind == valueNames {
+			item.Insert = directive.Quote(item.Label)
+		}
+		switch {
+		case arg.repeat && arg.form != formWord:
+			// Keep the caret next to the value for a following list separator.
+			item = item.WithoutTrailingSpace()
+		case !single && item.Placeholder == "":
+			item.Continue = true
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func labeledItems(names []string, summary string) []Item {
+	out := make([]Item, len(names))
+	for i, name := range names {
+		out[i] = Item{Label: name, Summary: summary}
+	}
+	return out
 }

--- a/internal/intellisense/directives.go
+++ b/internal/intellisense/directives.go
@@ -19,9 +19,10 @@ func directiveItems() []Item {
 			aliases[j] = alias.Tag()
 		}
 		items[i] = Item{
-			Label:   spec.Name.Tag(),
-			Aliases: aliases,
-			Summary: spec.Summary,
+			Label:           spec.Name.Tag(),
+			Aliases:         aliases,
+			Summary:         spec.Summary,
+			noTrailingSpace: spec.Args == directive.ArgNone,
 		}
 		if spec.Name == directive.RTS {
 			items[i].Insert = directive.RTS.Tag() + " pre-request"
@@ -981,9 +982,15 @@ type directiveSource struct{}
 func (directiveSource) Provide(ctx Context, sc Scope) []Item {
 	switch ctx.Kind {
 	case KindDirective:
-		return filter(directives, ctx.Query)
+		items := filter(directives, ctx.Query)
+		if ctx.needsCommentPrefix {
+			for i, item := range items {
+				items[i] = item.withInsertPrefix(directive.CommentPrefix)
+			}
+		}
+		return items
 	case KindDirectiveArg:
-		name := directive.Name(ctx.Directive).Canonical()
+		name := ctx.DirectiveName.Canonical()
 		if ctx.ArgKey == "use" {
 			return filter(profileItems(name, sc.Profiles), ctx.Query)
 		}

--- a/internal/intellisense/directives_test.go
+++ b/internal/intellisense/directives_test.go
@@ -17,11 +17,17 @@ func contains(items []Item, label string) bool {
 	return false
 }
 
+// suggest places the caret at the end of the line.
+func suggest(line string, sc Scope) []Item {
+	ctx, ok := Analyze(testLines{line}, 0, len([]rune(line)))
+	if !ok {
+		return nil
+	}
+	return directiveSource{}.Provide(ctx, sc)
+}
+
 func argOptions(name, query string) []Item {
-	return directiveSource{}.Provide(
-		Context{Kind: KindDirectiveArg, DirectiveName: directive.Name(name), Query: query},
-		Scope{},
-	)
+	return suggest("# @"+name+" "+query, Scope{})
 }
 
 func TestDirectiveCatalogContainsRequiredDirectives(t *testing.T) {
@@ -58,11 +64,7 @@ func TestRTSDirectiveInsertsExplicitPreRequestMode(t *testing.T) {
 }
 
 func TestBareDirectiveSuggestionsInsertCanonicalComment(t *testing.T) {
-	bare := directiveSource{}.Provide(Context{
-		Kind:               KindDirective,
-		Query:              "rt",
-		needsCommentPrefix: true,
-	}, Scope{})
+	bare := suggest("@rt", Scope{})
 	if len(bare) != 1 || bare[0].Label != "@rts" {
 		t.Fatalf("bare @rt suggestions = %v, want @rts", bare)
 	}
@@ -70,11 +72,7 @@ func TestBareDirectiveSuggestionsInsertCanonicalComment(t *testing.T) {
 		t.Fatalf("bare @rts insert = %q, want %q", got, "# @rts pre-request")
 	}
 
-	alias := directiveSource{}.Provide(Context{
-		Kind:               KindDirective,
-		Query:              "desc",
-		needsCommentPrefix: true,
-	}, Scope{})
+	alias := suggest("@desc", Scope{})
 	if len(alias) != 1 || alias[0].Label != "@description" {
 		t.Fatalf("bare @desc suggestions = %v, want canonical @description", alias)
 	}
@@ -82,10 +80,7 @@ func TestBareDirectiveSuggestionsInsertCanonicalComment(t *testing.T) {
 		t.Fatalf("bare @desc insert = %q, want %q", got, "# @description")
 	}
 
-	commented := directiveSource{}.Provide(
-		Context{Kind: KindDirective, Query: "rt"},
-		Scope{},
-	)
+	commented := suggest("# @rt", Scope{})
 	if got := commented[0].InsertText(); got != "@rts pre-request" {
 		t.Fatalf("bare completion mutated the directive catalog: %q", got)
 	}
@@ -144,7 +139,7 @@ func TestDirectiveArgsFilterByPrefix(t *testing.T) {
 	}
 
 	mock := argOptions("mock", "")
-	for _, label := range []string{"sequence=", "sequence-key=", "interpolate=false"} {
+	for _, label := range []string{"sequence=", "sequence-key=", "interpolate="} {
 		if !contains(mock, label) {
 			t.Fatalf("mock args missing %q: %v", label, mock)
 		}
@@ -221,16 +216,15 @@ func TestTraceArgsProvidePlaceholders(t *testing.T) {
 
 func TestCompareArgsIncludeEnvironments(t *testing.T) {
 	sc := Scope{Environments: []string{"dev", "prod"}}
-	ctx := Context{Kind: KindDirectiveArg, DirectiveName: directive.Compare, Query: ""}
-	items := directiveSource{}.Provide(ctx, sc)
+	items := suggest("# @compare ", sc)
 	for _, label := range []string{"base=", "baseline=", "group=", "dev", "prod"} {
 		if !contains(items, label) {
 			t.Fatalf("compare suggestions missing %q: %v", label, items)
 		}
 	}
-	// Static options must not be mutated by appended environments.
-	if got := len(directiveArgs[directive.Compare]); got != 3 {
-		t.Fatalf("compare static args mutated, len = %d", got)
+	// Suggestions must not modify the shared catalog.
+	if got := len(argsFor(directive.Compare).named); got != 2 {
+		t.Fatalf("compare declares %d options, want base and group", got)
 	}
 }
 
@@ -239,8 +233,7 @@ func TestCompareArgsIncludeGroupsAndProfiles(t *testing.T) {
 		"api": {"dev", "prod"},
 		"app": {"dev app 1", "dev app 2"},
 	}}
-	ctx := Context{Kind: KindDirectiveArg, DirectiveName: directive.Compare}
-	items := directiveSource{}.Provide(ctx, sc)
+	items := suggest("# @compare ", sc)
 	for _, label := range []string{
 		"group=",
 		"group=api",
@@ -255,22 +248,14 @@ func TestCompareArgsIncludeGroupsAndProfiles(t *testing.T) {
 		}
 	}
 
-	groups := directiveSource{}.Provide(Context{
-		Kind:          KindDirectiveArg,
-		DirectiveName: directive.Compare,
-		ArgKey:        "group",
-	}, sc)
+	groups := suggest("# @compare group=", sc)
 	for _, label := range []string{"api", "app"} {
 		if !contains(groups, label) {
 			t.Fatalf("group value suggestions missing %q: %v", label, groups)
 		}
 	}
 
-	bases := directiveSource{}.Provide(Context{
-		Kind:          KindDirectiveArg,
-		DirectiveName: directive.Compare,
-		ArgKey:        "base",
-	}, sc)
+	bases := suggest("# @compare base=", sc)
 	if !contains(bases, "dev app 2") {
 		t.Fatalf("baseline suggestions missing grouped profile: %v", bases)
 	}
@@ -285,24 +270,15 @@ func TestUseValueOffersProfileNames(t *testing.T) {
 		},
 	}
 
-	apply := directiveSource{}.Provide(
-		Context{Kind: KindDirectiveArg, DirectiveName: directive.Apply, ArgKey: "use"},
-		sc,
-	)
+	apply := suggest("# @apply use=", sc)
 	if !contains(apply, "jsonApi") {
 		t.Fatalf("apply use= missing patch profile: %v", apply)
 	}
-	ssh := directiveSource{}.Provide(
-		Context{Kind: KindDirectiveArg, DirectiveName: directive.SSH, ArgKey: "use"},
-		sc,
-	)
+	ssh := suggest("# @ssh use=", sc)
 	if !contains(ssh, "edge") {
 		t.Fatalf("ssh use= missing profile: %v", ssh)
 	}
-	k8s := directiveSource{}.Provide(
-		Context{Kind: KindDirectiveArg, DirectiveName: directive.K8s, ArgKey: "use"},
-		sc,
-	)
+	k8s := suggest("# @k8s use=", sc)
 	if !contains(k8s, "cluster") {
 		t.Fatalf("k8s use= missing profile: %v", k8s)
 	}

--- a/internal/intellisense/directives_test.go
+++ b/internal/intellisense/directives_test.go
@@ -19,7 +19,7 @@ func contains(items []Item, label string) bool {
 
 func argOptions(name, query string) []Item {
 	return directiveSource{}.Provide(
-		Context{Kind: KindDirectiveArg, Directive: name, Query: query},
+		Context{Kind: KindDirectiveArg, DirectiveName: directive.Name(name), Query: query},
 		Scope{},
 	)
 }
@@ -55,6 +55,53 @@ func TestRTSDirectiveInsertsExplicitPreRequestMode(t *testing.T) {
 		return
 	}
 	t.Fatal("directive catalog missing @rts")
+}
+
+func TestBareDirectiveSuggestionsInsertCanonicalComment(t *testing.T) {
+	bare := directiveSource{}.Provide(Context{
+		Kind:               KindDirective,
+		Query:              "rt",
+		needsCommentPrefix: true,
+	}, Scope{})
+	if len(bare) != 1 || bare[0].Label != "@rts" {
+		t.Fatalf("bare @rt suggestions = %v, want @rts", bare)
+	}
+	if got := bare[0].InsertText(); got != "# @rts pre-request" {
+		t.Fatalf("bare @rts insert = %q, want %q", got, "# @rts pre-request")
+	}
+
+	alias := directiveSource{}.Provide(Context{
+		Kind:               KindDirective,
+		Query:              "desc",
+		needsCommentPrefix: true,
+	}, Scope{})
+	if len(alias) != 1 || alias[0].Label != "@description" {
+		t.Fatalf("bare @desc suggestions = %v, want canonical @description", alias)
+	}
+	if got := alias[0].InsertText(); got != "# @description" {
+		t.Fatalf("bare @desc insert = %q, want %q", got, "# @description")
+	}
+
+	commented := directiveSource{}.Provide(
+		Context{Kind: KindDirective, Query: "rt"},
+		Scope{},
+	)
+	if got := commented[0].InsertText(); got != "@rts pre-request" {
+		t.Fatalf("bare completion mutated the directive catalog: %q", got)
+	}
+}
+
+func TestDirectiveSpacingComesFromSpecs(t *testing.T) {
+	specs := directive.Specs()
+	if len(directives) != len(specs) {
+		t.Fatalf("directive items = %d, specs = %d", len(directives), len(specs))
+	}
+	for i, spec := range specs {
+		want := spec.Args != directive.ArgNone
+		if got := directives[i].AppendsSpace(KindDirective); got != want {
+			t.Errorf("%s appends space = %v, want %v", spec.Name.Tag(), got, want)
+		}
+	}
 }
 
 func TestDirectiveArgsFilterByPrefix(t *testing.T) {
@@ -174,7 +221,7 @@ func TestTraceArgsProvidePlaceholders(t *testing.T) {
 
 func TestCompareArgsIncludeEnvironments(t *testing.T) {
 	sc := Scope{Environments: []string{"dev", "prod"}}
-	ctx := Context{Kind: KindDirectiveArg, Directive: "compare", Query: ""}
+	ctx := Context{Kind: KindDirectiveArg, DirectiveName: directive.Compare, Query: ""}
 	items := directiveSource{}.Provide(ctx, sc)
 	for _, label := range []string{"base=", "baseline=", "group=", "dev", "prod"} {
 		if !contains(items, label) {
@@ -192,7 +239,7 @@ func TestCompareArgsIncludeGroupsAndProfiles(t *testing.T) {
 		"api": {"dev", "prod"},
 		"app": {"dev app 1", "dev app 2"},
 	}}
-	ctx := Context{Kind: KindDirectiveArg, Directive: "compare"}
+	ctx := Context{Kind: KindDirectiveArg, DirectiveName: directive.Compare}
 	items := directiveSource{}.Provide(ctx, sc)
 	for _, label := range []string{
 		"group=",
@@ -209,9 +256,9 @@ func TestCompareArgsIncludeGroupsAndProfiles(t *testing.T) {
 	}
 
 	groups := directiveSource{}.Provide(Context{
-		Kind:      KindDirectiveArg,
-		Directive: "compare",
-		ArgKey:    "group",
+		Kind:          KindDirectiveArg,
+		DirectiveName: directive.Compare,
+		ArgKey:        "group",
 	}, sc)
 	for _, label := range []string{"api", "app"} {
 		if !contains(groups, label) {
@@ -220,9 +267,9 @@ func TestCompareArgsIncludeGroupsAndProfiles(t *testing.T) {
 	}
 
 	bases := directiveSource{}.Provide(Context{
-		Kind:      KindDirectiveArg,
-		Directive: "compare",
-		ArgKey:    "base",
+		Kind:          KindDirectiveArg,
+		DirectiveName: directive.Compare,
+		ArgKey:        "base",
 	}, sc)
 	if !contains(bases, "dev app 2") {
 		t.Fatalf("baseline suggestions missing grouped profile: %v", bases)
@@ -239,21 +286,21 @@ func TestUseValueOffersProfileNames(t *testing.T) {
 	}
 
 	apply := directiveSource{}.Provide(
-		Context{Kind: KindDirectiveArg, Directive: "apply", ArgKey: "use"},
+		Context{Kind: KindDirectiveArg, DirectiveName: directive.Apply, ArgKey: "use"},
 		sc,
 	)
 	if !contains(apply, "jsonApi") {
 		t.Fatalf("apply use= missing patch profile: %v", apply)
 	}
 	ssh := directiveSource{}.Provide(
-		Context{Kind: KindDirectiveArg, Directive: "ssh", ArgKey: "use"},
+		Context{Kind: KindDirectiveArg, DirectiveName: directive.SSH, ArgKey: "use"},
 		sc,
 	)
 	if !contains(ssh, "edge") {
 		t.Fatalf("ssh use= missing profile: %v", ssh)
 	}
 	k8s := directiveSource{}.Provide(
-		Context{Kind: KindDirectiveArg, Directive: "k8s", ArgKey: "use"},
+		Context{Kind: KindDirectiveArg, DirectiveName: directive.K8s, ArgKey: "use"},
 		sc,
 	)
 	if !contains(k8s, "cluster") {

--- a/internal/intellisense/headers.go
+++ b/internal/intellisense/headers.go
@@ -66,7 +66,7 @@ func (headerSource) Provide(ctx Context, _ Scope) []Item {
 	case KindHeaderName:
 		return filter(headerNameItems, ctx.Query)
 	case KindHeaderValue:
-		return filter(headerValues[ctx.HeaderName], ctx.Query)
+		return filter(headerValues[ctx.header], ctx.Query)
 	default:
 		return nil
 	}
@@ -76,6 +76,7 @@ var headerNameItems = func() []Item {
 	out := make([]Item, len(headerNames))
 	for i, h := range headerNames {
 		h.Insert = h.Label + ":"
+		h.Continue = true
 		out[i] = h
 	}
 	return out

--- a/internal/intellisense/headers.go
+++ b/internal/intellisense/headers.go
@@ -66,7 +66,7 @@ func (headerSource) Provide(ctx Context, _ Scope) []Item {
 	case KindHeaderName:
 		return filter(headerNameItems, ctx.Query)
 	case KindHeaderValue:
-		return filter(headerValues[ctx.Directive], ctx.Query)
+		return filter(headerValues[ctx.HeaderName], ctx.Query)
 	default:
 		return nil
 	}

--- a/internal/intellisense/item.go
+++ b/internal/intellisense/item.go
@@ -11,19 +11,29 @@ type Item struct {
 	Aliases []string
 	Summary string
 
-	// Insert is written in place of the typed token. Empty inserts Label.
+	// Insert replaces the typed token. If empty, Label is used.
 	Insert string
 
-	// Placeholder is the example value inside the inserted text that an editor
-	// selects, so the next keystroke types over it. Writing it out instead of a
-	// caret offset keeps delimiters around the value, such as a closing paren,
-	// outside the selection.
+	// CursorBack leaves the caret this many runes before the end of InsertText.
+	CursorBack int
+
+	// Placeholder is the inserted example text selected for replacement.
+	// Surrounding delimiters, such as parentheses, stay outside the selection.
 	Placeholder string
+
+	// Continue opens suggestions at the new caret position after insertion.
+	Continue bool
 
 	noTrailingSpace bool
 }
 
-// InsertText is what an editor writes when the item is accepted.
+// WithoutTrailingSpace returns a copy that adds no space after insertion.
+func (it Item) WithoutTrailingSpace() Item {
+	it.noTrailingSpace = true
+	return it
+}
+
+// InsertText returns the text to insert when the item is accepted.
 func (it Item) InsertText() string {
 	if it.Insert != "" {
 		return it.Insert
@@ -31,17 +41,26 @@ func (it Item) InsertText() string {
 	return it.Label
 }
 
-func (it Item) withInsertPrefix(prefix string) Item {
-	if prefix != "" {
-		it.Insert = prefix + it.InsertText()
+func cutCall(usage string) (call, argv string) {
+	name, rest, ok := strings.Cut(usage, "(")
+	if !ok {
+		return usage, ""
 	}
+	args, ok := strings.CutSuffix(rest, ")")
+	if !ok {
+		return usage, ""
+	}
+	return name, args
+}
+
+func (it Item) withInsertPrefix(prefix string) Item {
+	it.Insert = prefix + it.InsertText()
 	return it
 }
 
-// AppendsSpace reports whether accepting the item should leave the caret ready
-// for another token in the current completion context.
+// AppendsSpace reports whether to add a space after insertion in this context.
 func (it Item) AppendsSpace(kind Kind) bool {
-	if it.noTrailingSpace {
+	if it.noTrailingSpace || it.CursorBack > 0 {
 		return false
 	}
 	switch kind {
@@ -52,8 +71,8 @@ func (it Item) AppendsSpace(kind Kind) bool {
 	}
 }
 
-// PlaceholderRange locates Placeholder in InsertText as rune offsets. The last
-// match wins because a placeholder is the value at the end of an example.
+// PlaceholderRange returns the rune range [start, end) of Placeholder in InsertText.
+// It uses the last match to select the value if the same text appears earlier.
 func (it Item) PlaceholderRange() (start, end int, ok bool) {
 	if it.Placeholder == "" {
 		return 0, 0, false

--- a/internal/intellisense/item.go
+++ b/internal/intellisense/item.go
@@ -19,6 +19,8 @@ type Item struct {
 	// caret offset keeps delimiters around the value, such as a closing paren,
 	// outside the selection.
 	Placeholder string
+
+	noTrailingSpace bool
 }
 
 // InsertText is what an editor writes when the item is accepted.
@@ -27,6 +29,27 @@ func (it Item) InsertText() string {
 		return it.Insert
 	}
 	return it.Label
+}
+
+func (it Item) withInsertPrefix(prefix string) Item {
+	if prefix != "" {
+		it.Insert = prefix + it.InsertText()
+	}
+	return it
+}
+
+// AppendsSpace reports whether accepting the item should leave the caret ready
+// for another token in the current completion context.
+func (it Item) AppendsSpace(kind Kind) bool {
+	if it.noTrailingSpace {
+		return false
+	}
+	switch kind {
+	case KindVariable, KindHeaderValue, KindScheme:
+		return false
+	default:
+		return true
+	}
 }
 
 // PlaceholderRange locates Placeholder in InsertText as rune offsets. The last

--- a/internal/intellisense/item_test.go
+++ b/internal/intellisense/item_test.go
@@ -3,6 +3,8 @@ package intellisense
 import (
 	"slices"
 	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/directive"
 )
 
 // catalogItems is every static suggestion the engine can offer, so a new entry
@@ -121,5 +123,58 @@ func TestInsertTextFallsBackToLabel(t *testing.T) {
 	}
 	if got := (Item{Label: "Accept", Insert: "Accept:"}).InsertText(); got != "Accept:" {
 		t.Fatalf("InsertText = %q, want the insert", got)
+	}
+}
+
+func TestWithInsertPrefixPreservesPlaceholder(t *testing.T) {
+	original := Item{
+		Label:       "@setting",
+		Insert:      "@setting timeout=5s",
+		Placeholder: "5s",
+	}
+	prefixed := original.withInsertPrefix(directive.CommentPrefix)
+
+	if got := prefixed.InsertText(); got != "# @setting timeout=5s" {
+		t.Fatalf("prefixed insert = %q, want %q", got, "# @setting timeout=5s")
+	}
+	start, end, ok := prefixed.PlaceholderRange()
+	if !ok {
+		t.Fatal("prefixed item lost its placeholder")
+	}
+	if got := string([]rune(prefixed.InsertText())[start:end]); got != "5s" {
+		t.Fatalf("prefixed placeholder = %q, want %q", got, "5s")
+	}
+	if got := original.InsertText(); got != "@setting timeout=5s" {
+		t.Fatalf("prefixing mutated the original item: %q", got)
+	}
+}
+
+func TestItemAppendsSpace(t *testing.T) {
+	tests := []struct {
+		name string
+		item Item
+		kind Kind
+		want bool
+	}{
+		{name: "directive with arguments", kind: KindDirective, want: true},
+		{
+			name: "directive without arguments",
+			item: Item{noTrailingSpace: true},
+			kind: KindDirective,
+		},
+		{name: "method", kind: KindMethod, want: true},
+		{name: "header name", kind: KindHeaderName, want: true},
+		{name: "directive argument", kind: KindDirectiveArg, want: true},
+		{name: "variable", kind: KindVariable},
+		{name: "header value", kind: KindHeaderValue},
+		{name: "scheme", kind: KindScheme},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.item.AppendsSpace(tt.kind); got != tt.want {
+				t.Fatalf("AppendsSpace(%v) = %v, want %v", tt.kind, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/intellisense/item_test.go
+++ b/internal/intellisense/item_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/directive"
 )
 
-// catalogItems is every static suggestion the engine can offer, so a new entry
-// is checked without being listed here.
 func catalogItems() []Item {
 	items := slices.Clone(directives)
 	items = append(items, methods...)
@@ -18,8 +16,13 @@ func catalogItems() []Item {
 	for _, values := range headerValues {
 		items = append(items, values...)
 	}
-	for _, args := range directiveArgs {
-		items = append(items, args...)
+	for _, table := range argTable {
+		if table.value != nil {
+			items = append(items, table.value.items()...)
+		}
+		for _, arg := range table.named {
+			items = append(items, arg.items()...)
+		}
 	}
 	return items
 }
@@ -41,9 +44,7 @@ func TestCatalogPlaceholdersAreInsertedText(t *testing.T) {
 	}
 }
 
-// An example value is there to be typed over, so an item that inserts more than
-// its label says which part of it is the example. What is left is punctuation
-// (the header colon) and a mode keyword with only one valid value.
+// Header colons and the fixed @rts mode need no placeholder.
 func TestCatalogExamplesAreSelectable(t *testing.T) {
 	for _, it := range catalogItems() {
 		insert := it.InsertText()

--- a/internal/intellisense/scope.go
+++ b/internal/intellisense/scope.go
@@ -5,6 +5,7 @@ type Scope struct {
 	Environments      []string
 	EnvironmentGroups map[string][]string
 	Profiles          ProfileSet
+	RequestNames      []string
 }
 
 type VarRef struct {

--- a/internal/intellisense/sources_test.go
+++ b/internal/intellisense/sources_test.go
@@ -51,14 +51,14 @@ func TestHeaderSource(t *testing.T) {
 	}
 
 	values := headerSource{}.Provide(
-		Context{Kind: KindHeaderValue, Directive: "content-type", Query: "app"},
+		Context{Kind: KindHeaderValue, HeaderName: "content-type", Query: "app"},
 		Scope{},
 	)
 	if !contains(values, "application/json") {
 		t.Fatalf("content-type values missing application/json: %v", values)
 	}
 	if got := (headerSource{}).Provide(
-		Context{Kind: KindHeaderValue, Directive: "x-unknown"},
+		Context{Kind: KindHeaderValue, HeaderName: "x-unknown"},
 		Scope{},
 	); got != nil {
 		t.Fatalf("expected nil for unknown header values, got %v", got)

--- a/internal/intellisense/sources_test.go
+++ b/internal/intellisense/sources_test.go
@@ -51,14 +51,14 @@ func TestHeaderSource(t *testing.T) {
 	}
 
 	values := headerSource{}.Provide(
-		Context{Kind: KindHeaderValue, HeaderName: "content-type", Query: "app"},
+		Context{Kind: KindHeaderValue, header: "content-type", Query: "app"},
 		Scope{},
 	)
 	if !contains(values, "application/json") {
 		t.Fatalf("content-type values missing application/json: %v", values)
 	}
 	if got := (headerSource{}).Provide(
-		Context{Kind: KindHeaderValue, HeaderName: "x-unknown"},
+		Context{Kind: KindHeaderValue, header: "x-unknown"},
 		Scope{},
 	); got != nil {
 		t.Fatalf("expected nil for unknown header values, got %v", got)

--- a/internal/intellisense/variables.go
+++ b/internal/intellisense/variables.go
@@ -2,25 +2,26 @@ package intellisense
 
 import "github.com/unkn0wn-root/resterm/internal/vars/dynamic"
 
-// builtinVars mirrors the helper registry, so a new helper needs no second
-// list here.
 var builtinVars = builtinItems()
 
 func builtinItems() []Item {
 	helpers := dynamic.Helpers()
 	items := make([]Item, 0, len(helpers))
 	for _, h := range helpers {
-		items = append(items, Item{
+		item := Item{
 			Label:   h.Name(),
 			Aliases: h.Aliases(),
 			Summary: helperSummary(h),
-		})
+		}
+		if usage := h.Usage(); usage != "" {
+			item.Insert = usage
+			_, item.Placeholder = cutCall(usage)
+		}
+		items = append(items, item)
 	}
 	return items
 }
 
-// helperSummary shows the call form, since the label alone does not say a
-// helper takes arguments.
 func helperSummary(h dynamic.Descriptor) string {
 	if h.Usage() == "" {
 		return h.Summary()
@@ -39,7 +40,15 @@ func (variableSource) Provide(ctx Context, sc Scope) []Item {
 		items = append(items, Item{Label: v.Name, Summary: varSummary(v)})
 	}
 	items = append(items, builtinVars...)
-	return filter(items, ctx.Query)
+	items = filter(items, ctx.Query)
+	for i := range items {
+		if ctx.call {
+			items[i].Insert, items[i].Placeholder = items[i].Label, ""
+			continue
+		}
+		items[i].Insert = items[i].InsertText() + ctx.closing
+	}
+	return items
 }
 
 func varSummary(v VarRef) string {

--- a/internal/oauth/authcode.go
+++ b/internal/oauth/authcode.go
@@ -120,18 +120,18 @@ func pickState(raw string) (string, error) {
 func pickMethod(raw string) string {
 	v := strings.ToLower(strings.TrimSpace(raw))
 	switch v {
-	case "plain":
-		return "plain"
+	case CodeChallengePlain:
+		return CodeChallengePlain
 	default:
-		return "s256"
+		return CodeChallengeS256
 	}
 }
 
 func buildChallenge(verifier, method string) (string, error) {
 	switch strings.ToLower(method) {
-	case "plain":
+	case CodeChallengePlain:
 		return verifier, nil
-	case "s256":
+	case CodeChallengeS256:
 		sum := sha256Sum([]byte(verifier))
 		return base64.RawURLEncoding.EncodeToString(sum), nil
 	default:

--- a/internal/oauth/config.go
+++ b/internal/oauth/config.go
@@ -10,6 +10,9 @@ const (
 	ClientAuthBasic = "basic"
 	ClientAuthBody  = "body"
 
+	CodeChallengePlain = "plain"
+	CodeChallengeS256  = "s256"
+
 	DefaultHeader = "Authorization"
 )
 

--- a/internal/prompt/cmdline.go
+++ b/internal/prompt/cmdline.go
@@ -145,13 +145,24 @@ func (l Line) clamp(cursor int) int {
 }
 
 func Quote(value string) string {
+	text, _ := quoteAt(value, len([]rune(value)))
+	return text
+}
+
+// quoteAt quotes value and adjusts the caret's rune offset.
+func quoteAt(value string, cursor int) (string, int) {
 	if value != "" && !strings.ContainsFunc(value, unicode.IsSpace) &&
 		!strings.ContainsAny(value, `"'`) {
-		return value
+		return value, cursor
 	}
 
-	// A backslash right before the closing quote would escape it, so a trailing
-	// run of them stays outside. Windows directories end in one.
+	// Keep trailing backslashes outside the quotes so they cannot escape the closing quote.
 	quoted := strings.TrimRight(value, `\`)
-	return `"` + strings.ReplaceAll(quoted, `"`, `\"`) + `"` + value[len(quoted):]
+	text := `"` + strings.ReplaceAll(quoted, `"`, `\"`) + `"` + value[len(quoted):]
+
+	runes := []rune(quoted)
+	if cursor >= len(runes) {
+		return text, cursor + 2 + strings.Count(quoted, `"`)
+	}
+	return text, cursor + 1 + strings.Count(string(runes[:cursor]), `"`)
 }

--- a/internal/prompt/path.go
+++ b/internal/prompt/path.go
@@ -13,16 +13,37 @@ type PathSpec struct {
 	Files       files.PathFilter
 	FileSummary string
 	Confine     bool
-	CommaList   bool
+	Separators  SeparatorPolicy
 	AcceptDirs  bool
 	ExpandHome  bool
 	Quote       bool
 }
 
+// SeparatorPolicy defines which characters separate paths in a list.
+type SeparatorPolicy uint8
+
+const (
+	SeparatorNone SeparatorPolicy = iota
+	SeparatorComma
+	SeparatorPathList
+)
+
+func (p SeparatorPolicy) separates(r rune) bool {
+	switch p {
+	case SeparatorComma:
+		return r == ','
+	case SeparatorPathList:
+		return strings.ContainsRune(",; \t\n", r)
+	default:
+		return false
+	}
+}
+
 type PathRequest struct {
-	Value string
-	Edit  Edit
-	Spec  PathSpec
+	Value  string // decoded value before the caret
+	Suffix string // decoded value after the caret
+	Edit   Edit
+	Spec   PathSpec
 }
 
 type PathProvider interface {
@@ -36,6 +57,7 @@ type pathQuery struct {
 	typed     string
 	prefix    string
 	committed string
+	suffix    string
 }
 
 type pathCandidate struct {
@@ -48,10 +70,13 @@ type pathCandidate struct {
 func newPathQuery(r PathRequest) (pathQuery, bool) {
 	value := r.Value
 	committed := ""
-	if r.Spec.CommaList {
-		if comma := strings.LastIndexByte(value, ','); comma >= 0 {
-			committed, value = value[:comma+1], value[comma+1:]
-		}
+	if at := strings.LastIndexFunc(value, r.Spec.Separators.separates); at >= 0 {
+		committed, value = value[:at+1], value[at+1:]
+	}
+	// Preserve later paths when replacing the current entry.
+	suffix := ""
+	if at := strings.IndexFunc(r.Suffix, r.Spec.Separators.separates); at >= 0 {
+		suffix = r.Suffix[at:]
 	}
 
 	typed, prefix := filepath.Split(value)
@@ -88,13 +113,14 @@ func newPathQuery(r PathRequest) (pathQuery, bool) {
 		typed:     typed,
 		prefix:    prefix,
 		committed: committed,
+		suffix:    suffix,
 	}, true
 }
 
 func (q pathQuery) classify(entries []DirEntry) []pathCandidate {
 	out := make([]pathCandidate, 0, len(entries))
 	for _, entry := range entries {
-		if q.spec.CommaList && strings.ContainsRune(entry.Name, ',') {
+		if strings.IndexFunc(entry.Name, q.spec.Separators.separates) >= 0 {
 			continue
 		}
 		if !entry.Dir && !q.accepts(filepath.Join(q.dir, entry.Name)) {
@@ -136,10 +162,17 @@ func (q pathQuery) accepts(path string) bool {
 }
 
 func (q pathQuery) replace(value string) Edit {
+	cursor := len([]rune(value))
+	value += q.suffix
 	if q.spec.Quote {
-		value = Quote(value)
+		value, cursor = quoteAt(value, cursor)
 	}
-	return Edit{Start: q.edit.Start, End: q.edit.End, Text: value}
+	return Edit{
+		Start:      q.edit.Start,
+		End:        q.edit.End,
+		Text:       value,
+		CursorBack: len([]rune(value)) - cursor,
+	}
 }
 
 func within(root, path string) bool {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -6,6 +6,9 @@ type Edit struct {
 	Start int
 	End   int
 	Text  string
+
+	// CursorBack leaves the caret this many runes before the end of Text.
+	CursorBack int
 }
 
 func (e Edit) Apply(input string) (string, int, error) {
@@ -24,7 +27,7 @@ func (e Edit) Apply(input string) (string, int, error) {
 	out = append(out, runes[:e.Start]...)
 	out = append(out, text...)
 	out = append(out, runes[e.End:]...)
-	return string(out), e.Start + len(text), nil
+	return string(out), e.Start + len(text) - e.CursorBack, nil
 }
 
 type Item struct {

--- a/internal/prompt/session.go
+++ b/internal/prompt/session.go
@@ -24,11 +24,7 @@ type pathCandidates struct {
 }
 
 func (s *PathSession) Reset() {
-	s.gen++
-	s.live = false
-	s.current = pathQuery{}
-	s.cache = make(map[string]*pathListing)
-	s.pending = make(map[string]bool)
+	*s = PathSession{gen: s.gen + 1}
 }
 
 func (s *PathSession) Suggest(
@@ -41,10 +37,16 @@ func (s *PathSession) Suggest(
 		s.forget()
 		return nil, DirLoad{}, false
 	}
+	items, load = s.SuggestPath(request)
+	return items, load, true
+}
+
+// SuggestPath completes a path whose value and replacement range the caller has supplied.
+func (s *PathSession) SuggestPath(request PathRequest) ([]Item, DirLoad) {
 	query, ok := newPathQuery(request)
 	if !ok {
 		s.forget()
-		return nil, DirLoad{}, true
+		return nil, DirLoad{}
 	}
 
 	if s.cache == nil {
@@ -55,13 +57,13 @@ func (s *PathSession) Suggest(
 	s.current = query
 
 	if listing, ok := s.cache[query.dir]; ok {
-		return listing.items(query), DirLoad{}, true
+		return listing.items(query), DirLoad{}
 	}
 	if s.pending[query.dir] {
-		return nil, DirLoad{}, true
+		return nil, DirLoad{}
 	}
 	s.pending[query.dir] = true
-	return nil, DirLoad{Dir: query.dir, Gen: s.gen}, true
+	return nil, DirLoad{Dir: query.dir, Gen: s.gen}
 }
 
 func (s *PathSession) Deliver(r DirRead) ([]Item, bool) {
@@ -82,6 +84,7 @@ func (s *PathSession) Deliver(r DirRead) ([]Item, bool) {
 	return listing.items(s.current), true
 }
 
+// forget drops the current query but keeps the directory listings.
 func (s *PathSession) forget() {
 	s.live = false
 	s.current = pathQuery{}

--- a/internal/prompt/session_test.go
+++ b/internal/prompt/session_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/unkn0wn-root/resterm/internal/files"
@@ -189,6 +190,49 @@ func TestPathSessionKeepsFiltersSeparate(t *testing.T) {
 	}
 	if got := itemLabels(items); !slices.Equal(got, []string{"one.http", "two.json"}) {
 		t.Fatalf("all-file items = %q", got)
+	}
+}
+
+func TestPathSessionCompletesCurrentPathListSegment(t *testing.T) {
+	for _, tt := range []struct{ input, want string }{
+		{"first.pem; second.pem, th|", `"first.pem; second.pem, third.pem"|`},
+		{"først.pem,th|ird.pem,last.pem", "først.pem,third.pem|,last.pem"},
+		{"first.pem; th|ird.pem; last.pem", `"first.pem; third.pem|; last.pem"`},
+		{`først"file.pem,th|ird.pem; last.pem`, `"først\"file.pem,third.pem|; last.pem"`},
+		{`first.pem; th|ird.pem; C:\certs\`, `"first.pem; third.pem|; C:\certs"\`},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			before, after, _ := strings.Cut(tt.input, "|")
+			input := before + after
+			var session PathSession
+			_, load := session.SuggestPath(PathRequest{
+				Value:  before,
+				Suffix: after,
+				Edit:   Edit{End: len([]rune(input))},
+				Spec: PathSpec{
+					Root:        t.TempDir(),
+					Files:       files.AnyPathFilter(),
+					FileSummary: "certificate",
+					Separators:  SeparatorPathList,
+					Quote:       true,
+				},
+			})
+			items, ok := session.Deliver(DirRead{
+				DirLoad: load,
+				Entries: []DirEntry{{Name: "third.pem"}, {Name: "three words.pem"}},
+			})
+			if !ok || len(items) != 1 {
+				t.Fatalf("path-list items = %#v", items)
+			}
+			got, cursor, err := items[0].Edit.Apply(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			prefix, suffix, _ := strings.Cut(tt.want, "|")
+			if got != prefix+suffix || cursor != len([]rune(prefix)) {
+				t.Fatalf("path-list edit = %q at %d, want %q at %d", got, cursor, prefix+suffix, len([]rune(prefix)))
+			}
+		})
 	}
 }
 

--- a/internal/protocol/grpcx/options_apply.go
+++ b/internal/protocol/grpcx/options_apply.go
@@ -2,7 +2,9 @@ package grpcx
 
 import (
 	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/bytesize"
@@ -34,6 +36,11 @@ var sizeSettings = []struct {
 var compressors = map[string]string{
 	compressionNone: "",
 	"gzip":          "gzip",
+}
+
+// CompressionNames returns the supported grpc-compression values in sorted order.
+func CompressionNames() []string {
+	return slices.Sorted(maps.Keys(compressors))
 }
 
 func invalidSetting(key optionSettingKey, val, want string) error {

--- a/internal/ui/completion_prompt.go
+++ b/internal/ui/completion_prompt.go
@@ -24,6 +24,7 @@ const (
 	promptCommandLine promptID = iota + 1
 	promptOpenPath
 	promptResponseSave
+	promptEditor
 )
 
 type pathReadMsg struct {
@@ -214,5 +215,7 @@ func (m *Model) handlePathRead(msg pathReadMsg) {
 		m.openPathPrompt.deliver(msg.read)
 	case promptResponseSave:
 		m.responseSavePrompt.deliver(msg.read)
+	case promptEditor:
+		m.editor.deliverPathCompletion(msg.read)
 	}
 }

--- a/internal/ui/completion_source.go
+++ b/internal/ui/completion_source.go
@@ -124,6 +124,6 @@ func requestPathSpec(root string) prompt.PathSpec {
 		Files:       files.RequestPathFilter(),
 		FileSummary: "request file",
 		Confine:     true,
-		CommaList:   true,
+		Separators:  prompt.SeparatorComma,
 	}
 }

--- a/internal/ui/editor_completion.go
+++ b/internal/ui/editor_completion.go
@@ -1,0 +1,308 @@
+package ui
+
+import (
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/unkn0wn-root/resterm/internal/intellisense"
+)
+
+type completionState struct {
+	active        bool
+	anchorOffset  int
+	replaceEnd    int
+	selection     int
+	preview       bool
+	popupLabelW   int
+	popupSummaryW int
+	filtered      []intellisense.Item
+	ctx           intellisense.Context
+}
+
+func (s *completionState) deactivate() {
+	*s = completionState{}
+}
+
+func (s *completionState) update(
+	anchor int,
+	filtered []intellisense.Item,
+	ctx intellisense.Context,
+) {
+	if len(filtered) == 0 {
+		s.deactivate()
+		return
+	}
+	reset := !s.active || s.anchorOffset != anchor
+	if reset || s.selection >= len(filtered) {
+		s.selection = 0
+	}
+	s.active = true
+	s.anchorOffset = anchor
+	s.replaceEnd = anchor + max(ctx.End-ctx.Start, 0)
+	s.filtered = filtered
+	s.ctx = ctx
+	labelW, summaryW := completionPopupPreference(filtered)
+	if reset {
+		s.popupLabelW = labelW
+		s.popupSummaryW = summaryW
+		return
+	}
+	s.popupLabelW = max(s.popupLabelW, labelW)
+	s.popupSummaryW = max(s.popupSummaryW, summaryW)
+}
+
+func (s *completionState) move(delta int) {
+	if !s.active || len(s.filtered) == 0 {
+		return
+	}
+	count := len(s.filtered)
+	idx := (s.selection + delta) % count
+	if idx < 0 {
+		idx += count
+	}
+	s.selection = idx
+}
+
+func (s *completionState) setPreview(open bool) {
+	if !s.active || len(s.filtered) == 0 {
+		s.preview = false
+		return
+	}
+	s.preview = open
+}
+
+func (s *completionState) togglePreview() {
+	s.setPreview(!s.preview)
+}
+
+func (s completionState) display(limit int) (items []intellisense.Item, selected int, ok bool) {
+	if !s.active || len(s.filtered) == 0 || limit <= 0 {
+		return nil, 0, false
+	}
+	start, end := popupWindow(s.selection, limit, len(s.filtered))
+	return s.filtered[start:end], s.selection - start, true
+}
+
+func completionPopupPreference(items []intellisense.Item) (int, int) {
+	labelW := 0
+	summaryW := 0
+	for _, item := range items {
+		labelW = max(labelW, visibleWidth(item.Label))
+		summaryW = max(summaryW, visibleWidth(item.Summary))
+	}
+	return labelW, summaryW
+}
+
+func (e *requestEditor) SetCompletionEnabled(enabled bool) {
+	e.completionEnabled = enabled
+	if !enabled {
+		e.closeCompletions()
+	}
+}
+
+// SetCompletionScope stores document and environment data for completion.
+// Call it when either changes.
+func (e *requestEditor) SetCompletionScope(scope intellisense.Scope) {
+	e.scope = scope
+}
+
+func (e requestEditor) hasActiveCompletion() bool {
+	return e.completion.active && len(e.completion.filtered) > 0
+}
+
+func (e *requestEditor) handleCompletionKeys(msg tea.KeyMsg) (bool, tea.Cmd) {
+	if !e.hasActiveCompletion() {
+		return false, nil
+	}
+	switch msg.String() {
+	case "down", "ctrl+n":
+		e.completion.move(1)
+		return true, nil
+	case "up", "ctrl+p", "shift+tab":
+		e.completion.move(-1)
+		return true, nil
+	case "right":
+		e.completion.setPreview(true)
+		return true, nil
+	case "left":
+		if e.completion.preview {
+			e.completion.setPreview(false)
+			return true, nil
+		}
+		return false, nil
+	case "ctrl+l", "?", "shift+/":
+		e.completion.togglePreview()
+		return true, nil
+	case "esc":
+		if e.completion.preview {
+			e.completion.setPreview(false)
+			return true, nil
+		}
+		return false, nil
+	case "tab", "enter", "ctrl+m":
+		cmd := e.applyCompletion()
+		return true, cmd
+	default:
+		return false, nil
+	}
+}
+
+func (e *requestEditor) dismissCompletion() bool {
+	if !e.completion.active {
+		return false
+	}
+	if e.completion.preview {
+		e.completion.setPreview(false)
+		return true
+	}
+	e.closeCompletions()
+	return true
+}
+
+func (e *requestEditor) updateCompletions(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "enter", "ctrl+m", "esc":
+		e.closeCompletions()
+		return nil
+	case " ":
+		// A space ends most tokens, but inside a path it is ordinary text.
+		if ctx, line, ok := e.completionAt(); ok && ctx.Kind == intellisense.KindPath {
+			return e.showCompletions(ctx, line)
+		}
+		e.closeCompletions()
+		return nil
+	case "backspace", "ctrl+h", "delete":
+		if !e.completion.active && !e.editingPath() {
+			return nil
+		}
+		return e.refreshCompletions()
+	default:
+		return e.refreshCompletions()
+	}
+}
+
+func (e *requestEditor) refreshCompletions() tea.Cmd {
+	ctx, line, ok := e.completionAt()
+	if !ok {
+		e.closeCompletions()
+		return nil
+	}
+	if e.caretInsideToken() {
+		// Keep the current popup while editing inside a token.
+		return nil
+	}
+	return e.showCompletions(ctx, line)
+}
+
+func (e *requestEditor) openCompletions() tea.Cmd {
+	ctx, line, ok := e.completionAt()
+	if !ok {
+		e.closeCompletions()
+		return nil
+	}
+	return e.showCompletions(ctx, line)
+}
+
+func (e *requestEditor) completionAt() (intellisense.Context, int, bool) {
+	if !e.completionEnabled {
+		return intellisense.Context{}, 0, false
+	}
+	line := e.Line()
+	ctx, ok := intellisense.Analyze(e, line, e.caretColumn())
+	return ctx, line, ok
+}
+
+func (e *requestEditor) editingPath() bool {
+	ctx, _, ok := e.completionAt()
+	return ok && ctx.Kind == intellisense.KindPath
+}
+
+func (e *requestEditor) caretColumn() int {
+	info := e.LineInfo()
+	return min(max(info.StartColumn+info.ColumnOffset, 0), len(e.LineRunes(e.Line())))
+}
+
+func (e *requestEditor) caretInsideToken() bool {
+	cur := e.LineRunes(e.Line())
+	col := e.caretColumn()
+	return col < len(cur) && intellisense.IsTokenRune(cur[col])
+}
+
+func (e *requestEditor) showCompletions(ctx intellisense.Context, line int) tea.Cmd {
+	if ctx.Kind == intellisense.KindPath {
+		return e.showPathCompletions(ctx, line)
+	}
+	e.paths.reset()
+	items := e.engine.Suggest(ctx, e.scope)
+	if len(items) == 0 {
+		e.completion.deactivate()
+		return nil
+	}
+	e.completion.update(e.offsetForPosition(line, ctx.Start), items, ctx)
+	return nil
+}
+
+func (e *requestEditor) closeCompletions() {
+	e.completion.deactivate()
+	e.paths.reset()
+}
+
+// NextCompletion selects the next item or opens suggestions at the caret.
+func (e requestEditor) NextCompletion() (requestEditor, tea.Cmd) {
+	if e.hasActiveCompletion() {
+		e.completion.move(1)
+		return e, nil
+	}
+	return e, e.openCompletions()
+}
+
+func (e *requestEditor) applyCompletion() tea.Cmd {
+	if !e.hasActiveCompletion() {
+		return nil
+	}
+	selected := e.completion.filtered[e.completion.selection]
+	start := e.completion.anchorOffset
+	end := e.completion.replaceEnd
+	caret := e.caretPosition()
+	runes := []rune(e.Value())
+	if start < 0 || end < start || end > len(runes) || caret.Offset < start {
+		e.closeCompletions()
+		return nil
+	}
+	after := runes[end:]
+
+	addSpace := selected.AppendsSpace(e.completion.ctx.Kind) &&
+		(len(after) == 0 || !unicode.IsSpace(after[0]))
+	e.pushUndoSnapshot()
+
+	updated := append([]rune{}, runes[:start]...)
+	updated = append(updated, []rune(selected.InsertText())...)
+	if addSpace {
+		updated = append(updated, ' ')
+	}
+	exit := len(updated)
+	updated = append(updated, after...)
+
+	prevView := e.ViewStart()
+	if value := string(updated); value != e.Value() {
+		e.storeValue(value) // Keep the current path session.
+	}
+	e.SetViewStart(prevView)
+
+	caretOffset := exit - selected.CursorBack
+	if from, to, ok := selected.PlaceholderRange(); ok {
+		e.startPlaceholder(start+from, start+to, exit)
+		caretOffset = start + from
+	} else {
+		e.clearSelection()
+	}
+	line, col := e.positionForOffset(caretOffset)
+	e.moveCursorTo(line, col)
+	e.applySelectionHighlight()
+	if selected.Placeholder == "" && selected.Continue {
+		e.completion.deactivate()
+		return e.openCompletions()
+	}
+	e.closeCompletions()
+	return nil
+}

--- a/internal/ui/editor_completion_chain_test.go
+++ b/internal/ui/editor_completion_chain_test.go
@@ -1,0 +1,288 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/unkn0wn-root/resterm/internal/intellisense"
+	"github.com/unkn0wn-root/resterm/internal/prompt"
+)
+
+func selectEditorCompletion(t *testing.T, editor *requestEditor, label string) {
+	t.Helper()
+	for i, item := range editor.completion.filtered {
+		if item.Label == label {
+			editor.completion.selection = i
+			return
+		}
+	}
+	t.Fatalf("completion %q not found in %v", label, editor.completion.filtered)
+}
+
+func editorCompletionLabels(editor requestEditor) []string {
+	labels := make([]string, len(editor.completion.filtered))
+	for i, item := range editor.completion.filtered {
+		labels[i] = item.Label
+	}
+	return labels
+}
+
+func deliverEditorPathRead(t *testing.T, editor *requestEditor, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected a pending path read")
+	}
+	msg, ok := cmd().(pathReadMsg)
+	if !ok {
+		t.Fatalf("path read command returned %T", msg)
+	}
+	if msg.id != promptEditor {
+		t.Fatalf("path read prompt = %v, want editor", msg.id)
+	}
+	editor.deliverPathCompletion(msg.read)
+}
+
+func TestRequestEditorChainsTypedDirectiveStages(t *testing.T) {
+	editor := newTestEditor("# @auth ")
+	editor.moveCursorTo(0, len([]rune(editor.Value())))
+	editor.SetCompletionEnabled(true)
+	editor.openCompletions()
+
+	selectEditorCompletion(t, &editor, "oauth2")
+	editor.applyCompletion()
+	if got := editor.Value(); got != "# @auth oauth2 " {
+		t.Fatalf("oauth2 stage = %q", got)
+	}
+
+	selectEditorCompletion(t, &editor, "grant=")
+	editor.applyCompletion()
+	if got := editor.Value(); got != "# @auth oauth2 grant=" {
+		t.Fatalf("grant stage = %q", got)
+	}
+
+	selectEditorCompletion(t, &editor, "client_credentials")
+	editor.applyCompletion()
+	if got := editor.Value(); got != "# @auth oauth2 grant=client_credentials " {
+		t.Fatalf("grant value = %q", got)
+	}
+	if !editor.hasActiveCompletion() {
+		t.Fatal("expected remaining OAuth options after accepting the grant")
+	}
+	if slices.Contains(editorCompletionLabels(editor), "grant=") {
+		t.Fatalf("completed grant was offered again: %v", editor.completion.filtered)
+	}
+}
+
+func TestRequestEditorBrowsesAndChainsUsePaths(t *testing.T) {
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "modules")
+	if err := os.Mkdir(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for path, content := range map[string]string{
+		filepath.Join(root, "ignored.txt"):      "ignored",
+		filepath.Join(moduleDir, "helpers.rts"): "export let helper = 1",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	editor := newTestEditor("# @use ")
+	editor.moveCursorTo(0, len([]rune(editor.Value())))
+	editor.SetCompletionRoot(root)
+	editor.SetCompletionEnabled(true)
+	deliverEditorPathRead(t, &editor, editor.openCompletions())
+
+	labels := editorCompletionLabels(editor)
+	if slices.Contains(labels, "ignored.txt") {
+		t.Fatalf("RTS path suggestions included ignored.txt: %v", labels)
+	}
+
+	selectEditorCompletion(t, &editor, "modules/")
+	deliverEditorPathRead(t, &editor, editor.applyCompletion())
+	if got := editor.Value(); got != "# @use modules/" {
+		t.Fatalf("directory completion = %q", got)
+	}
+
+	selectEditorCompletion(t, &editor, "helpers.rts")
+	editor.applyCompletion()
+	if got := editor.Value(); got != "# @use modules/helpers.rts " {
+		t.Fatalf("file completion = %q", got)
+	}
+	if !editor.hasActiveCompletion() || !slices.Contains(editorCompletionLabels(editor), "as") {
+		t.Fatalf("expected @use alias stage, got %v", editor.completion.filtered)
+	}
+}
+
+func TestRequestEditorKeepsBrowsingAcrossSpacesInPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "module with spaces.rts"), []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	editor := newTestEditor(`# @use "module`)
+	editor.moveCursorTo(0, len([]rune(editor.Value())))
+	editor.SetCompletionRoot(root)
+	editor.SetCompletionEnabled(true)
+	deliverEditorPathRead(t, &editor, editor.openCompletions())
+
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if got := editor.Value(); got != `# @use "module ` {
+		t.Fatalf("editor value = %q", got)
+	}
+	if !editor.hasActiveCompletion() {
+		t.Fatal("the space closed the path popup")
+	}
+	selectEditorCompletion(t, &editor, "module with spaces.rts")
+	editor.applyCompletion()
+	if got := editor.Value(); got != "# @use \"module with spaces.rts\" " {
+		t.Fatalf("quoted path completion = %q", got)
+	}
+}
+
+func TestContextualCtrlNInEditorInsertMode(t *testing.T) {
+	m := New(Config{WorkspaceRoot: t.TempDir()})
+	m.focus = focusEditor
+	m.editor.SetValue("# @auth ")
+	m.editor.moveCursorTo(0, len([]rune(m.editor.Value())))
+	_ = m.setInsertMode(true, false)
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if !m.editor.hasActiveCompletion() {
+		t.Fatal("inactive Ctrl+N did not open contextual choices")
+	}
+	if m.showNewFileModal {
+		t.Fatal("Ctrl+N opened New Request in editor insert mode")
+	}
+	selection := m.editor.completion.selection
+	m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if m.editor.completion.selection == selection {
+		t.Fatal("active Ctrl+N did not select the next completion")
+	}
+
+	m.editor.SetValue("GET https://example.test")
+	m.editor.moveCursorTo(0, len([]rune(m.editor.Value())))
+	m.editor.completion.deactivate()
+	m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if m.editor.completion.active || m.showNewFileModal {
+		t.Fatal("Ctrl+N with no contextual choices should be a no-op")
+	}
+
+	_ = m.setInsertMode(false, false)
+	m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if !m.showNewFileModal {
+		t.Fatal("Ctrl+N outside editor insert mode did not keep New Request behavior")
+	}
+}
+
+func TestRequestEditorRejectsStalePathReads(t *testing.T) {
+	for _, change := range []string{"document", "caret", "root", "dismiss", "disable", "reopen"} {
+		t.Run(change, func(t *testing.T) {
+			editor := newTestEditor("# @use ")
+			editor.moveCursorTo(0, len([]rune(editor.Value())))
+			editor.SetCompletionRoot(t.TempDir())
+			editor.SetCompletionEnabled(true)
+			// Control delivery order so the test does not depend on read timing.
+			cmd := editor.openCompletions()
+			if cmd == nil {
+				t.Fatal("expected directory read")
+			}
+			msg := cmd().(pathReadMsg)
+			msg.read.Entries = []prompt.DirEntry{{Name: "module.rts"}}
+			switch change {
+			case "document":
+				editor.SetValue("# @auth ")
+			case "caret":
+				editor.moveCursorTo(0, 0)
+			case "root":
+				editor.SetCompletionRoot(t.TempDir())
+			case "dismiss":
+				editor.closeCompletions()
+			case "disable":
+				editor.SetCompletionEnabled(false)
+			case "reopen":
+				editor.closeCompletions()
+				cmd := editor.openCompletions()
+				if cmd == nil {
+					t.Fatal("reopened completion did not read the directory")
+				}
+				fresh := cmd().(pathReadMsg)
+				fresh.read.Entries = []prompt.DirEntry{{Name: "fresh.rts"}}
+				editor.deliverPathCompletion(fresh.read)
+			}
+			editor.deliverPathCompletion(msg.read)
+			if change == "reopen" {
+				if got := editorCompletionLabels(editor); !slices.Equal(got, []string{"fresh.rts"}) {
+					t.Fatalf("late read replaced the new session's suggestions: %v", got)
+				}
+				return
+			}
+			if editor.hasActiveCompletion() {
+				t.Fatalf("late read survived %s: %+v", change, editor.completion)
+			}
+		})
+	}
+}
+
+func TestRequestEditorPendingPathReadUsesLatestQuery(t *testing.T) {
+	editor := newTestEditor("# @use ")
+	editor.moveCursorTo(0, len([]rune(editor.Value())))
+	editor.SetCompletionRoot(t.TempDir())
+	editor.SetCompletionEnabled(true)
+	cmd := editor.openCompletions()
+	if cmd == nil {
+		t.Fatal("expected directory read")
+	}
+	msg := cmd().(pathReadMsg)
+	msg.read.Entries = []prompt.DirEntry{{Name: "module.rts"}, {Name: "another.rts"}}
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("mod")})
+	if next := editor.openCompletions(); next != nil {
+		t.Fatal("same directory started a duplicate read")
+	}
+	editor.deliverPathCompletion(msg.read)
+	if got := editorCompletionLabels(editor); !slices.Equal(got, []string{"module.rts"}) {
+		t.Fatalf("pending read did not use latest query: %v", got)
+	}
+	editor.applyCompletion()
+	if got := editor.Value(); got != "# @use module.rts " {
+		t.Fatalf("pending read used stale replacement offsets: %q", got)
+	}
+}
+
+func TestRequestEditorCompletesOneProfileListSegment(t *testing.T) {
+	for _, input := range []string{
+		"# @apply use=|ø,use=two,use=three",
+		"# @apply use=ø|,use=two,use=three",
+		"# @apply use=one,use=|ø,use=three",
+		"# @apply use=one,use=ø|,use=three",
+	} {
+		t.Run(input, func(t *testing.T) {
+			at := strings.IndexByte(input, '|')
+			line := strings.Replace(input, "|", "", 1)
+			editor := newTestEditor(line)
+			editor.moveCursorTo(0, len([]rune(input[:at])))
+			editor.SetCompletionScope(intellisense.Scope{Profiles: intellisense.ProfileSet{
+				Patch: []string{"øne", "one", "two", "three"},
+			}})
+			editor.SetCompletionEnabled(true)
+			editor.openCompletions()
+			labels := editorCompletionLabels(editor)
+			if slices.Contains(labels, "three") {
+				t.Fatal("offered a profile already selected after the caret")
+			}
+			if strings.Contains(line, "use=one") && slices.Contains(labels, "one") {
+				t.Fatal("offered a profile already selected before the caret")
+			}
+			selectEditorCompletion(t, &editor, "øne")
+			editor.applyCompletion()
+			if want := strings.Replace(line, "ø", "øne", 1); editor.Value() != want {
+				t.Fatalf("list completion = %q, want %q", editor.Value(), want)
+			}
+		})
+	}
+}

--- a/internal/ui/editor_completion_edit_test.go
+++ b/internal/ui/editor_completion_edit_test.go
@@ -1,0 +1,149 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/unkn0wn-root/resterm/internal/intellisense"
+)
+
+func TestRequestEditorCompletionPreservesExistingText(t *testing.T) {
+	cases := []struct {
+		name, input, label, want string
+	}{
+		{"header delimiter", "GET https://example.test\nCont|ent-Type: application/json", "Content-Type", "GET https://example.test\nContent-Type: application/json"},
+		{"header without delimiter", "GET https://example.test\nCont|ent-Type", "Content-Type", "GET https://example.test\nContent-Type: "},
+		{"header spacing", "GET https://example.test\nCont|ent-Type:    application/json", "Content-Type", "GET https://example.test\nContent-Type:    application/json"},
+		{"URL suffix", "GET htt|ps://example.test/v1", "https://", "GET https://example.test/v1"},
+		{"partial scheme delimiter", "GET ht|tp:/example.test/v1", "https://", "GET https://example.test/v1"},
+		{"different scheme", "GET h|ttps://example.test/v1?q=ø#part", "http://", "GET http://example.test/v1?q=ø#part"},
+		{"spaced template", "GET https://{{ ho| }}", "host", "GET https://{{ host }}"},
+		{"partial template delimiter", "GET https://{{ ho| }/v1", "host", "GET https://{{ host }}/v1"},
+		{"missing template delimiter", "GET https://{{ ho| ", "host", "GET https://{{ host }}"},
+		{"existing helper arguments", "GET https://{{ $randomI|nt(10, 20) }}", "$randomInt", "GET https://{{ $randomInt(10, 20) }}"},
+		{"spaced helper arguments", "GET https://{{ $randomI|nt (10, 20) }}", "$randomInt", "GET https://{{ $randomInt (10, 20) }}"},
+		{"unfinished helper arguments", "GET https://{{ $randomI|nt(10, ", "$randomInt", "GET https://{{ $randomInt(10, "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before, after, _ := strings.Cut(tc.input, "|")
+			editor := newTestEditor(before + after)
+			line := strings.Count(before, "\n")
+			col := len([]rune(before[strings.LastIndexByte(before, '\n')+1:]))
+			editor.moveCursorTo(line, col)
+			editor.SetCompletionScope(intellisense.Scope{Variables: []intellisense.VarRef{{Name: "host"}}})
+			editor.SetCompletionEnabled(true)
+			editor, _ = editor.NextCompletion()
+			selectEditorCompletion(t, &editor, tc.label)
+			editor.applyCompletion()
+			if got := editor.Value(); got != tc.want {
+				t.Fatalf("got %q; want %q", got, tc.want)
+			}
+			if editor.hasSelection() {
+				t.Fatal("completion selected existing text as a placeholder")
+			}
+		})
+	}
+}
+
+func TestRequestEditorRefreshesPathsAfterReopen(t *testing.T) {
+	for _, change := range []string{"disable", "dismiss", "document"} {
+		t.Run(change, func(t *testing.T) {
+			root := t.TempDir()
+			editor := newTestEditor("# @use ")
+			editor.moveCursorTo(0, len([]rune(editor.Value())))
+			editor.SetCompletionRoot(root)
+			editor.SetCompletionEnabled(true)
+			deliverEditorPathRead(t, &editor, editor.openCompletions())
+			if cmd := editor.openCompletions(); cmd != nil {
+				t.Fatal("repeated query reread the directory in the same session")
+			}
+			switch change {
+			case "disable":
+				editor.SetCompletionEnabled(false)
+			case "dismiss":
+				editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			case "document":
+				editor.SetValue("# @use n")
+				editor.moveCursorTo(0, len([]rune(editor.Value())))
+			}
+			if err := os.WriteFile(filepath.Join(root, "new.rts"), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			editor.SetCompletionEnabled(true)
+			deliverEditorPathRead(t, &editor, editor.openCompletions())
+			if got := editorCompletionLabels(editor); !slices.Contains(got, "new.rts") {
+				t.Fatalf("new file missing after reopening completion: %v", got)
+			}
+		})
+	}
+}
+
+func TestRequestEditorCompletesPathListAtCaret(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "twø.pem"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, input := range []string{
+		"# @settings http-root-cas=tw|o.pem,three.pem",
+		"# @settings http-root-cas=one.pem,tw|o.pem,three.pem",
+		"# @settings grpc-root-cas=one.pem;tw|o.pem;three.pem",
+		`# @settings http-root-cas="one.pem; tw|o.pem, three.pem"`,
+		`# @setting http-root-cas "one.pem; tw|o.pem, three.pem"`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			before, after, _ := strings.Cut(input, "|")
+			editor := newTestEditor(before + after)
+			editor.moveCursorTo(0, len([]rune(before)))
+			editor.SetCompletionRoot(root)
+			editor.SetCompletionEnabled(true)
+			deliverEditorPathRead(t, &editor, editor.openCompletions())
+			selectEditorCompletion(t, &editor, "twø.pem")
+			editor.applyCompletion()
+			want := strings.Replace(before+after, "two.pem", "twø.pem", 1)
+			if got := editor.Value(); got != want {
+				t.Fatalf("path list = %q, want %q", got, want)
+			}
+			end := strings.Index(want, "twø.pem") + len("twø.pem")
+			if got := editor.caretPosition().Offset; got != len([]rune(want[:end])) {
+				t.Fatalf("caret = %d, want it after the completed path", got)
+			}
+			if editor.hasActiveCompletion() {
+				t.Fatal("accepting a file reopened completion for the same path")
+			}
+		})
+	}
+}
+
+func TestRequestEditorBrowsesDirectoryInsidePathList(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "certs"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "certs", "two.pem"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const input = `# @settings http-root-cas="one.pem; ce|, three.pem"`
+	before, after, _ := strings.Cut(input, "|")
+	editor := newTestEditor(before + after)
+	editor.moveCursorTo(0, len([]rune(before)))
+	editor.SetCompletionRoot(root)
+	editor.SetCompletionEnabled(true)
+	deliverEditorPathRead(t, &editor, editor.openCompletions())
+	selectEditorCompletion(t, &editor, "certs/")
+	deliverEditorPathRead(t, &editor, editor.applyCompletion())
+	selectEditorCompletion(t, &editor, "two.pem")
+	editor.applyCompletion()
+	if got, want := editor.Value(), `# @settings http-root-cas="one.pem; certs/two.pem, three.pem"`; got != want {
+		t.Fatalf("path list = %q, want %q", got, want)
+	}
+
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'X'}})
+	if got, want := editor.Value(), `# @settings http-root-cas="one.pem; certs/two.pemX, three.pem"`; got != want {
+		t.Fatalf("text after completion = %q, want %q", got, want)
+	}
+}

--- a/internal/ui/editor_completion_path.go
+++ b/internal/ui/editor_completion_path.go
@@ -1,0 +1,114 @@
+package ui
+
+import (
+	"path/filepath"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/unkn0wn-root/resterm/internal/files"
+	"github.com/unkn0wn-root/resterm/internal/intellisense"
+	"github.com/unkn0wn-root/resterm/internal/prompt"
+)
+
+// Save the revision and caret position to reject directory reads after an edit or move.
+type editorPathCompletion struct {
+	session     prompt.PathSession
+	root        string
+	ctx         intellisense.Context
+	lineOffset  int
+	revision    uint64
+	caretOffset int
+}
+
+func (p *editorPathCompletion) reset() {
+	p.session.Reset()
+	p.ctx = intellisense.Context{}
+}
+
+// SetCompletionRoot sets the base directory for relative path suggestions.
+func (e *requestEditor) SetCompletionRoot(dir string) {
+	dir = filepath.Clean(dir)
+	if e.paths.root == dir {
+		return
+	}
+	e.closeCompletions()
+	e.paths.root = dir
+}
+
+func (e *requestEditor) showPathCompletions(ctx intellisense.Context, line int) tea.Cmd {
+	items, load := e.paths.session.SuggestPath(prompt.PathRequest{
+		Value:  ctx.Query,
+		Suffix: ctx.Path.Suffix,
+		Edit:   prompt.Edit{Start: ctx.Start, End: ctx.End},
+		Spec:   editorPathSpec(e.paths.root, ctx.Path),
+	})
+	e.paths.ctx = ctx
+	e.paths.lineOffset = e.offsetForPosition(line, 0)
+	e.paths.revision = e.Revision()
+	e.paths.caretOffset = e.caretPosition().Offset
+	e.setPathCompletionItems(items)
+	if !load.Pending() {
+		return nil
+	}
+	return readPathDir(promptEditor, load)
+}
+
+func editorPathSpec(root string, ctx intellisense.PathContext) prompt.PathSpec {
+	filter, summary := files.AnyPathFilter(), "file"
+	switch ctx.Kind {
+	case intellisense.PathRTS:
+		filter, summary = files.KindPathFilter(files.KindScript), "RestermScript module"
+	case intellisense.PathGraphQL:
+		filter, summary = files.KindPathFilter(files.KindGraphQL), "GraphQL file"
+	case intellisense.PathJSON:
+		filter, summary = files.KindPathFilter(files.KindJSON), "JSON file"
+	case intellisense.PathScript:
+		filter, summary = files.KindPathFilter(files.KindScript, files.KindJavaScript), "script file"
+	}
+	separators := prompt.SeparatorNone
+	if ctx.List {
+		separators = prompt.SeparatorPathList
+	}
+	return prompt.PathSpec{
+		Root:        root,
+		Files:       filter,
+		FileSummary: summary,
+		Separators:  separators,
+		ExpandHome:  ctx.Home,
+		Quote:       ctx.Quote,
+	}
+}
+
+func (e *requestEditor) deliverPathCompletion(read prompt.DirRead) {
+	if !e.completionEnabled || e.paths.revision != e.Revision() ||
+		e.paths.caretOffset != e.caretPosition().Offset {
+		e.paths.reset()
+	}
+	items, ok := e.paths.session.Deliver(read)
+	if !ok {
+		return
+	}
+	e.setPathCompletionItems(items)
+}
+
+func (e *requestEditor) setPathCompletionItems(items []prompt.Item) {
+	ctx := e.paths.ctx
+	converted := make([]intellisense.Item, 0, len(items))
+	for _, item := range items {
+		out := intellisense.Item{
+			Label:      item.Label,
+			Summary:    item.Summary,
+			Insert:     item.Edit.Text,
+			CursorBack: item.Edit.CursorBack,
+			Continue:   item.Continue,
+		}
+		if ctx.Path.Continues && item.Edit.CursorBack == 0 {
+			out.Continue = true
+		}
+		// Add no space while entering a directory or completing the rest of the line.
+		if item.Continue || !ctx.Path.Quote {
+			out = out.WithoutTrailingSpace()
+		}
+		converted = append(converted, out)
+	}
+	e.completion.update(e.paths.lineOffset+ctx.Start, converted, ctx)
+}

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -108,6 +108,7 @@ type requestEditor struct {
 	placeholderExit   int
 	engine            intellisense.Engine
 	scope             intellisense.Scope
+	paths             editorPathCompletion
 }
 
 type sourceStyler interface {
@@ -132,105 +133,6 @@ type editorSearch struct {
 	matches []searchMatch
 	index   int
 	active  bool
-}
-
-type completionState struct {
-	active        bool
-	anchorOffset  int
-	selection     int
-	preview       bool
-	popupLabelW   int
-	popupSummaryW int
-	filtered      []intellisense.Item
-	ctx           intellisense.Context
-}
-
-func (s *completionState) deactivate() {
-	s.active = false
-	s.filtered = nil
-	s.selection = 0
-	s.preview = false
-	s.popupLabelW = 0
-	s.popupSummaryW = 0
-	s.anchorOffset = 0
-	s.ctx = intellisense.Context{}
-}
-
-func (s *completionState) update(
-	anchor int,
-	filtered []intellisense.Item,
-	ctx intellisense.Context,
-) {
-	if len(filtered) == 0 {
-		s.deactivate()
-		return
-	}
-	reset := !s.active || s.anchorOffset != anchor
-	if reset || s.selection >= len(filtered) {
-		s.selection = 0
-	}
-	s.active = true
-	s.anchorOffset = anchor
-	s.filtered = filtered
-	s.ctx = ctx
-	labelW, summaryW := completionPopupPreference(filtered)
-	if reset {
-		s.popupLabelW = labelW
-		s.popupSummaryW = summaryW
-		return
-	}
-	if labelW > s.popupLabelW {
-		s.popupLabelW = labelW
-	}
-	if summaryW > s.popupSummaryW {
-		s.popupSummaryW = summaryW
-	}
-}
-
-func (s *completionState) move(delta int) {
-	if !s.active || len(s.filtered) == 0 {
-		return
-	}
-	count := len(s.filtered)
-	idx := (s.selection + delta) % count
-	if idx < 0 {
-		idx += count
-	}
-	s.selection = idx
-}
-
-func (s *completionState) setPreview(open bool) {
-	if !s.active || len(s.filtered) == 0 {
-		s.preview = false
-		return
-	}
-	s.preview = open
-}
-
-func (s *completionState) togglePreview() {
-	s.setPreview(!s.preview)
-}
-
-func (s completionState) display(limit int) (items []intellisense.Item, selected int, ok bool) {
-	if !s.active || len(s.filtered) == 0 || limit <= 0 {
-		return nil, 0, false
-	}
-	start, end := popupWindow(s.selection, limit, len(s.filtered))
-	return s.filtered[start:end], s.selection - start, true
-}
-
-func completionPopupPreference(items []intellisense.Item) (int, int) {
-	labelW := 0
-	summaryW := 0
-	for _, item := range items {
-		if w := visibleWidth(item.Label); w > labelW {
-			labelW = w
-		}
-		if w := visibleWidth(item.Summary); w > summaryW {
-			summaryW = w
-		}
-	}
-	return labelW, summaryW
 }
 
 func newRequestEditor() requestEditor {
@@ -265,6 +167,11 @@ func (e *requestEditor) SetValue(value string) {
 		return
 	}
 
+	e.closeCompletions()
+	e.storeValue(value)
+}
+
+func (e *requestEditor) storeValue(value string) {
 	e.Model.SetValue(value)
 	// Classify the normalized text stored by the textarea.
 	e.noteContentChanged(e.Value())
@@ -553,160 +460,6 @@ func (e requestEditor) selectionSummaryRange() (
 	return start, end
 }
 
-func (e *requestEditor) SetCompletionEnabled(enabled bool) {
-	e.completionEnabled = enabled
-	if !enabled {
-		e.completion.deactivate()
-	}
-}
-
-// SetCompletionScope updates the document-derived data used by context-aware
-// completions (variables, environments, profiles). It is refreshed on document
-// or environment changes, not per keystroke.
-func (e *requestEditor) SetCompletionScope(scope intellisense.Scope) {
-	e.scope = scope
-}
-
-func (e requestEditor) hasActiveCompletion() bool {
-	return e.completion.active && len(e.completion.filtered) > 0
-}
-
-func (e *requestEditor) handleCompletionKeys(msg tea.KeyMsg) (bool, tea.Cmd) {
-	if !e.hasActiveCompletion() {
-		return false, nil
-	}
-	switch msg.String() {
-	case "down", "ctrl+n":
-		e.completion.move(1)
-		return true, nil
-	case "up", "ctrl+p", "shift+tab":
-		e.completion.move(-1)
-		return true, nil
-	case "right":
-		e.completion.setPreview(true)
-		return true, nil
-	case "left":
-		if e.completion.preview {
-			e.completion.setPreview(false)
-			return true, nil
-		}
-		return false, nil
-	case "ctrl+l", "?", "shift+/":
-		e.completion.togglePreview()
-		return true, nil
-	case "esc":
-		if e.completion.preview {
-			e.completion.setPreview(false)
-			return true, nil
-		}
-		return false, nil
-	case "tab", "enter", "ctrl+m":
-		cmd := e.applyCompletion()
-		return true, cmd
-	default:
-		return false, nil
-	}
-}
-
-func (e *requestEditor) dismissCompletion() bool {
-	if !e.completion.active {
-		return false
-	}
-	if e.completion.preview {
-		e.completion.setPreview(false)
-		return true
-	}
-	e.completion.deactivate()
-	return true
-}
-
-func (e *requestEditor) updateCompletions(msg tea.KeyMsg) {
-	switch msg.String() {
-	case " ", "enter", "ctrl+m":
-		e.completion.deactivate()
-	case "backspace", "ctrl+h", "delete":
-		if e.completion.active {
-			e.refreshCompletions()
-		}
-	default:
-		e.refreshCompletions()
-	}
-}
-
-func (e *requestEditor) refreshCompletions() {
-	if !e.completionEnabled {
-		e.completion.deactivate()
-		return
-	}
-	line := e.Line()
-	cur := e.LineRunes(line)
-	info := e.LineInfo()
-	col := min(max(info.StartColumn+info.ColumnOffset, 0), len(cur))
-
-	ctx, ok := intellisense.Analyze(e, line, col)
-	if !ok {
-		e.completion.deactivate()
-		return
-	}
-	if col < len(cur) && intellisense.IsTokenRune(cur[col]) {
-		// Caret sits before more token characters; keep the current popup.
-		return
-	}
-	filtered := e.engine.Suggest(ctx, e.scope)
-	if len(filtered) == 0 {
-		e.completion.deactivate()
-		return
-	}
-	anchor := e.offsetForPosition(line, ctx.Start)
-	e.completion.update(anchor, filtered, ctx)
-}
-
-func (e *requestEditor) applyCompletion() tea.Cmd {
-	if !e.hasActiveCompletion() {
-		return nil
-	}
-	selected := e.completion.filtered[e.completion.selection]
-	start := e.completion.anchorOffset
-	caret := e.caretPosition()
-	if start < 0 || caret.Offset < start {
-		e.completion.deactivate()
-		return nil
-	}
-	runes := []rune(e.Value())
-	after := runes[min(caret.Offset, len(runes)):]
-
-	addSpace := selected.AppendsSpace(e.completion.ctx.Kind) &&
-		(len(after) == 0 || !unicode.IsSpace(after[0]))
-	e.pushUndoSnapshot()
-
-	updated := append([]rune{}, runes[:start]...)
-	updated = append(updated, []rune(selected.InsertText())...)
-	if addSpace {
-		// The separator goes in now, so the caret can exit past it and be ready
-		// for the next token.
-		updated = append(updated, ' ')
-	}
-	exit := len(updated)
-	updated = append(updated, after...)
-
-	prevView := e.ViewStart()
-	e.SetValue(string(updated))
-	e.SetViewStart(prevView)
-
-	caretOffset := exit
-	if from, to, ok := selected.PlaceholderRange(); ok {
-		e.startPlaceholder(start+from, start+to, exit)
-		caretOffset = start + from
-	} else {
-		e.clearSelection()
-	}
-	line, col := e.positionForOffset(caretOffset)
-	e.moveCursorTo(line, col)
-	e.applySelectionHighlight()
-	e.completion.deactivate()
-	return nil
-}
-
 func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 	beforeValue := e.Value()
 	beforeRevision := e.revision
@@ -752,7 +505,7 @@ func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 			e.clearSelection()
 			handled = true
 		}
-		e.completion.deactivate()
+		e.closeCompletions()
 	case "ctrl+c":
 		if text := e.selectedText(); text != "" {
 			cmds = append(cmds, (&e).copyToClipboard(text, ""))
@@ -932,7 +685,9 @@ func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {
 	}
 
 	after := e.caretPosition()
-	e.updateCompletions(keyMsg)
+	if completionCmd := e.updateCompletions(keyMsg); completionCmd != nil {
+		cmds = append(cmds, completionCmd)
+	}
 	if transformed.String() != keyMsg.String() && !e.hasSelection() {
 		e.clearSelection()
 	}
@@ -1415,7 +1170,7 @@ func (e requestEditor) ApplyInsertAction(
 	}
 
 	editorPtr.pendingMotion = ""
-	editorPtr.completion.deactivate()
+	editorPtr.closeCompletions()
 	editorPtr.applySelectionHighlight()
 
 	var refreshCmd tea.Cmd

--- a/internal/ui/editor_state.go
+++ b/internal/ui/editor_state.go
@@ -675,7 +675,7 @@ func (e *requestEditor) applyCompletion() tea.Cmd {
 	runes := []rune(e.Value())
 	after := runes[min(caret.Offset, len(runes)):]
 
-	addSpace := completionAddsSpace(e.completion.ctx.Kind) &&
+	addSpace := selected.AppendsSpace(e.completion.ctx.Kind) &&
 		(len(after) == 0 || !unicode.IsSpace(after[0]))
 	e.pushUndoSnapshot()
 
@@ -705,15 +705,6 @@ func (e *requestEditor) applyCompletion() tea.Cmd {
 	e.applySelectionHighlight()
 	e.completion.deactivate()
 	return nil
-}
-
-func completionAddsSpace(kind intellisense.Kind) bool {
-	switch kind {
-	case intellisense.KindVariable, intellisense.KindHeaderValue, intellisense.KindScheme:
-		return false
-	default:
-		return true
-	}
 }
 
 func (e requestEditor) Update(msg tea.Msg) (requestEditor, tea.Cmd) {

--- a/internal/ui/editor_state_test.go
+++ b/internal/ui/editor_state_test.go
@@ -2148,8 +2148,8 @@ func TestRequestEditorCompletionsVariableFromScope(t *testing.T) {
 	}
 
 	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	if got := editor.Value(); got != "GET https://{{host" {
-		t.Fatalf("expected variable inserted without trailing space, got %q", got)
+	if got := editor.Value(); got != "GET https://{{host}}" {
+		t.Fatalf("expected variable inserted with its missing closers, got %q", got)
 	}
 }
 

--- a/internal/ui/editor_state_test.go
+++ b/internal/ui/editor_state_test.go
@@ -2099,6 +2099,9 @@ func TestRequestEditorCompletionsHeaderNameInHeaderSection(t *testing.T) {
 	if got := editor.Value(); got != "GET https://example.com\nContent-Type: " {
 		t.Fatalf("expected header name with colon and space, got %q", got)
 	}
+	if !editor.hasActiveCompletion() || !collectHintLabels(editor.completion.filtered)["application/json"] {
+		t.Fatalf("expected chained header values, got %+v", editor.completion)
+	}
 }
 
 func TestRequestEditorCompletionsHeaderValue(t *testing.T) {

--- a/internal/ui/editor_state_test.go
+++ b/internal/ui/editor_state_test.go
@@ -1463,6 +1463,100 @@ func TestRequestEditorCompletionsSuggestAndAccept(t *testing.T) {
 	}
 }
 
+func TestRequestEditorCompletionsAddMissingDirectiveComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial string
+		typed   string
+		want    string
+	}{
+		{name: "bare", typed: "@na", want: "# @name "},
+		{name: "indented", initial: "  ", typed: "@na", want: "  # @name "},
+		{name: "hash comment unchanged", initial: "# ", typed: "@na", want: "# @name "},
+		{name: "slash comment unchanged", initial: "// ", typed: "@na", want: "// @name "},
+		{name: "dash comment unchanged", initial: "-- ", typed: "@na", want: "-- @name "},
+		{name: "special insert preserved", typed: "@rt", want: "# @rts pre-request "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			editor := newTestEditor(tt.initial)
+			editorPtr := &editor
+			editorPtr.moveCursorTo(0, utf8.RuneCountInString(tt.initial))
+			editorPtr.SetCompletionEnabled(true)
+
+			editor = typeRunes(editor, tt.typed)
+			if !editor.completion.active {
+				t.Fatalf("expected completion for %q", editor.Value())
+			}
+			editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			if got := editor.Value(); got != tt.want {
+				t.Fatalf("accepted completion = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestEditorBareNoArgDirectiveDoesNotAddSpace(t *testing.T) {
+	editor := newTestEditor("")
+	editorPtr := &editor
+	editorPtr.SetCompletionEnabled(true)
+
+	editor = typeRunes(editor, "@no-l")
+	if !editor.completion.active {
+		t.Fatal("expected completion for bare @no-l")
+	}
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := editor.Value(); got != "# @no-log" {
+		t.Fatalf("accepted completion = %q, want %q", got, "# @no-log")
+	}
+
+	doc := parser.Parse(
+		"completion.http",
+		[]byte(editor.Value()+"\nGET https://example.test\n"),
+	)
+	if len(doc.Errors) != 0 || len(doc.Requests) != 1 {
+		t.Fatalf("completed directive did not parse: errors=%v requests=%d", doc.Errors, len(doc.Requests))
+	}
+	if !doc.Requests[0].Metadata.NoLog {
+		t.Fatal("completed @no-log directive was not applied")
+	}
+}
+
+func TestRequestEditorBareDirectiveCompletionIsOneUndoStep(t *testing.T) {
+	editor := newTestEditor("")
+	editorPtr := &editor
+	editorPtr.SetCompletionEnabled(true)
+
+	editor = typeRunes(editor, "@na")
+	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	editor, cmd := editor.UndoLastChange()
+	_ = editorEventFromCmd(t, cmd)
+	if got := editor.Value(); got != "@na" {
+		t.Fatalf("undo restored %q, want %q", got, "@na")
+	}
+}
+
+func TestRequestEditorBareDirectiveCompletionCanBeDismissed(t *testing.T) {
+	editor := newTestEditor("")
+	editorPtr := &editor
+	editorPtr.SetCompletionEnabled(true)
+
+	editor = typeRunes(editor, "@na")
+	if !editor.completion.active {
+		t.Fatal("expected completion for bare @na")
+	}
+	if !(&editor).dismissCompletion() {
+		t.Fatal("expected active completion to be dismissed")
+	}
+	if got := editor.Value(); got != "@na" {
+		t.Fatalf("dismiss changed editor value to %q", got)
+	}
+	if editor.completion.active {
+		t.Fatal("expected completion to close after dismissal")
+	}
+}
+
 func TestRequestEditorCompletionsStayClosedAfterSpaces(t *testing.T) {
 	editor := newTestEditor("")
 	editor.SetCompletionEnabled(true)
@@ -1901,14 +1995,26 @@ func TestRequestEditorRightFinishesCompletionPlaceholder(t *testing.T) {
 	}
 }
 
-func TestRequestEditorCompletionsIgnoreNonCommentContext(t *testing.T) {
-	editor := newTestEditor("")
-	editorPtr := &editor
-	editorPtr.SetCompletionEnabled(true)
+func TestRequestEditorCompletionsPreserveBareVariablesAndEmbeddedAt(t *testing.T) {
+	tests := []string{
+		"@name = value",
+		"@future",
+		"prefix @na",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			editor := newTestEditor("")
+			editorPtr := &editor
+			editorPtr.SetCompletionEnabled(true)
 
-	editor, _ = editor.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'@'}})
-	if editor.completion.active {
-		t.Fatal("expected completion to stay inactive when typing @ outside a comment")
+			editor = typeRunes(editor, input)
+			if got := editor.Value(); got != input {
+				t.Fatalf("typed value = %q, want %q", got, input)
+			}
+			if editor.completion.active {
+				t.Fatal("expected completion to stay inactive")
+			}
+		})
 	}
 }
 

--- a/internal/ui/help_modal.go
+++ b/internal/ui/help_modal.go
@@ -153,6 +153,8 @@ func (m *Model) handleHelpKey(msg tea.KeyMsg) tea.Cmd {
 
 func (m Model) helpSections() []helpSection {
 	editorEntries := []helpEntry{
+		{"Ctrl+N / Up / Down", "Open or move through contextual completions in insert mode"},
+		{"Tab / Enter", "Accept the selected editor completion"},
 		{"h / j / k / l", "Move left / down / up / right"},
 		{"w / b / e", "Word forward / back / end (W / B / E for WORD)"},
 		{"0 / ^ / $", "Line start / first non-blank / line end"},
@@ -234,7 +236,10 @@ func (m Model) helpSections() []helpSection {
 					m.helpActionKey(bindings.ActionOpenFileInEditor, "g e"),
 					"Open file in external editor",
 				},
-				{m.helpActionKey(bindings.ActionOpenNewFileModal, "Ctrl+N"), "Create request file"},
+				{
+					m.helpActionKey(bindings.ActionOpenNewFileModal, "Ctrl+N"),
+					"Create request file (outside editor insert mode)",
+				},
 				{m.helpActionKey(bindings.ActionOpenPathModal, "Ctrl+O"), "Browse for a file or workspace"},
 				{
 					m.helpActionKey(bindings.ActionReloadWorkspace, "Ctrl+Shift+O"),

--- a/internal/ui/model_command_hints.go
+++ b/internal/ui/model_command_hints.go
@@ -60,6 +60,7 @@ func (m *Model) editorCommandHints() []commandHint {
 		return []commandHint{
 			{key: "Esc", label: "Normal"},
 			m.commandActionHint(bindings.ActionSendRequest, "Send"),
+			{key: "Ctrl+N", label: "Choices"},
 			{key: "Tab", label: "Complete"},
 		}
 	}

--- a/internal/ui/model_completion.go
+++ b/internal/ui/model_completion.go
@@ -1,7 +1,10 @@
 package ui
 
 import (
+	"path/filepath"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/intellisense"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
@@ -11,6 +14,11 @@ import (
 func (m *Model) refreshCompletionScope() {
 	scope := buildCompletionScope(m.doc, m.ws.cat, m.ws.sel)
 	m.editor.SetCompletionScope(scope)
+	root := m.ws.root
+	if m.currentFile != "" {
+		root = filepath.Dir(m.currentFile)
+	}
+	m.editor.SetCompletionRoot(root)
 }
 
 func buildCompletionScope(
@@ -46,6 +54,7 @@ func buildCompletionScope(
 			for _, v := range req.Variables {
 				add(v.Name, "request", v.Secret)
 			}
+			scope.RequestNames = appendRequestName(scope.RequestNames, req.Metadata.Name)
 		}
 		for _, c := range doc.Constants {
 			add(c.Name, "const", false)
@@ -65,6 +74,17 @@ func buildCompletionScope(
 	}
 	scope.Environments, scope.EnvironmentGroups = completionEnvironments(cat)
 	return scope
+}
+
+// Keep the first spelling of each request name, ignoring case.
+func appendRequestName(names []string, name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" || slices.ContainsFunc(names, func(known string) bool {
+		return strings.EqualFold(known, name)
+	}) {
+		return names
+	}
+	return append(names, name)
 }
 
 func completionEnvironments(cat vars.Catalog) ([]string, map[string][]string) {

--- a/internal/ui/model_completion_test.go
+++ b/internal/ui/model_completion_test.go
@@ -14,7 +14,12 @@ func TestBuildCompletionScope(t *testing.T) {
 		Globals:   []restfile.Variable{{Name: "gToken", Secret: true}},
 		Variables: []restfile.Variable{{Name: "host"}},
 		Requests: []*restfile.Request{
-			{Variables: []restfile.Variable{{Name: "reqId"}}},
+			{
+				Metadata:  restfile.RequestMetadata{Name: "Create User"},
+				Variables: []restfile.Variable{{Name: "reqId"}},
+			},
+			{Metadata: restfile.RequestMetadata{Name: "create user"}},
+			{Metadata: restfile.RequestMetadata{Name: " Health "}},
 		},
 		Constants: []restfile.Constant{{Name: "apiVersion"}},
 		Patches:   []restfile.PatchProfile{{Name: "jsonApi"}},
@@ -74,6 +79,9 @@ func TestBuildCompletionScope(t *testing.T) {
 	}
 	if !reflect.DeepEqual(scope.Profiles, wantProfiles) {
 		t.Fatalf("profiles = %+v, want %+v", scope.Profiles, wantProfiles)
+	}
+	if want := []string{"Create User", "Health"}; !reflect.DeepEqual(scope.RequestNames, want) {
+		t.Fatalf("request names = %q, want stable case-folded de-duplication %q", scope.RequestNames, want)
 	}
 }
 

--- a/internal/ui/model_update.go
+++ b/internal/ui/model_update.go
@@ -1164,11 +1164,11 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 // Keep the cached application frame only for messages handled entirely by an
 // open modal. All other messages may change the frame behind it.
 func (m *Model) modalKeepsUnderlay(msg tea.Msg) bool {
-	switch msg.(type) {
+	switch typed := msg.(type) {
 	case tea.KeyMsg:
 		return m.modalCapturesGlobalKeys()
 	case pathReadMsg:
-		return true
+		return typed.id != promptEditor
 	default:
 		return false
 	}
@@ -1314,6 +1314,15 @@ func (m *Model) handleKeyWithChord(msg tea.KeyMsg, allowChord bool) tea.Cmd {
 		if cmd := m.sendRequestFromList(false); cmd != nil {
 			return combine(cmd)
 		}
+	}
+
+	// In editor insert mode, Ctrl+N takes priority over the New Request binding.
+	if m.focus == focusEditor && m.editorInsertMode && keyStr == "ctrl+n" {
+		cmd := m.mutateEditor(func(ed requestEditor) (requestEditor, tea.Cmd) {
+			return ed.NextCompletion()
+		})
+		m.suppressEditorKey = true
+		return combine(cmd)
 	}
 
 	if shortcutKey != "" {


### PR DESCRIPTION
Expand editor completion with directive option values, scoped request and environment names, and filesystem paths. Accepting a suggestion opens the next relevant choices, while Ctrl+N opens completion at the caret in insert mode.