### PR TITLE
RST-353: strutured vars err

### DIFF
--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2466,7 +2466,7 @@ resterm collection export --workspace ./api --out ./shared/api-bundle
 
 ### Editor diagnostics
 
-Diagnostics are enabled by default for `.http`, `.rest`, and unnamed request buffers. They show the parser's existing warnings and errors, such as unknown directives, mistyped option keys, missing values, and conflicting options. Diagnostics refresh when you leave insert mode, without saving the buffer or changing the active request. They do not refresh while you type, even if you pause. Existing markings stay until an edit invalidates their source ranges, then clear until you return to normal mode. Changes made in normal mode, such as undo or deletion, use a short debounce.
+Diagnostics are enabled by default for `.http`, `.rest`, and unnamed request buffers. They show the parser's existing warnings and errors, such as unknown directives, mistyped option keys, missing values, conflicting options, and placeholders such as `{{token}` that never close. Diagnostics refresh when you leave insert mode, without saving the buffer or changing the active request. They do not refresh while you type, even if you pause. Existing markings stay until an edit invalidates their source ranges, then clear until you return to normal mode. Changes made in normal mode, such as undo or deletion, use a short debounce.
 
 `K` (Shift+K) in normal mode opens a popup beside the cursor with diagnostics on that line. Findings under the cursor appear first; errors take priority over warnings. `Enter` opens related documentation when available, `PgUp` / `PgDown` scroll long messages, and `Esc` or cursor movement closes the popup. On a line without diagnostics, `K` opens contextual help as before. In insert mode, `K` types normally.
 
@@ -2645,7 +2645,8 @@ Open one in Resterm, switch to the appropriate environment (`resterm.env.json`),
 ## Troubleshooting & Tips
 
 - Use `Ctrl+P` to force a reparse if the navigator seems out of sync with editor changes.
-- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, expanded bodies, gRPC targets and messages, and WebSocket steps. Explain previews keep the placeholder intact and list the unresolved names.
+- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, expanded bodies, gRPC targets and messages, and WebSocket steps. Errors in the URL, headers, and inline or file bodies name the variable and point at the placeholder with its file, line, and column, and the TUI quotes the line. Explain previews keep the placeholder intact and list the unresolved names.
+- A placeholder that never closes, such as `{{token}`, is sent as literal text. The editor diagnostics warn about it before you send.
 - Combine `@capture request ...` with test scripts to assert on response headers without cluttering file/global scopes.
 - Inline curl import works best with single commands. Complex shell pipelines may need manual cleanup.
 - `Ctrl+Shift+V` pins the focused response pane, which is useful for comparing the last good response with the current attempt.

--- a/docs/resterm.md
+++ b/docs/resterm.md
@@ -2645,7 +2645,7 @@ Open one in Resterm, switch to the appropriate environment (`resterm.env.json`),
 ## Troubleshooting & Tips
 
 - Use `Ctrl+P` to force a reparse if the navigator seems out of sync with editor changes.
-- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, expanded bodies, gRPC targets and messages, and WebSocket steps. Errors in the URL, headers, and inline or file bodies name the variable and point at the placeholder with its file, line, and column, and the TUI quotes the line. Explain previews keep the placeholder intact and list the unresolved names.
+- If a template fails to expand (undefined variable), Resterm blocks the send and reports the missing variable. This covers URLs, query parameters, headers, auth values, expanded bodies, gRPC targets and messages, and WebSocket steps. Errors in the URL, headers, and inline or file bodies name the variable and point at the placeholder with its file, line, and column, and the TUI quotes the line. A failing `{{= ... }}` expression keeps its script diagnostics and points at the expression. Explain previews keep the placeholder intact and list the unresolved names.
 - A placeholder that never closes, such as `{{token}`, is sent as literal text. The editor diagnostics warn about it before you send.
 - Combine `@capture request ...` with test scripts to assert on response headers without cluttering file/global scopes.
 - Inline curl import works best with single commands. Complex shell pipelines may need manual cleanup.

--- a/internal/diag/chain.go
+++ b/internal/diag/chain.go
@@ -99,10 +99,24 @@ func (s *chainState) entries(err error, depth int) []ChainEntry {
 
 	if wrapped, ok := err.(errUnwrapper); ok {
 		if child := wrapped.Unwrap(); child != nil {
-			return s.entries(child, depth+1)
+			return s.wrapperChain(err, child, depth)
 		}
 	}
 	return leafChain(err, s)
+}
+
+func (s *chainState) wrapperChain(err, child error, depth int) []ChainEntry {
+	msg, cause := err.Error(), child.Error()
+	if msg == cause {
+		return s.entries(child, depth+1)
+	}
+	if op, ok := strings.CutSuffix(msg, ": "+cause); ok && cause != "" {
+		return s.typedWrapper(ChainOperation, classify(err), op, child, depth)
+	}
+	if s.shouldSkip(msg) {
+		return nil
+	}
+	return []ChainEntry{{Class: classify(err), Kind: ChainCause, Message: msg}}
 }
 
 func (s *chainState) typedWrapper(

--- a/internal/diag/redact.go
+++ b/internal/diag/redact.go
@@ -1,14 +1,15 @@
 package diag
 
-// Redact masks diagnostic text without changing the original report or its
-// source excerpt. Spans refer to the caller's source and would become invalid
-// if that text were rewritten.
+// Redact masks diagnostic text and source excerpts in a copy of the report.
+// Source lines may contain secrets outside the failing span.
 func (r Report) Redact(mask func(string) string) Report {
 	if mask == nil {
 		return r
 	}
+	r.Source = redactSource(r.Source, mask)
 	r.Items = redactEach(r.Items, func(d Diagnostic) Diagnostic {
 		d.Message = mask(d.Message)
+		d.Source = redactSource(d.Source, mask)
 		d.Span = redactSpan(d.Span, mask)
 		d.Labels = redactEach(d.Labels, func(l Label) Label {
 			l.Message = mask(l.Message)
@@ -36,6 +37,13 @@ func redactChain(src []ChainEntry, mask func(string) string) []ChainEntry {
 		e.Children = redactChain(e.Children, mask)
 		return e
 	})
+}
+
+func redactSource(src []byte, mask func(string) string) []byte {
+	if len(src) == 0 {
+		return src
+	}
+	return []byte(mask(string(src)))
 }
 
 func redactSpan(s Span, mask func(string) string) Span {

--- a/internal/directive/continuation.go
+++ b/internal/directive/continuation.go
@@ -26,6 +26,14 @@ func (n Name) Continuation() Continuation {
 	return spec.Continues
 }
 
+func (n Name) ScriptArgs() bool {
+	switch n.Continuation() {
+	case ContinueExpr, ContinueCapture:
+		return true
+	}
+	return false
+}
+
 // UnclosedError reports a directive argument with a missing delimiter.
 type UnclosedError struct {
 	Directive Name

--- a/internal/directive/spec_test.go
+++ b/internal/directive/spec_test.go
@@ -115,6 +115,26 @@ func TestNameContinuation(t *testing.T) {
 	}
 }
 
+func TestNameScriptArgs(t *testing.T) {
+	tests := map[Name]bool{
+		Assert:       true,
+		When:         true,
+		Capture:      true,
+		Patch:        true,
+		Match:        false,
+		Auth:         false,
+		RequestName:  false,
+		Name("void"): false,
+	}
+	for name, want := range tests {
+		t.Run(name.String(), func(t *testing.T) {
+			if got := name.ScriptArgs(); got != want {
+				t.Fatalf("%s script args = %v, want %v", name.Tag(), got, want)
+			}
+		})
+	}
+}
+
 func TestSpecsContinueOnlyWithStructuredArguments(t *testing.T) {
 	for _, spec := range Specs() {
 		if spec.Continues == ContinueNone {

--- a/internal/engine/request/engine.go
+++ b/internal/engine/request/engine.go
@@ -187,6 +187,7 @@ func (e *Engine) ExecuteWith(
 	res := xexec.RunRequest(flow{ctx: x})
 	end := time.Now()
 	res.Timing = requestTiming(start, end, res)
+	res.Err = e.withSource(res.Err, doc)
 	res = e.redactResult(res, doc, env)
 	if opt.Record {
 		e.record(doc, req, runResult{

--- a/internal/engine/request/expr_position_test.go
+++ b/internal/engine/request/expr_position_test.go
@@ -1,0 +1,53 @@
+package request
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
+	engcfg "github.com/unkn0wn-root/resterm/internal/engine"
+	"github.com/unkn0wn-root/resterm/internal/parser"
+	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
+)
+
+// A failing expression keeps its script report and points at the expression
+// inside the body, past the comment line the parser drops.
+func TestExecuteReportsExpressionErrorAtItsPlaceholder(t *testing.T) {
+	client := httpx.NewClientWithOptions(
+		httpx.WithHTTPFactory(func(httpx.Options) (*http.Client, error) {
+			t.Fatal("transport must not be built")
+			return nil, nil
+		}),
+	)
+	eng := New(engcfg.Config{Client: client, SourceDiagnostics: true}, nil)
+	src := "### Users\n" +
+		"POST https://example.com/users\n" +
+		"\n" +
+		"{\n" +
+		"# note\n" +
+		"  \"id\": \"{{= nosuch.value }}\"\n" +
+		"}\n"
+	doc := parser.Parse("requests.http", []byte(src))
+
+	res, err := eng.ExecuteWith(doc, doc.Requests[0], testEnv(""), ExecOptions{})
+	if err != nil {
+		t.Fatalf("ExecuteWith() error = %v", err)
+	}
+	if res.Err == nil {
+		t.Fatal("expected an expression error")
+	}
+
+	got := diag.Render(res.Err)
+	for _, want := range []string{
+		"error[script]: ",
+		"--> requests.http:6:14\n",
+		"6 |   \"id\": \"{{= nosuch.value }}\"\n",
+		"| " + strings.Repeat(" ", 13) + "^",
+		"at requests.http:6:14 in {{= nosuch.value }}",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Render() missing %q in %q", want, got)
+		}
+	}
+}

--- a/internal/engine/request/expr_position_test.go
+++ b/internal/engine/request/expr_position_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/protocol/httpx"
 )
 
-// A failing expression keeps its script report and points at the expression
-// inside the body, past the comment line the parser drops.
 func TestExecuteReportsExpressionErrorAtItsPlaceholder(t *testing.T) {
 	client := httpx.NewClientWithOptions(
 		httpx.WithHTTPFactory(func(httpx.Options) (*http.Client, error) {

--- a/internal/engine/request/proto.go
+++ b/internal/engine/request/proto.go
@@ -136,7 +136,7 @@ func prepareGRPCRequest(
 	}
 
 	if res != nil {
-		target, err := res.ExpandTemplates(grpcReq.Target)
+		target, err := res.ExpandTemplatesAt(grpcReq.Target, req.URLPos())
 		if err != nil {
 			return diag.WrapAs(diag.ClassProtocol, err, "expand grpc target")
 		}
@@ -182,7 +182,7 @@ func prepareGRPCRequest(
 		}
 		for k, vs := range req.Headers {
 			for i, v := range vs {
-				out, err := res.ExpandTemplates(v)
+				out, err := res.ExpandTemplatesAt(v, req.HeaderPos(k, v))
 				if err != nil {
 					return diag.WrapAsf(diag.ClassProtocol, err, "expand header %s", k)
 				}
@@ -195,7 +195,7 @@ func prepareGRPCRequest(
 	if grpcReq.Target == "" {
 		return diag.New(diag.ClassProtocol, "grpc target not specified")
 	}
-	req.URL = grpcReq.Target
+	req.SetURL(grpcReq.Target)
 	return nil
 }
 

--- a/internal/engine/request/rts.go
+++ b/internal/engine/request/rts.go
@@ -354,7 +354,7 @@ func (e *Engine) evalRTSValue(
 	pos rts.Pos,
 ) (rts.Value, error) {
 	v, err := e.re.Eval(ctx, rt, expr, pos)
-	return v, e.rtsErr(err, doc)
+	return v, e.withSource(err, doc)
 }
 
 func (e *Engine) evalRTSAssert(
@@ -365,7 +365,7 @@ func (e *Engine) evalRTSAssert(
 	pos rts.Pos,
 ) (rts.Value, error) {
 	v, err := e.re.EvalAssertion(ctx, rt, expr, pos)
-	return v, e.rtsErr(err, doc)
+	return v, e.withSource(err, doc)
 }
 
 func (e *Engine) evalRTSString(
@@ -376,7 +376,7 @@ func (e *Engine) evalRTSString(
 	pos rts.Pos,
 ) (string, error) {
 	s, err := e.re.EvalStr(ctx, rt, expr, pos)
-	return s, e.rtsErr(err, doc)
+	return s, e.withSource(err, doc)
 }
 
 func (e *Engine) rtsEvalValue(ctx context.Context, in EvalInput) (rts.Value, error) {
@@ -1053,7 +1053,7 @@ func applyPatchMethod(req *restfile.Request, val *string) {
 
 func applyPatchURL(req *restfile.Request, val *string) {
 	if val != nil && req != nil {
-		req.URL = strings.TrimSpace(*val)
+		req.SetURL(strings.TrimSpace(*val))
 	}
 }
 
@@ -1069,7 +1069,7 @@ func applyPatchQuery(req *restfile.Request, q map[string]*string) error {
 	if err != nil {
 		return fmt.Errorf("invalid url after @apply: %w", err)
 	}
-	req.URL = out
+	req.SetURL(out)
 	return nil
 }
 
@@ -1095,9 +1095,7 @@ func applyPatchBody(req *restfile.Request, val *string) {
 	if req == nil || val == nil {
 		return
 	}
-	req.Body.FilePath = ""
-	req.Body.Text = *val
-	req.Body.GraphQL = nil
+	req.SetBodyText(*val)
 }
 
 func applyPatchAuth(req *restfile.Request, auth *restfile.AuthSpec, set bool) {

--- a/internal/engine/request/vars.go
+++ b/internal/engine/request/vars.go
@@ -130,7 +130,7 @@ func (e *Engine) rtsPosForLineCol(doc *restfile.Document, req *restfile.Request,
 	return ps
 }
 
-func (e *Engine) rtsErr(err error, doc *restfile.Document) error {
+func (e *Engine) withSource(err error, doc *restfile.Document) error {
 	if err == nil || !e.cfg.SourceDiagnostics {
 		return err
 	}
@@ -146,8 +146,8 @@ func canAttachSource(rep diag.Report, doc *restfile.Document) bool {
 	if doc == nil || len(doc.Raw) == 0 || len(rep.Items) == 0 {
 		return false
 	}
-	p := rep.Items[0].Span.Start.Path
-	return p == "" || p == doc.Path
+	start := rep.Items[0].Span.Start
+	return start.Line > 0 && (start.Path == "" || start.Path == doc.Path)
 }
 
 func (e *Engine) rtsBase(doc *restfile.Document, base string) string {

--- a/internal/parser/body.go
+++ b/internal/parser/body.go
@@ -60,7 +60,6 @@ func (b *documentBuilder) handleMultipartBodyLine(ln line) bool {
 		return false
 	}
 	b.request.http.AppendBodyLine(ln.no, ln.raw, ln.eol)
-	b.warnUnclosed(ln.raw, diag.Pos{Line: ln.no, Col: 1})
 	b.appendLine(ln.raw)
 	return true
 }
@@ -161,7 +160,6 @@ func (b *documentBuilder) handleBodyLine(ln line) {
 		return
 	}
 	b.request.http.AppendBodyLine(ln.no, ln.raw, ln.eol)
-	b.warnUnclosed(ln.raw, diag.Pos{Line: ln.no, Col: 1})
 }
 
 func (b *documentBuilder) locateURL(ln line, col int) {

--- a/internal/parser/body.go
+++ b/internal/parser/body.go
@@ -288,5 +288,5 @@ func (r *requestBuilder) applyHTTPBody(req *restfile.Request) {
 	if mime := r.http.MimeType(); mime != "" {
 		req.Body.MimeType = mime
 	}
-	req.Body.Line = r.http.BodyLine()
+	req.Body.Lines = r.http.BodyLines()
 }

--- a/internal/parser/body.go
+++ b/internal/parser/body.go
@@ -3,7 +3,9 @@ package parser
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/http/version"
@@ -36,7 +38,7 @@ func (b *documentBuilder) handleBlankLine(ln line) bool {
 		return true
 	}
 
-	b.request.http.AppendBodyLine("", ln.eol)
+	b.request.http.AppendBodyLine(ln.no, "", ln.eol)
 	b.appendLine(ln.raw)
 	return true
 }
@@ -57,7 +59,8 @@ func (b *documentBuilder) handleMultipartBodyLine(ln line) bool {
 		!b.request.multipart.bodyLine(ln.text) {
 		return false
 	}
-	b.request.http.AppendBodyLine(ln.raw, ln.eol)
+	b.request.http.AppendBodyLine(ln.no, ln.raw, ln.eol)
+	b.warnUnclosed(ln.raw, diag.Pos{Line: ln.no, Col: 1})
 	b.appendLine(ln.raw)
 	return true
 }
@@ -72,12 +75,14 @@ func (b *documentBuilder) handleMethodLine(ln line) bool {
 		}
 
 		b.request.http.SetMethodAndURL(strings.ToUpper(fields[0]), target)
+		b.locateURL(ln, urlCol(ln.raw, true))
 		b.request.grpc.SetTarget(target)
 		b.appendLine(ln.raw)
 		return true
 	}
 
 	ml, ok, err := httpbuilder.ParseMethodLine(ln.raw)
+	hasMethod := ok
 	if !ok && err == nil {
 		ml, ok, err = httpbuilder.ParseWebSocketURLLine(ln.raw)
 	}
@@ -90,6 +95,7 @@ func (b *documentBuilder) handleMethodLine(ln line) bool {
 		b.ensureRequest(ln.no)
 
 		b.request.http.SetMethodAndURL(ml.Method, ml.URL)
+		b.locateURL(ln, urlCol(ln.raw, hasMethod))
 		b.request.settings = version.SetIfMissing(b.request.settings, ml.Version)
 		b.appendLine(ln.raw)
 		return true
@@ -105,11 +111,13 @@ func (b *documentBuilder) handleHeaderLine(ln line) bool {
 	if before, after, ok := strings.Cut(ln.raw, ":"); ok {
 		headerName := strings.TrimSpace(before)
 		headerValue := strings.TrimSpace(after)
+		valueCol := len(ln.raw) - len(str.TrimLeft(after)) + 1
 		// A valid header must win before a GraphQL or gRPC raw-block collector.
 		// Both protocols accept arbitrary body lines, so offering the line to
 		// them first used to swallow valid gRPC headers as protobuf JSON.
 		if header.Valid(headerName) {
-			b.request.http.AddHeader(headerName, headerValue)
+			b.request.http.AddHeader(headerName, headerValue, ln.no, valueCol)
+			b.warnUnclosed(headerValue, diag.Pos{Line: ln.no, Col: valueCol})
 			b.appendLine(ln.raw)
 			return true
 		}
@@ -127,7 +135,7 @@ func (b *documentBuilder) handleHeaderLine(ln line) bool {
 		// the request stays what the file says.
 		b.addError(ln.no, fmt.Sprintf("header name %q is not an HTTP field name", headerName))
 		if headerName != "" {
-			b.request.http.AddHeader(headerName, headerValue)
+			b.request.http.AddHeader(headerName, headerValue, ln.no, valueCol)
 		}
 	} else if b.request.protoBodyLine(ln.raw) {
 		// A feature collecting a raw block takes non-header lines before the
@@ -152,7 +160,27 @@ func (b *documentBuilder) handleBodyLine(ln line) {
 		b.request.http.SetBodyFromFile(file)
 		return
 	}
-	b.request.http.AppendBodyLine(ln.raw, ln.eol)
+	b.request.http.AppendBodyLine(ln.no, ln.raw, ln.eol)
+	b.warnUnclosed(ln.raw, diag.Pos{Line: ln.no, Col: 1})
+}
+
+func (b *documentBuilder) locateURL(ln line, col int) {
+	b.request.http.SetURLPos(ln.no, col)
+	if col > 0 {
+		b.warnUnclosed(ln.raw[col-1:], diag.Pos{Line: ln.no, Col: col})
+	}
+}
+
+func urlCol(raw string, afterMethod bool) int {
+	rest := str.TrimLeft(raw)
+	if afterMethod {
+		i := strings.IndexFunc(rest, unicode.IsSpace)
+		if i < 0 {
+			return 0
+		}
+		rest = str.TrimLeft(rest[i:])
+	}
+	return len(raw) - len(rest) + 1
 }
 
 func parseHTTPBodyFile(line string, forceInline bool) (string, bool) {
@@ -260,4 +288,5 @@ func (r *requestBuilder) applyHTTPBody(req *restfile.Request) {
 	if mime := r.http.MimeType(); mime != "" {
 		req.Body.MimeType = mime
 	}
+	req.Body.Line = r.http.BodyLine()
 }

--- a/internal/parser/builder/http/builder.go
+++ b/internal/parser/builder/http/builder.go
@@ -203,7 +203,6 @@ func (b *Builder) AppendBodyLine(no int, text, term string) {
 	b.bodyLines = append(b.bodyLines, bodyLine{no: no, text: text, term: term})
 }
 
-// BodyLines lists the source line of each body line.
 func (b *Builder) BodyLines() []int {
 	if len(b.bodyLines) == 0 {
 		return nil

--- a/internal/parser/builder/http/builder.go
+++ b/internal/parser/builder/http/builder.go
@@ -116,6 +116,7 @@ func hasScheme(url string, schemes []string) bool {
 }
 
 type bodyLine struct {
+	no   int
 	text string
 	term string
 }
@@ -129,7 +130,6 @@ type Builder struct {
 	headerLines  []restfile.HeaderLine
 	headerDone   bool
 	bodyLines    []bodyLine
-	bodyLine     int
 	bodyFromFile string
 	mimeType     string
 }
@@ -199,15 +199,20 @@ func (b *Builder) MarkHeadersDone() {
 	b.headerDone = true
 }
 
-func (b *Builder) AppendBodyLine(line int, text, term string) {
-	if len(b.bodyLines) == 0 {
-		b.bodyLine = line
-	}
-	b.bodyLines = append(b.bodyLines, bodyLine{text: text, term: term})
+func (b *Builder) AppendBodyLine(no int, text, term string) {
+	b.bodyLines = append(b.bodyLines, bodyLine{no: no, text: text, term: term})
 }
 
-func (b *Builder) BodyLine() int {
-	return b.bodyLine
+// BodyLines lists the source line of each body line.
+func (b *Builder) BodyLines() []int {
+	if len(b.bodyLines) == 0 {
+		return nil
+	}
+	lines := make([]int, len(b.bodyLines))
+	for i, ln := range b.bodyLines {
+		lines[i] = ln.no
+	}
+	return lines
 }
 
 func (b *Builder) SetBodyFromFile(path string) {

--- a/internal/parser/builder/http/builder.go
+++ b/internal/parser/builder/http/builder.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/unkn0wn-root/resterm/internal/http/version"
+	"github.com/unkn0wn-root/resterm/internal/restfile"
 	str "github.com/unkn0wn-root/resterm/internal/util"
 )
 
@@ -122,9 +123,13 @@ type bodyLine struct {
 type Builder struct {
 	method       string
 	url          string
+	urlLine      int
+	urlCol       int
 	headers      stdhttp.Header
+	headerLines  []restfile.HeaderLine
 	headerDone   bool
 	bodyLines    []bodyLine
+	bodyLine     int
 	bodyFromFile string
 	mimeType     string
 }
@@ -154,6 +159,14 @@ func (b *Builder) URL() string {
 	return b.url
 }
 
+func (b *Builder) SetURLPos(line, col int) {
+	b.urlLine, b.urlCol = line, col
+}
+
+func (b *Builder) URLPos() (line, col int) {
+	return b.urlLine, b.urlCol
+}
+
 func (b *Builder) Headers() stdhttp.Header {
 	if b.headers == nil {
 		b.headers = make(stdhttp.Header)
@@ -165,12 +178,17 @@ func (b *Builder) HeaderMap() stdhttp.Header {
 	return b.headers
 }
 
-func (b *Builder) AddHeader(name, value string) {
+func (b *Builder) AddHeader(name, value string, line, col int) {
 	headers := b.Headers()
 	headers.Add(name, value)
+	b.headerLines = append(b.headerLines, restfile.HeaderLine{Name: name, Value: value, Line: line, Col: col})
 	if strings.EqualFold(name, "Content-Type") {
 		b.mimeType = value
 	}
+}
+
+func (b *Builder) HeaderLines() []restfile.HeaderLine {
+	return b.headerLines
 }
 
 func (b *Builder) HeaderDone() bool {
@@ -181,8 +199,15 @@ func (b *Builder) MarkHeadersDone() {
 	b.headerDone = true
 }
 
-func (b *Builder) AppendBodyLine(text, term string) {
+func (b *Builder) AppendBodyLine(line int, text, term string) {
+	if len(b.bodyLines) == 0 {
+		b.bodyLine = line
+	}
 	b.bodyLines = append(b.bodyLines, bodyLine{text: text, term: term})
+}
+
+func (b *Builder) BodyLine() int {
+	return b.bodyLine
 }
 
 func (b *Builder) SetBodyFromFile(path string) {

--- a/internal/parser/diagnostics.go
+++ b/internal/parser/diagnostics.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/rts"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -17,14 +18,42 @@ func (b *documentBuilder) warnUnclosed(text string, start diag.Pos) {
 	}
 }
 
+// Scan the full body because placeholders can span lines.
+// Skip warnings for bodies whose builders do not record source lines.
+func (b *documentBuilder) warnUnclosedBody(req *restfile.Request) {
+	for _, u := range vars.UnclosedPlaceholdersLocated(req.Body.Text, req.LocateBody) {
+		if u.Span.Start.Line <= 0 {
+			continue
+		}
+		b.pushWarning(restfile.ParseDiagnostic{Message: unclosedMessage(u), Span: u.Span})
+	}
+}
+
 func (b *documentBuilder) warnUnclosedArgs(d parsedDirective) {
-	for _, u := range vars.UnclosedPlaceholders(d.Args, diag.Pos{}) {
+	for _, u := range d.unclosedPlaceholders() {
 		item := restfile.ParseDiagnostic{Message: unclosedMessage(u), Span: d.nameSpan}
 		if span, ok := d.argumentSpan(u.Off, u.Off+len(u.Text)); ok {
 			item.Span = span
 		}
 		b.pushWarning(item)
 	}
+}
+
+func (d parsedDirective) unclosedPlaceholders() []vars.Unclosed {
+	args := d.Args
+	if d.scriptArgs() {
+		args = rts.MaskText(args)
+	}
+	return vars.UnclosedPlaceholders(args, diag.Pos{})
+}
+
+// Template captures expand placeholders even inside quotes.
+func (d parsedDirective) scriptArgs() bool {
+	if d.Name == directive.Capture {
+		_, _, expr := cutCapture(d.Args)
+		return captureMode(expr) == restfile.CaptureExprModeRTS
+	}
+	return d.Name.ScriptArgs()
 }
 
 func unclosedMessage(u vars.Unclosed) string {

--- a/internal/parser/diagnostics.go
+++ b/internal/parser/diagnostics.go
@@ -8,7 +8,28 @@ import (
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
+
+func (b *documentBuilder) warnUnclosed(text string, start diag.Pos) {
+	for _, u := range vars.UnclosedPlaceholders(text, start) {
+		b.pushWarning(restfile.ParseDiagnostic{Message: unclosedMessage(u), Span: u.Span})
+	}
+}
+
+func (b *documentBuilder) warnUnclosedArgs(d parsedDirective) {
+	for _, u := range vars.UnclosedPlaceholders(d.Args, diag.Pos{}) {
+		item := restfile.ParseDiagnostic{Message: unclosedMessage(u), Span: d.nameSpan}
+		if span, ok := d.argumentSpan(u.Off, u.Off+len(u.Text)); ok {
+			item.Span = span
+		}
+		b.pushWarning(item)
+	}
+}
+
+func unclosedMessage(u vars.Unclosed) string {
+	return "placeholder " + u.Text + " is not closed with }}"
+}
 
 func Diagnostics(doc *restfile.Document) diag.Report {
 	rep := diag.Report{Path: doc.Path, Source: doc.Raw}

--- a/internal/parser/diagnostics_test.go
+++ b/internal/parser/diagnostics_test.go
@@ -1,12 +1,14 @@
 package parser
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/directive"
+	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
 func TestDiagnosticSourceSpans(t *testing.T) {
@@ -166,5 +168,107 @@ func BenchmarkDiagnostics(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		Diagnostics(Parse("large.http", source))
+	}
+}
+
+func TestUnclosedPlaceholderWarnings(t *testing.T) {
+	for _, tt := range []struct {
+		name, source string
+		want         []string // "line:marked text" for each warning
+	}{
+		{
+			name:   "request line",
+			source: "GET http://x/{{id}",
+			want:   []string{"1:{{id}"},
+		},
+		{
+			name:   "header value",
+			source: "GET http://x\nAuthorization: Bearer {{tok}",
+			want:   []string{"2:{{tok}"},
+		},
+		{
+			name:   "variable value",
+			source: "@a = {{b}\nGET http://x",
+			want:   []string{"1:{{b}"},
+		},
+		{
+			name:   "directive argument",
+			source: "GET http://x\n# @auth bearer {{tok}",
+			want:   []string{"2:{{tok}"},
+		},
+		{
+			name:   "body line, comments dropped from the body",
+			source: "POST http://x\n\n{\n# note\n  \"a\": \"{{tok}\"\n}",
+			want:   []string{"5:{{tok}"},
+		},
+		{
+			name:   "two on one body line",
+			source: "POST http://x\n\n{\"a\":\"{{x}\",\"b\":\"{{y}\"}",
+			want:   []string{"3:{{x}", "3:{{y}"},
+		},
+		{
+			name:   "multipart part",
+			source: "POST http://x\nContent-Type: multipart/form-data; boundary=b\n\n--b\nx: {{y}\n--b--",
+			want:   []string{"5:{{y}"},
+		},
+		{
+			name:   "placeholder spanning body lines",
+			source: "@tok = 1\n\nPOST http://x\n\n{\n  \"a\": \"{{\ntok\n}}\"\n}",
+		},
+		{
+			name:   "opening never closed anywhere in the body",
+			source: "POST http://x\n\n{\n  \"a\": \"{{\ntok\n\"\n}",
+			want:   []string{"4:{{"},
+		},
+		{
+			name:   "braces quoted in a script argument",
+			source: "GET http://x\n# @assert contains(\"{{\", \"{\")",
+		},
+		{
+			// Balance the braces so the parser accepts the complete directive.
+			name:   "script argument outside its strings",
+			source: "GET http://x\n# @assert contains(\"{{\", \"{\") && {{tok} == 1 }",
+			want:   []string{"2:{{tok}"},
+		},
+		{
+			name:   "quoted value of a plain argument",
+			source: "GET http://x\n# @auth bearer \"{{tok}\"",
+			want:   []string{"2:{{tok}"},
+		},
+		{
+			name:   "braces in a script comment",
+			source: "GET http://x\n# @assert true # {{bad}",
+		},
+		{
+			name:   "braces quoted in an RTS capture",
+			source: "GET http://x\n# @capture request x = json(\"{{\")",
+		},
+		{
+			name:   "quoted braces in a template capture",
+			source: "GET http://x\n# @capture request x {{response.status}} \"{{bad}\"",
+			want:   []string{"2:{{bad}"},
+		},
+		{
+			name:   "gRPC message",
+			source: "# @grpc pkg.Svc/M\nGRPC localhost:50051\n\n{\n  \"a\": \"{{tok}\"\n}",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := Parse("test.http", []byte(tt.source))
+			if len(doc.Errors) != 0 {
+				t.Fatalf("errors = %+v", doc.Errors)
+			}
+			var got []string
+			for _, item := range doc.Warnings {
+				marked := sourceSpanText(t, tt.source, item.Span)
+				if want := unclosedMessage(vars.Unclosed{Text: marked}); item.Message != want {
+					t.Fatalf("warning %q does not name what it marks, want %q", item.Message, want)
+				}
+				got = append(got, fmt.Sprintf("%d:%s", item.Span.Start.Line, marked))
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("warnings = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/parser/dispatch.go
+++ b/internal/parser/dispatch.go
@@ -84,6 +84,9 @@ func (b *documentBuilder) routeDirective(d parsedDirective) directiveOutcome {
 		b.warn(d, ignoredDirectiveWarning(d.Call))
 		return out
 	}
+	if out == directiveApplied {
+		b.warnUnclosedArgs(d)
+	}
 	if out == directiveApplied && d.Name.ValueRequired() && !directive.HasValue(d.Args) {
 		return b.reject(d, d.Spelling.Tag()+" value missing")
 	}

--- a/internal/parser/document.go
+++ b/internal/parser/document.go
@@ -255,6 +255,7 @@ func (b *documentBuilder) flushRequest(_ int) {
 	b.finalizeRetry()
 
 	req := b.request.build()
+	b.warnUnclosedBody(req)
 	b.lintRequestCaptures(req)
 	b.lintRequestPolicies(req)
 	if req.Method != "" && req.URL != "" {

--- a/internal/parser/metadata.go
+++ b/internal/parser/metadata.go
@@ -287,18 +287,21 @@ func (b *documentBuilder) parseCaptureDirective(d parsedDirective) (restfile.Cap
 		b.warn(d, "@capture missing expression after capture name")
 		return restfile.CaptureSpec{}, false
 	}
-	mode := restfile.CaptureExprModeRTS
-	if capture.HasUnquotedTemplateMarker(expression) {
-		mode = restfile.CaptureExprModeTemplate
-	}
 	return restfile.CaptureSpec{
 		Scope:      scope,
 		Name:       name,
 		Expression: expression,
-		Mode:       mode,
+		Mode:       captureMode(expression),
 		Secret:     secret,
 		Line:       d.lines.Start,
 	}, true
+}
+
+func captureMode(expr string) restfile.CaptureExprMode {
+	if capture.HasUnquotedTemplateMarker(expr) {
+		return restfile.CaptureExprModeTemplate
+	}
+	return restfile.CaptureExprModeRTS
 }
 
 func cutCapture(rest string) (scope, name, expr string) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -4904,3 +4904,24 @@ func TestHeaderNameThatIsNotAFieldNameIsReported(t *testing.T) {
 		t.Error("the reported header was dropped, want the request to match the file")
 	}
 }
+
+// Comment lines are dropped from the body, so the body's lines are not
+// adjacent in the file. Each retained line keeps its own source line.
+func TestParseBodyLinesSkipComments(t *testing.T) {
+	src := "POST https://example.com\n\n{\n# note\n  \"token\": \"{{auth.token}}\"\n}\n"
+	doc := Parse("requests.http", []byte(src))
+	req := doc.Requests[0]
+
+	if want := "{\n  \"token\": \"{{auth.token}}\"\n}"; req.Body.Text != want {
+		t.Fatalf("body = %q, want %q", req.Body.Text, want)
+	}
+	if want := []int{3, 5, 6}; !reflect.DeepEqual(req.Body.Lines, want) {
+		t.Fatalf("body lines = %v, want %v", req.Body.Lines, want)
+	}
+	if pos := req.LocateBody(2, 13); pos.Path != "requests.http" || pos.Line != 5 || pos.Col != 13 {
+		t.Fatalf("LocateBody(2, 13) = %+v, want requests.http:5:13", pos)
+	}
+	if pos := req.LocateBody(4, 1); pos.Line != 0 {
+		t.Fatalf("LocateBody past the body = %+v, want zero", pos)
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -4905,8 +4905,6 @@ func TestHeaderNameThatIsNotAFieldNameIsReported(t *testing.T) {
 	}
 }
 
-// Comment lines are dropped from the body, so the body's lines are not
-// adjacent in the file. Each retained line keeps its own source line.
 func TestParseBodyLinesSkipComments(t *testing.T) {
 	src := "POST https://example.com\n\n{\n# note\n  \"token\": \"{{auth.token}}\"\n}\n"
 	doc := Parse("requests.http", []byte(src))

--- a/internal/parser/request.go
+++ b/internal/parser/request.go
@@ -92,6 +92,7 @@ func (r *requestBuilder) build() *restfile.Request {
 
 	vars := append([]restfile.Variable(nil), r.variables...)
 
+	urlLine, urlCol := r.http.URLPos()
 	req := &restfile.Request{
 		Metadata:  r.metadata,
 		Method:    r.http.Method(),
@@ -106,6 +107,9 @@ func (r *requestBuilder) build() *restfile.Request {
 		},
 		SourcePath:   r.sourcePath,
 		OriginalText: strings.Join(r.originalLines, "\n"),
+		URLLine:      urlLine,
+		URLCol:       urlCol,
+		HeaderLines:  r.http.HeaderLines(),
 	}
 
 	appliedBody := false

--- a/internal/parser/variables.go
+++ b/internal/parser/variables.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
 	"github.com/unkn0wn-root/resterm/internal/vars"
@@ -35,6 +36,7 @@ func (b *documentBuilder) handleVariableLine(ln line) bool {
 		}
 	}
 	b.addScopedVariable(name, value, ln.no, scope, secret)
+	b.warnUnclosed(value, diag.Pos{Line: ln.no, Col: ln.indent + len(ln.text) - len(value) + 1})
 	b.appendLine(ln.raw)
 	return true
 }

--- a/internal/prerequest/prerequest.go
+++ b/internal/prerequest/prerequest.go
@@ -75,7 +75,7 @@ func Apply(req *restfile.Request, out Output) error {
 		req.Method = *out.Method
 	}
 	if out.URL != nil {
-		req.URL = *out.URL
+		req.SetURL(*out.URL)
 	}
 	if len(out.Query) > 0 {
 		if err := applyQuery(req, out.Query); err != nil {
@@ -84,9 +84,7 @@ func Apply(req *restfile.Request, out Output) error {
 	}
 	applyHeaders(req, out.Headers, out.HeaderDels)
 	if out.Body != nil {
-		req.Body.FilePath = ""
-		req.Body.Text = *out.Body
-		req.Body.GraphQL = nil
+		req.SetBodyText(*out.Body)
 	}
 	SetRequestVars(req, out.Variables)
 	return nil

--- a/internal/protocol/httpx/auth.go
+++ b/internal/protocol/httpx/auth.go
@@ -59,7 +59,7 @@ func ResolveAuth(
 		if value == "" || resolver == nil {
 			return vars.Expansion{Value: value}, nil
 		}
-		out, err := resolver.ExpandTemplatesResult(value)
+		out, err := resolver.ExpandTemplatesResultAt(value, auth.Pos())
 		if err != nil {
 			op := fmt.Sprintf("expand %s auth %s", kind, param)
 			if at := auth.Origin(); at != "" {

--- a/internal/protocol/httpx/body.go
+++ b/internal/protocol/httpx/body.go
@@ -18,13 +18,6 @@ type bodyPlan struct {
 	url string
 }
 
-func (p bodyPlan) effectiveURL(defaultURL string) string {
-	if p.url != "" {
-		return p.url
-	}
-	return defaultURL
-}
-
 func (c *Client) prepareBody(
 	req *restfile.Request,
 	resolver *vars.Resolver,
@@ -38,17 +31,18 @@ func (c *Client) prepareBody(
 
 	switch {
 	case req.Body.FilePath != "":
-		data, _, err := c.readFile(lookup, req.Body.FilePath, "body file")
+		data, path, err := c.readFile(lookup, req.Body.FilePath, "body file")
 		if err != nil {
 			return bodyPlan{}, err
 		}
 
 		if resolver != nil && req.Body.Options.ExpandTemplates {
-			text := string(data)
-			expanded, err := resolver.ExpandTemplates(text)
+			start := diag.Pos{Path: path, Line: 1, Col: 1}
+			expanded, err := resolver.ExpandTemplatesAt(string(data), start)
 			if err != nil {
-				return bodyPlan{}, diag.WrapAsf(diag.ClassProtocol, err,
+				return bodyPlan{}, diag.WrapAs(diag.ClassProtocol, err,
 					"expand body file templates",
+					diag.WithSource(path, data),
 				)
 			}
 
@@ -59,7 +53,7 @@ func (c *Client) prepareBody(
 		expanded := req.Body.Text
 		if resolver != nil {
 			var err error
-			expanded, err = resolver.ExpandTemplates(req.Body.Text)
+			expanded, err = resolver.ExpandTemplatesAt(req.Body.Text, req.BodyPos())
 			if err != nil {
 				return bodyPlan{}, diag.WrapAs(diag.ClassProtocol, err, "expand body template")
 			}

--- a/internal/protocol/httpx/body.go
+++ b/internal/protocol/httpx/body.go
@@ -53,7 +53,7 @@ func (c *Client) prepareBody(
 		expanded := req.Body.Text
 		if resolver != nil {
 			var err error
-			expanded, err = resolver.ExpandTemplatesAt(req.Body.Text, req.BodyPos())
+			expanded, err = resolver.ExpandTemplatesLocated(req.Body.Text, req.LocateBody)
 			if err != nil {
 				return bodyPlan{}, diag.WrapAs(diag.ClassProtocol, err, "expand body template")
 			}

--- a/internal/protocol/httpx/request_build.go
+++ b/internal/protocol/httpx/request_build.go
@@ -79,7 +79,7 @@ func (c *Client) prepareRequest(
 		resolver,
 		opts,
 		reader,
-		plan.effectiveURL(req.URL),
+		plan.url,
 	)
 	if err != nil {
 		return preparedHTTPRequest{options: effective, optionsSet: true}, err
@@ -131,11 +131,16 @@ func (c *Client) buildHTTPRequest(
 		)
 	}
 
+	urlPos := req.URLPos()
+	if urlOverride != "" {
+		urlPos = diag.Pos{}
+	}
 	target, err := resolveRequestTarget(
 		cmp.Or(urlOverride, req.URL),
 		opts.BaseURL,
 		resolver,
 		requestSchemeOf(req),
+		urlPos,
 	)
 	if err != nil {
 		return nil, opts, err
@@ -159,7 +164,7 @@ func (c *Client) buildHTTPRequest(
 			for _, value := range values {
 				finalValue := value
 				if resolver != nil {
-					expanded, expandErr := resolver.ExpandTemplates(value)
+					expanded, expandErr := resolver.ExpandTemplatesAt(value, req.HeaderPos(name, value))
 					if expandErr != nil {
 						op := "expand header " + name
 						if at := req.Origin(); at != "" {

--- a/internal/protocol/httpx/request_test.go
+++ b/internal/protocol/httpx/request_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/http/header"
 	"github.com/unkn0wn-root/resterm/internal/http/version"
 	"github.com/unkn0wn-root/resterm/internal/restfile"
@@ -567,5 +568,29 @@ func TestApplyAuthenticationLenientAPIKeyPlacement(t *testing.T) {
 				t.Fatalf("api key with unknown placement must not touch the query, got %q", got)
 			}
 		})
+	}
+}
+
+func TestBuildHTTPRequestLocatesBodyVariableAfterComment(t *testing.T) {
+	req := &restfile.Request{
+		Method:     "POST",
+		URL:        "https://example.com",
+		SourcePath: "requests.http",
+		Body: restfile.BodySource{
+			Text:  "{\n  \"token\": \"{{auth.token}}\"\n}",
+			Lines: []int{3, 5, 6},
+		},
+	}
+
+	_, _, _, err := NewClient(nil).BuildHTTPRequest(context.Background(), req, vars.NewResolver(), Options{})
+	if err == nil {
+		t.Fatal("expected an expansion error")
+	}
+	got := diag.Render(err)
+	want := "error[protocol]: undefined variable: auth.token\n" +
+		"--> requests.http:5:13\n" +
+		"expand body template"
+	if got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
 	}
 }

--- a/internal/protocol/httpx/target.go
+++ b/internal/protocol/httpx/target.go
@@ -33,8 +33,9 @@ func resolveRequestTarget(
 	rawTarget, rawBase string,
 	resolver *vars.Resolver,
 	scheme requestScheme,
+	pos diag.Pos,
 ) (string, error) {
-	target, err := expandURL(rawTarget, resolver, "url")
+	target, err := expandURL(rawTarget, resolver, "url", pos)
 	if err != nil {
 		return "", err
 	}
@@ -188,7 +189,7 @@ func (s requestScheme) apply(u *url.URL) error {
 // The base is read only once a target actually needs it, so an unset, unresolved
 // or invalid base-url never fails a request that already carries a full URL.
 func resolveBaseURL(raw string, resolver *vars.Resolver) (*url.URL, error) {
-	expanded, err := expandURL(raw, resolver, "base-url")
+	expanded, err := expandURL(raw, resolver, "base-url", diag.Pos{})
 	if err != nil {
 		return nil, err
 	}
@@ -217,11 +218,11 @@ func resolveBaseURL(raw string, resolver *vars.Resolver) (*url.URL, error) {
 	return base, nil
 }
 
-func expandURL(raw string, resolver *vars.Resolver, label string) (string, error) {
+func expandURL(raw string, resolver *vars.Resolver, label string, pos diag.Pos) (string, error) {
 	if resolver == nil {
 		return raw, nil
 	}
-	expanded, err := resolver.ExpandTemplates(raw)
+	expanded, err := resolver.ExpandTemplatesAt(raw, pos)
 	if err != nil {
 		return "", wrapTargetError(err, "expand "+label)
 	}

--- a/internal/protocol/httpx/target_matrix_test.go
+++ b/internal/protocol/httpx/target_matrix_test.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
 )
 
 // Generate combinations to check that a schemeless target never introduces
@@ -77,7 +79,7 @@ func TestResolveRequestTargetHostileTargets(t *testing.T) {
 func resolveChecked(t *testing.T, raw string) *url.URL {
 	t.Helper()
 
-	got, err := resolveRequestTarget(raw, "", nil, schemeHTTP)
+	got, err := resolveRequestTarget(raw, "", nil, schemeHTTP, diag.Pos{})
 	if err != nil {
 		return nil
 	}

--- a/internal/protocol/httpx/target_test.go
+++ b/internal/protocol/httpx/target_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/vars"
 )
 
@@ -130,7 +131,7 @@ func TestResolveRequestTargetRFCReferences(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveRequestTarget(tt.target, tt.base, nil, tt.scheme)
+			got, err := resolveRequestTarget(tt.target, tt.base, nil, tt.scheme, diag.Pos{})
 			if err != nil {
 				t.Fatalf("resolveRequestTarget() error = %v", err)
 			}
@@ -147,7 +148,7 @@ func TestResolveRequestTargetExpandsTargetAndBase(t *testing.T) {
 		"resource": "users/42",
 	}))
 
-	got, err := resolveRequestTarget("{{resource}}", "{{api}}", resolver, schemeHTTP)
+	got, err := resolveRequestTarget("{{resource}}", "{{api}}", resolver, schemeHTTP, diag.Pos{})
 	if err != nil {
 		t.Fatalf("resolveRequestTarget() error = %v", err)
 	}
@@ -196,7 +197,7 @@ func TestResolveRequestTargetExpandsBeforeFillingInScheme(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{"host": tt.host}))
-			got, err := resolveRequestTarget(tt.target, tt.base, resolver, schemeHTTP)
+			got, err := resolveRequestTarget(tt.target, tt.base, resolver, schemeHTTP, diag.Pos{})
 			if err != nil {
 				t.Fatalf("resolveRequestTarget() error = %v", err)
 			}
@@ -210,7 +211,7 @@ func TestResolveRequestTargetExpandsBeforeFillingInScheme(t *testing.T) {
 func TestResolveRequestTargetBareHostVariableNeedsBaseURL(t *testing.T) {
 	resolver := vars.NewResolver(vars.NewMapProvider("env", map[string]string{"host": "example.com"}))
 
-	_, err := resolveRequestTarget("{{host}}/users", "", resolver, schemeHTTP)
+	_, err := resolveRequestTarget("{{host}}/users", "", resolver, schemeHTTP, diag.Pos{})
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -240,7 +241,7 @@ func TestResolveRequestTargetPreservesAbsoluteURLs(t *testing.T) {
 				t.Fatalf("url.Parse(%q) error = %v", raw, err)
 			}
 
-			resolved, err := resolveRequestTarget(raw, "", nil, schemeHTTP)
+			resolved, err := resolveRequestTarget(raw, "", nil, schemeHTTP, diag.Pos{})
 			if err != nil {
 				t.Fatalf("resolveRequestTarget() error = %v", err)
 			}
@@ -288,7 +289,7 @@ func TestResolveRequestTargetValidatesBaseWhenNeeded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := resolveRequestTarget("users", tt.base, nil, schemeHTTP)
+			_, err := resolveRequestTarget("users", tt.base, nil, schemeHTTP, diag.Pos{})
 			if err == nil {
 				t.Fatal("expected an error")
 			}
@@ -397,6 +398,7 @@ func TestResolveRequestTargetReportsExpansionAndProtocolErrors(t *testing.T) {
 				tt.base,
 				tt.resolver,
 				tt.scheme,
+				diag.Pos{},
 			)
 			if err == nil {
 				t.Fatal("expected an error")

--- a/internal/restfile/auth.go
+++ b/internal/restfile/auth.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/directive"
 )
 
@@ -106,4 +107,11 @@ func cloneAuthParams(src map[string]string) map[string]string {
 	dst := make(map[string]string, len(src))
 	maps.Copy(dst, src)
 	return dst
+}
+
+func (a *AuthSpec) Pos() diag.Pos {
+	if a.Line <= 0 {
+		return diag.Pos{}
+	}
+	return diag.Pos{Path: a.SourcePath, Line: a.Line}
 }

--- a/internal/restfile/clone.go
+++ b/internal/restfile/clone.go
@@ -181,6 +181,7 @@ func cloneApplySpecs(src []ApplySpec) []ApplySpec {
 
 func cloneBodySource(src BodySource) BodySource {
 	src.GraphQL = clonePtr(src.GraphQL)
+	src.Lines = slices.Clone(src.Lines)
 	return src
 }
 

--- a/internal/restfile/clone.go
+++ b/internal/restfile/clone.go
@@ -17,6 +17,7 @@ func (req *Request) Clone() *Request {
 	dst.Headers = req.Headers.Clone()
 	dst.Settings = maps.Clone(req.Settings)
 	dst.Variables = slices.Clone(req.Variables)
+	dst.HeaderLines = slices.Clone(req.HeaderLines)
 	dst.Metadata = req.Metadata.Clone()
 	dst.Body = cloneBodySource(req.Body)
 	dst.GRPC = cloneGRPCRequest(req.GRPC)

--- a/internal/restfile/clone_test.go
+++ b/internal/restfile/clone_test.go
@@ -179,3 +179,14 @@ func TestDocumentCloneIsIndependent(t *testing.T) {
 		t.Fatal("mutating clone changed source document")
 	}
 }
+
+func TestRequestCloneCopiesBodyLines(t *testing.T) {
+	req := &Request{Body: BodySource{Text: "{}", Lines: []int{3}}}
+
+	dst := req.Clone()
+	dst.Body.Lines[0] = 9
+
+	if req.Body.Lines[0] != 3 {
+		t.Fatalf("clone shares body lines: %v", req.Body.Lines)
+	}
+}

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -97,8 +97,8 @@ type BodySource struct {
 	MimeType string
 	GraphQL  *GraphQLBody
 	Options  BodyOptions
-	// Lines holds the source line of each line of Text. Comment lines are
-	// dropped, so body lines need not be adjacent.
+	// Lines maps each line of Text to its original file line.
+	// Gaps come from removed comments.
 	Lines []int
 }
 
@@ -468,7 +468,6 @@ func (req *Request) URLPos() diag.Pos {
 	return diag.Pos{Path: req.SourcePath, Line: req.URLLine, Col: req.URLCol}
 }
 
-// LocateBody maps a line and column of the inline body text to the source.
 func (req *Request) LocateBody(line, col int) diag.Pos {
 	if line < 1 || line > len(req.Body.Lines) {
 		return diag.Pos{}

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -97,6 +97,14 @@ type BodySource struct {
 	MimeType string
 	GraphQL  *GraphQLBody
 	Options  BodyOptions
+	Line     int
+}
+
+type HeaderLine struct {
+	Name  string
+	Value string
+	Line  int
+	Col   int
 }
 
 // Scenarios that share a method and path merge into one route when compiled.
@@ -434,6 +442,9 @@ type Request struct {
 	LineRange    LineRange
 	SourcePath   string
 	OriginalText string
+	URLLine      int
+	URLCol       int
+	HeaderLines  []HeaderLine
 	GRPC         *GRPCRequest
 	SSE          *SSERequest
 	WebSocket    *WebSocketRequest
@@ -446,6 +457,39 @@ func (req *Request) Origin() string {
 		return ""
 	}
 	return origin(req.SourcePath, req.LineRange.Start)
+}
+
+func (req *Request) URLPos() diag.Pos {
+	if req.URLLine <= 0 {
+		return diag.Pos{}
+	}
+	return diag.Pos{Path: req.SourcePath, Line: req.URLLine, Col: req.URLCol}
+}
+
+func (req *Request) BodyPos() diag.Pos {
+	if req.Body.Line <= 0 {
+		return diag.Pos{}
+	}
+	return diag.Pos{Path: req.SourcePath, Line: req.Body.Line, Col: 1}
+}
+
+// Match by name and value because scripts can change or reorder headers.
+func (req *Request) HeaderPos(name, value string) diag.Pos {
+	for _, h := range req.HeaderLines {
+		if h.Value == value && strings.EqualFold(h.Name, name) {
+			return diag.Pos{Path: req.SourcePath, Line: h.Line, Col: h.Col}
+		}
+	}
+	return diag.Pos{}
+}
+
+func (req *Request) SetURL(url string) {
+	req.URL = url
+	req.URLLine, req.URLCol = 0, 0
+}
+
+func (req *Request) SetBodyText(text string) {
+	req.Body = BodySource{Text: text, MimeType: req.Body.MimeType, Options: req.Body.Options}
 }
 
 // RepeatUnsupported returns the protocol name when @poll or @retry cannot be used.

--- a/internal/restfile/types.go
+++ b/internal/restfile/types.go
@@ -97,7 +97,9 @@ type BodySource struct {
 	MimeType string
 	GraphQL  *GraphQLBody
 	Options  BodyOptions
-	Line     int
+	// Lines holds the source line of each line of Text. Comment lines are
+	// dropped, so body lines need not be adjacent.
+	Lines []int
 }
 
 type HeaderLine struct {
@@ -466,11 +468,12 @@ func (req *Request) URLPos() diag.Pos {
 	return diag.Pos{Path: req.SourcePath, Line: req.URLLine, Col: req.URLCol}
 }
 
-func (req *Request) BodyPos() diag.Pos {
-	if req.Body.Line <= 0 {
+// LocateBody maps a line and column of the inline body text to the source.
+func (req *Request) LocateBody(line, col int) diag.Pos {
+	if line < 1 || line > len(req.Body.Lines) {
 		return diag.Pos{}
 	}
-	return diag.Pos{Path: req.SourcePath, Line: req.Body.Line, Col: 1}
+	return diag.Pos{Path: req.SourcePath, Line: req.Body.Lines[line-1], Col: col}
 }
 
 // Match by name and value because scripts can change or reorder headers.

--- a/internal/rts/group.go
+++ b/internal/rts/group.go
@@ -1,37 +1,5 @@
 package rts
 
-import "bytes"
-
-// Mask replaces strings, comments, and nested groups with spaces while keeping
-// byte offsets intact. Top-level tokens remain so callers can find separators.
-func Mask(src string) string {
-	out := bytes.Repeat([]byte{' '}, len(src))
-	lx := NewLexer("", []byte(src))
-	depth := 0
-	for {
-		tok := lx.Next()
-		if tok.K == EOF {
-			return string(out)
-		}
-		var keep bool
-		switch tok.K {
-		case LPAREN, LBRACK, LBRACE:
-			keep = depth == 0
-			depth++
-		case RPAREN, RBRACK, RBRACE:
-			depth = max(depth-1, 0)
-			keep = depth == 0
-		case STRING, ILLEGAL, AUTO_SEMI:
-			continue
-		default:
-			keep = depth == 0
-		}
-		if keep {
-			copy(out[lx.start:lx.i], src[lx.start:lx.i])
-		}
-	}
-}
-
 // OpenGroup returns the delimiter for the innermost unclosed group in src.
 // Groups inside strings and comments are ignored.
 // A mismatched closer does not close a group.

--- a/internal/rts/group_test.go
+++ b/internal/rts/group_test.go
@@ -38,44 +38,6 @@ func TestOpenGroup(t *testing.T) {
 	}
 }
 
-func TestMask(t *testing.T) {
-	tests := []struct {
-		name string
-		src  string
-		want string
-	}{
-		{name: "empty"},
-		{name: "plain text is kept", src: "status == 200", want: "status == 200"},
-		{name: "string is hidden", src: `a == "b c"`, want: "a ==      "},
-		{name: "comment is hidden", src: "a == 1 # note", want: "a == 1       "},
-		{name: "group keeps its delimiters", src: "sum(1, 2) == 3", want: "sum(    ) == 3"},
-		{name: "nested group is hidden", src: "f(g(x)) as y", want: "f(    ) as y"},
-		{name: "separator survives a group", src: "f(a) => b", want: "f( ) => b"},
-		{name: "separator inside a group is hidden", src: "f(a => b)", want: "f(      )"},
-		{name: "separator inside a string is hidden", src: `f("=>") => c`, want: "f(    ) => c"},
-		{name: "open group hides the rest", src: "f(a, b", want: "f(    "},
-		{name: "stray closer is kept", src: "a ) b", want: "a ) b"},
-		{name: "line breaks go too", src: "f(\n  a\n) as x", want: "f(     ) as x"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := Mask(tt.src)
-			if got != tt.want {
-				t.Fatalf("Mask(%q) = %q, want %q", tt.src, got, tt.want)
-			}
-			if len(got) != len(tt.src) {
-				t.Fatalf("Mask(%q) length = %d, want %d", tt.src, len(got), len(tt.src))
-			}
-			for i := range got {
-				if got[i] != ' ' && got[i] != tt.src[i] {
-					t.Fatalf("Mask(%q)[%d] = %q, want %q", tt.src, i, got[i], tt.src[i])
-				}
-			}
-		})
-	}
-}
-
 func TestGroupScannerMatchesOpenGroup(t *testing.T) {
 	sources := []string{
 		"sum(1, 2)",

--- a/internal/rts/mask.go
+++ b/internal/rts/mask.go
@@ -1,0 +1,50 @@
+package rts
+
+import "bytes"
+
+// Mask hides strings, comments, and group contents with spaces.
+// Byte offsets stay the same, so callers can find top-level separators.
+func Mask(src string) string {
+	out := bytes.Repeat([]byte{' '}, len(src))
+	lx := NewLexer("", []byte(src))
+	depth := 0
+	for {
+		tok := lx.Next()
+		if tok.K == EOF {
+			return string(out)
+		}
+		var keep bool
+		switch tok.K {
+		case LPAREN, LBRACK, LBRACE:
+			keep = depth == 0
+			depth++
+		case RPAREN, RBRACK, RBRACE:
+			depth = max(depth-1, 0)
+			keep = depth == 0
+		case STRING, ILLEGAL, AUTO_SEMI:
+			continue
+		default:
+			keep = depth == 0
+		}
+		if keep {
+			copy(out[lx.start:lx.i], src[lx.start:lx.i])
+		}
+	}
+}
+
+// MaskText hides strings and comments with spaces, including line breaks.
+// It keeps code inside groups and preserves byte offsets.
+func MaskText(src string) string {
+	out := bytes.Repeat([]byte{' '}, len(src))
+	lx := NewLexer("", []byte(src))
+	for {
+		tok := lx.Next()
+		if tok.K == EOF {
+			return string(out)
+		}
+		if tok.K == STRING || tok.K == ILLEGAL || tok.K == AUTO_SEMI {
+			continue
+		}
+		copy(out[lx.start:lx.i], src[lx.start:lx.i])
+	}
+}

--- a/internal/rts/mask_test.go
+++ b/internal/rts/mask_test.go
@@ -1,0 +1,79 @@
+package rts
+
+import "testing"
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{name: "empty"},
+		{name: "plain text is kept", src: "status == 200", want: "status == 200"},
+		{name: "string is hidden", src: `a == "b c"`, want: "a ==      "},
+		{name: "comment is hidden", src: "a == 1 # note", want: "a == 1       "},
+		{name: "group keeps its delimiters", src: "sum(1, 2) == 3", want: "sum(    ) == 3"},
+		{name: "nested group is hidden", src: "f(g(x)) as y", want: "f(    ) as y"},
+		{name: "separator survives a group", src: "f(a) => b", want: "f( ) => b"},
+		{name: "separator inside a group is hidden", src: "f(a => b)", want: "f(      )"},
+		{name: "separator inside a string is hidden", src: `f("=>") => c`, want: "f(    ) => c"},
+		{name: "open group hides the rest", src: "f(a, b", want: "f(    "},
+		{name: "stray closer is kept", src: "a ) b", want: "a ) b"},
+		{name: "line breaks go too", src: "f(\n  a\n) as x", want: "f(     ) as x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Mask(tt.src)
+			if got != tt.want {
+				t.Fatalf("Mask(%q) = %q, want %q", tt.src, got, tt.want)
+			}
+			if len(got) != len(tt.src) {
+				t.Fatalf("Mask(%q) length = %d, want %d", tt.src, len(got), len(tt.src))
+			}
+			for i := range got {
+				if got[i] != ' ' && got[i] != tt.src[i] {
+					t.Fatalf("Mask(%q)[%d] = %q, want %q", tt.src, i, got[i], tt.src[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMaskText(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{name: "empty"},
+		{name: "plain text is kept", src: "status == 200", want: "status == 200"},
+		{name: "string is hidden", src: `contains("{{", "{")`, want: "contains(    ,    )"},
+		{name: "comment is hidden", src: "x == 1 # {{", want: "x == 1     "},
+		{name: "comment marker inside a string", src: `x == "# {{"`, want: "x ==       "},
+		{name: "quote inside a comment", src: `x == 1 # "{{`, want: "x == 1      "},
+		{name: "unterminated string is hidden", src: `x == "{{`, want: "x ==    "},
+		{name: "nested group is kept", src: "f(g(x)) as y", want: "f(g(x)) as y"},
+		{name: "braces outside a string are kept", src: `f("{{") && {{x}`, want: `f(    ) && {{x}`},
+		// RTS comments start with #; the parser removes directive comment prefixes.
+		{name: "no // comment", src: "x == 1 // {{", want: "x == 1 // {{"},
+		{name: "line breaks go too", src: "f(\n  a\n) as x", want: "f(   a ) as x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := MaskText(tt.src)
+			if got != tt.want {
+				t.Fatalf("MaskText(%q) = %q, want %q", tt.src, got, tt.want)
+			}
+			if len(got) != len(tt.src) {
+				t.Fatalf("MaskText(%q) length = %d, want %d", tt.src, len(got), len(tt.src))
+			}
+			for i := range got {
+				if got[i] != ' ' && got[i] != tt.src[i] {
+					t.Fatalf("MaskText(%q)[%d] = %q, want %q", tt.src, i, got[i], tt.src[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -358,8 +358,8 @@ func (r *Resolver) ExpandTemplatesAt(input string, pos ExprPos) (string, error) 
 	return CompileTemplate(input).render(r, pos, at(pos), true, true, nil)
 }
 
-// ExpandTemplatesLocated is ExpandTemplatesAt for input whose lines are not
-// adjacent in the source file, such as a body with its comments removed.
+// ExpandTemplatesLocated uses locate to find source positions when lines
+// have been removed from input, such as comments in a request body.
 func (r *Resolver) ExpandTemplatesLocated(input string, locate Locator) (string, error) {
 	return CompileTemplate(input).render(r, r.exprPos, locate, true, true, nil)
 }

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -211,7 +211,7 @@ func (r *Resolver) expandValue(
 
 	st.names[key] = true
 	st.stack = append(st.stack, name)
-	out, err := CompileTemplate(raw).render(r, pos, diag.Pos{}, allowDynamic, allowExpr, st)
+	out, err := CompileTemplate(raw).render(r, pos, nil, allowDynamic, allowExpr, st)
 	st.stack = st.stack[:len(st.stack)-1]
 	delete(st.names, key)
 
@@ -343,27 +343,33 @@ func providerLabel(p Provider) string {
 }
 
 func (r *Resolver) ExpandTemplates(input string) (string, error) {
-	return CompileTemplate(input).render(r, r.exprPos, diag.Pos{}, true, true, nil)
+	return CompileTemplate(input).render(r, r.exprPos, nil, true, true, nil)
 }
 
 // ExpandTemplatesResult expands input and reports whether resolution encountered
 // any undefined variables, including when a lenient resolver suppresses the error.
 func (r *Resolver) ExpandTemplatesResult(input string) (Expansion, error) {
-	return CompileTemplate(input).renderResult(r, r.exprPos, diag.Pos{}, true, true, nil)
+	return CompileTemplate(input).renderResult(r, r.exprPos, nil, true, true, nil)
 }
 
 // ExpandTemplatesAt uses pos as the start of input in the source file.
 // Without a column, errors point to the whole line.
 func (r *Resolver) ExpandTemplatesAt(input string, pos ExprPos) (string, error) {
-	return CompileTemplate(input).render(r, pos, pos, true, true, nil)
+	return CompileTemplate(input).render(r, pos, at(pos), true, true, nil)
+}
+
+// ExpandTemplatesLocated is ExpandTemplatesAt for input whose lines are not
+// adjacent in the source file, such as a body with its comments removed.
+func (r *Resolver) ExpandTemplatesLocated(input string, locate Locator) (string, error) {
+	return CompileTemplate(input).render(r, r.exprPos, locate, true, true, nil)
 }
 
 func (r *Resolver) ExpandTemplatesResultAt(input string, pos ExprPos) (Expansion, error) {
-	return CompileTemplate(input).renderResult(r, pos, pos, true, true, nil)
+	return CompileTemplate(input).renderResult(r, pos, at(pos), true, true, nil)
 }
 
 func (r *Resolver) ExpandTemplatesStatic(input string) (string, error) {
-	return CompileTemplate(input).render(r, r.exprPos, diag.Pos{}, false, false, nil)
+	return CompileTemplate(input).render(r, r.exprPos, nil, false, false, nil)
 }
 
 func (r *Resolver) SetTrace(tr *Trace) {
@@ -558,5 +564,5 @@ func ReplaceTemplateVars(input string, fn func(match, name string) string) strin
 	if fn == nil {
 		return input
 	}
-	return CompileTemplate(input).replace(func(seg tplSeg) string { return fn(seg.text, seg.name) })
+	return CompileTemplate(input).replace(func(seg tplSeg, _ int) string { return fn(seg.text, seg.name) })
 }

--- a/internal/vars/resolver.go
+++ b/internal/vars/resolver.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/unkn0wn-root/resterm/internal/diag"
 	"github.com/unkn0wn-root/resterm/internal/vars/dynamic"
 )
 
@@ -37,11 +38,7 @@ func providerValue(p Provider, name string) (Value, bool) {
 	return Value{Text: text}, ok
 }
 
-type ExprPos struct {
-	Path string
-	Line int
-	Col  int
-}
+type ExprPos = diag.Pos
 
 type ExprEval func(expr string, pos ExprPos) (string, error)
 
@@ -214,7 +211,7 @@ func (r *Resolver) expandValue(
 
 	st.names[key] = true
 	st.stack = append(st.stack, name)
-	out, err := CompileTemplate(raw).render(r, pos, allowDynamic, allowExpr, st)
+	out, err := CompileTemplate(raw).render(r, pos, diag.Pos{}, allowDynamic, allowExpr, st)
 	st.stack = st.stack[:len(st.stack)-1]
 	delete(st.names, key)
 
@@ -346,21 +343,27 @@ func providerLabel(p Provider) string {
 }
 
 func (r *Resolver) ExpandTemplates(input string) (string, error) {
-	return CompileTemplate(input).render(r, r.exprPos, true, true, nil)
+	return CompileTemplate(input).render(r, r.exprPos, diag.Pos{}, true, true, nil)
 }
 
 // ExpandTemplatesResult expands input and reports whether resolution encountered
 // any undefined variables, including when a lenient resolver suppresses the error.
 func (r *Resolver) ExpandTemplatesResult(input string) (Expansion, error) {
-	return CompileTemplate(input).renderResult(r, r.exprPos, true, true, nil)
+	return CompileTemplate(input).renderResult(r, r.exprPos, diag.Pos{}, true, true, nil)
 }
 
+// ExpandTemplatesAt uses pos as the start of input in the source file.
+// Without a column, errors point to the whole line.
 func (r *Resolver) ExpandTemplatesAt(input string, pos ExprPos) (string, error) {
-	return CompileTemplate(input).render(r, pos, true, true, nil)
+	return CompileTemplate(input).render(r, pos, pos, true, true, nil)
+}
+
+func (r *Resolver) ExpandTemplatesResultAt(input string, pos ExprPos) (Expansion, error) {
+	return CompileTemplate(input).renderResult(r, pos, pos, true, true, nil)
 }
 
 func (r *Resolver) ExpandTemplatesStatic(input string) (string, error) {
-	return CompileTemplate(input).render(r, r.exprPos, false, false, nil)
+	return CompileTemplate(input).render(r, r.exprPos, diag.Pos{}, false, false, nil)
 }
 
 func (r *Resolver) SetTrace(tr *Trace) {
@@ -385,10 +388,14 @@ var ErrUndefinedVariable = errors.New("undefined variable")
 // never mask a cycle or broken expression seen later. Callers that classify
 // on ErrUndefinedVariable depend on this order.
 func PreferStructural(firstErr, err error) error {
-	if firstErr == nil || (!errors.Is(err, ErrUndefinedVariable) && errors.Is(firstErr, ErrUndefinedVariable)) {
+	if replaces(err, firstErr) {
 		return err
 	}
 	return firstErr
+}
+
+func replaces(err, firstErr error) bool {
+	return firstErr == nil || (!errors.Is(err, ErrUndefinedVariable) && errors.Is(firstErr, ErrUndefinedVariable))
 }
 
 // resolveName resolves one placeholder name. A non-nil error means the
@@ -551,5 +558,5 @@ func ReplaceTemplateVars(input string, fn func(match, name string) string) strin
 	if fn == nil {
 		return input
 	}
-	return CompileTemplate(input).replace(fn)
+	return CompileTemplate(input).replace(func(seg tplSeg) string { return fn(seg.text, seg.name) })
 }

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -23,7 +23,6 @@ type Template struct {
 type tplSeg struct {
 	text string // literal text, or the raw {{...}} match when ph is set
 	name string // trimmed placeholder name, blank for literals and {{ }}
-	off  int    // byte offset in src
 	ph   bool
 }
 
@@ -44,20 +43,43 @@ func CompileTemplate(input string) Template {
 	last := 0
 	for _, m := range ms {
 		if m[0] > last {
-			segs = append(segs, tplSeg{text: input[last:m[0]], off: last})
+			segs = append(segs, tplSeg{text: input[last:m[0]]})
 		}
 		segs = append(segs, tplSeg{
 			text: input[m[0]:m[1]],
 			name: strings.TrimSpace(input[m[2]:m[3]]),
-			off:  m[0],
 			ph:   true,
 		})
 		last = m[1]
 	}
 	if last < len(input) {
-		segs = append(segs, tplSeg{text: input[last:], off: last})
+		segs = append(segs, tplSeg{text: input[last:]})
 	}
 	return Template{src: input, segs: segs}
+}
+
+// Locator maps a one-based line and byte column of template text to its
+// source position. A zero result leaves the text unlocated.
+type Locator func(line, col int) diag.Pos
+
+// at locates text written in one piece at pos.
+func at(pos diag.Pos) Locator {
+	return func(line, col int) diag.Pos { return posAt(pos, line, col) }
+}
+
+// posAt is line and col of text written in one piece at pos. Without a
+// column, only lines are located.
+func posAt(pos diag.Pos, line, col int) diag.Pos {
+	switch {
+	case pos.Line <= 0:
+		return diag.Pos{}
+	case pos.Col <= 0:
+		return diag.Pos{Path: pos.Path, Line: pos.Line + line - 1}
+	case line == 1:
+		return diag.Pos{Path: pos.Path, Line: pos.Line, Col: pos.Col + col - 1}
+	default:
+		return diag.Pos{Path: pos.Path, Line: pos.Line + line - 1, Col: col}
+	}
 }
 
 type PlaceholderError struct {
@@ -69,13 +91,15 @@ type PlaceholderError struct {
 func (e *PlaceholderError) Error() string { return e.Err.Error() }
 func (e *PlaceholderError) Unwrap() error { return e.Err }
 
-// The caller sets the error class.
+// The report the failure already carries wins, so an RTS error keeps its
+// class, position, and stack. The placeholder's span fills in only when that
+// report has no position. The caller sets the error class.
 func (e *PlaceholderError) Diagnostic() diag.Report {
-	return diag.Report{Items: []diag.Diagnostic{{
-		Severity: diag.SeverityError,
-		Message:  e.Err.Error(),
-		Span:     e.Span,
-	}}}
+	rep := diag.ReportOf(e.Err)
+	if it := &rep.Items[0]; it.Span.Start.Line <= 0 && e.Span.Start.Line > 0 {
+		it.Span = e.Span
+	}
+	return rep
 }
 
 // Render expands the template the same way ExpandTemplates does. An
@@ -83,22 +107,24 @@ func (e *PlaceholderError) Diagnostic() diag.Report {
 // the first structural error (cycle, depth, expression) if any occurred,
 // otherwise the first undefined variable.
 func (t Template) Render(r *Resolver) (string, error) {
-	return t.render(r, r.exprPos, diag.Pos{}, true, true, nil)
+	return t.render(r, r.exprPos, nil, true, true, nil)
 }
 
 func (t Template) render(
 	r *Resolver,
-	pos, start diag.Pos,
+	pos diag.Pos,
+	locate Locator,
 	allowDynamic, allowExpr bool,
 	st *expandState,
 ) (string, error) {
-	result, err := t.renderResult(r, pos, start, allowDynamic, allowExpr, st)
+	result, err := t.renderResult(r, pos, locate, allowDynamic, allowExpr, st)
 	return result.Value, err
 }
 
 func (t Template) renderResult(
 	r *Resolver,
-	pos, start diag.Pos,
+	pos diag.Pos,
+	locate Locator,
 	allowDynamic, allowExpr bool,
 	st *expandState,
 ) (Expansion, error) {
@@ -111,12 +137,17 @@ func (t Template) renderResult(
 	lenientRoot := st == nil && r.lenient
 	var firstErr error
 	var failed tplSeg
+	var failedOff int
 	var undef bool
-	out := t.replace(func(seg tplSeg) string {
+	out := t.replace(func(seg tplSeg, off int) string {
 		if seg.name == "" {
 			return seg.text
 		}
-		value, err := r.resolveName(seg.name, pos, allowDynamic, allowExpr, st)
+		at := pos
+		if locate != nil && seg.name[0] == '=' {
+			at = t.exprPos(seg, off, pos, locate)
+		}
+		value, err := r.resolveName(seg.name, at, allowDynamic, allowExpr, st)
 		if err != nil {
 			undefined := errors.Is(err, ErrUndefinedVariable)
 			if undefined {
@@ -126,7 +157,7 @@ func (t Template) renderResult(
 				return seg.text
 			}
 			if replaces(err, firstErr) {
-				firstErr, failed = err, seg
+				firstErr, failed, failedOff = err, seg, off
 			}
 			return seg.text
 		}
@@ -135,35 +166,58 @@ func (t Template) renderResult(
 	// Nested values come from other declarations, so report the placeholder
 	// in this template.
 	if firstErr != nil && st == nil {
-		firstErr = &PlaceholderError{Match: failed.text, Span: t.span(failed, start), Err: firstErr}
+		firstErr = &PlaceholderError{Match: failed.text, Span: t.span(failed, failedOff, locate), Err: firstErr}
 	}
 	return Expansion{Value: out, HasUndefinedVariables: undef}, firstErr
 }
 
-func (t Template) span(seg tplSeg, start diag.Pos) diag.Span {
-	switch {
-	case start.Line <= 0:
+// span locates the placeholder seg that starts at byte off of the input.
+func (t Template) span(seg tplSeg, off int, locate Locator) diag.Span {
+	if locate == nil {
 		return diag.Span{}
-	case start.Col <= 0:
-		return diag.Span{Start: start}
 	}
-	from := advance(start, t.src[:seg.off])
-	return diag.Span{Start: from, End: advance(from, seg.text)}
+	start := locate(textPos(t.src[:off]))
+	if start.Line <= 0 {
+		return diag.Span{}
+	}
+	end := locate(textPos(t.src[:off+len(seg.text)]))
+	if end.Line <= 0 {
+		end = start
+	}
+	return diag.Span{Start: start, End: end}
 }
 
-func advance(pos diag.Pos, text string) diag.Pos {
-	if i := strings.LastIndexByte(text, '\n'); i >= 0 {
-		pos.Line += strings.Count(text, "\n")
-		pos.Col = len(text) - i
+// exprPos is where the expression of the {{= ...}} placeholder seg at byte
+// off starts, so an evaluation error points into the file. It falls back to
+// pos when the placeholder has no full position.
+func (t Template) exprPos(seg tplSeg, off int, pos diag.Pos, locate Locator) diag.Pos {
+	p := locate(textPos(t.src[:off+exprOffset(seg.text)]))
+	if p.Line <= 0 || p.Col <= 0 {
 		return pos
 	}
-	pos.Col += len(text)
-	return pos
+	return p
 }
 
-// replace rebuilds the input and passes every placeholder through fn, even a
-// blank {{ }}.
-func (t Template) replace(fn func(seg tplSeg) string) string {
+// exprOffset follows the trimming resolveName applies to an {{= ...}} match.
+func exprOffset(match string) int {
+	inner := match[2 : len(match)-2]
+	name := strings.TrimLeftFunc(inner, unicode.IsSpace)
+	rest := name[1:]
+	expr := strings.TrimLeftFunc(rest, unicode.IsSpace)
+	return 2 + len(inner) - len(name) + 1 + len(rest) - len(expr)
+}
+
+// textPos is the one-based line and column just past text.
+func textPos(text string) (line, col int) {
+	if i := strings.LastIndexByte(text, '\n'); i >= 0 {
+		return 1 + strings.Count(text, "\n"), len(text) - i
+	}
+	return 1, len(text) + 1
+}
+
+// replace rebuilds the input and passes every placeholder through fn with
+// its byte offset in the input, even a blank {{ }}.
+func (t Template) replace(fn func(seg tplSeg, off int) string) string {
 	if len(t.segs) == 0 {
 		return ""
 	}
@@ -171,12 +225,14 @@ func (t Template) replace(fn func(seg tplSeg) string) string {
 		return t.segs[0].text
 	}
 	var b strings.Builder
+	off := 0
 	for _, s := range t.segs {
 		if s.ph {
-			b.WriteString(fn(s))
+			b.WriteString(fn(s, off))
 		} else {
 			b.WriteString(s.text)
 		}
+		off += len(s.text)
 	}
 	return b.String()
 }
@@ -187,37 +243,48 @@ type Unclosed struct {
 	Span diag.Span
 }
 
+// UnclosedPlaceholders runs on every parsed line, so it scans by hand
+// instead of through templateVarPattern and allocates only for a finding.
 func UnclosedPlaceholders(input string, start diag.Pos) []Unclosed {
-	if !HasPlaceholder(input) {
-		return nil
-	}
-	closed := templateVarPattern.FindAllStringIndex(input, -1)
 	var out []Unclosed
-	for off, c := 0, 0; ; {
+	for off := 0; ; {
 		i := strings.Index(input[off:], "{{")
 		if i < 0 {
 			return out
 		}
 		i += off
-		for c < len(closed) && closed[c][1] <= i {
-			c++
-		}
-		if c < len(closed) && closed[c][0] <= i {
-			off = closed[c][1]
+		if end, ok := placeholderEnd(input, i); ok {
+			off = end
 			continue
 		}
 		end := i + 2 + nameLen(input[i+2:])
 		if end < len(input) && input[end] == '}' {
 			end++
 		}
-		from := advance(start, input[:i])
-		out = append(out, Unclosed{
-			Text: input[i:end],
-			Off:  i,
-			Span: diag.Span{Start: from, End: advance(from, input[i:end])},
-		})
+		out = append(out, Unclosed{Text: input[i:end], Off: i, Span: spanIn(input, start, i, end)})
 		off = end
 	}
+}
+
+// placeholderEnd is where the placeholder opening at i ends, if one does.
+// It mirrors templateVarPattern: at least one byte other than "}", then "}}".
+func placeholderEnd(input string, i int) (int, bool) {
+	j := strings.IndexByte(input[i+2:], '}')
+	if j < 1 {
+		return 0, false
+	}
+	j += i + 2
+	if j+1 < len(input) && input[j+1] == '}' {
+		return j + 2, true
+	}
+	return 0, false
+}
+
+func spanIn(input string, start diag.Pos, i, end int) diag.Span {
+	line, col := textPos(input[:i])
+	from := posAt(start, line, col)
+	line, col = textPos(input[:end])
+	return diag.Span{Start: from, End: posAt(start, line, col)}
 }
 
 func nameLen(s string) int {

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"unicode"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
 )
 
 var templateVarPattern = regexp.MustCompile(`\{\{([^}]+)\}\}`)
@@ -13,12 +16,14 @@ var templateVarPattern = regexp.MustCompile(`\{\{([^}]+)\}\}`)
 // traversal implementation behind ExpandTemplates, Render and
 // ReplaceTemplateVars, so all of them agree on what counts as a placeholder.
 type Template struct {
+	src  string
 	segs []tplSeg
 }
 
 type tplSeg struct {
 	text string // literal text, or the raw {{...}} match when ph is set
 	name string // trimmed placeholder name, blank for literals and {{ }}
+	off  int    // byte offset in src
 	ph   bool
 }
 
@@ -32,26 +37,45 @@ func CompileTemplate(input string) Template {
 		if input == "" {
 			return Template{}
 		}
-		return Template{segs: []tplSeg{{text: input}}}
+		return Template{src: input, segs: []tplSeg{{text: input}}}
 	}
 
 	segs := make([]tplSeg, 0, 2*len(ms)+1)
 	last := 0
 	for _, m := range ms {
 		if m[0] > last {
-			segs = append(segs, tplSeg{text: input[last:m[0]]})
+			segs = append(segs, tplSeg{text: input[last:m[0]], off: last})
 		}
 		segs = append(segs, tplSeg{
 			text: input[m[0]:m[1]],
 			name: strings.TrimSpace(input[m[2]:m[3]]),
+			off:  m[0],
 			ph:   true,
 		})
 		last = m[1]
 	}
 	if last < len(input) {
-		segs = append(segs, tplSeg{text: input[last:]})
+		segs = append(segs, tplSeg{text: input[last:], off: last})
 	}
-	return Template{segs: segs}
+	return Template{src: input, segs: segs}
+}
+
+type PlaceholderError struct {
+	Match string
+	Span  diag.Span
+	Err   error
+}
+
+func (e *PlaceholderError) Error() string { return e.Err.Error() }
+func (e *PlaceholderError) Unwrap() error { return e.Err }
+
+// The caller sets the error class.
+func (e *PlaceholderError) Diagnostic() diag.Report {
+	return diag.Report{Items: []diag.Diagnostic{{
+		Severity: diag.SeverityError,
+		Message:  e.Err.Error(),
+		Span:     e.Span,
+	}}}
 }
 
 // Render expands the template the same way ExpandTemplates does. An
@@ -59,22 +83,22 @@ func CompileTemplate(input string) Template {
 // the first structural error (cycle, depth, expression) if any occurred,
 // otherwise the first undefined variable.
 func (t Template) Render(r *Resolver) (string, error) {
-	return t.render(r, r.exprPos, true, true, nil)
+	return t.render(r, r.exprPos, diag.Pos{}, true, true, nil)
 }
 
 func (t Template) render(
 	r *Resolver,
-	pos ExprPos,
+	pos, start diag.Pos,
 	allowDynamic, allowExpr bool,
 	st *expandState,
 ) (string, error) {
-	result, err := t.renderResult(r, pos, allowDynamic, allowExpr, st)
+	result, err := t.renderResult(r, pos, start, allowDynamic, allowExpr, st)
 	return result.Value, err
 }
 
 func (t Template) renderResult(
 	r *Resolver,
-	pos ExprPos,
+	pos, start diag.Pos,
 	allowDynamic, allowExpr bool,
 	st *expandState,
 ) (Expansion, error) {
@@ -86,31 +110,60 @@ func (t Template) renderResult(
 	// declared value can never mask a cycle or broken expression next to it.
 	lenientRoot := st == nil && r.lenient
 	var firstErr error
+	var failed tplSeg
 	var undef bool
-	out := t.replace(func(match, name string) string {
-		if name == "" {
-			return match
+	out := t.replace(func(seg tplSeg) string {
+		if seg.name == "" {
+			return seg.text
 		}
-		value, err := r.resolveName(name, pos, allowDynamic, allowExpr, st)
+		value, err := r.resolveName(seg.name, pos, allowDynamic, allowExpr, st)
 		if err != nil {
 			undefined := errors.Is(err, ErrUndefinedVariable)
 			if undefined {
 				undef = true
 			}
 			if lenientRoot && undefined {
-				return match
+				return seg.text
 			}
-			firstErr = PreferStructural(firstErr, err)
-			return match
+			if replaces(err, firstErr) {
+				firstErr, failed = err, seg
+			}
+			return seg.text
 		}
 		return value
 	})
+	// Nested values come from other declarations, so report the placeholder
+	// in this template.
+	if firstErr != nil && st == nil {
+		firstErr = &PlaceholderError{Match: failed.text, Span: t.span(failed, start), Err: firstErr}
+	}
 	return Expansion{Value: out, HasUndefinedVariables: undef}, firstErr
+}
+
+func (t Template) span(seg tplSeg, start diag.Pos) diag.Span {
+	switch {
+	case start.Line <= 0:
+		return diag.Span{}
+	case start.Col <= 0:
+		return diag.Span{Start: start}
+	}
+	from := advance(start, t.src[:seg.off])
+	return diag.Span{Start: from, End: advance(from, seg.text)}
+}
+
+func advance(pos diag.Pos, text string) diag.Pos {
+	if i := strings.LastIndexByte(text, '\n'); i >= 0 {
+		pos.Line += strings.Count(text, "\n")
+		pos.Col = len(text) - i
+		return pos
+	}
+	pos.Col += len(text)
+	return pos
 }
 
 // replace rebuilds the input and passes every placeholder through fn, even a
 // blank {{ }}.
-func (t Template) replace(fn func(match, name string) string) string {
+func (t Template) replace(fn func(seg tplSeg) string) string {
 	if len(t.segs) == 0 {
 		return ""
 	}
@@ -120,10 +173,57 @@ func (t Template) replace(fn func(match, name string) string) string {
 	var b strings.Builder
 	for _, s := range t.segs {
 		if s.ph {
-			b.WriteString(fn(s.text, s.name))
+			b.WriteString(fn(s))
 		} else {
 			b.WriteString(s.text)
 		}
 	}
 	return b.String()
+}
+
+type Unclosed struct {
+	Text string
+	Off  int // byte offset in the input
+	Span diag.Span
+}
+
+func UnclosedPlaceholders(input string, start diag.Pos) []Unclosed {
+	if !HasPlaceholder(input) {
+		return nil
+	}
+	closed := templateVarPattern.FindAllStringIndex(input, -1)
+	var out []Unclosed
+	for off, c := 0, 0; ; {
+		i := strings.Index(input[off:], "{{")
+		if i < 0 {
+			return out
+		}
+		i += off
+		for c < len(closed) && closed[c][1] <= i {
+			c++
+		}
+		if c < len(closed) && closed[c][0] <= i {
+			off = closed[c][1]
+			continue
+		}
+		end := i + 2 + nameLen(input[i+2:])
+		if end < len(input) && input[end] == '}' {
+			end++
+		}
+		from := advance(start, input[:i])
+		out = append(out, Unclosed{
+			Text: input[i:end],
+			Off:  i,
+			Span: diag.Span{Start: from, End: advance(from, input[i:end])},
+		})
+		off = end
+	}
+}
+
+func nameLen(s string) int {
+	i := strings.IndexFunc(s, func(r rune) bool { return unicode.IsSpace(r) || r == '{' || r == '}' })
+	if i < 0 {
+		return len(s)
+	}
+	return i
 }

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -234,17 +234,23 @@ type Unclosed struct {
 	Span diag.Span
 }
 
-// This runs on every parsed line. Scanning without the regex avoids
-// allocations when all placeholders are closed.
+// UnclosedPlaceholders reports unfinished placeholders relative to start.
 func UnclosedPlaceholders(input string, start diag.Pos) []Unclosed {
+	return UnclosedPlaceholdersLocated(input, at(start))
+}
+
+// UnclosedPlaceholdersLocated reports unfinished placeholders using locate
+// to map their positions back to the source.
+func UnclosedPlaceholdersLocated(input string, locate Locator) []Unclosed {
 	var out []Unclosed
+	sc := newUnclosedScan(input)
 	for off := 0; ; {
 		i := strings.Index(input[off:], "{{")
 		if i < 0 {
 			return out
 		}
 		i += off
-		if end, ok := placeholderEnd(input, i); ok {
+		if end, ok := sc.closes(i); ok {
 			off = end
 			continue
 		}
@@ -252,29 +258,71 @@ func UnclosedPlaceholders(input string, start diag.Pos) []Unclosed {
 		if end < len(input) && input[end] == '}' {
 			end++
 		}
-		out = append(out, Unclosed{Text: input[i:end], Off: i, Span: spanIn(input, start, i, end)})
+		out = append(out, Unclosed{Text: input[i:end], Off: i, Span: sc.span(locate, i, end)})
 		off = end
 	}
 }
 
-// Keep this consistent with templateVarPattern: {{}} is invalid, but {{ }} is valid.
-func placeholderEnd(input string, i int) (int, bool) {
-	j := strings.IndexByte(input[i+2:], '}')
-	if j < 1 {
-		return 0, false
-	}
-	j += i + 2
-	if j+1 < len(input) && input[j+1] == '}' {
-		return j + 2, true
-	}
-	return 0, false
+// Scan offsets must only move forward to avoid rescanning long inputs.
+type unclosedScan struct {
+	input   string
+	brace   int // next '}', or len(input) if none remain
+	line    int
+	col     int
+	lineOff int // byte offset for line and col
 }
 
-func spanIn(input string, start diag.Pos, i, end int) diag.Span {
-	line, col := textPos(input[:i])
-	from := posAt(start, line, col)
-	line, col = textPos(input[:end])
-	return diag.Span{Start: from, End: posAt(start, line, col)}
+func newUnclosedScan(input string) unclosedScan {
+	return unclosedScan{input: input, brace: braceFrom(input, 0), line: 1, col: 1}
+}
+
+// Keep this consistent with templateVarPattern: {{}} is invalid, but {{ }} is valid.
+func (s *unclosedScan) closes(i int) (int, bool) {
+	j := s.nextBrace(i + 2)
+	if j < i+3 || j+1 >= len(s.input) || s.input[j+1] != '}' {
+		return 0, false
+	}
+	return j + 2, true
+}
+
+func (s *unclosedScan) nextBrace(from int) int {
+	if s.brace < from {
+		s.brace = braceFrom(s.input, from)
+	}
+	return s.brace
+}
+
+func braceFrom(input string, off int) int {
+	i := strings.IndexByte(input[off:], '}')
+	if i < 0 {
+		return len(input)
+	}
+	return off + i
+}
+
+func (s *unclosedScan) span(locate Locator, i, end int) diag.Span {
+	start := locate(s.lineCol(i))
+	if start.Line <= 0 {
+		return diag.Span{}
+	}
+	last := locate(s.lineCol(end))
+	if last.Line <= 0 {
+		last = start
+	}
+	return diag.Span{Start: start, End: last}
+}
+
+// lineCol returns the line and byte column at off, both starting at 1.
+func (s *unclosedScan) lineCol(off int) (line, col int) {
+	seg := s.input[s.lineOff:off]
+	if i := strings.LastIndexByte(seg, '\n'); i >= 0 {
+		s.line += strings.Count(seg, "\n")
+		s.col = len(seg) - i
+	} else {
+		s.col += len(seg)
+	}
+	s.lineOff = off
+	return s.line, s.col
 }
 
 func nameLen(s string) int {

--- a/internal/vars/template.go
+++ b/internal/vars/template.go
@@ -58,17 +58,14 @@ func CompileTemplate(input string) Template {
 	return Template{src: input, segs: segs}
 }
 
-// Locator maps a one-based line and byte column of template text to its
-// source position. A zero result leaves the text unlocated.
+// Locator maps template positions to source positions. Lines and byte columns
+// start at 1. Return a zero position when the source location is unknown.
 type Locator func(line, col int) diag.Pos
 
-// at locates text written in one piece at pos.
 func at(pos diag.Pos) Locator {
 	return func(line, col int) diag.Pos { return posAt(pos, line, col) }
 }
 
-// posAt is line and col of text written in one piece at pos. Without a
-// column, only lines are located.
 func posAt(pos diag.Pos, line, col int) diag.Pos {
 	switch {
 	case pos.Line <= 0:
@@ -91,9 +88,8 @@ type PlaceholderError struct {
 func (e *PlaceholderError) Error() string { return e.Err.Error() }
 func (e *PlaceholderError) Unwrap() error { return e.Err }
 
-// The report the failure already carries wins, so an RTS error keeps its
-// class, position, and stack. The placeholder's span fills in only when that
-// report has no position. The caller sets the error class.
+// Keep the original error's class, location, and stack.
+// Use the placeholder's location only if the error has none.
 func (e *PlaceholderError) Diagnostic() diag.Report {
 	rep := diag.ReportOf(e.Err)
 	if it := &rep.Items[0]; it.Span.Start.Line <= 0 && e.Span.Start.Line > 0 {
@@ -171,7 +167,6 @@ func (t Template) renderResult(
 	return Expansion{Value: out, HasUndefinedVariables: undef}, firstErr
 }
 
-// span locates the placeholder seg that starts at byte off of the input.
 func (t Template) span(seg tplSeg, off int, locate Locator) diag.Span {
 	if locate == nil {
 		return diag.Span{}
@@ -187,9 +182,6 @@ func (t Template) span(seg tplSeg, off int, locate Locator) diag.Span {
 	return diag.Span{Start: start, End: end}
 }
 
-// exprPos is where the expression of the {{= ...}} placeholder seg at byte
-// off starts, so an evaluation error points into the file. It falls back to
-// pos when the placeholder has no full position.
 func (t Template) exprPos(seg tplSeg, off int, pos diag.Pos, locate Locator) diag.Pos {
 	p := locate(textPos(t.src[:off+exprOffset(seg.text)]))
 	if p.Line <= 0 || p.Col <= 0 {
@@ -198,7 +190,7 @@ func (t Template) exprPos(seg tplSeg, off int, pos diag.Pos, locate Locator) dia
 	return p
 }
 
-// exprOffset follows the trimming resolveName applies to an {{= ...}} match.
+// Skip the same leading whitespace as resolveName so error positions match.
 func exprOffset(match string) int {
 	inner := match[2 : len(match)-2]
 	name := strings.TrimLeftFunc(inner, unicode.IsSpace)
@@ -207,7 +199,7 @@ func exprOffset(match string) int {
 	return 2 + len(inner) - len(name) + 1 + len(rest) - len(expr)
 }
 
-// textPos is the one-based line and column just past text.
+// textPos returns the position after text, counting lines and byte columns from 1.
 func textPos(text string) (line, col int) {
 	if i := strings.LastIndexByte(text, '\n'); i >= 0 {
 		return 1 + strings.Count(text, "\n"), len(text) - i
@@ -215,8 +207,7 @@ func textPos(text string) (line, col int) {
 	return 1, len(text) + 1
 }
 
-// replace rebuilds the input and passes every placeholder through fn with
-// its byte offset in the input, even a blank {{ }}.
+// fn receives every placeholder, including blank {{ }}, and its byte offset.
 func (t Template) replace(fn func(seg tplSeg, off int) string) string {
 	if len(t.segs) == 0 {
 		return ""
@@ -243,8 +234,8 @@ type Unclosed struct {
 	Span diag.Span
 }
 
-// UnclosedPlaceholders runs on every parsed line, so it scans by hand
-// instead of through templateVarPattern and allocates only for a finding.
+// This runs on every parsed line. Scanning without the regex avoids
+// allocations when all placeholders are closed.
 func UnclosedPlaceholders(input string, start diag.Pos) []Unclosed {
 	var out []Unclosed
 	for off := 0; ; {
@@ -266,8 +257,7 @@ func UnclosedPlaceholders(input string, start diag.Pos) []Unclosed {
 	}
 }
 
-// placeholderEnd is where the placeholder opening at i ends, if one does.
-// It mirrors templateVarPattern: at least one byte other than "}", then "}}".
+// Keep this consistent with templateVarPattern: {{}} is invalid, but {{ }} is valid.
 func placeholderEnd(input string, i int) (int, bool) {
 	j := strings.IndexByte(input[i+2:], '}')
 	if j < 1 {

--- a/internal/vars/template_test.go
+++ b/internal/vars/template_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/unkn0wn-root/resterm/internal/diag"
 )
@@ -235,5 +236,54 @@ func referenceUnclosed(input string) []Unclosed {
 		}
 		out = append(out, Unclosed{Text: input[i:end], Off: i})
 		off = end
+	}
+}
+
+// The old scanner took seconds here; the limit leaves room for slower machines.
+func TestUnclosedPlaceholdersScanLinearly(t *testing.T) {
+	input := strings.Repeat("{", 256*1024)
+
+	start := time.Now()
+	got := UnclosedPlaceholders(input, diag.Pos{Line: 1, Col: 1})
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("scan took %s, want well under a second", elapsed)
+	}
+	if want := len(input) / 2; len(got) != want {
+		t.Fatalf("found %d openings, want %d", len(got), want)
+	}
+}
+
+func TestUnclosedPlaceholdersLocated(t *testing.T) {
+	lines := []int{4, 9}
+	locate := func(line, col int) diag.Pos {
+		if line < 1 || line > len(lines) {
+			return diag.Pos{}
+		}
+		return diag.Pos{Path: "b.http", Line: lines[line-1], Col: col}
+	}
+
+	got := UnclosedPlaceholdersLocated("{{ok}} x\n  {{tok} y", locate)
+
+	want := diag.Span{
+		Start: diag.Pos{Path: "b.http", Line: 9, Col: 3},
+		End:   diag.Pos{Path: "b.http", Line: 9, Col: 9},
+	}
+	if len(got) != 1 || got[0].Text != "{{tok}" || got[0].Span != want {
+		t.Fatalf("findings = %+v, want one {{tok} at %+v", got, want)
+	}
+}
+
+func TestUnclosedPlaceholdersSpanLines(t *testing.T) {
+	input := "{\n  \"a\": \"{{\ntok\n}}\"\n}"
+
+	if got := UnclosedPlaceholders(input, diag.Pos{Line: 1, Col: 1}); len(got) != 0 {
+		t.Fatalf("findings = %+v, want none", got)
+	}
+	if got, err := NewResolver(
+		NewMapProvider("test", map[string]string{"tok": "1"}),
+	).ExpandTemplates(input); err != nil ||
+		!strings.Contains(got, `"1"`) {
+		t.Fatalf("expanded = %q, err = %v", got, err)
 	}
 }

--- a/internal/vars/template_test.go
+++ b/internal/vars/template_test.go
@@ -92,8 +92,6 @@ func placeholderErr(t *testing.T, err error) *PlaceholderError {
 	return pe
 }
 
-// An expression failure already carries a report. Wrapping it in a
-// placeholder must keep that report's class, position, and stack.
 func TestPlaceholderErrorKeepsExpressionReport(t *testing.T) {
 	inner := &reportErr{msg: "x is not defined", rep: diag.Report{Items: []diag.Diagnostic{{
 		Class:    diag.ClassScript,
@@ -191,8 +189,6 @@ func TestExpandTemplatesAtWithoutColumnLocatesLine(t *testing.T) {
 	}
 }
 
-// The hand scan must agree with templateVarPattern on what opens a
-// placeholder, so the reference rebuilds the finding from the pattern.
 func TestUnclosedPlaceholdersMatchesPattern(t *testing.T) {
 	inputs := []string{
 		"{{ok}} {{auth.token} and {{host} {{ name } {{{x}}} {{",

--- a/internal/vars/template_test.go
+++ b/internal/vars/template_test.go
@@ -1,9 +1,13 @@
 package vars
 
 import (
+	"errors"
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/unkn0wn-root/resterm/internal/diag"
 )
 
 // Callers rely on fn seeing every regex match, including a blank {{ }} with
@@ -68,5 +72,172 @@ func TestCompileTemplateRenderResolvesDynamics(t *testing.T) {
 	}
 	if _, err := strconv.ParseInt(out, 10, 64); err != nil {
 		t.Fatalf("Render($timestamp) = %q, want a unix timestamp", out)
+	}
+}
+
+type reportErr struct {
+	msg string
+	rep diag.Report
+}
+
+func (e *reportErr) Error() string           { return e.msg }
+func (e *reportErr) Diagnostic() diag.Report { return e.rep }
+
+func placeholderErr(t *testing.T, err error) *PlaceholderError {
+	t.Helper()
+	var pe *PlaceholderError
+	if !errors.As(err, &pe) {
+		t.Fatalf("error = %T %v, want *PlaceholderError", err, err)
+	}
+	return pe
+}
+
+// An expression failure already carries a report. Wrapping it in a
+// placeholder must keep that report's class, position, and stack.
+func TestPlaceholderErrorKeepsExpressionReport(t *testing.T) {
+	inner := &reportErr{msg: "x is not defined", rep: diag.Report{Items: []diag.Diagnostic{{
+		Class:    diag.ClassScript,
+		Severity: diag.SeverityError,
+		Message:  "x is not defined",
+		Span:     diag.Span{Start: diag.Pos{Path: "lib.rts", Line: 3, Col: 5}},
+		Frames:   []diag.StackFrame{{Name: "helper", Pos: diag.Pos{Path: "lib.rts", Line: 3, Col: 5}}},
+	}}}}
+	r := NewResolver()
+	r.SetExprEval(func(string, ExprPos) (string, error) { return "", inner })
+
+	_, err := r.ExpandTemplatesAt("{{= helper() }}", diag.Pos{Path: "requests.http", Line: 6, Col: 1})
+	err = diag.WrapAs(diag.ClassProtocol, err, "expand body template")
+
+	got := diag.Render(err)
+	want := "error[script]: x is not defined\n" +
+		"--> lib.rts:3:5\n" +
+		"expand body template\n" +
+		"Stack:\n" +
+		"  at lib.rts:3:5 in helper"
+	if got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestPlaceholderErrorFillsMissingPosition(t *testing.T) {
+	inner := &reportErr{msg: "boom", rep: diag.Report{Items: []diag.Diagnostic{{
+		Class: diag.ClassScript, Severity: diag.SeverityError, Message: "boom",
+	}}}}
+	r := NewResolver()
+	r.SetExprEval(func(string, ExprPos) (string, error) { return "", inner })
+
+	_, err := r.ExpandTemplatesAt("id={{= fail() }}", diag.Pos{Path: "requests.http", Line: 6, Col: 1})
+
+	rep := placeholderErr(t, err).Diagnostic()
+	if rep.Class() != diag.ClassScript ||
+		rep.Items[0].Span.Start != (diag.Pos{Path: "requests.http", Line: 6, Col: 4}) {
+		t.Fatalf("report = %+v, want class script at requests.http:6:4", rep.Items[0])
+	}
+}
+
+func TestExpressionEvaluatesAtItsPlaceholder(t *testing.T) {
+	var got []ExprPos
+	r := NewResolver()
+	r.SetExprEval(func(_ string, pos ExprPos) (string, error) {
+		got = append(got, pos)
+		return "1", nil
+	})
+
+	if _, err := r.ExpandTemplatesAt("id={{= 1+1 }}\n{{=2}}", diag.Pos{Path: "a.http", Line: 4, Col: 10}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.ExpandTemplatesAt("{{= 1 }}", diag.Pos{Path: "auth.http", Line: 3}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []ExprPos{
+		{Path: "a.http", Line: 4, Col: 17},
+		{Path: "a.http", Line: 5, Col: 4},
+		{Path: "auth.http", Line: 3},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expression positions = %+v, want %+v", got, want)
+	}
+}
+
+func TestExpandTemplatesLocatedMapsLines(t *testing.T) {
+	lines := []int{3, 5, 6}
+	locate := func(line, col int) diag.Pos {
+		if line < 1 || line > len(lines) {
+			return diag.Pos{}
+		}
+		return diag.Pos{Path: "requests.http", Line: lines[line-1], Col: col}
+	}
+
+	_, err := NewResolver().ExpandTemplatesLocated("{\n  \"token\": \"{{auth.token}}\"\n}", locate)
+
+	pe := placeholderErr(t, err)
+	want := diag.Span{
+		Start: diag.Pos{Path: "requests.http", Line: 5, Col: 13},
+		End:   diag.Pos{Path: "requests.http", Line: 5, Col: 27},
+	}
+	if pe.Match != "{{auth.token}}" || pe.Span != want || !strings.Contains(err.Error(), "auth.token") {
+		t.Fatalf("placeholder = %q at %+v, want %+v", pe.Match, pe.Span, want)
+	}
+}
+
+func TestExpandTemplatesAtWithoutColumnLocatesLine(t *testing.T) {
+	start := diag.Pos{Path: "auth.http", Line: 3}
+
+	_, err := NewResolver().ExpandTemplatesAt("Bearer {{token}}", start)
+
+	if pe := placeholderErr(t, err); pe.Span != (diag.Span{Start: start, End: start}) {
+		t.Fatalf("span = %+v, want the directive line", pe.Span)
+	}
+}
+
+// The hand scan must agree with templateVarPattern on what opens a
+// placeholder, so the reference rebuilds the finding from the pattern.
+func TestUnclosedPlaceholdersMatchesPattern(t *testing.T) {
+	inputs := []string{
+		"{{ok}} {{auth.token} and {{host} {{ name } {{{x}}} {{",
+		"{{}}", "{{a}b}}", "{{a{{b}}", "a\n{{x}\n{{y}}", "plain", "{{", "}}{{", "{{ }}", "{{a}}}",
+	}
+	for _, input := range inputs {
+		got := UnclosedPlaceholders(input, diag.Pos{Line: 1, Col: 1})
+		want := referenceUnclosed(input)
+		if len(got) != len(want) {
+			t.Fatalf("%q: got %+v, want %+v", input, got, want)
+		}
+		for i := range want {
+			if got[i].Text != want[i].Text || got[i].Off != want[i].Off {
+				t.Fatalf("%q: finding %d = %+v, want %+v", input, i, got[i], want[i])
+			}
+		}
+	}
+	got := UnclosedPlaceholders("a\n{{x}\n{{y}}", diag.Pos{Path: "b.http", Line: 4, Col: 3})
+	want := diag.Span{Start: diag.Pos{Path: "b.http", Line: 5, Col: 1}, End: diag.Pos{Path: "b.http", Line: 5, Col: 5}}
+	if len(got) != 1 || got[0].Span != want {
+		t.Fatalf("span = %+v, want %+v", got, want)
+	}
+}
+
+func referenceUnclosed(input string) []Unclosed {
+	closed := templateVarPattern.FindAllStringIndex(input, -1)
+	var out []Unclosed
+	for off, c := 0, 0; ; {
+		i := strings.Index(input[off:], "{{")
+		if i < 0 {
+			return out
+		}
+		i += off
+		for c < len(closed) && closed[c][1] <= i {
+			c++
+		}
+		if c < len(closed) && closed[c][0] <= i {
+			off = closed[c][1]
+			continue
+		}
+		end := i + 2 + nameLen(input[i+2:])
+		if end < len(input) && input[end] == '}' {
+			end++
+		}
+		out = append(out, Unclosed{Text: input[i:end], Off: i})
+		off = end
 	}
 }


### PR DESCRIPTION
When a variable such as `{{auth.token}}` cannot be resolved, the error now identifies the placeholder’s file, line, and column where that information is available. The TUI can also show the relevant source line.
Errors from `{{= ... }}` expressions retain their original script error category, location, and stack trace.

The changes also:

- Track source locations for URLs, headers, authentication values, and inline or external body templates.
- Keep body locations correct when comments have been removed during parsing.
- Clear outdated location information when scripts replace URLs or bodies.
- Preserve useful context from wrapped errors and redact known secrets from source excerpts.
- Scan unfinished placeholders without repeatedly searching the same text, avoiding large slowdowns on malformed input.

Placeholder warnings follow how the text is actually used. Valid multiline placeholders are accepted, and braces inside RTS strings or comments are ignored. Template captures still check placeholders inside quotes because those quotes do not prevent expansion. Body warnings without a usable source location are skipped.

Unfinished placeholders such as `{{token}` remain literal text when sent; the new warning helps users catch them beforehand. Missing variables in complete placeholders continue to block sending, while Explain previews preserve unresolved values.